### PR TITLE
New variables, mixins and classes for DS6 typography #6 #18

### DIFF
--- a/browser.json
+++ b/browser.json
@@ -20,6 +20,7 @@
         "@ebay/skin/spinner",
         "@ebay/skin/switch",
         "@ebay/skin/tab",
-        "@ebay/skin/textbox"
+        "@ebay/skin/textbox",
+        "@ebay/skin/typography"
     ]
 }

--- a/dist/less/ds4/variables.less
+++ b/dist/less/ds4/variables.less
@@ -1,5 +1,15 @@
 @import "../variables-common.less";
 
+// Typography
+//----------------------------
+
+@font-family-osx: "Helvetica Neue", Helvetica;
+@font-family-windows: Arial;
+@font-family-android: Roboto;
+@font-family-sans-serif: @font-family-osx, @font-family-windows, @font-family-android, sans-serif;
+@font-family-base: @font-family-sans-serif;
+@font-family-market-sans: @marketsans-fontname, @font-family-sans-serif;
+
 // Font Files
 //-------------------------
 
@@ -17,6 +27,25 @@
 //------------------------------------
 
 @outline-dotted: 1px dotted @color-core-gray-dim;
+
+// Font-sizes (1rem = 16px)
+//----------------------
+
+@font-size-12: 0.75rem;
+@font-size-13: 0.8125rem;
+@font-size-14: 0.875rem;
+@font-size-15: 0.9375rem;
+@font-size-16: 1rem;        // size currently verboten in DSL
+@font-size-17: 1.062rem;
+@font-size-18: 1.125rem;    // size currently verboten in DSL
+@font-size-20: 1.25rem;
+@font-size-24: 1.5rem;
+@font-size-28: 1.75rem;
+@font-size-30: 1.875rem;
+@font-size-36: 2.25rem;
+@font-size-44: 2.75rem;
+@font-size-50: 3.125rem;
+@font-size-56: 3.5rem;
 
 // Hiearchy Variables
 
@@ -41,6 +70,14 @@
 @font-size-desktop-body-2: @font-size-15;
 @font-size-desktop-caption-1: @font-size-14;
 @font-size-desktop-caption-2: @font-size-13;
+
+// Font-weights
+//-------------------------
+
+@font-weight-thin: 100;
+@font-weight-light: 200;
+@font-weight-regular: 400;
+@font-weight-medium: 500;
 
 // Core Colours
 //-----------------------------

--- a/dist/less/ds6/mixins.less
+++ b/dist/less/ds6/mixins.less
@@ -1,1 +1,81 @@
 @import '../mixins-common.less';
+
+// Typography
+//-----------------------------
+
+.ds6-typography-headline-1() {
+    font-size: @ds6-font-size-headline-1;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 30px;
+}
+
+.ds6-typography-headline-2() {
+    font-size: @ds6-font-size-headline-2;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 28px;
+}
+
+.ds6-typography-headline-3() {
+    font-size: @ds6-font-size-headline-3;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 26px;
+}
+
+.ds6-typography-title-1() {
+    font-size: @ds6-font-size-title-1;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 24px;
+}
+
+.ds6-typography-title-2() {
+    font-size: @ds6-font-size-title-2;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 20px;
+}
+
+.ds6-typography-title-3() {
+    font-size: @ds6-font-size-title-3;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 18px;
+}
+
+.ds6-typography-title-4() {
+    font-size: @ds6-font-size-title-4;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 16px;
+}
+
+.ds6-typography-body-1() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-body-1;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 20px;
+}
+
+.ds6-typography-caption-1() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-caption-1;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 15px;
+}
+
+.ds6-typography-caption-2() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-caption-2;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 14px;
+}
+
+.ds6-typography-caption-3() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-caption-3;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 14px;
+}
+
+.ds6-typography-legal-1() {
+    color: @ds6-color-light;
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-legal-1;
+    font-weight: @ds6-font-weight-regular;
+}

--- a/dist/less/ds6/variables.less
+++ b/dist/less/ds6/variables.less
@@ -1,9 +1,62 @@
 @import '../variables-common.less';
 
-@ds6-color-core-default: #111820;
-@ds6-color-core-light: #767676;
-@ds6-color-core-link: #006efc;
-@ds6-color-core-visited: #6666d1;
+// Colours
+//----------------------
 
-@ds6-color-interface-button-blue: @ds6-color-core-link;
-@ds6-color-interface-button-grey: #e5e5e5;
+@ds6-color-default: #111820;
+@ds6-color-light: #767676;
+
+@ds6-color-link: #006efc;
+@ds6-color-visited: #6666d1;
+
+@ds6-color-disabled: #e5e5e5;
+
+@ds6-color-critical: #c9002c;
+@ds6-color-success: #147133;
+
+@ds6-color-button-blue: @ds6-color-link;
+@ds6-color-button-grey: @ds6-color-disabled;
+
+// Typography
+//----------------------------
+
+@ds6-font-family-primary: @marketsans-fontname, "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
+@ds6-font-family-secondary: "Helvetica Neue", Arial, sans-serif;
+
+// Font-sizes (1rem = 16px)
+//----------------------
+
+@ds6-font-size-10: 0.6125rem;
+@ds6-font-size-12: 0.75rem;
+@ds6-font-size-13: 0.8125rem;
+@ds6-font-size-14: 0.875rem;
+@ds6-font-size-16: 1rem;
+@ds6-font-size-18: 1.125rem;
+@ds6-font-size-20: 1.25rem;
+@ds6-font-size-22: 1.375rem;
+@ds6-font-size-24: 1.5rem;
+@ds6-font-size-26: 1.625rem;
+@ds6-font-size-28: 1.75rem;
+
+@ds6-font-size-headline-1: @ds6-font-size-28;
+@ds6-font-size-headline-2: @ds6-font-size-26;
+@ds6-font-size-headline-3: @ds6-font-size-24;
+
+@ds6-font-size-title-1: @ds6-font-size-22;
+@ds6-font-size-title-2: @ds6-font-size-18;
+@ds6-font-size-title-3: @ds6-font-size-16;
+@ds6-font-size-title-4: @ds6-font-size-16;
+
+@ds6-font-size-body-1: @ds6-font-size-14;
+
+@ds6-font-size-caption-1: @ds6-font-size-13;
+@ds6-font-size-caption-2: @ds6-font-size-12;
+@ds6-font-size-caption-3: @ds6-font-size-12;
+
+@ds6-font-size-legal-1: @ds6-font-size-12;
+
+// Font-weights
+//-------------------------
+
+@ds6-font-weight-bold: 700;
+@ds6-font-weight-regular: 500;

--- a/dist/less/variables-common.less
+++ b/dist/less/variables-common.less
@@ -1,44 +1,8 @@
-// Typography
-//----------------------------
-
-@font-family-osx: "Helvetica Neue", Helvetica;
-@font-family-windows: Arial;
-@font-family-android: Roboto;
-@font-family-sans-serif: @font-family-osx, @font-family-windows, @font-family-android, sans-serif;
-@font-family-base: @font-family-sans-serif;
-@font-family-market-sans: @marketsans-name, @font-family-sans-serif;
-
-// Font-sizes (1rem = 16px)
-//----------------------
-
-@font-size-12: 0.75rem;
-@font-size-13: 0.8125rem;
-@font-size-14: 0.875rem;
-@font-size-15: 0.9375rem;
-@font-size-16: 1rem;        // size currently verboten in DSL
-@font-size-17: 1.062rem;
-@font-size-18: 1.125rem;    // size currently verboten in DSL
-@font-size-20: 1.25rem;
-@font-size-24: 1.5rem;
-@font-size-28: 1.75rem;
-@font-size-30: 1.875rem;
-@font-size-36: 2.25rem;
-@font-size-44: 2.75rem;
-@font-size-50: 3.125rem;
-@font-size-56: 3.5rem;
-
-// Font-weights
-//-------------------------
-
-@font-weight-thin: 100;
-@font-weight-light: 200;
-@font-weight-regular: 400;
-@font-weight-medium: 500;
-
 // Font Files
 //-------------------------
 
 @marketsans-url: "https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/";
-@marketsans-name: "Market Sans";
+@marketsans-fontname: "Market Sans";
+@marketsans-name: @marketsans-fontname; // deprecated in favour of @marketsans-fontname. Remove in next major version change.
 @marketsans-filename-regular: "MarketSans-Regular-WebS";
 @marketsans-filename-bold: "MarketSans-SemiBold-WebS";

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -1,0 +1,65 @@
+.headline-1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 30px;
+}
+.headline-2 {
+  font-size: 1.625rem;
+  font-weight: 700;
+  line-height: 28px;
+}
+.headline-3 {
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 26px;
+}
+.title-1 {
+  font-size: 1.375rem;
+  font-weight: 700;
+  line-height: 24px;
+}
+.title-2 {
+  font-size: 1.125rem;
+  font-weight: 500;
+  line-height: 20px;
+}
+.title-3 {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 18px;
+}
+.title-4 {
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 16px;
+}
+.body-1 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 20px;
+}
+.caption-1 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 15px;
+}
+.caption-2 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 14px;
+}
+.caption-3 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 14px;
+}
+.legal-1 {
+  color: #767676;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+}

--- a/docs/_includes/ds6/less.html
+++ b/docs/_includes/ds6/less.html
@@ -1,0 +1,37 @@
+<div id="less">
+    <h2>@ebay/skin/less</h2>
+    <p>The LESS module contains variables and mixins.</p>
+    <h3 id="less-colour">Colour Variables</h3>
+    <div class="demo">
+        <div class="demo__inner">
+            <ul class="colour">
+                <li class="color-default">@ds6-color-default</li>
+                <li class="color-light">@ds6-color-light</li>
+                <li class="color-disabled">@ds6-color-disabled</li>
+                <li class="color-link">@ds6-color-link</li>
+                <li class="color-visited">@ds6-color-visited</li>
+                <li class="color-critical">@ds6-color-critical</li>
+                <li class="color-success">@ds6-color-success</li>
+            </ul>
+        </div>
+    </div>
+    <h3 id="less-typography">Typography Mixins</h3>
+    <div class="demo">
+        <div class="demo__inner">
+            <ul class="typography">
+                <li class="headline-1">.ds6-typography-headline-1</li>
+                <li class="headline-2">.ds6-typography-headline-2</li>
+                <li class="headline-3">.ds6-typography-headline-3</li>
+                <li class="title-1">.ds6-typography-title-1</li>
+                <li class="title-2">.ds6-typography-title-2</li>
+                <li class="title-3">.ds6-typography-title-3</li>
+                <li class="title-4">.ds6-typography-title-4</li>
+                <li class="body-1">.ds6-typography-body-1</li>
+                <li class="caption-1">.ds6-typography-caption-1</li>
+                <li class="caption-2">.ds6-typography-caption-2</li>
+                <li class="caption-3">.ds6-typography-caption-3</li>
+                <li class="legal-1">.ds6-typography-legal-1</li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/docs/_includes/ds6/typography.html
+++ b/docs/_includes/ds6/typography.html
@@ -1,0 +1,22 @@
+<div id="typography">
+    <h2>@ebay/skin/typography</h2>
+    <p>Static sites that do not have access to LESS preprocessor can leverage the Skin type ramp via the typography module.</p>
+    <div class="demo">
+        <div class="demo__inner">
+            <ul class="typography">
+                <li class="headline-1">.headline-1</li>
+                <li class="headline-2">.headline-2</li>
+                <li class="headline-3">.headline-3</li>
+                <li class="title-1">.title-1</li>
+                <li class="title-2">.title-2</li>
+                <li class="title-3">.title-3</li>
+                <li class="title-4">.title-4</li>
+                <li class="body-1">.body-1</li>
+                <li class="caption-1">.caption-1</li>
+                <li class="caption-2">.caption-2</li>
+                <li class="caption-3">.caption-3</li>
+                <li class="legal-1">.legal-1</li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/docs/ds6/index.html
+++ b/docs/ds6/index.html
@@ -31,7 +31,8 @@ title: Skin DS6
 </svg>
 <h1>eBay Skin DS6</h1>
 
-<p>Coming soon.</p>
+{% include ds6/less.html %}
+{% include ds6/typography.html %}
 
 <!--
 

--- a/docs/src/less/ds6/index.less
+++ b/docs/src/less/ds6/index.less
@@ -1,3 +1,63 @@
 [hidden] {
     display: none;
 }
+
+h1 {
+    .ds6-typography-headline-1;
+}
+
+h2 {
+    .ds6-typography-headline-2;
+}
+
+h3 {
+    .ds6-typography-headline-3;
+}
+
+.typography,
+.colour {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+        margin: 16px;
+    }
+}
+
+.colour li::before {
+    content: '';
+    display: inline-block;
+    height: 20px;
+    margin-right: 16px;
+    vertical-align: middle;
+    width: 20px;
+}
+
+.color-default::before {
+    background-color: @ds6-color-default;
+}
+
+.color-light::before {
+    background-color: @ds6-color-light;
+}
+
+.color-link::before {
+    background-color: @ds6-color-link;
+}
+
+.color-visited::before {
+    background-color: @ds6-color-visited;
+}
+
+.color-disabled::before {
+    background-color: @ds6-color-disabled;
+}
+
+.color-critical::before {
+    background-color: @ds6-color-critical;
+}
+
+.color-success::before {
+    background-color: @ds6-color-success;
+}

--- a/docs/static/ds6/docs.css
+++ b/docs/static/ds6/docs.css
@@ -1,2 +1,2 @@
-[hidden]{display:none}
+[hidden]{display:none}h1{font-size:1.75rem;font-weight:700;line-height:30px}h2{font-size:1.625rem;font-weight:700;line-height:28px}h3{font-size:1.5rem;font-weight:500;line-height:26px}.typography,.colour{list-style-type:none;margin:0;padding:0}.typography li,.colour li{margin:16px}.colour li::before{content:'';display:inline-block;height:20px;margin-right:16px;vertical-align:middle;width:20px}.color-default::before{background-color:#111820}.color-light::before{background-color:#767676}.color-link::before{background-color:#006efc}.color-visited::before{background-color:#6666d1}.color-disabled::before{background-color:#e5e5e5}.color-critical::before{background-color:#c9002c}.color-success::before{background-color:#147133}
 

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -226,3 +226,68 @@ button.page-notice {
 .flyout-notice a {
   outline-color: white;
 }
+.headline-1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 30px;
+}
+.headline-2 {
+  font-size: 1.625rem;
+  font-weight: 700;
+  line-height: 28px;
+}
+.headline-3 {
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 26px;
+}
+.title-1 {
+  font-size: 1.375rem;
+  font-weight: 700;
+  line-height: 24px;
+}
+.title-2 {
+  font-size: 1.125rem;
+  font-weight: 500;
+  line-height: 20px;
+}
+.title-3 {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 18px;
+}
+.title-4 {
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 16px;
+}
+.body-1 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 20px;
+}
+.caption-1 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 15px;
+}
+.caption-2 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 14px;
+}
+.caption-3 {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 14px;
+}
+.legal-1 {
+  color: #767676;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+}

--- a/less.browser.json
+++ b/less.browser.json
@@ -1,6 +1,8 @@
 {
     "dependencies": [
         "less-import: ./dist/less/ds4/variables.less",
-        "less-import: ./dist/less/ds4/mixins.less"
+        "less-import: ./dist/less/ds4/mixins.less",
+        "less-import: ./dist/less/ds6/variables.less",
+        "less-import: ./dist/less/ds6/mixins.less"
     ]
 }

--- a/src/less/bundles/skin/ds6/skin.less
+++ b/src/less/bundles/skin/ds6/skin.less
@@ -4,3 +4,4 @@
 @import "../../../global/ds6/global.less";
 @import "../../../button/ds6/button.less";
 @import "../../../notice/ds6/notice.less";
+@import "../../../typography/ds6/typography.less";

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -19,7 +19,7 @@
 
 .btn--primary,
 .fake-btn--primary {
-    background-color: @ds6-color-interface-button-blue;
+    background-color: @ds6-color-button-blue;
     border: 0 none;
     color: white;
     font-weight: bold;
@@ -28,8 +28,8 @@
 .btn--secondary,
 .fake-btn--secondary {
   background-color: white;
-  border: 1px solid @ds6-color-interface-button-grey;
-  color: @ds6-color-interface-button-blue;
+  border: 1px solid @ds6-color-button-grey;
+  color: @ds6-color-button-blue;
 }
 
 .btn--fluid,

--- a/src/less/global/ds6/global.less
+++ b/src/less/global/ds6/global.less
@@ -2,7 +2,7 @@
 @import "../../less/ds6/variables.less";
 
 body {
-    color: @ds6-color-core-default;
-    font-family: @font-family-market-sans;
-    font-size: @font-size-14;
+    color: @ds6-color-default;
+    font-family: @ds6-font-family-primary;
+    font-size: @ds6-font-size-14;
 }

--- a/src/less/less/ds4/variables.less
+++ b/src/less/less/ds4/variables.less
@@ -1,5 +1,15 @@
 @import "../variables-common.less";
 
+// Typography
+//----------------------------
+
+@font-family-osx: "Helvetica Neue", Helvetica;
+@font-family-windows: Arial;
+@font-family-android: Roboto;
+@font-family-sans-serif: @font-family-osx, @font-family-windows, @font-family-android, sans-serif;
+@font-family-base: @font-family-sans-serif;
+@font-family-market-sans: @marketsans-fontname, @font-family-sans-serif;
+
 // Font Files
 //-------------------------
 
@@ -17,6 +27,25 @@
 //------------------------------------
 
 @outline-dotted: 1px dotted @color-core-gray-dim;
+
+// Font-sizes (1rem = 16px)
+//----------------------
+
+@font-size-12: 0.75rem;
+@font-size-13: 0.8125rem;
+@font-size-14: 0.875rem;
+@font-size-15: 0.9375rem;
+@font-size-16: 1rem;        // size currently verboten in DSL
+@font-size-17: 1.062rem;
+@font-size-18: 1.125rem;    // size currently verboten in DSL
+@font-size-20: 1.25rem;
+@font-size-24: 1.5rem;
+@font-size-28: 1.75rem;
+@font-size-30: 1.875rem;
+@font-size-36: 2.25rem;
+@font-size-44: 2.75rem;
+@font-size-50: 3.125rem;
+@font-size-56: 3.5rem;
 
 // Hiearchy Variables
 
@@ -41,6 +70,14 @@
 @font-size-desktop-body-2: @font-size-15;
 @font-size-desktop-caption-1: @font-size-14;
 @font-size-desktop-caption-2: @font-size-13;
+
+// Font-weights
+//-------------------------
+
+@font-weight-thin: 100;
+@font-weight-light: 200;
+@font-weight-regular: 400;
+@font-weight-medium: 500;
 
 // Core Colours
 //-----------------------------

--- a/src/less/less/ds6/mixins.less
+++ b/src/less/less/ds6/mixins.less
@@ -1,1 +1,81 @@
 @import '../mixins-common.less';
+
+// Typography
+//-----------------------------
+
+.ds6-typography-headline-1() {
+    font-size: @ds6-font-size-headline-1;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 30px;
+}
+
+.ds6-typography-headline-2() {
+    font-size: @ds6-font-size-headline-2;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 28px;
+}
+
+.ds6-typography-headline-3() {
+    font-size: @ds6-font-size-headline-3;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 26px;
+}
+
+.ds6-typography-title-1() {
+    font-size: @ds6-font-size-title-1;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 24px;
+}
+
+.ds6-typography-title-2() {
+    font-size: @ds6-font-size-title-2;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 20px;
+}
+
+.ds6-typography-title-3() {
+    font-size: @ds6-font-size-title-3;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 18px;
+}
+
+.ds6-typography-title-4() {
+    font-size: @ds6-font-size-title-4;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 16px;
+}
+
+.ds6-typography-body-1() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-body-1;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 20px;
+}
+
+.ds6-typography-caption-1() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-caption-1;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 15px;
+}
+
+.ds6-typography-caption-2() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-caption-2;
+    font-weight: @ds6-font-weight-bold;
+    line-height: 14px;
+}
+
+.ds6-typography-caption-3() {
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-caption-3;
+    font-weight: @ds6-font-weight-regular;
+    line-height: 14px;
+}
+
+.ds6-typography-legal-1() {
+    color: @ds6-color-light;
+    font-family: @ds6-font-family-secondary;
+    font-size: @ds6-font-size-legal-1;
+    font-weight: @ds6-font-weight-regular;
+}

--- a/src/less/less/ds6/variables.less
+++ b/src/less/less/ds6/variables.less
@@ -1,9 +1,62 @@
 @import '../variables-common.less';
 
-@ds6-color-core-default: #111820;
-@ds6-color-core-light: #767676;
-@ds6-color-core-link: #006efc;
-@ds6-color-core-visited: #6666d1;
+// Colours
+//----------------------
 
-@ds6-color-interface-button-blue: @ds6-color-core-link;
-@ds6-color-interface-button-grey: #e5e5e5;
+@ds6-color-default: #111820;
+@ds6-color-light: #767676;
+
+@ds6-color-link: #006efc;
+@ds6-color-visited: #6666d1;
+
+@ds6-color-disabled: #e5e5e5;
+
+@ds6-color-critical: #c9002c;
+@ds6-color-success: #147133;
+
+@ds6-color-button-blue: @ds6-color-link;
+@ds6-color-button-grey: @ds6-color-disabled;
+
+// Typography
+//----------------------------
+
+@ds6-font-family-primary: @marketsans-fontname, "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
+@ds6-font-family-secondary: "Helvetica Neue", Arial, sans-serif;
+
+// Font-sizes (1rem = 16px)
+//----------------------
+
+@ds6-font-size-10: 0.6125rem;
+@ds6-font-size-12: 0.75rem;
+@ds6-font-size-13: 0.8125rem;
+@ds6-font-size-14: 0.875rem;
+@ds6-font-size-16: 1rem;
+@ds6-font-size-18: 1.125rem;
+@ds6-font-size-20: 1.25rem;
+@ds6-font-size-22: 1.375rem;
+@ds6-font-size-24: 1.5rem;
+@ds6-font-size-26: 1.625rem;
+@ds6-font-size-28: 1.75rem;
+
+@ds6-font-size-headline-1: @ds6-font-size-28;
+@ds6-font-size-headline-2: @ds6-font-size-26;
+@ds6-font-size-headline-3: @ds6-font-size-24;
+
+@ds6-font-size-title-1: @ds6-font-size-22;
+@ds6-font-size-title-2: @ds6-font-size-18;
+@ds6-font-size-title-3: @ds6-font-size-16;
+@ds6-font-size-title-4: @ds6-font-size-16;
+
+@ds6-font-size-body-1: @ds6-font-size-14;
+
+@ds6-font-size-caption-1: @ds6-font-size-13;
+@ds6-font-size-caption-2: @ds6-font-size-12;
+@ds6-font-size-caption-3: @ds6-font-size-12;
+
+@ds6-font-size-legal-1: @ds6-font-size-12;
+
+// Font-weights
+//-------------------------
+
+@ds6-font-weight-bold: 700;
+@ds6-font-weight-regular: 500;

--- a/src/less/less/variables-common.less
+++ b/src/less/less/variables-common.less
@@ -1,44 +1,8 @@
-// Typography
-//----------------------------
-
-@font-family-osx: "Helvetica Neue", Helvetica;
-@font-family-windows: Arial;
-@font-family-android: Roboto;
-@font-family-sans-serif: @font-family-osx, @font-family-windows, @font-family-android, sans-serif;
-@font-family-base: @font-family-sans-serif;
-@font-family-market-sans: @marketsans-name, @font-family-sans-serif;
-
-// Font-sizes (1rem = 16px)
-//----------------------
-
-@font-size-12: 0.75rem;
-@font-size-13: 0.8125rem;
-@font-size-14: 0.875rem;
-@font-size-15: 0.9375rem;
-@font-size-16: 1rem;        // size currently verboten in DSL
-@font-size-17: 1.062rem;
-@font-size-18: 1.125rem;    // size currently verboten in DSL
-@font-size-20: 1.25rem;
-@font-size-24: 1.5rem;
-@font-size-28: 1.75rem;
-@font-size-30: 1.875rem;
-@font-size-36: 2.25rem;
-@font-size-44: 2.75rem;
-@font-size-50: 3.125rem;
-@font-size-56: 3.5rem;
-
-// Font-weights
-//-------------------------
-
-@font-weight-thin: 100;
-@font-weight-light: 200;
-@font-weight-regular: 400;
-@font-weight-medium: 500;
-
 // Font Files
 //-------------------------
 
 @marketsans-url: "https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/";
-@marketsans-name: "Market Sans";
+@marketsans-fontname: "Market Sans";
+@marketsans-name: @marketsans-fontname; // deprecated in favour of @marketsans-fontname. Remove in next major version change.
 @marketsans-filename-regular: "MarketSans-Regular-WebS";
 @marketsans-filename-bold: "MarketSans-SemiBold-WebS";

--- a/src/less/notice/ds6/notice-base.less
+++ b/src/less/notice/ds6/notice-base.less
@@ -46,7 +46,7 @@ button.page-notice {
     h2,
     h3,
     h4 {
-        font-size: @font-size-20;
+        font-size: @ds6-font-size-20;
         margin: 0;
         width: 100%;
     }

--- a/src/less/typography/ds6/typography.less
+++ b/src/less/typography/ds6/typography.less
@@ -1,0 +1,50 @@
+@import "../../less/ds6/variables.less";
+@import "../../less/ds6/mixins.less";
+
+.headline-1 {
+    .ds6-typography-headline-1;
+}
+
+.headline-2 {
+    .ds6-typography-headline-2;
+}
+
+.headline-3 {
+    .ds6-typography-headline-3;
+}
+
+.title-1 {
+    .ds6-typography-title-1;
+}
+
+.title-2 {
+    .ds6-typography-title-2;
+}
+
+.title-3 {
+    .ds6-typography-title-3;
+}
+
+.title-4 {
+    .ds6-typography-title-4;
+}
+
+.body-1 {
+    .ds6-typography-body-1;
+}
+
+.caption-1 {
+    .ds6-typography-caption-1;
+}
+
+.caption-2 {
+    .ds6-typography-caption-2;
+}
+
+.caption-3 {
+    .ds6-typography-caption-3;
+}
+
+.legal-1 {
+    .ds6-typography-legal-1;
+}

--- a/typography.browser.json
+++ b/typography.browser.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": [
+        {
+            "path": "./dist/typography/ds6/typography.css",
+            "if-flag": "skin-ds6"
+        }
+    ]
+}


### PR DESCRIPTION
First of all, my apologies for combining two separate issues in one PR (#6 and #18). They are however very closely related.

Notes to reviewer:

* `Caption 4` has been removed from type ramp until further notice (it still exists in screenshot for now)
* Some variables and mixins were moved out of "common-variables.less" into "ds4/variables.less"
* Some existing DS6 variables and mixins were renamed. Because ds6 is not yet ready for use (and not officially announced) we do not consider this a breaking change (v3.1.0 will be the first release that people can start using DS6)
* `less.browser.json` contains access to DS4 and DS6 variables and mixins without any conditional dependency. I think this should work okay, but we can review again in future if need be.
* No test page is created. I think we can just use the docs page for now (see below).
* Typography module has only been created for DS6 (i.e. by passing `skin-ds6` lasso flag). If people find it useful we can also maybe add it to DS4.

We have a separate ticket for making the ds6 webpage look nice (#11), in the meantime I have updated the ds6 page with some basic usage information:

![screen shot 2017-09-05 at 11 00 26 am](https://user-images.githubusercontent.com/38065/30076262-24aa630c-922d-11e7-9384-5ebe12077582.png)