### PR TITLE
Adding font-display to unblock rendering of texts

### DIFF
--- a/dist/marketsans/marketsans.css
+++ b/dist/marketsans/marketsans.css
@@ -4,6 +4,7 @@
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: optional;
 }
 @font-face {
   font-family: "Market Sans";
@@ -11,4 +12,5 @@
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  font-display: optional;
 }

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -1486,6 +1486,7 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: optional;
 }
 @font-face {
   font-family: "Market Sans";
@@ -1493,6 +1494,7 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  font-display: optional;
 }
 .menu,
 .fake-menu {

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -1486,6 +1486,7 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: optional;
 }
 @font-face {
   font-family: "Market Sans";
@@ -1493,6 +1494,7 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  font-display: optional;
 }
 .menu,
 .fake-menu {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -10,6 +10,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: optional;
 }
 @font-face {
   font-family: "Market Sans";
@@ -17,6 +18,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  font-display: optional;
 }
 body {
   color: #111820;

--- a/src/fonts/marketsans/MarketSans-Regular-WebS.css
+++ b/src/fonts/marketsans/MarketSans-Regular-WebS.css
@@ -8,4 +8,5 @@
     url('MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg'); /* Legacy iOS */
     font-weight: normal;
     font-style: normal;
+    font-display: optional;
 }

--- a/src/fonts/marketsans/MarketSans-SemiBold-WebS.css
+++ b/src/fonts/marketsans/MarketSans-SemiBold-WebS.css
@@ -8,4 +8,5 @@
     url('MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg'); /* Legacy iOS */
     font-weight: bold;
     font-style: normal;
+    font-display: optional;
 }


### PR DESCRIPTION
## Description
Text on the page is blocked from displaying with default font placeholder till custom font file is downloaded unless its [reaches timeout](https://developers.google.com/web/updates/2016/02/font-display). `Font-display: optional` does not block the text from showing it

## More information
https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display

## More discussion,
https://github.com/eBay/skin/pull/21