### PR TITLE
Global: support font loading mechanism #8

### DIFF
--- a/dist/global/ds6/global.css
+++ b/dist/global/ds6/global.css
@@ -1,5 +1,5 @@
 body {
   color: #111820;
-  font-family: "Market Sans", "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
 }

--- a/dist/less/ds6/mixins.less
+++ b/dist/less/ds6/mixins.less
@@ -46,28 +46,28 @@
 }
 
 .ds6-typography-body-1() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-body-1;
     font-weight: @ds6-font-weight-regular;
     line-height: 20px;
 }
 
 .ds6-typography-caption-1() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-caption-1;
     font-weight: @ds6-font-weight-regular;
     line-height: 15px;
 }
 
 .ds6-typography-caption-2() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-caption-2;
     font-weight: @ds6-font-weight-bold;
     line-height: 14px;
 }
 
 .ds6-typography-caption-3() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-caption-3;
     font-weight: @ds6-font-weight-regular;
     line-height: 14px;
@@ -75,7 +75,7 @@
 
 .ds6-typography-legal-1() {
     color: @ds6-color-light;
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-legal-1;
     font-weight: @ds6-font-weight-regular;
 }

--- a/dist/less/ds6/variables.less
+++ b/dist/less/ds6/variables.less
@@ -20,8 +20,8 @@
 // Typography
 //----------------------------
 
-@ds6-font-family-primary: @marketsans-fontname, "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
-@ds6-font-family-secondary: "Helvetica Neue", Arial, sans-serif;
+@ds6-font-family-custom: @marketsans-fontname, @ds6-font-family-default;
+@ds6-font-family-default: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
 
 // Font-sizes (1rem = 16px)
 //----------------------

--- a/dist/marketsans/marketsans.css
+++ b/dist/marketsans/marketsans.css
@@ -4,7 +4,9 @@
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }
 @font-face {
   font-family: "Market Sans";
@@ -12,5 +14,7 @@
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -34,32 +34,32 @@
   line-height: 16px;
 }
 .body-1 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
   font-weight: 500;
   line-height: 20px;
 }
 .caption-1 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.8125rem;
   font-weight: 500;
   line-height: 15px;
 }
 .caption-2 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 700;
   line-height: 14px;
 }
 .caption-3 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 500;
   line-height: 14px;
 }
 .legal-1 {
   color: #767676;
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 500;
 }

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -1486,7 +1486,9 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }
 @font-face {
   font-family: "Market Sans";
@@ -1494,7 +1496,9 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }
 .menu,
 .fake-menu {

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -1486,7 +1486,9 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }
 @font-face {
   font-family: "Market Sans";
@@ -1494,7 +1496,9 @@ select.listbox__control--borderless:focus {
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }
 .menu,
 .fake-menu {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -10,7 +10,9 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS') format('svg');
   font-weight: normal;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }
 @font-face {
   font-family: "Market Sans";
@@ -18,12 +20,17 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   src: url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.eot?#iefix') format('embedded-opentype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff2') format('woff2'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.woff') format('woff'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.ttf') format('truetype'), url('https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS') format('svg');
   font-weight: bold;
   font-style: normal;
+  /* csslint ignore:start */
   font-display: optional;
+  /* csslint ignore:end */
 }
 body {
   color: #111820;
-  font-family: "Market Sans", "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
+}
+body {
+  font-family: "Market Sans", "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
 }
 /* UNFINISHED. WORK IN PROGRESS */
 .btn,
@@ -264,32 +271,32 @@ button.page-notice {
   line-height: 16px;
 }
 .body-1 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
   font-weight: 500;
   line-height: 20px;
 }
 .caption-1 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.8125rem;
   font-weight: 500;
   line-height: 15px;
 }
 .caption-2 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 700;
   line-height: 14px;
 }
 .caption-3 {
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 500;
   line-height: 14px;
 }
 .legal-1 {
   color: #767676;
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 500;
 }

--- a/src/less/bundles/skin/ds6/skin.less
+++ b/src/less/bundles/skin/ds6/skin.less
@@ -1,7 +1,7 @@
 // Source file for CDN's ds6/skin.min.css
 
 @import "../../../marketsans/marketsans.less";
-@import "../../../global/ds6/global.less";
+@import "../../../global/ds6/global-static.less";
 @import "../../../button/ds6/button.less";
 @import "../../../notice/ds6/notice.less";
 @import "../../../typography/ds6/typography.less";

--- a/src/less/global/ds6/global-static.less
+++ b/src/less/global/ds6/global-static.less
@@ -1,0 +1,5 @@
+@import "global.less";
+
+body {
+    font-family: @ds6-font-family-custom;
+}

--- a/src/less/global/ds6/global.less
+++ b/src/less/global/ds6/global.less
@@ -3,6 +3,6 @@
 
 body {
     color: @ds6-color-default;
-    font-family: @ds6-font-family-primary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-14;
 }

--- a/src/less/less/ds6/mixins.less
+++ b/src/less/less/ds6/mixins.less
@@ -46,28 +46,28 @@
 }
 
 .ds6-typography-body-1() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-body-1;
     font-weight: @ds6-font-weight-regular;
     line-height: 20px;
 }
 
 .ds6-typography-caption-1() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-caption-1;
     font-weight: @ds6-font-weight-regular;
     line-height: 15px;
 }
 
 .ds6-typography-caption-2() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-caption-2;
     font-weight: @ds6-font-weight-bold;
     line-height: 14px;
 }
 
 .ds6-typography-caption-3() {
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-caption-3;
     font-weight: @ds6-font-weight-regular;
     line-height: 14px;
@@ -75,7 +75,7 @@
 
 .ds6-typography-legal-1() {
     color: @ds6-color-light;
-    font-family: @ds6-font-family-secondary;
+    font-family: @ds6-font-family-default;
     font-size: @ds6-font-size-legal-1;
     font-weight: @ds6-font-weight-regular;
 }

--- a/src/less/less/ds6/variables.less
+++ b/src/less/less/ds6/variables.less
@@ -20,8 +20,8 @@
 // Typography
 //----------------------------
 
-@ds6-font-family-primary: @marketsans-fontname, "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
-@ds6-font-family-secondary: "Helvetica Neue", Arial, sans-serif;
+@ds6-font-family-custom: @marketsans-fontname, @ds6-font-family-default;
+@ds6-font-family-default: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
 
 // Font-sizes (1rem = 16px)
 //----------------------

--- a/src/less/marketsans/marketsans.less
+++ b/src/less/marketsans/marketsans.less
@@ -12,7 +12,9 @@
     url('@{marketsans-url}@{marketsans-filename-regular}.svg#@{marketsans-filename-regular}') format('svg'); // Legacy iOS
     font-weight: normal;
     font-style: normal;
+    /* csslint ignore:start */
     font-display: optional;
+    /* csslint ignore:end */
 }
 
 @font-face {
@@ -25,5 +27,7 @@
     url('@{marketsans-url}@{marketsans-filename-bold}.svg#@{marketsans-filename-bold}') format('svg'); // Legacy iOS
     font-weight: bold;
     font-style: normal;
+    /* csslint ignore:start */
     font-display: optional;
+    /* csslint ignore:end */
 }


### PR DESCRIPTION
See #8 for details.

Notes about PR:

* Two LESS variables were renamed (@ds6-font-family-primary & @ds6-font-family-secondary)
* CSS Lint ignore was added for `font-display` property
* Default font-family was expanded from `"Helvetica Neue", Arial, sans-serif;` to `"Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;`
* New global-static.less file was created
   * `src/less/bundles/skin` was updated to use `global-static.less`. This bundle generates a css file in `_cdn` (skin.min.css) and `docs` (skin.css)
   * the generated css files contain a slightly inefficient ungrouped selector, but I'm willing to let that slide to keep the build and project structure simple