### PR TITLE
Remove instruction on scoped package workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ Skin is [MIT](LICENSE) licensed.
 
 Skin is available as the `@ebay/skin` package on [NPM](https://www.npmjs.com/). Skin is also available on a [CDN](https://ebay.github.io/skin#cdn).
 
-**IMPORTANT! PLEASE READ:** Users of eBay's *internal* NPM repository must add the following exception to their `.npmrc` file or `.yarnrc` file, respectively, in order to support the scoped package name:
-
-For NPM: `@ebay:registry=https://registry.npmjs.org`
-
-For Yarn: `"@ebay:registry" "https://registry.npmjs.org/"`
-
-If you are using the public NPM repository, then you can safely ignore this requirement.
-
 ## Versioning
 
 As of v3, Skin follows [Semantic Versioning](http://semver.org).

--- a/docs/_includes/install.html
+++ b/docs/_includes/install.html
@@ -2,17 +2,6 @@
     <h2>Install</h2>
     <p>As of v3, Skin is distributed as the <span class="highlight">@ebay/skin</span> package on the public NPM repository.</p>
 
-    <p>Users of eBay's <em>internal</em> NPM repository must add the following exception to their <span class="highlight">.npmrc</span> file or <span class="highlight">.yarnrc</span> file, respectively, in order to support the scoped package name:</p>
-    {% highlight html %}
-#.npmrc
-@ebay:registry=https://registry.npmjs.org
-
-#.yarnrc
-"@ebay:registry" "https://registry.npmjs.org/"
-    {% endhighlight %}
-
-    <p>If you are using the public NPM repository, then you can safely ignore this exception.</p>
-
     <p>The package can be installed to the <span class="highlight">node_modules</span> folder of your working directory by using the <span class="highlight">npm install</span> command:</p>
     {% highlight html %}
 npm install @ebay/skin


### PR DESCRIPTION
Remove the installation instruction for eBay internal NPM repository. This is not necessary anymore since eBay NPM repository now supports scoped package properly.

I've tested with npm or yarn install & it works without the `ebay:registry` workaround.