### PR TITLE
Checkbox and Radio: Enhancement for custom colour variant #41

### DIFF
--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -47,6 +47,12 @@
             transform: scale(0.9);
   }
 }
+.checkbox__control[type="checkbox"] + .checkbox__icon--inherit {
+  color: inherit;
+}
+.checkbox__control[type="checkbox"]:checked + .checkbox__icon--inherit use {
+  fill: inherit;
+}
 .checkbox__control[type="checkbox"]:focus + .checkbox__icon {
   outline: 1px dotted #767676;
 }

--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -47,6 +47,12 @@
             transform: scale(0.9);
   }
 }
+.radio__control[type="radio"] + .radio__icon--inherit {
+  color: inherit;
+}
+.radio__control[type="radio"]:checked + .radio__icon--inherit use {
+  fill: inherit;
+}
 .radio__control[type="radio"]:focus + .radio__icon {
   outline: 1px dotted #767676;
 }

--- a/docs/_includes/checkbox.html
+++ b/docs/_includes/checkbox.html
@@ -7,7 +7,8 @@
         <li><a href="#checkbox-default">Default Checkbox</a></li>
         <li><a href="#checkbox-disabled">Disabled Checkbox</a></li>
         <li><a href="#checkbox-group">Grouped Checkbox</a></li>
-        <li><a href="#checkbox-custom">Custom Checkbox</a></li>
+        <li><a href="#checkbox-color">Custom Color Checkbox</a></li>
+        <li><a href="#checkbox-icon">Custom Icon Checkbox</a></li>
     </ul>
 
     <h3 id="checkbox-default">Default Checkbox</h3>
@@ -108,16 +109,15 @@
 </fieldset>
     {% endhighlight %}
 
-<!--
-
-    <h3 id="checkbox-svg">Inline SVG Checkbox</h3>
-    <p>Inline SVG is also supported. The <span class="highlight">hidden</span> attribute ensures that the SVG icon is not visible when CSS is disabled and also helps prevent a flash of unstyled content (FOUC).</span>
+    <h3 id="checkbox-color">Custom Colour Checkbox</h3>
+    <p>The default checkbox shown above uses an SVG background image, and therefore has a fixed colour. Inline SVG, while slightly more verbose, honours the CSS cascade, thus allowing any possible colour for the checkbox icon.</p>
+    <p>The <span class="highlight">checkbox__icon</span> element requires the <span class="highlight">checkbox__icon--inherit</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <span class="checkbox">
+            <span class="checkbox" style="color: #5ba71b">
                 <input aria-label="Inline SVG checkbox example" class="checkbox__control" type="checkbox" />
-                <span class="checkbox__icon" hidden>
+                <span class="checkbox__icon checkbox__icon--inherit" hidden>
                     <svg aria-hidden="true" focusable="false">
                         <use xlink:href="#svg-icon-checkbox"></use>
                     </svg>
@@ -127,9 +127,9 @@
     </div>
 
     {% highlight html %}
-<span class="checkbox">
+<span class="checkbox" style="color: #5ba71b">
     <input class="checkbox__control" type="checkbox" />
-    <span class="checkbox__icon" hidden>
+    <span class="checkbox__icon checkbox__icon--inherit" hidden>
         <svg aria-hidden="true" focusable="false">
             <use xlink:href="#svg-icon-checkbox"></use>
         </svg>
@@ -137,7 +137,9 @@
 </span>
     {% endhighlight %}
 
+    <p><strong>NOTE:</strong> The <span class="highlight">hidden</span> attribute ensures that the SVG icon is not visible if the page is in a non-CSS state; it also helps prevent a flash of unstyled content (FOUC).
     <p>The following SVG symbol definition is required:</p>
+
     {% highlight html %}
 <svg hidden>
     <symbol id="svg-icon-checkbox" viewBox="0 0 32 32">
@@ -147,22 +149,20 @@
 </svg>
     {% endhighlight %}
 
--->
-
-    <h3 id="checkbox-custom">Custom Checkbox</h3>
-    <p>Use the <span class="highlight">checkbox__custom-control</span> element class to create a custom styled checkbox that can use any inline SVG for it's checked and unchecked states. An added benefit of inline SVG is that it will inherit the current text colour.</p>
-    <p>Be careful when using a custom checkbox; the icon must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
+    <h3 id="checkbox-icon">Custom Icon Checkbox</h3>
+    <p>Use the <span class="highlight">checkbox__custom-control</span> element class to create a custom styled checkbox that can use any inline SVG for it's checked and unchecked states.</p>
+    <p>Be careful when using a custom checkbox; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="checkbox">
                 <input aria-label="Custom checkbox example" class="checkbox__custom-control" id="checkbox-custom-1" name="checkbox-custom-1" type="checkbox" />
-                <span class="checkbox__icon" hidden>
+                <span class="checkbox__icon" hidden style="color: #5ba71b">
                     <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
                         <use xlink:href="#svg-icon-checkbox-unchecked"></use>
                     </svg>
                     <svg aria-hidden="true" class="checkbox__checked" focusable="false">
-                        <use xlink:href="#svg-icon-checkbox-checked"></use>
+                        <use xlink:href="#svg-icon-confirmation"></use>
                     </svg>
                 </span>
             </span>
@@ -172,17 +172,15 @@
     {% highlight html %}
 <span class="checkbox">
     <input class="checkbox__custom-control" id="checkbox-custom" name="checkbox-custom" type="checkbox" />
-    <span class="checkbox__icon" hidden>
+    <span class="checkbox__icon" hidden style="color: #5ba71b">
         <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
             <use xlink:href="#svg-icon-checkbox-unchecked"></use>
         </svg>
         <svg aria-hidden="true" class="checkbox__checked" focusable="false">
-            <use xlink:href="#svg-icon-checkbox-checked"></use>
+            <use xlink:href="#svg-icon-confirmation"></use>
         </svg>
     </span>
 </span>
     {% endhighlight %}
-
-    <p><strong>NOTE:</strong> The <span class="highlight">hidden</span> attribute ensures that the SVG icon is not visible when CSS is disabled and also helps prevent a flash of unstyled content (FOUC).
 
 </div>

--- a/docs/_includes/radio.html
+++ b/docs/_includes/radio.html
@@ -7,7 +7,8 @@
         <li><a href="#radio-default">Default Radio</a></li>
         <li><a href="#radio-disabled">Disabled Radio</a></li>
         <li><a href="#radio-group">Grouped Radio</a></li>
-        <li><a href="#radio-custom">Custom Radio</a></li>
+        <li><a href="#radio-color">Custom Color Radio</a></li>
+        <li><a href="#radio-icon">Custom Icon Radio</a></li>
     </ul>
 
     <h3 id="radio-default">Default Radio</h3>
@@ -107,15 +108,15 @@
 </fieldset>
     {% endhighlight %}
 
-<!--
-    <h3 id="radio-svg">Radio SVG</h3>
-    <p>Inline SVG is also supported. The <span class="highlight">hidden</span> attribute ensures that the SVG icon is not visible when CSS is disabled and also helps prevent a flash of unstyled content (FOUC).</span>
+    <h3 id="radio-color">Custom Colour Radio</h3>
+    <p>The default radio shown above uses an SVG background image, and therefore has a fixed colour. Inline SVG, while slightly more verbose, honours the CSS cascade, thus allowing any possible colour for the radio icon.</p>
+    <p>The <span class="highlight">radio__icon</span> element requires the <span class="highlight">radio__icon--inherit</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <span class="radio">
+            <span class="radio" style="color: #5ba71b">
                 <input aria-label="Default radio example" class="radio__control" type="radio" />
-                <span class="radio__icon" hidden>
+                <span class="radio__icon radio__icon--inherit" hidden>
                     <svg aria-hidden="true" focusable="false">
                         <use xlink:href="#svg-icon-radio"></use>
                     </svg>
@@ -125,9 +126,9 @@
     </div>
 
     {% highlight html %}
-<span class="radio">
+<span class="radio" style="color: #5ba71b">
     <input class="radio__control" type="radio" />
-    <span class="radio__icon" hidden>
+    <span class="radio__icon radio__icon--inherit" hidden>
         <svg aria-hidden="true" focusable="false">
             <use xlink:href="#svg-icon-radio"></use>
         </svg>
@@ -135,7 +136,9 @@
 </span>
     {% endhighlight %}
 
+    <p><strong>NOTE:</strong> The <span class="highlight">hidden</span> attribute ensures that the SVG icon is not visible if the page is in a non-CSS state; it also helps prevent a flash of unstyled content (FOUC).</p>
     <p>The following SVG symbol definition is required:</p>
+
     {% highlight html %}
 <svg hidden>
     <symbol id="svg-icon-radio" viewBox="0 0 32 32">
@@ -145,21 +148,21 @@
     </symbol>
 </svg>
     {% endhighlight %}
--->
 
-    <h3 id="radio-custom">Custom Radio</h3>
-    <p>Use the <span class="highlight">radio__custom-control</span> element class to create a custom styled radio that can use any inline SVG for it's checked and unchecked states. An added benefit of inline SVG is that it will inherit the current text colour.</p>
-    <p>Be careful when using custom radios; the icons must still give enough <em>affordance</em> to a user that they represents an interactive control.</p>
+    <h3 id="radio-custom">Custom Icon Radio</h3>
+    <p>Use the <span class="highlight">radio__custom-control</span> element class to create a custom styled radio that can use any inline SVG for it's checked and unchecked states.</p>
+    <p>Be careful when using a custom radio; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
+
     <div class="demo">
         <div class="demo__inner">
-            <span class="field__control radio">
+            <span class="field__control radio" style="color: #5ba71b">
                 <input aria-label="Custom radio example" class="radio__custom-control" id="custom-radio-1" type="radio" value="1" name="radio-custom" />
-                <span class="radio__icon" hidden>
+                <span class="radio__icon radio__icon--inherit" hidden>
                     <svg aria-hidden="true" class="radio__unchecked" focusable="false">
                         <use xlink:href="#svg-icon-radio-unchecked"></use>
                     </svg>
                     <svg aria-hidden="true" class="radio__checked" focusable="false">
-                        <use xlink:href="#svg-icon-radio-checked"></use>
+                        <use xlink:href="#svg-icon-confirmation"></use>
                     </svg>
                 </span>
             </span>
@@ -167,18 +170,17 @@
     </div>
 
     {% highlight html %}
-<span class="field__control radio">
+<span class="field__control radio" style="color: #5ba71b">
     <input class="radio__custom-control" id="custom-radio-1" type="radio" value="1" name="radio-custom" />
-    <span class="radio__icon" hidden>
+    <span class="radio__icon radio__icon--inherit" hidden>
         <svg aria-hidden="true" class="radio__unchecked" focusable="false">
             <use xlink:href="#svg-icon-radio-unchecked"></use>
         </svg>
         <svg aria-hidden="true" class="radio__checked" focusable="false">
-            <use xlink:href="#svg-icon-radio-checked"></use>
+            <use xlink:href="#svg-icon-confirmation"></use>
         </svg>
     </span>
 </span>
     {% endhighlight %}
 
-    <p><strong>NOTE:</strong> The <span class="highlight">hidden</span> attribute ensures that the SVG icon is not visible when CSS is disabled and also helps prevent a flash of unstyled content (FOUC).</span>
 </div>

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -677,6 +677,12 @@ body .grid .card {
             transform: scale(0.9);
   }
 }
+.checkbox__control[type="checkbox"] + .checkbox__icon--inherit {
+  color: inherit;
+}
+.checkbox__control[type="checkbox"]:checked + .checkbox__icon--inherit use {
+  fill: inherit;
+}
 .checkbox__control[type="checkbox"]:focus + .checkbox__icon {
   outline: 1px dotted #767676;
 }
@@ -2110,6 +2116,12 @@ a.pagination__item {
     -webkit-transform: scale(0.9);
             transform: scale(0.9);
   }
+}
+.radio__control[type="radio"] + .radio__icon--inherit {
+  color: inherit;
+}
+.radio__control[type="radio"]:checked + .radio__icon--inherit use {
+  fill: inherit;
 }
 .radio__control[type="radio"]:focus + .radio__icon {
   outline: 1px dotted #767676;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -677,6 +677,12 @@ body .grid .card {
             transform: scale(0.9);
   }
 }
+.checkbox__control[type="checkbox"] + .checkbox__icon--inherit {
+  color: inherit;
+}
+.checkbox__control[type="checkbox"]:checked + .checkbox__icon--inherit use {
+  fill: inherit;
+}
 .checkbox__control[type="checkbox"]:focus + .checkbox__icon {
   outline: 1px dotted #767676;
 }
@@ -2110,6 +2116,12 @@ a.pagination__item {
     -webkit-transform: scale(0.9);
             transform: scale(0.9);
   }
+}
+.radio__control[type="radio"] + .radio__icon--inherit {
+  color: inherit;
+}
+.radio__control[type="radio"]:checked + .radio__icon--inherit use {
+  fill: inherit;
 }
 .radio__control[type="radio"]:focus + .radio__icon {
   outline: 1px dotted #767676;

--- a/docs/test/checkbox/ds4/index.html
+++ b/docs/test/checkbox/ds4/index.html
@@ -14,6 +14,10 @@ title: Checkbox
     <symbol id="svg-icon-checkbox-unchecked" viewBox="0 0 32 32">
         <path d="M25.107 32.030h-18.214c-3.456 0-6.268-2.81-6.268-6.264v-19.529c0-3.456 2.812-6.268 6.268-6.268h18.214c3.456 0 6.268 2.812 6.268 6.268v19.529c0 3.452-2.812 6.264-6.268 6.264zM6.893 1.85c-2.419 0-4.386 1.967-4.386 4.386v19.529c0 2.417 1.967 4.382 4.386 4.382h18.214c2.419 0 4.386-1.965 4.386-4.382v-19.529c0-2.419-1.967-4.386-4.386-4.386h-18.214z"></path>
     </symbol>
+    <symbol id="svg-icon-confirmation" viewBox="0 0 32 32">
+        <path fill="#5ba71b" d="M16.009 32c-8.842 0-16.009-7.168-16.009-16.009s7.168-16.009 16.009-16.009c8.842 0 16.009 7.168 16.009 16.009 0 0.007 0 0.013 0 0.020-0.011 8.833-7.174 15.99-16.009 15.99 0 0 0 0 0 0zM16.009 2.319c0 0 0 0 0 0-7.561 0-13.69 6.129-13.69 13.69s6.129 13.69 13.69 13.69c7.561 0 13.69-6.129 13.69-13.69s-6.129-13.69-13.69-13.69z"></path>
+        <path fill="#5ba71b" d="M14.841 23.448c-0.001 0-0.003 0-0.004 0-0.247 0-0.473-0.091-0.646-0.242l-6.232-5.305c-0.213-0.182-0.347-0.451-0.347-0.751 0-0.545 0.442-0.987 0.987-0.987 0.245 0 0.469 0.089 0.641 0.237l5.434 4.637 8.181-10.741c0.183-0.238 0.468-0.39 0.788-0.39 0.548 0 0.992 0.444 0.992 0.992 0 0.228-0.077 0.438-0.206 0.605l-8.81 11.573c-0.137 0.199-0.39 0.358-0.682 0.389l-0.116 0z"></path>
+    </symbol>
 </svg>
 
 <h2>Default</h2>
@@ -33,7 +37,7 @@ title: Checkbox
     </span>
 </div>
 
-<h2>Inline SVG</h2>
+<h2>Inline SVG (legacy)</h2>
 <div class="test">
     <span class="checkbox">
         <input aria-label="Inline SVG checkbox example" class="checkbox__control" type="checkbox" value="1" name="test2a" />
@@ -46,7 +50,7 @@ title: Checkbox
 </div>
 
 
-<h2>Inline SVG Disabled</h2>
+<h2>Inline SVG Disabled (legacy)</h2>
 <div class="test">
     <span class="checkbox">
         <input aria-label="Disabled Inline SVG checkbox example" class="checkbox__control" disabled type="checkbox" value="1" name="test2b" />
@@ -58,31 +62,55 @@ title: Checkbox
     </span>
 </div>
 
-<h2>Custom</h2>
+<h2>Custom Colour</h2>
 <div class="test">
-    <span class="checkbox">
+    <span class="checkbox" style="color: #5ba71b">
+        <input aria-label="Inline SVG checkbox example" class="checkbox__control" type="checkbox" />
+        <span class="checkbox__icon checkbox__icon--inherit" hidden>
+            <svg aria-hidden="true" focusable="false">
+                <use xlink:href="#svg-icon-checkbox"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Colour, Disabled</h2>
+<div class="test">
+    <span class="checkbox" style="color: #5ba71b">
+        <input aria-label="Inline SVG checkbox example" class="checkbox__control" disabled type="checkbox" />
+        <span class="checkbox__icon checkbox__icon--inherit" hidden>
+            <svg aria-hidden="true" focusable="false">
+                <use xlink:href="#svg-icon-checkbox"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Icon</h2>
+<div class="test">
+    <span class="checkbox" style="color: #5ba71b">
         <input aria-label="Custom checkbox example" class="checkbox__custom-control" type="checkbox" value="1" name="test3a" />
         <span class="checkbox__icon" hidden>
             <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
                 <use xlink:href="#svg-icon-checkbox-unchecked"></use>
             </svg>
             <svg aria-hidden="true" class="checkbox__checked" focusable="false">
-                <use xlink:href="#svg-icon-checkbox-checked"></use>
+                <use xlink:href="#svg-icon-confirmation"></use>
             </svg>
         </span>
     </span>
 </div>
 
-<h2>Custom Disabled</h2>
+<h2>Custom Icon Disabled</h2>
 <div class="test">
-    <span class="checkbox">
+    <span class="checkbox" style="color: #5ba71b">
         <input aria-label="Default checkbox example" class="checkbox__custom-control" disabled type="checkbox" value="1" name="test3b" />
         <span class="checkbox__icon" hidden>
             <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
                 <use xlink:href="#svg-icon-checkbox-unchecked"></use>
             </svg>
             <svg aria-hidden="true" class="checkbox__checked" focusable="false">
-                <use xlink:href="#svg-icon-checkbox-checked"></use>
+                <use xlink:href="#svg-icon-confirmation"></use>
             </svg>
         </span>
     </span>

--- a/docs/test/radio/ds4/index.html
+++ b/docs/test/radio/ds4/index.html
@@ -15,6 +15,10 @@ title: Radio
     <symbol id="svg-icon-radio-unchecked" viewBox="0 0 32 32">
         <path d="M16 31.6c-8.667 0-15.719-6.999-15.719-15.6s7.052-15.6 15.719-15.6 15.719 6.999 15.719 15.6c0 8.604-7.052 15.6-15.719 15.6zM16 2.178c-7.687 0-13.941 6.201-13.941 13.822s6.254 13.822 13.941 13.822 13.941-6.201 13.941-13.822-6.254-13.822-13.941-13.822z"></path>
     </symbol>
+    <symbol id="svg-icon-confirmation" viewBox="0 0 32 32">
+        <path fill="#5ba71b" d="M16.009 32c-8.842 0-16.009-7.168-16.009-16.009s7.168-16.009 16.009-16.009c8.842 0 16.009 7.168 16.009 16.009 0 0.007 0 0.013 0 0.020-0.011 8.833-7.174 15.99-16.009 15.99 0 0 0 0 0 0zM16.009 2.319c0 0 0 0 0 0-7.561 0-13.69 6.129-13.69 13.69s6.129 13.69 13.69 13.69c7.561 0 13.69-6.129 13.69-13.69s-6.129-13.69-13.69-13.69z"></path>
+        <path fill="#5ba71b" d="M14.841 23.448c-0.001 0-0.003 0-0.004 0-0.247 0-0.473-0.091-0.646-0.242l-6.232-5.305c-0.213-0.182-0.347-0.451-0.347-0.751 0-0.545 0.442-0.987 0.987-0.987 0.245 0 0.469 0.089 0.641 0.237l5.434 4.637 8.181-10.741c0.183-0.238 0.468-0.39 0.788-0.39 0.548 0 0.992 0.444 0.992 0.992 0 0.228-0.077 0.438-0.206 0.605l-8.81 11.573c-0.137 0.199-0.39 0.358-0.682 0.389l-0.116 0z"></path>
+    </symbol>
 </svg>
 
 <h2>Default</h2>
@@ -38,7 +42,7 @@ title: Radio
     </span>
 </div>
 
-<h2>Inline SVG</h2>
+<h2>Inline SVG (legacy)</h2>
 <div class="test">
     <span class="radio">
         <input aria-label="Inline SVG radio example" class="radio__control" type="radio" value="1" name="test3" />
@@ -58,7 +62,7 @@ title: Radio
     </span>
 </div>
 
-<h2>Inline SVG - Disabled</h2>
+<h2>Inline SVG - Disabled (legacy)</h2>
 <div class="test">
     <span class="radio">
         <input aria-label="Disabled inline SVG radio example" class="radio__control" disabled type="radio" value="1" name="test4" />
@@ -70,16 +74,40 @@ title: Radio
     </span>
 </div>
 
-<h2>Custom</h2>
-<div class="test">
+<h2>Custom Colour</h2>
+<div class="test" style="color: #5ba71b">
     <span class="radio">
-        <input aria-label="Custom radio example" class="radio__custom-control" type="radio" value="1" name="test5" />
+        <input aria-label="Custom colour example" class="radio__control" type="radio" value="1" name="test4" />
+        <span class="radio__icon radio__icon--inherit" hidden>
+            <svg aria-hidden="true" focusable="false">
+                <use xlink:href="#svg-icon-radio"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Colour, Disabled</h2>
+<div class="test" style="color: #5ba71b">
+    <span class="radio">
+        <input aria-label="Custom colour disabled example" class="radio__control" disabled type="radio" value="1" name="test4" />
+        <span class="radio__icon radio__icon--inherit" hidden>
+            <svg aria-hidden="true" focusable="false">
+                <use xlink:href="#svg-icon-radio"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Icon</h2>
+<div class="test" style="color: #5ba71b">
+    <span class="radio">
+        <input aria-label="Custom icon example" class="radio__custom-control" type="radio" value="1" name="test5" />
         <span class="radio__icon" hidden>
             <svg aria-hidden="true" class="radio__unchecked" focusable="false">
                 <use xlink:href="#svg-icon-radio-unchecked"></use>
             </svg>
             <svg aria-hidden="true" class="radio__checked" focusable="false">
-                <use xlink:href="#svg-icon-radio-checked" fill="#ffcc00"></use>
+                <use xlink:href="#svg-icon-confirmation"></use>
             </svg>
         </span>
     </span>
@@ -90,14 +118,14 @@ title: Radio
                 <use xlink:href="#svg-icon-radio-unchecked"></use>
             </svg>
             <svg aria-hidden="true" class="radio__checked" focusable="false">
-                <use xlink:href="#svg-icon-radio-checked" fill="#ffcc00"></use>
+                <use xlink:href="#svg-icon-confirmation"></use>
             </svg>
         </span>
     </span>
 </div>
 
-<h2>Custom Disabled</h2>
-<div class="test">
+<h2>Custom Icon, Disabled</h2>
+<div class="test" style="color: #5ba71b">
     <span class="radio">
         <input aria-label="Custom radio example" class="radio__custom-control" disabled type="radio" value="1" name="test6" />
         <span class="radio__icon" hidden>
@@ -105,7 +133,7 @@ title: Radio
                 <use xlink:href="#svg-icon-radio-unchecked"></use>
             </svg>
             <svg aria-hidden="true" class="radio__checked" focusable="false">
-                <use xlink:href="#svg-icon-radio-checked" fill="#ffcc00"></use>
+                <use xlink:href="#svg-icon-confirmation"></use>
             </svg>
         </span>
     </span>
@@ -116,7 +144,7 @@ title: Radio
                 <use xlink:href="#svg-icon-radio-unchecked"></use>
             </svg>
             <svg aria-hidden="true" class="radio__checked" focusable="false">
-                <use xlink:href="#svg-icon-radio-checked" fill="#ffcc00"></use>
+                <use xlink:href="#svg-icon-confirmation"></use>
             </svg>
         </span>
     </span>

--- a/src/less/checkbox/ds4/checkbox-base.less
+++ b/src/less/checkbox/ds4/checkbox-base.less
@@ -25,6 +25,14 @@
         fill: @color-core-blue;
     }
 
+    + .checkbox__icon--inherit {
+        color: inherit;
+    }
+
+    &:checked + .checkbox__icon--inherit use {
+        fill: inherit;
+    }
+
     &:focus + .checkbox__icon {
         outline: @outline-dotted;
     }

--- a/src/less/radio/ds4/radio-base.less
+++ b/src/less/radio/ds4/radio-base.less
@@ -25,6 +25,14 @@
         fill: @color-core-blue;
     }
 
+    + .radio__icon--inherit {
+        color: inherit;
+    }
+
+    &:checked + .radio__icon--inherit use {
+        fill: inherit;
+    }
+
     &:focus + .radio__icon {
         outline: @outline-dotted;
     }


### PR DESCRIPTION
Issue: #41

Just baking in a little more flexibility, without changing the API too much. Might change the modifier from `checkbox__icon--inherit` to something else before it goes live. Maybe `checkbox__icon--custom`.

## Checkbox

![screen shot 2017-11-30 at 4 09 51 pm](https://user-images.githubusercontent.com/38065/33461917-753221fc-d5e9-11e7-9018-b17ee17c477a.png)

## Radio

![screen shot 2017-11-30 at 4 09 37 pm](https://user-images.githubusercontent.com/38065/33461920-76c376a6-d5e9-11e7-93df-f60ae61a90fd.png)
