### PR TITLE
LESS: add new DS6 classes, mixins and variables for typography #39

### DIFF
--- a/dist/less/ds6/mixins.less
+++ b/dist/less/ds6/mixins.less
@@ -3,79 +3,39 @@
 // Typography
 //-----------------------------
 
-.ds6-typography-headline-1() {
-    font-size: @ds6-font-size-headline-1;
+.ds6-typography-giant-2() {
+    font-size: @ds6-font-size-giant-2;
     font-weight: @ds6-font-weight-bold;
-    line-height: 30px;
+    line-height: 46px;
 }
 
-.ds6-typography-headline-2() {
-    font-size: @ds6-font-size-headline-2;
+.ds6-typography-giant-1() {
+    font-size: @ds6-font-size-giant-1;
     font-weight: @ds6-font-weight-bold;
+    line-height: 40px;
+}
+
+.ds6-typography-large-2() {
+    font-size: @ds6-font-size-large-2;
+    line-height: 32px;
+}
+
+.ds6-typography-large-1() {
+    font-size: @ds6-font-size-large-1;
     line-height: 28px;
 }
 
-.ds6-typography-headline-3() {
-    font-size: @ds6-font-size-headline-3;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 26px;
-}
-
-.ds6-typography-title-1() {
-    font-size: @ds6-font-size-title-1;
-    font-weight: @ds6-font-weight-bold;
+.ds6-typography-medium() {
+    font-size: @ds6-font-size-medium;
     line-height: 24px;
 }
 
-.ds6-typography-title-2() {
-    font-size: @ds6-font-size-title-2;
-    font-weight: @ds6-font-weight-regular;
+.ds6-typography-regular() {
+    font-size: @ds6-font-size-regular;
     line-height: 20px;
 }
 
-.ds6-typography-title-3() {
-    font-size: @ds6-font-size-title-3;
-    font-weight: @ds6-font-weight-bold;
+.ds6-typography-small() {
+    font-size: @ds6-font-size-small;
     line-height: 18px;
-}
-
-.ds6-typography-title-4() {
-    font-size: @ds6-font-size-title-4;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 16px;
-}
-
-.ds6-typography-body-1() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-body-1;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 20px;
-}
-
-.ds6-typography-caption-1() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-caption-1;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 15px;
-}
-
-.ds6-typography-caption-2() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-caption-2;
-    font-weight: @ds6-font-weight-bold;
-    line-height: 14px;
-}
-
-.ds6-typography-caption-3() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-caption-3;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 14px;
-}
-
-.ds6-typography-legal-1() {
-    color: @ds6-color-light;
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-legal-1;
-    font-weight: @ds6-font-weight-regular;
 }

--- a/dist/less/ds6/variables.less
+++ b/dist/less/ds6/variables.less
@@ -59,23 +59,16 @@
 @ds6-font-size-24: 1.5rem;
 @ds6-font-size-26: 1.625rem;
 @ds6-font-size-28: 1.75rem;
+@ds6-font-size-30: 1.8625rem;
+@ds6-font-size-36: 2.25rem;
 
-@ds6-font-size-headline-1: @ds6-font-size-28;
-@ds6-font-size-headline-2: @ds6-font-size-26;
-@ds6-font-size-headline-3: @ds6-font-size-24;
-
-@ds6-font-size-title-1: @ds6-font-size-22;
-@ds6-font-size-title-2: @ds6-font-size-18;
-@ds6-font-size-title-3: @ds6-font-size-16;
-@ds6-font-size-title-4: @ds6-font-size-16;
-
-@ds6-font-size-body-1: @ds6-font-size-14;
-
-@ds6-font-size-caption-1: @ds6-font-size-13;
-@ds6-font-size-caption-2: @ds6-font-size-12;
-@ds6-font-size-caption-3: @ds6-font-size-12;
-
-@ds6-font-size-legal-1: @ds6-font-size-12;
+@ds6-font-size-giant-2: @ds6-font-size-36;
+@ds6-font-size-giant-1: @ds6-font-size-30;
+@ds6-font-size-large-2: @ds6-font-size-24;
+@ds6-font-size-large-1: @ds6-font-size-20;
+@ds6-font-size-medium: @ds6-font-size-16;
+@ds6-font-size-regular: @ds6-font-size-14;
+@ds6-font-size-small: @ds6-font-size-12;
 
 // Font-weights
 //-------------------------

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -1,30 +1,30 @@
-.giant-2 {
+.giant-text-2 {
   font-size: 2.25rem;
   font-weight: 700;
   line-height: 46px;
 }
-.giant-1 {
+.giant-text-1 {
   font-size: 1.8625rem;
   font-weight: 700;
   line-height: 40px;
 }
-.large-2 {
+.large-text-2 {
   font-size: 1.5rem;
   line-height: 32px;
 }
-.large-1 {
+.large-text-1 {
   font-size: 1.25rem;
   line-height: 28px;
 }
-.medium {
+.medium-text {
   font-size: 1rem;
   line-height: 24px;
 }
-.regular {
+.regular-text {
   font-size: 0.875rem;
   line-height: 20px;
 }
-.small {
+.small-text {
   font-size: 0.75rem;
   line-height: 18px;
 }

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -1,0 +1,30 @@
+.giant-2 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  line-height: 46px;
+}
+.giant-1 {
+  font-size: 1.8625rem;
+  font-weight: 700;
+  line-height: 40px;
+}
+.large-2 {
+  font-size: 1.5rem;
+  line-height: 32px;
+}
+.large-1 {
+  font-size: 1.25rem;
+  line-height: 28px;
+}
+.medium {
+  font-size: 1rem;
+  line-height: 24px;
+}
+.regular {
+  font-size: 0.875rem;
+  line-height: 20px;
+}
+.small {
+  font-size: 0.75rem;
+  line-height: 18px;
+}

--- a/docs/_includes/ds6/less.html
+++ b/docs/_includes/ds6/less.html
@@ -2,27 +2,20 @@
     <h2>@ebay/skin/less</h2>
     <p>The LESS module contains variables and mixins.</p>
 
-    <!--
     <h3 id="less-typography">Typography</h3>
     <div class="demo">
         <div class="demo__inner">
             <ul class="demo-typography">
-                <li class="headline-1">.ds6-typography-headline-1</li>
-                <li class="headline-2">.ds6-typography-headline-2</li>
-                <li class="headline-3">.ds6-typography-headline-3</li>
-                <li class="title-1">.ds6-typography-title-1</li>
-                <li class="title-2">.ds6-typography-title-2</li>
-                <li class="title-3">.ds6-typography-title-3</li>
-                <li class="title-4">.ds6-typography-title-4</li>
-                <li class="body-1">.ds6-typography-body-1</li>
-                <li class="caption-1">.ds6-typography-caption-1</li>
-                <li class="caption-2">.ds6-typography-caption-2</li>
-                <li class="caption-3">.ds6-typography-caption-3</li>
-                <li class="legal-1">.ds6-typography-legal-1</li>
+                <li class="giant-2">.ds6-typography-giant-2</li>
+                <li class="giant-1">.ds6-typography-giant-1</li>
+                <li class="large-2">.ds6-typography-large-2</li>
+                <li class="large-1">.ds6-typography-large-1</li>
+                <li class="medium">.ds6-typography-medium</li>
+                <li class="regular">.ds6-typography-regular</li>
+                <li class="small">.ds6-typography-small</li>
             </ul>
         </div>
     </div>
-    -->
 
     <h3 id="less-colour">Color Palette</h3>
     <div class="demo">

--- a/docs/_includes/ds6/less.html
+++ b/docs/_includes/ds6/less.html
@@ -6,13 +6,13 @@
     <div class="demo">
         <div class="demo__inner">
             <ul class="demo-typography">
-                <li class="giant-2">.ds6-typography-giant-2</li>
-                <li class="giant-1">.ds6-typography-giant-1</li>
-                <li class="large-2">.ds6-typography-large-2</li>
-                <li class="large-1">.ds6-typography-large-1</li>
-                <li class="medium">.ds6-typography-medium</li>
-                <li class="regular">.ds6-typography-regular</li>
-                <li class="small">.ds6-typography-small</li>
+                <li class="giant-text-2">.ds6-typography-giant-2</li>
+                <li class="giant-text-1">.ds6-typography-giant-1</li>
+                <li class="large-text-2">.ds6-typography-large-2</li>
+                <li class="large-text-1">.ds6-typography-large-1</li>
+                <li class="medium-text">.ds6-typography-medium</li>
+                <li class="regular-text">.ds6-typography-regular</li>
+                <li class="small-text">.ds6-typography-small</li>
             </ul>
         </div>
     </div>

--- a/docs/_includes/ds6/typography.html
+++ b/docs/_includes/ds6/typography.html
@@ -4,13 +4,13 @@
     <div class="demo">
         <div class="demo__inner">
             <ul class="typography">
-                <li class="giant-2">.giant-2</li>
-                <li class="giant-1">.giant-1</li>
-                <li class="large-2">.large-2</li>
-                <li class="large-1">.large-1</li>
-                <li class="medium">.medium</li>
-                <li class="regular">.regular</li>
-                <li class="small">.small</li>
+                <li class="giant-text-2">.giant-text-2</li>
+                <li class="giant-text-1">.giant-text-1</li>
+                <li class="large-text-2">.large-text-2</li>
+                <li class="large-text-1">.large-text-1</li>
+                <li class="medium-text">.medium-text</li>
+                <li class="regular-text">.regular-text</li>
+                <li class="small-text">.small-text</li>
             </ul>
         </div>
     </div>

--- a/docs/_includes/ds6/typography.html
+++ b/docs/_includes/ds6/typography.html
@@ -4,18 +4,13 @@
     <div class="demo">
         <div class="demo__inner">
             <ul class="typography">
-                <li class="headline-1">.headline-1</li>
-                <li class="headline-2">.headline-2</li>
-                <li class="headline-3">.headline-3</li>
-                <li class="title-1">.title-1</li>
-                <li class="title-2">.title-2</li>
-                <li class="title-3">.title-3</li>
-                <li class="title-4">.title-4</li>
-                <li class="body-1">.body-1</li>
-                <li class="caption-1">.caption-1</li>
-                <li class="caption-2">.caption-2</li>
-                <li class="caption-3">.caption-3</li>
-                <li class="legal-1">.legal-1</li>
+                <li class="giant-2">.giant-2</li>
+                <li class="giant-1">.giant-1</li>
+                <li class="large-2">.large-2</li>
+                <li class="large-1">.large-1</li>
+                <li class="medium">.medium</li>
+                <li class="regular">.regular</li>
+                <li class="small">.small</li>
             </ul>
         </div>
     </div>

--- a/docs/ds6/index.html
+++ b/docs/ds6/index.html
@@ -29,6 +29,7 @@ title: Skin DS6
         <li><a href="#listbox">@ebay/skin/listbox</a></li>
         <li><a href="#menu">@ebay/skin/menu</a></li>
         <li><a href="#svg">@ebay/skin/svg</a></li>
+        <li><a href="#typography">@ebay/skin/typography</a></li>
     </ul>
     {% include ds6/global.html %}
     {% include ds6/less.html %}
@@ -38,4 +39,5 @@ title: Skin DS6
     {% include ds6/listbox.html %}
     {% include ds6/menu.html %}
     {% include ds6/svg.html %}
+    {% include ds6/typography.html %}
 </main>

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -596,33 +596,33 @@ span.listbox__arrow {
   -webkit-transform: rotate(180deg);
           transform: rotate(180deg);
 }
-.giant-2 {
+.giant-text-2 {
   font-size: 2.25rem;
   font-weight: 700;
   line-height: 46px;
 }
-.giant-1 {
+.giant-text-1 {
   font-size: 1.8625rem;
   font-weight: 700;
   line-height: 40px;
 }
-.large-2 {
+.large-text-2 {
   font-size: 1.5rem;
   line-height: 32px;
 }
-.large-1 {
+.large-text-1 {
   font-size: 1.25rem;
   line-height: 28px;
 }
-.medium {
+.medium-text {
   font-size: 1rem;
   line-height: 24px;
 }
-.regular {
+.regular-text {
   font-size: 0.875rem;
   line-height: 20px;
 }
-.small {
+.small-text {
   font-size: 0.75rem;
   line-height: 18px;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -596,6 +596,36 @@ span.listbox__arrow {
   -webkit-transform: rotate(180deg);
           transform: rotate(180deg);
 }
+.giant-2 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  line-height: 46px;
+}
+.giant-1 {
+  font-size: 1.8625rem;
+  font-weight: 700;
+  line-height: 40px;
+}
+.large-2 {
+  font-size: 1.5rem;
+  line-height: 32px;
+}
+.large-1 {
+  font-size: 1.25rem;
+  line-height: 28px;
+}
+.medium {
+  font-size: 1rem;
+  line-height: 24px;
+}
+.regular {
+  font-size: 0.875rem;
+  line-height: 20px;
+}
+.small {
+  font-size: 0.75rem;
+  line-height: 18px;
+}
 .clearfix::before,
 .clearfix::after {
   display: table;

--- a/src/less/bundles/skin/ds6/skin.less
+++ b/src/less/bundles/skin/ds6/skin.less
@@ -5,8 +5,7 @@
 @import "../../../button/ds6/button.less";
 @import "../../../color/ds6/color.less";
 @import "../../../icon/ds6/icon.less";
-// @import "../../../menu/ds6/menu.less";
 @import "../../../dropdown/ds6/dropdown.less";
 // @import "../../../notice/ds6/notice.less";
-// @import "../../../typography/ds6/typography.less";
+@import "../../../typography/ds6/typography.less";
 @import "../../../utility/ds6/utility.less";

--- a/src/less/less/ds6/mixins.less
+++ b/src/less/less/ds6/mixins.less
@@ -3,79 +3,39 @@
 // Typography
 //-----------------------------
 
-.ds6-typography-headline-1() {
-    font-size: @ds6-font-size-headline-1;
+.ds6-typography-giant-2() {
+    font-size: @ds6-font-size-giant-2;
     font-weight: @ds6-font-weight-bold;
-    line-height: 30px;
+    line-height: 46px;
 }
 
-.ds6-typography-headline-2() {
-    font-size: @ds6-font-size-headline-2;
+.ds6-typography-giant-1() {
+    font-size: @ds6-font-size-giant-1;
     font-weight: @ds6-font-weight-bold;
+    line-height: 40px;
+}
+
+.ds6-typography-large-2() {
+    font-size: @ds6-font-size-large-2;
+    line-height: 32px;
+}
+
+.ds6-typography-large-1() {
+    font-size: @ds6-font-size-large-1;
     line-height: 28px;
 }
 
-.ds6-typography-headline-3() {
-    font-size: @ds6-font-size-headline-3;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 26px;
-}
-
-.ds6-typography-title-1() {
-    font-size: @ds6-font-size-title-1;
-    font-weight: @ds6-font-weight-bold;
+.ds6-typography-medium() {
+    font-size: @ds6-font-size-medium;
     line-height: 24px;
 }
 
-.ds6-typography-title-2() {
-    font-size: @ds6-font-size-title-2;
-    font-weight: @ds6-font-weight-regular;
+.ds6-typography-regular() {
+    font-size: @ds6-font-size-regular;
     line-height: 20px;
 }
 
-.ds6-typography-title-3() {
-    font-size: @ds6-font-size-title-3;
-    font-weight: @ds6-font-weight-bold;
+.ds6-typography-small() {
+    font-size: @ds6-font-size-small;
     line-height: 18px;
-}
-
-.ds6-typography-title-4() {
-    font-size: @ds6-font-size-title-4;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 16px;
-}
-
-.ds6-typography-body-1() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-body-1;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 20px;
-}
-
-.ds6-typography-caption-1() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-caption-1;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 15px;
-}
-
-.ds6-typography-caption-2() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-caption-2;
-    font-weight: @ds6-font-weight-bold;
-    line-height: 14px;
-}
-
-.ds6-typography-caption-3() {
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-caption-3;
-    font-weight: @ds6-font-weight-regular;
-    line-height: 14px;
-}
-
-.ds6-typography-legal-1() {
-    color: @ds6-color-light;
-    font-family: @ds6-font-family-default;
-    font-size: @ds6-font-size-legal-1;
-    font-weight: @ds6-font-weight-regular;
 }

--- a/src/less/less/ds6/variables.less
+++ b/src/less/less/ds6/variables.less
@@ -59,23 +59,16 @@
 @ds6-font-size-24: 1.5rem;
 @ds6-font-size-26: 1.625rem;
 @ds6-font-size-28: 1.75rem;
+@ds6-font-size-30: 1.8625rem;
+@ds6-font-size-36: 2.25rem;
 
-@ds6-font-size-headline-1: @ds6-font-size-28;
-@ds6-font-size-headline-2: @ds6-font-size-26;
-@ds6-font-size-headline-3: @ds6-font-size-24;
-
-@ds6-font-size-title-1: @ds6-font-size-22;
-@ds6-font-size-title-2: @ds6-font-size-18;
-@ds6-font-size-title-3: @ds6-font-size-16;
-@ds6-font-size-title-4: @ds6-font-size-16;
-
-@ds6-font-size-body-1: @ds6-font-size-14;
-
-@ds6-font-size-caption-1: @ds6-font-size-13;
-@ds6-font-size-caption-2: @ds6-font-size-12;
-@ds6-font-size-caption-3: @ds6-font-size-12;
-
-@ds6-font-size-legal-1: @ds6-font-size-12;
+@ds6-font-size-giant-2: @ds6-font-size-36;
+@ds6-font-size-giant-1: @ds6-font-size-30;
+@ds6-font-size-large-2: @ds6-font-size-24;
+@ds6-font-size-large-1: @ds6-font-size-20;
+@ds6-font-size-medium: @ds6-font-size-16;
+@ds6-font-size-regular: @ds6-font-size-14;
+@ds6-font-size-small: @ds6-font-size-12;
 
 // Font-weights
 //-------------------------

--- a/src/less/typography/ds6/typography-base.less
+++ b/src/less/typography/ds6/typography-base.less
@@ -1,47 +1,27 @@
-.headline-1 {
-    .ds6-typography-headline-1;
+.giant-2 {
+    .ds6-typography-giant-2;
 }
 
-.headline-2 {
-    .ds6-typography-headline-2;
+.giant-1 {
+    .ds6-typography-giant-1;
 }
 
-.headline-3 {
-    .ds6-typography-headline-3;
+.large-2 {
+    .ds6-typography-large-2;
 }
 
-.title-1 {
-    .ds6-typography-title-1;
+.large-1 {
+    .ds6-typography-large-1;
 }
 
-.title-2 {
-    .ds6-typography-title-2;
+.medium {
+    .ds6-typography-medium;
 }
 
-.title-3 {
-    .ds6-typography-title-3;
+.regular {
+    .ds6-typography-regular;
 }
 
-.title-4 {
-    .ds6-typography-title-4;
-}
-
-.body-1 {
-    .ds6-typography-body-1;
-}
-
-.caption-1 {
-    .ds6-typography-caption-1;
-}
-
-.caption-2 {
-    .ds6-typography-caption-2;
-}
-
-.caption-3 {
-    .ds6-typography-caption-3;
-}
-
-.legal-1 {
-    .ds6-typography-legal-1;
+.small {
+    .ds6-typography-small;
 }

--- a/src/less/typography/ds6/typography-base.less
+++ b/src/less/typography/ds6/typography-base.less
@@ -1,27 +1,27 @@
-.giant-2 {
+.giant-text-2 {
     .ds6-typography-giant-2;
 }
 
-.giant-1 {
+.giant-text-1 {
     .ds6-typography-giant-1;
 }
 
-.large-2 {
+.large-text-2 {
     .ds6-typography-large-2;
 }
 
-.large-1 {
+.large-text-1 {
     .ds6-typography-large-1;
 }
 
-.medium {
+.medium-text {
     .ds6-typography-medium;
 }
 
-.regular {
+.regular-text {
     .ds6-typography-regular;
 }
 
-.small {
+.small-text {
     .ds6-typography-small;
 }

--- a/src/less/typography/ds6/typography.less
+++ b/src/less/typography/ds6/typography.less
@@ -1,4 +1,4 @@
 @import "../../less/ds6/variables.less";
 @import "../../less/ds6/mixins.less";
 
-//@import "typography-base.less";
+@import "typography-base.less";


### PR DESCRIPTION
See issue #39 for spec.

Still awaiting clarification on what font-weight `secondary` is, and whether Market Sans even supports font weight other than regular or bold.

**Question**: are we okay with the classnames `medium`, `regular`, `small` etc. Or are they too generic? I'm kind of okay with them them, but maybe `medium-text`, `regular-text`, `small-text` is another alternative.

<img width="556" alt="screen shot 2018-02-05 at 1 44 40 pm" src="https://user-images.githubusercontent.com/38065/35832503-639eafa0-0a82-11e8-87a5-f21fa61d9994.png">

<img width="553" alt="screen shot 2018-02-05 at 1 45 03 pm" src="https://user-images.githubusercontent.com/38065/35832515-6bd5fe3a-0a82-11e8-9bfa-890593c4eeac.png">
