### PR TITLE
LESS: create mixins for DS6 iconography #94

### DIFF
--- a/dist/icon/ds6/icon.css
+++ b/dist/icon/ds6/icon.css
@@ -22,12 +22,15 @@ svg.icon--close {
   width: 17px;
 }
 span.icon {
+  background-repeat: no-repeat;
   display: inline-block;
   vertical-align: middle;
-  background-repeat: no-repeat;
 }
 span.icon--close {
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%2017%2017%22%3E%3Cpath%20fill=%22none%22%20stroke=%22currentColor%22%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20stroke-width=%222%22%20d=%22M1.11%201.78l14.15%2014.15m-14.09-.07L15.32%201.72%22/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  display: inline-block;
+  vertical-align: middle;
+  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2717%27%20height%3D%2717%27%3E%3Cpath%20fill=%22none%22%20stroke=%22currentColor%22%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20stroke-width=%222%22%20d=%22M1.11%201.78l14.15%2014.15m-14.09-.07L15.32%201.72%22%3E%3C/path%3E%3C/svg%3E');
   height: 17px;
   width: 17px;
 }

--- a/dist/less/ds6/mixins.less
+++ b/dist/less/ds6/mixins.less
@@ -89,3 +89,16 @@
     .ds6-typography-small;
     color: @ds6-color-g206-gray;
 }
+
+.background-icon-base() {
+    background-repeat: no-repeat;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.icon-close() {
+    .background-icon-base;
+    background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2717%27%20height%3D%2717%27%3E%3Cpath%20fill=%22none%22%20stroke=%22currentColor%22%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20stroke-width=%222%22%20d=%22M1.11%201.78l14.15%2014.15m-14.09-.07L15.32%201.72%22%3E%3C/path%3E%3C/svg%3E');
+    height: 17px;
+    width: 17px;
+}

--- a/docs/_includes/ds6/icon.html
+++ b/docs/_includes/ds6/icon.html
@@ -1,6 +1,9 @@
 <div id="icon">
     <h2><span class="secondary-text">@ebay/skin/</span>icon</h2>
-    <p>The icon module allows direct access to the Skin iconography via inline SVG. Although Skin itself also utilises background SVG in some cases (via data uri), the benefit of inline SVG is that the icon will inherit the color of it's containing element. This behaviour can be useful when crafting custom buttons and controls.</p>
+    <p>The icon module allows direct access to the Skin iconography via inline SVG or background SVG.</p>
+    <p><strong>NOTE:</strong> inline SVG will inherit the color of it's containing element; this behaviour can be useful when crafting custom buttons and controls.</p>
+
+    <h3>Inline SVG</h3>
     <p>To avoid gigantic SVG icons when in a non-CSS (edge-case) state, we use the SVG width and height attributes to override the default 300x150 size.</p>
     <p>See the <a href="#svg">@ebay/skin/svg</a> module for instructions on how to import SVG symbols, and yes, we will be adding more icons in an upcoming release!</p>
 
@@ -32,6 +35,18 @@
 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="17" width="17">
     <use xlink:href="#icon-close"></use>
 </svg>
+        {% endhighlight %}
+    </div>
+
+    <h3>Background SVG</h3>
+    <p>Background SVGs have a fixed stroke colour. This colour cannot be changed via CSS.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="icon icon--close"></span>
+        </div>
+        {% highlight html %}
+<span class="icon icon--close"></span>
         {% endhighlight %}
     </div>
 

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -359,12 +359,15 @@ svg.icon--close {
   width: 17px;
 }
 span.icon {
+  background-repeat: no-repeat;
   display: inline-block;
   vertical-align: middle;
-  background-repeat: no-repeat;
 }
 span.icon--close {
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%2017%2017%22%3E%3Cpath%20fill=%22none%22%20stroke=%22currentColor%22%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20stroke-width=%222%22%20d=%22M1.11%201.78l14.15%2014.15m-14.09-.07L15.32%201.72%22/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  display: inline-block;
+  vertical-align: middle;
+  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2717%27%20height%3D%2717%27%3E%3Cpath%20fill=%22none%22%20stroke=%22currentColor%22%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20stroke-width=%222%22%20d=%22M1.11%201.78l14.15%2014.15m-14.09-.07L15.32%201.72%22%3E%3C/path%3E%3C/svg%3E');
   height: 17px;
   width: 17px;
 }

--- a/src/less/icon/ds6/icon.less
+++ b/src/less/icon/ds6/icon.less
@@ -1,4 +1,4 @@
-@import "../../less/mixins-common.less";
+@import "../../less/ds6/mixins.less";
 
 // SVG Icons
 //-----------------------------
@@ -29,13 +29,11 @@ svg.icon--close {
 
 // Inline (span) icons.
 //-----------------------------
+
 span.icon {
-    display: inline-block;
-    vertical-align: middle;
-    background-repeat: no-repeat;
+    .background-icon-base;
 }
+
 span.icon--close {
-    background-image: url('data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%2017%2017%22%3E%3Cpath%20fill=%22none%22%20stroke=%22currentColor%22%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20stroke-width=%222%22%20d=%22M1.11%201.78l14.15%2014.15m-14.09-.07L15.32%201.72%22/%3E%3C/svg%3E');
-    height: 17px;
-    width: 17px;
+    .icon-close;
 }

--- a/src/less/less/ds6/mixins.less
+++ b/src/less/less/ds6/mixins.less
@@ -89,3 +89,16 @@
     .ds6-typography-small;
     color: @ds6-color-g206-gray;
 }
+
+.background-icon-base() {
+    background-repeat: no-repeat;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.icon-close() {
+    .background-icon-base;
+    background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2717%27%20height%3D%2717%27%3E%3Cpath%20fill=%22none%22%20stroke=%22currentColor%22%20stroke-linecap=%22round%22%20stroke-linejoin=%22round%22%20stroke-width=%222%22%20d=%22M1.11%201.78l14.15%2014.15m-14.09-.07L15.32%201.72%22%3E%3C/path%3E%3C/svg%3E');
+    height: 17px;
+    width: 17px;
+}


### PR DESCRIPTION
Hoping this Less mixin for the close icon will unblock @sharma46bhawana on page notice dismiss.

I have only added the close icon for now. We can add more icons as mixins in future if we agree on this pattern and approach. I also added a new section to the docs for bg svg.

<img width="635" alt="screen shot 2018-03-14 at 6 21 21 pm" src="https://user-images.githubusercontent.com/38065/37439266-94e316a6-27b4-11e8-8cbf-2bf4547914d7.png">

I will be out all day tomorrow, so I will be unable to respond to PR comments. I recommend that @seangates, @DylanPiercey or @sharma46bhawana push any changes themselves directly to this branch and merge, rather than wait for me.

I was in a bit of a rush, so my apologies in advance if you see something amiss.