### PR TITLE
Menu: remove bold styling on :active item

### DIFF
--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -90,12 +90,6 @@ a.fake-menu__item:focus,
 button.fake-menu__item:focus {
   outline: 1px solid #c7c7c7;
 }
-div.menu__item[role^="menuitem"]:active,
-div.listbox__option[role^="option"]:active,
-a.fake-menu__item:active,
-button.fake-menu__item:active {
-  font-weight: bold;
-}
 div.menu__item[role^="menuitem"]:active .menu__status,
 div.listbox__option[role^="option"]:active .menu__status,
 a.fake-menu__item:active .menu__status,

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -442,12 +442,6 @@ a.fake-menu__item:focus,
 button.fake-menu__item:focus {
   outline: 1px solid #c7c7c7;
 }
-div.menu__item[role^="menuitem"]:active,
-div.listbox__option[role^="option"]:active,
-a.fake-menu__item:active,
-button.fake-menu__item:active {
-  font-weight: bold;
-}
 div.menu__item[role^="menuitem"]:active .menu__status,
 div.listbox__option[role^="option"]:active .menu__status,
 a.fake-menu__item:active .menu__status,

--- a/src/less/dropdown/ds6/dropdown-base.less
+++ b/src/less/dropdown/ds6/dropdown-base.less
@@ -85,8 +85,6 @@ button.fake-menu__item {
     }
 
     &:active {
-        font-weight: bold;
-
         .menu__status,
         .listbox__status,
         .fake-menu__status {


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- remove `font-weight: bold` on `:active` menu items

## Context
<!--- Why did you make these changes, and why in this particular way? -->
From recent discussions with the design team, it was clarified that the bold treatment is meant for selected items, but not for `:active` items. This is an improvement for issues of reflow due to sizing changes on bold text vs regular text on click.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
https://github.com/eBay/skin/issues/86 (partial fix)

