### PR TITLE
Minor fixes

### DIFF
--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -12,7 +12,7 @@
   text-align: center;
   vertical-align: middle;
 }
-.pagination__items > li {
+.pagination__items > li:not([hidden]) {
   display: inline-block;
   margin-right: 8px;
   width: 48px;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1001,7 +1001,7 @@ span.inline-notice {
   text-align: center;
   vertical-align: middle;
 }
-.pagination__items > li {
+.pagination__items > li:not([hidden]) {
   display: inline-block;
   margin-right: 8px;
   width: 48px;

--- a/src/less/pagination/ds6/pagination-base.less
+++ b/src/less/pagination/ds6/pagination-base.less
@@ -12,7 +12,7 @@
     padding: 0;
     text-align: center;
     vertical-align: middle;
-    > li {
+    > li:not([hidden]) {
         display: inline-block;
         margin-right: 8px;
         width: 48px;


### PR DESCRIPTION
## Description
Changes to use `hidden` attribute without adding more specificity

## Context
The `display: inline-block` was overriding the `display: none` in the `hidden` attribute.