### PR TITLE
Fix less-import pointing to non existent dependency

### DIFF
--- a/gh.browser.json
+++ b/gh.browser.json
@@ -11,7 +11,7 @@
         "less-import: ./src/less/icon/ds6/icon-mixin.less",
         "less-import: ./src/less/listbox/ds6/listbox-mixin.less",
         "less-import: ./src/less/notice/ds6/notice-mixin.less",
-        "less-import: ./src/less/notice/ds6/pagination-mixin.less",
+        "less-import: ./src/less/pagination/ds6/pagination-mixin.less",
         "less-import: ./src/less/typography/ds6/typography-mixin.less",
         "less-import: ./src/less/utility/ds6/utility-mixin.less"
     ]


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
Fix a less import

## Context
This was generating a lasso-less error. After some debugging I found out that we were importing the wrong `less` path

