### PR TITLE
129 menu grow by default

### DIFF
--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -42,7 +42,8 @@ span.combobox {
   border: 1px solid #c7c7c7;
   box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   box-sizing: border-box;
-  width: 100%;
+  min-width: calc(100%);
+  width: auto;
 }
 span.menu__items[role="menu"],
 div.combobox__options[role="listbox"],
@@ -155,11 +156,12 @@ button.fake-menu__item {
       align-self: center;
   color: #111820;
   fill: currentColor;
-  height: 1em;
+  height: 8px;
+  margin-left: 8px;
   stroke: currentColor;
   stroke-width: 0;
   visibility: hidden;
-  width: 1em;
+  width: 8px;
 }
 span.menu__status,
 span.combobox__status,
@@ -167,24 +169,19 @@ span.fake-menu__status {
   background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%278%27%20height%3D%277%27%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23111820%22%20d%3D%22M0%203.70913219%202.21049749%206%208%200%22%3E%3C/path%3E%3C/svg%3E');
   background-position: right center;
   background-repeat: no-repeat;
-  height: 1em;
   -ms-flex-negative: 0;
       flex-shrink: 0;
   pointer-events: none;
   width: 1em;
 }
-.menu__items--grow[role="menu"],
-.menu__items--grow-reverse[role="menu"],
-.combobox__options--grow[role="listbox"],
-.combobox__options--grow-reverse[role="listbox"],
-.fake-menu__items--grow,
-.fake-menu__items--grow-reverse {
-  min-width: calc(100%);
-  width: auto;
+.menu__items--match-width[role="menu"],
+.combobox__options--match-width[role="listbox"],
+.fake-menu__items--match-width {
+  width: 100%;
 }
-.menu__items--grow-reverse[role="menu"],
-.combobox__options--grow-reverse[role="listbox"],
-.fake-menu__items--grow-reverse {
+.menu__items--reverse[role="menu"],
+.combobox__options--reverse[role="listbox"],
+.fake-menu__items--reverse {
   right: 0;
 }
 .combobox {

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -174,9 +174,9 @@ span.fake-menu__status {
   pointer-events: none;
   width: 1em;
 }
-.menu__items--match-width[role="menu"],
-.combobox__options--match-width[role="listbox"],
-.fake-menu__items--match-width {
+.menu__items--fix-width[role="menu"],
+.combobox__options--fix-width[role="listbox"],
+.fake-menu__items--fix-width {
   width: 100%;
 }
 .menu__items--reverse[role="menu"],

--- a/docs/_includes/ds6/menu.html
+++ b/docs/_includes/ds6/menu.html
@@ -215,8 +215,8 @@
     <p><strong>TIP:</strong> A fake menu can contain a mix of anchor tags and button tags.</p>
 
     <h3 id="menu-growth">Matched Width Menu</h3>
-    <p>Use the <span class="highlight">menu__items--match-width</span> or <span class="highlight">fake-menu__items--match-width</span> element modifier to match the width of any menu items to the button width. This is useful in cases where the menu overlay needs to be constrained to the button width, usually to accomodate spacing and layout.</p>
-    <p><strong>NOTE: </strong> The <span class="highlight">match-width</span> modifier only works on menus that use a <span class="highlight">span</span> tag.</p>
+    <p>Use the <span class="highlight">menu__items--fix-width</span> or <span class="highlight">fake-menu__items--fix-width</span> element modifier to match the width of any menu items to the button width. This is useful in cases where the menu overlay needs to be constrained to the button width, usually to accomodate spacing and layout.</p>
+    <p><strong>NOTE: </strong> The <span class="highlight">fix-width</span> modifier only works on menus that use a <span class="highlight">span</span> tag.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -227,7 +227,7 @@
                         <span class="expand-btn__icon"></span>
                     </span>
                 </button>
-                <div class="menu__items menu__items--match-width" role="menu">
+                <div class="menu__items menu__items--fix-width" role="menu">
                     <div class="menu__item" role="menuitem">
                         <span>Item 1 with a long string</span>
                     </div>
@@ -249,7 +249,7 @@
             <span class="expand-btn__icon"></span>
         </span>
     </button>
-    <div class="menu__items menu__items--match-width" role="menu">
+    <div class="menu__items menu__items--fix-width" role="menu">
         <div class="menu__item" role="menuitem">
             <span>Item 1 with a long string</span>
         </div>

--- a/docs/_includes/ds6/menu.html
+++ b/docs/_includes/ds6/menu.html
@@ -214,8 +214,8 @@
 
     <p><strong>TIP:</strong> A fake menu can contain a mix of anchor tags and button tags.</p>
 
-    <h3 id="menu-growth">Matched Width Menu</h3>
-    <p>Use the <span class="highlight">menu__items--fix-width</span> or <span class="highlight">fake-menu__items--fix-width</span> element modifier to match the width of any menu items to the button width. This is useful in cases where the menu overlay needs to be constrained to the button width, usually to accomodate spacing and layout.</p>
+    <h3 id="menu-growth">Fixed Width Menu</h3>
+    <p>Use the <span class="highlight">menu__items--fix-width</span> or <span class="highlight">fake-menu__items--fix-width</span> element modifier to fix the width of any menu items to the button width. This is useful in cases where the menu overlay needs to be constrained to the button width, usually to accomodate spacing and layout.</p>
     <p><strong>NOTE: </strong> The <span class="highlight">fix-width</span> modifier only works on menus that use a <span class="highlight">span</span> tag.</p>
 
     <div class="demo">

--- a/docs/_includes/ds6/menu.html
+++ b/docs/_includes/ds6/menu.html
@@ -15,7 +15,9 @@
                     </span>
                 </button>
                 <div class="menu__items" role="menu">
-                    <div class="menu__item" role="menuitem"><span>Item 1</span></div>
+                    <div class="menu__item" role="menuitem">
+                        <span>Item 1 with a long string</span>
+                    </div>
                     <div class="menu__item" role="menuitem"><span>Item 2</span></div>
                     <div class="menu__item" role="menuitem"><span>Item 3</span></div>
                 </div>
@@ -30,13 +32,19 @@
         </span>
     </button>
     <div class="menu__items" role="menu">
-        <div class="menu__item" role="menuitem"><span>Item 1</span></div>
+        <div class="menu__item" role="menuitem">
+            <span>Item 1 with a long string</span>
+        </div>
         <div class="menu__item" role="menuitem"><span>Item 2</span></div>
         <div class="menu__item" role="menuitem"><span>Item 3</span></div>
     </div>
 </span>
         {% endhighlight %}
     </div>
+
+    <p><strong>TIP:</strong> Use the
+        <span class="highlight">menu__items--reverse</span> or
+        <span class="highlight">fake-menu__items--reverse</span> element modifier to fly out the menu overlay in reverse direction.</p>
 
     <h3 id="menu-radio">Radio Menu</h3>
     <p>For single-select state, use role <span class="highlight">menuitemradio</span> on each menu item.</p>
@@ -206,9 +214,9 @@
 
     <p><strong>TIP:</strong> A fake menu can contain a mix of anchor tags and button tags.</p>
 
-    <h3 id="menu-growth">Growth Menu</h3>
-    <p>Use the <span class="highlight">menu__items--grow</span> or <span class="highlight">fake-menu__items--grow</span> element modifier to slightly grow the width of any menu items container. This is useful in cases where the menu overlay needs to be slightly wider than the button, usually to accomodate menu items with long text.</p>
-    <p><strong>NOTE: </strong> The growth modifier only works on menus that use a <span class="highlight">span</span> tag.</p>
+    <h3 id="menu-growth">Matched Width Menu</h3>
+    <p>Use the <span class="highlight">menu__items--match-width</span> or <span class="highlight">fake-menu__items--match-width</span> element modifier to match the width of any menu items to the button width. This is useful in cases where the menu overlay needs to be constrained to the button width, usually to accomodate spacing and layout.</p>
+    <p><strong>NOTE: </strong> The <span class="highlight">match-width</span> modifier only works on menus that use a <span class="highlight">span</span> tag.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -219,9 +227,9 @@
                         <span class="expand-btn__icon"></span>
                     </span>
                 </button>
-                <div class="menu__items menu__items--grow" role="menu">
+                <div class="menu__items menu__items--match-width" role="menu">
                     <div class="menu__item" role="menuitem">
-                        <span>Item 1 - Lorem ipsum dolor sit amet</span>
+                        <span>Item 1 with a long string</span>
                     </div>
                     <div class="menu__item" role="menuitem">
                         <span>Item 2</span>
@@ -241,9 +249,9 @@
             <span class="expand-btn__icon"></span>
         </span>
     </button>
-    <div class="menu__items menu__items--grow" role="menu">
+    <div class="menu__items menu__items--match-width" role="menu">
         <div class="menu__item" role="menuitem">
-            <span>Item 1 - Lorem ipsum dolor sit amet</span>
+            <span>Item 1 with a long string</span>
         </div>
         <div class="menu__item" role="menuitem">
             <span>Item 2</span>
@@ -255,10 +263,6 @@
 </span>
         {% endhighlight %}
     </div>
-
-    <p>TIP: Use the
-        <span class="highlight">menu__items--grow-reverse</span> or
-        <span class="highlight">fake-menu__items--grow-reverse</span> element modifier to grow the width of the menu overlay in reverse direction.</p>
 
     <h3 id="menu-borderless">Borderless Menu</h3>
     <p>Use the <span class="highlight">expand-btn--borderless</span> element modifier on the expand button

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -767,9 +767,9 @@ span.fake-menu__status {
   pointer-events: none;
   width: 1em;
 }
-.menu__items--match-width[role="menu"],
-.combobox__options--match-width[role="listbox"],
-.fake-menu__items--match-width {
+.menu__items--fix-width[role="menu"],
+.combobox__options--fix-width[role="listbox"],
+.fake-menu__items--fix-width {
   width: 100%;
 }
 .menu__items--reverse[role="menu"],

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -635,7 +635,8 @@ span.combobox {
   border: 1px solid #c7c7c7;
   box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   box-sizing: border-box;
-  width: 100%;
+  min-width: calc(100%);
+  width: auto;
 }
 span.menu__items[role="menu"],
 div.combobox__options[role="listbox"],
@@ -748,11 +749,12 @@ button.fake-menu__item {
       align-self: center;
   color: #111820;
   fill: currentColor;
-  height: 1em;
+  height: 8px;
+  margin-left: 8px;
   stroke: currentColor;
   stroke-width: 0;
   visibility: hidden;
-  width: 1em;
+  width: 8px;
 }
 span.menu__status,
 span.combobox__status,
@@ -760,24 +762,19 @@ span.fake-menu__status {
   background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%278%27%20height%3D%277%27%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23111820%22%20d%3D%22M0%203.70913219%202.21049749%206%208%200%22%3E%3C/path%3E%3C/svg%3E');
   background-position: right center;
   background-repeat: no-repeat;
-  height: 1em;
   -ms-flex-negative: 0;
       flex-shrink: 0;
   pointer-events: none;
   width: 1em;
 }
-.menu__items--grow[role="menu"],
-.menu__items--grow-reverse[role="menu"],
-.combobox__options--grow[role="listbox"],
-.combobox__options--grow-reverse[role="listbox"],
-.fake-menu__items--grow,
-.fake-menu__items--grow-reverse {
-  min-width: calc(100%);
-  width: auto;
+.menu__items--match-width[role="menu"],
+.combobox__options--match-width[role="listbox"],
+.fake-menu__items--match-width {
+  width: 100%;
 }
-.menu__items--grow-reverse[role="menu"],
-.combobox__options--grow-reverse[role="listbox"],
-.fake-menu__items--grow-reverse {
+.menu__items--reverse[role="menu"],
+.combobox__options--reverse[role="listbox"],
+.fake-menu__items--reverse {
   right: 0;
 }
 .combobox {

--- a/src/less/dropdown/ds6/dropdown-base.less
+++ b/src/less/dropdown/ds6/dropdown-base.less
@@ -174,9 +174,9 @@ span.fake-menu__status {
 // BEM element mods
 //-----------------------------
 
-.menu__items--match-width[role="menu"],
-.combobox__options--match-width[role="listbox"],
-.fake-menu__items--match-width {
+.menu__items--fix-width[role="menu"],
+.combobox__options--fix-width[role="listbox"],
+.fake-menu__items--fix-width {
     width: 100%;
 }
 

--- a/src/less/dropdown/ds6/dropdown-base.less
+++ b/src/less/dropdown/ds6/dropdown-base.less
@@ -53,7 +53,8 @@ span.combobox {
     border: 1px solid @ds6-color-g204-gray;
     box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
     box-sizing: border-box;
-    width: 100%;
+    min-width: calc(100%);
+    width: auto;
 }
 
 span.menu__items[role="menu"],
@@ -151,11 +152,12 @@ button.fake-menu__item {
     align-self: center;
     color: @ds6-color-g206-gray;
     fill: currentColor;
-    height: 1em;
+    height: 8px;
+    margin-left: 8px;
     stroke: currentColor;
     stroke-width: 0;
     visibility: hidden;
-    width: 1em;
+    width: 8px;
 }
 
 span.menu__status,
@@ -164,7 +166,6 @@ span.fake-menu__status {
     background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%278%27%20height%3D%277%27%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23111820%22%20d%3D%22M0%203.70913219%202.21049749%206%208%200%22%3E%3C/path%3E%3C/svg%3E');
     background-position: right center;
     background-repeat: no-repeat;
-    height: 1em;
     flex-shrink: 0; // prevent the icon from shrinking when label is long
     pointer-events: none;
     width: 1em;
@@ -173,18 +174,14 @@ span.fake-menu__status {
 // BEM element mods
 //-----------------------------
 
-.menu__items--grow[role="menu"],
-.menu__items--grow-reverse[role="menu"],
-.combobox__options--grow[role="listbox"],
-.combobox__options--grow-reverse[role="listbox"],
-.fake-menu__items--grow,
-.fake-menu__items--grow-reverse {
-    min-width: calc(100%);
-    width: auto;
+.menu__items--match-width[role="menu"],
+.combobox__options--match-width[role="listbox"],
+.fake-menu__items--match-width {
+    width: 100%;
 }
 
-.menu__items--grow-reverse[role="menu"],
-.combobox__options--grow-reverse[role="listbox"],
-.fake-menu__items--grow-reverse {
+.menu__items--reverse[role="menu"],
+.listbox__options--reverse[role="listbox"],
+.fake-menu__items--reverse {
     right: 0;
 }

--- a/src/less/dropdown/ds6/dropdown-base.less
+++ b/src/less/dropdown/ds6/dropdown-base.less
@@ -181,7 +181,7 @@ span.fake-menu__status {
 }
 
 .menu__items--reverse[role="menu"],
-.listbox__options--reverse[role="listbox"],
+.combobox__options--reverse[role="listbox"],
 .fake-menu__items--reverse {
     right: 0;
 }


### PR DESCRIPTION
The current menu is limited to the width of the parent button, but this change makes the menu grow by default. This change switches the rules, if the menu should have the options match the width of the parent button, then the modifier named `match-width` would be used.

## Description
- renamed the `grow` modifiers to `match-width`
- changed `grow-reverse` to simply `reverse`

## Context
Per design specs, menus should grow automatically.

## References
Closes #129 