### PR TITLE
Moving to base64 encoded, to avoid double-encoding;

### DIFF
--- a/dist/notice/ds4/notice.css
+++ b/dist/notice/ds4/notice.css
@@ -226,7 +226,7 @@ button.flyout-notice__close:focus span,
 button.page-notice__close:focus span,
 button.flyout-notice__close:hover span,
 button.page-notice__close:hover span {
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23999999%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzk5OSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
 }
 button.flyout-notice__close:active,
 button.page-notice__close:active {
@@ -248,7 +248,7 @@ button.page-notice__close span {
   display: inline-block;
   height: 12px;
   width: 12px;
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23555555%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzU1NSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
 }
 .flyout-notice__close {
   margin-top: 1px;

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -2021,7 +2021,7 @@ button.flyout-notice__close:focus span,
 button.page-notice__close:focus span,
 button.flyout-notice__close:hover span,
 button.page-notice__close:hover span {
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23999999%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzk5OSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
 }
 button.flyout-notice__close:active,
 button.page-notice__close:active {
@@ -2043,7 +2043,7 @@ button.page-notice__close span {
   display: inline-block;
   height: 12px;
   width: 12px;
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23555555%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzU1NSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
 }
 .flyout-notice__close {
   margin-top: 1px;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -2021,7 +2021,7 @@ button.flyout-notice__close:focus span,
 button.page-notice__close:focus span,
 button.flyout-notice__close:hover span,
 button.page-notice__close:hover span {
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23999999%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzk5OSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
 }
 button.flyout-notice__close:active,
 button.page-notice__close:active {
@@ -2043,7 +2043,7 @@ button.page-notice__close span {
   display: inline-block;
   height: 12px;
   width: 12px;
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23555555%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzU1NSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
 }
 .flyout-notice__close {
   margin-top: 1px;

--- a/src/less/notice/ds4/notice-base.less
+++ b/src/less/notice/ds4/notice-base.less
@@ -251,7 +251,7 @@ button.page-notice__close {
     &:hover {
         color: @color-icon-actionable-hover;
         span {
-            background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23999999%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+            background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzk5OSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
         }
     }
 
@@ -271,7 +271,7 @@ button.page-notice__close {
         display: inline-block;
         height: 12px;
         width: 12px;
-        background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Cpath%20fill%3D%22%23555555%22%20d%3D%22M31.427%202.846l-2.387-2.387-13.084%2013.082-13.082-13.082-2.386%202.387%2013.082%2013.082-13.082%2013.084%202.386%202.386%2013.082-13.082%2013.084%2013.082%202.386-2.386-13.084-13.084z%22%3E%3C/path%3E%3C/svg%3E');
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiI+PHBhdGggZmlsbD0iIzU1NSIgZD0iTTMxLjQyNyAyLjg0NkwyOS4wNC40NTkgMTUuOTU2IDEzLjU0MSAyLjg3NC40NTkuNDg4IDIuODQ2IDEzLjU3IDE1LjkyOC40ODggMjkuMDEybDIuMzg2IDIuMzg2IDEzLjA4Mi0xMy4wODJMMjkuMDQgMzEuMzk4bDIuMzg2LTIuMzg2LTEzLjA4NC0xMy4wODR6Ii8+PC9zdmc+');
     }
 }
 


### PR DESCRIPTION
## Description
- updated the SVG to be base64 encoded

## Context
When the SVG is URL encoded it can possibly be double-encoded by the browser. This causes it not to work properly. As we saw when working with the dialog close icon, we need to use base64 as it does not use any characters that need to be URL encoded, avoiding the issue.

## References
Closes #88 

/cc @tcorley