### PR TITLE
Fix last-child and first-child with space in dialog

### DIFF
--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -77,11 +77,11 @@
   min-height: 100%;
   box-sizing: border-box;
 }
-.dialog__body:first-child {
+.dialog__body > :first-child {
   margin-top: 0;
   padding-top: 0;
 }
-.dialog__body:last-child {
+.dialog__body > :last-child {
   margin-bottom: 0;
   padding-bottom: 0;
 }

--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -77,11 +77,11 @@
   min-height: 100%;
   box-sizing: border-box;
 }
-.dialog__body :first-child {
+.dialog__body:first-child {
   margin-top: 0;
   padding-top: 0;
 }
-.dialog__body :last-child {
+.dialog__body:last-child {
   margin-bottom: 0;
   padding-bottom: 0;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -460,11 +460,11 @@ span.expand-btn__icon {
   min-height: 100%;
   box-sizing: border-box;
 }
-.dialog__body :first-child {
+.dialog__body:first-child {
   margin-top: 0;
   padding-top: 0;
 }
-.dialog__body :last-child {
+.dialog__body:last-child {
   margin-bottom: 0;
   padding-bottom: 0;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -460,11 +460,11 @@ span.expand-btn__icon {
   min-height: 100%;
   box-sizing: border-box;
 }
-.dialog__body:first-child {
+.dialog__body > :first-child {
   margin-top: 0;
   padding-top: 0;
 }
-.dialog__body:last-child {
+.dialog__body > :last-child {
   margin-bottom: 0;
   padding-bottom: 0;
 }

--- a/src/less/dialog/ds6/dialog-base.less
+++ b/src/less/dialog/ds6/dialog-base.less
@@ -108,12 +108,12 @@
         min-height: 100%;
         box-sizing: border-box;
 
-        &:first-child {
+        & > :first-child {
             margin-top: 0;
             padding-top: 0;
         }
 
-        &:last-child {
+        & > :last-child {
             margin-bottom: 0;
             padding-bottom: 0;
         }

--- a/src/less/dialog/ds6/dialog-base.less
+++ b/src/less/dialog/ds6/dialog-base.less
@@ -108,12 +108,12 @@
         min-height: 100%;
         box-sizing: border-box;
 
-        & :first-child {
+        &:first-child {
             margin-top: 0;
             padding-top: 0;
         }
 
-        & :last-child {
+        &:last-child {
             margin-bottom: 0;
             padding-bottom: 0;
         }


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
I noticed that the last-child and first-child rules were being applied to *every* first and last child in components inside the dialog. I'm not sure if this was the intended behavior but I checked how other components do similar things and they don't intend to modify every div they contain.

## Context
Before:
```
.dialog__body :last-child // rules would be applied to every subtree inside the dialog
```

```
.dialog__body:last-child // rules only applied to last-child of `.dialog__body`
```
