### PR TITLE
Fix for empty label on expand button

### DIFF
--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -262,9 +262,17 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
+.expand-btn > span.expand-btn__icon:only-child,
 .expand-btn__cell > span.expand-btn__icon:only-child {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   margin: 0;
 }
+.expand-btn > span:empty + span.expand-btn__icon,
 .expand-btn__cell > span:empty + span.expand-btn__icon {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   margin-left: 0;
 }

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -262,3 +262,6 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
+button.expand-btn span.expand-btn__cell > span:empty + span.expand-btn__icon {
+  margin-left: 0;
+}

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -262,6 +262,9 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
+button.expand-btn span.expand-btn__cell > span.expand-btn__icon:only-child {
+  margin: 0;
+}
 button.expand-btn span.expand-btn__cell > span:empty + span.expand-btn__icon {
   margin-left: 0;
 }

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -262,9 +262,9 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
-button.expand-btn span.expand-btn__cell > span.expand-btn__icon:only-child {
+.expand-btn__cell > span.expand-btn__icon:only-child {
   margin: 0;
 }
-button.expand-btn span.expand-btn__cell > span:empty + span.expand-btn__icon {
+.expand-btn__cell > span:empty + span.expand-btn__icon {
   margin-left: 0;
 }

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -262,17 +262,9 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
-.expand-btn > span.expand-btn__icon:only-child,
-.expand-btn__cell > span.expand-btn__icon:only-child {
+span.expand-btn__icon:only-child {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   margin: 0;
-}
-.expand-btn > span:empty + span.expand-btn__icon,
-.expand-btn__cell > span:empty + span.expand-btn__icon {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  margin-left: 0;
 }

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -211,7 +211,7 @@
             </button>
         </div>
         <div class="demo__inner">
-            <button aria-expanded="false" class="expand-btn expand-btn-example">
+            <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
                 <span class="expand-btn__cell">
                     <span></span>
                     <span class="expand-btn__icon"></span>
@@ -225,9 +225,8 @@
         <span class="expand-btn__icon"></span>
     </span>
 </button>
-<button aria-expanded="false" class="expand-btn">
+<button aria-expanded="false" class="expand-btn" aria-label="Expand/Collapse">
     <span class="expand-btn__cell">
-        <span></span>
         <span class="expand-btn__icon"></span>
     </span>
 </button>

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -210,10 +210,24 @@
                 </span>
             </button>
         </div>
+        <div class="demo__inner">
+            <button aria-expanded="false" class="expand-btn expand-btn-example">
+                <span class="expand-btn__cell">
+                    <span></span>
+                    <span class="expand-btn__icon"></span>
+                </span>
+            </button>
+        </div>
         {% highlight html %}
 <button aria-expanded="false" class="expand-btn">
     <span class="expand-btn__cell">
         <span>Button</span>
+        <span class="expand-btn__icon"></span>
+    </span>
+</button>
+<button aria-expanded="false" class="expand-btn">
+    <span class="expand-btn__cell">
+        <span></span>
         <span class="expand-btn__icon"></span>
     </span>
 </button>

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -210,12 +210,6 @@
                 </span>
             </button>
         </div>
-        <div class="demo__inner">
-            <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
-                <span class="expand-btn__icon"></span>
-            </button>
-        </div>
-
         {% highlight html %}
 <button aria-expanded="false" class="expand-btn">
     <span class="expand-btn__cell">
@@ -223,6 +217,17 @@
         <span class="expand-btn__icon"></span>
     </span>
 </button>
+        {% endhighlight %}
+    </div>
+
+    <p>Can also be used with or without a text label.</p>
+    <div class="demo">
+        <div class="demo__inner">
+            <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
+                <span class="expand-btn__icon"></span>
+            </button>
+        </div>
+        {% highlight html %}
 <button aria-expanded="false" class="expand-btn" aria-label="Expand/Collapse">
     <span class="expand-btn__icon"></span>
 </button>

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -213,11 +213,16 @@
         <div class="demo__inner">
             <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
                 <span class="expand-btn__cell">
-                    <span></span>
                     <span class="expand-btn__icon"></span>
                 </span>
             </button>
         </div>
+        <div class="demo__inner">
+            <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
+                <span class="expand-btn__icon"></span>
+            </button>
+        </div>
+
         {% highlight html %}
 <button aria-expanded="false" class="expand-btn">
     <span class="expand-btn__cell">

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -212,13 +212,6 @@
         </div>
         <div class="demo__inner">
             <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
-                <span class="expand-btn__cell">
-                    <span class="expand-btn__icon"></span>
-                </span>
-            </button>
-        </div>
-        <div class="demo__inner">
-            <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
                 <span class="expand-btn__icon"></span>
             </button>
         </div>
@@ -227,11 +220,6 @@
 <button aria-expanded="false" class="expand-btn">
     <span class="expand-btn__cell">
         <span>Button</span>
-        <span class="expand-btn__icon"></span>
-    </span>
-</button>
-<button aria-expanded="false" class="expand-btn" aria-label="Expand/Collapse">
-    <span class="expand-btn__cell">
         <span class="expand-btn__icon"></span>
     </span>
 </button>

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -235,6 +235,9 @@
         <span class="expand-btn__icon"></span>
     </span>
 </button>
+<button aria-expanded="false" class="expand-btn" aria-label="Expand/Collapse">
+    <span class="expand-btn__icon"></span>
+</button>
         {% endhighlight %}
     </div>
 

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -345,10 +345,10 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
-button.expand-btn span.expand-btn__cell > span.expand-btn__icon:only-child {
+.expand-btn__cell > span.expand-btn__icon:only-child {
   margin: 0;
 }
-button.expand-btn span.expand-btn__cell > span:empty + span.expand-btn__icon {
+.expand-btn__cell > span:empty + span.expand-btn__icon {
   margin-left: 0;
 }
 .color-text-default {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -345,6 +345,9 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
+button.expand-btn span.expand-btn__cell > span.expand-btn__icon:only-child {
+  margin: 0;
+}
 button.expand-btn span.expand-btn__cell > span:empty + span.expand-btn__icon {
   margin-left: 0;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -345,10 +345,18 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
+.expand-btn > span.expand-btn__icon:only-child,
 .expand-btn__cell > span.expand-btn__icon:only-child {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   margin: 0;
 }
+.expand-btn > span:empty + span.expand-btn__icon,
 .expand-btn__cell > span:empty + span.expand-btn__icon {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   margin-left: 0;
 }
 .color-text-default {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -345,19 +345,11 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
-.expand-btn > span.expand-btn__icon:only-child,
-.expand-btn__cell > span.expand-btn__icon:only-child {
+span.expand-btn__icon:only-child {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   margin: 0;
-}
-.expand-btn > span:empty + span.expand-btn__icon,
-.expand-btn__cell > span:empty + span.expand-btn__icon {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  margin-left: 0;
 }
 .color-text-default {
   color: #111820;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -345,6 +345,9 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
+button.expand-btn span.expand-btn__cell > span:empty + span.expand-btn__icon {
+  margin-left: 0;
+}
 .color-text-default {
   color: #111820;
 }

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -309,15 +309,8 @@ span.expand-btn__icon {
     flex-shrink: 0;
     margin-left: 8px;
 
-    .expand-btn > &:only-child,
-    .expand-btn__cell > &:only-child {
+    &:only-child {
         display: flex;
         margin: 0;
-    }
-
-    .expand-btn > span:empty + &,
-    .expand-btn__cell > span:empty + & {
-        display: flex;
-        margin-left: 0;
     }
 }

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -309,11 +309,11 @@ span.expand-btn__icon {
     flex-shrink: 0;
     margin-left: 8px;
 
-    button.expand-btn span.expand-btn__cell > &:only-child {
+    .expand-btn__cell > &:only-child {
         margin: 0;
     }
 
-    button.expand-btn span.expand-btn__cell > span:empty + & {
+    .expand-btn__cell > span:empty + & {
         margin-left: 0;
     }
 }

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -309,11 +309,15 @@ span.expand-btn__icon {
     flex-shrink: 0;
     margin-left: 8px;
 
+    .expand-btn > &:only-child,
     .expand-btn__cell > &:only-child {
+        display: flex;
         margin: 0;
     }
 
+    .expand-btn > span:empty + &,
     .expand-btn__cell > span:empty + & {
+        display: flex;
         margin-left: 0;
     }
 }

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -309,6 +309,10 @@ span.expand-btn__icon {
     flex-shrink: 0;
     margin-left: 8px;
 
+    button.expand-btn span.expand-btn__cell > &:only-child {
+        margin: 0;
+    }
+
     button.expand-btn span.expand-btn__cell > span:empty + & {
         margin-left: 0;
     }

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -308,4 +308,8 @@ span.expand-btn__icon {
     background-size: contain;
     flex-shrink: 0;
     margin-left: 8px;
+
+    button.expand-btn span.expand-btn__cell > span:empty + & {
+        margin-left: 0;
+    }
 }


### PR DESCRIPTION
## Description
When the label is empty (or missing altogether) it will apply the correct margins to the icon.

## References
Closes #128 

## Screenshots
![image](https://user-images.githubusercontent.com/105656/39155630-0160490a-4710-11e8-9c07-47905467bf75.png)