### PR TITLE
Dialog margin fix

### DIFF
--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -11,11 +11,10 @@
   z-index: 1000;
 }
 .dialog__window {
-  background-color: #fff;
   left: 0;
   margin: auto;
-  margin-bottom: 15vh;
   min-height: 55px;
+  padding-bottom: 15vh;
   position: absolute;
   right: 0;
   top: 15%;
@@ -24,14 +23,28 @@
   min-width: calc(75% - 7px);
   max-width: calc(100% - 7px);
 }
+.dialog__window::before {
+  background-color: #fff;
+  bottom: 15vh;
+  content: "";
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
 .dialog__window--full,
 .dialog__window--left,
 .dialog__window--right {
   bottom: 0;
-  margin-bottom: 0;
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
+  padding-bottom: 0;
   top: 0;
+}
+.dialog__window--full::before,
+.dialog__window--left::before,
+.dialog__window--right::before {
+  bottom: 0;
 }
 .dialog__window--full .dialog__body,
 .dialog__window--left .dialog__body,
@@ -44,7 +57,6 @@
   float: right;
   position: -webkit-sticky;
   position: sticky;
-  z-index: 1;
 }
 .dialog__window--fill {
   min-height: 70vh;
@@ -72,6 +84,7 @@
   box-sizing: border-box;
   margin: 16px;
   min-height: 100%;
+  position: relative;
 }
 .dialog__close {
   background-color: #fff;
@@ -83,6 +96,7 @@
   position: absolute;
   right: 0;
   top: 0;
+  z-index: 1;
 }
 .dialog__close:hover,
 .dialog__close:focus {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -388,11 +388,10 @@ span.expand-btn__icon {
   z-index: 1000;
 }
 .dialog__window {
-  background-color: #fff;
   left: 0;
   margin: auto;
-  margin-bottom: 15vh;
   min-height: 55px;
+  padding-bottom: 15vh;
   position: absolute;
   right: 0;
   top: 15%;
@@ -401,14 +400,28 @@ span.expand-btn__icon {
   min-width: calc(75% - 7px);
   max-width: calc(100% - 7px);
 }
+.dialog__window::before {
+  background-color: #fff;
+  bottom: 15vh;
+  content: "";
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
 .dialog__window--full,
 .dialog__window--left,
 .dialog__window--right {
   bottom: 0;
-  margin-bottom: 0;
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
+  padding-bottom: 0;
   top: 0;
+}
+.dialog__window--full::before,
+.dialog__window--left::before,
+.dialog__window--right::before {
+  bottom: 0;
 }
 .dialog__window--full .dialog__body,
 .dialog__window--left .dialog__body,
@@ -421,7 +434,6 @@ span.expand-btn__icon {
   float: right;
   position: -webkit-sticky;
   position: sticky;
-  z-index: 1;
 }
 .dialog__window--fill {
   min-height: 70vh;
@@ -449,6 +461,7 @@ span.expand-btn__icon {
   box-sizing: border-box;
   margin: 16px;
   min-height: 100%;
+  position: relative;
 }
 .dialog__close {
   background-color: #fff;
@@ -460,6 +473,7 @@ span.expand-btn__icon {
   position: absolute;
   right: 0;
   top: 0;
+  z-index: 1;
 }
 .dialog__close:hover,
 .dialog__close:focus {

--- a/src/less/dialog/ds6/dialog-base.less
+++ b/src/less/dialog/ds6/dialog-base.less
@@ -37,16 +37,27 @@
     //-----------------------------
 
     &__window {
-        background-color: @ds6-color-g201-gray;
         left: 0;
         margin: auto;
-        margin-bottom: 15vh;
         min-height: 55px;
+        padding-bottom: 15vh;
         position: absolute;
         right: 0;
         top: 15%;
         will-change: opacity, transform;
         .create-grid(@cols: 8, @gutter: 8px, @size: 7, @min: 6, @max: 8);
+
+        // The background for the dialog window is on this pseudo element.
+        // This was done because `margin-bottom` in safari does not work properly with position absolute elements.
+        &::before {
+            background-color: @ds6-color-g201-gray;
+            bottom: 15vh;
+            content: "";
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 100%;
+        }
 
         // MODIFIERS
         //-----------------------------
@@ -55,10 +66,14 @@
         &--left,
         &--right {
             bottom: 0;
-            margin-bottom: 0;
             -webkit-overflow-scrolling: touch;
             overflow-y: auto;
+            padding-bottom: 0;
             top: 0;
+
+            &::before {
+                bottom: 0;
+            }
 
             .dialog {
                 &__body {
@@ -68,7 +83,6 @@
                 &__close {
                     float: right;
                     position: sticky;
-                    z-index: 1;
                 }
             }
         }
@@ -103,6 +117,7 @@
         box-sizing: border-box;
         margin: 16px;
         min-height: 100%;
+        position: relative;
     }
 
     &__close {
@@ -115,6 +130,7 @@
         position: absolute;
         right: 0;
         top: 0;
+        z-index: 1;
 
         &:hover,
         &:focus {


### PR DESCRIPTION
## Description
In this PR the margin at the bottom of the `fill` and `default` dialog's has been fixed.
This was done by changing the `margin-bottom` on the `dialog__window` to use `padding-bottom` and having the actual `background-color` applied to a pseudo element which accounts for this padding.

It is kind of tacky to be sure, but the best solution I have found.

## References

Closes #162 