### PR TITLE
Fix overflow of all buttons

### DIFF
--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -8,6 +8,7 @@ a.cta-btn {
   height: 40px;
   line-height: 40px;
   margin: 0;
+  max-width: 100%;
   padding: 0 16px;
   text-align: center;
   vertical-align: middle;
@@ -208,6 +209,16 @@ a.cta-btn--fluid {
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  width: 100%;
+}
+.btn__cell > span,
+.fake-btn__cell > span,
+.cta-btn__cell > span,
+.expand-btn__cell > span {
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   width: 100%;
 }
 .btn__cell,

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -188,7 +188,9 @@
         {% endhighlight %}
     </div>
 
-    <h4>Long text with overflow</h4>
+    <h4>Button overflow behavior</h4>
+
+    <p>Text of buttons with a fixed width (or max-width) will be truncated by default.</p>
 
     <div class="demo">
         <div class="demo__inner" style="max-width: 200px">
@@ -202,7 +204,7 @@
             </a>
         </div>
         {% highlight html %}
-<a class="cta-btn" href="http://www.ebay.com">
+<a class="cta-btn" href="http://www.ebay.com" style="max-width: 200px">
     <span class="cta-btn__cell">
         <span>Button with a lot of text</span>
         <svg aria-hidden="true" class="cta-btn__icon" focusable="false" height="8" width="8">

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -38,7 +38,7 @@
     <h3 id="button-primary">Secondary Button</h3>
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--secondary"> Button</button>
+            <button class="btn btn--secondary">Button</button>
         </div>
         {% highlight html %}
 <button class="btn btn--secondary">Button</button>
@@ -187,6 +187,32 @@
 </a>
         {% endhighlight %}
     </div>
+    
+    <h4>Long text with overflow</h4>
+    
+    <div class="demo">
+        <div class="demo__inner" style="max-width: 200px">
+            <a class="cta-btn" href="http://www.ebay.com">
+                <span class="cta-btn__cell">
+                    <span>Button with a lot of text</span>
+                    <svg aria-hidden="true" class="cta-btn__icon" focusable="false" height="8" width="8">
+                        <use xlink:href="#icon-arrow-right-bold"></use>
+                    </svg>
+                </span>
+            </a>
+        </div>
+        {% highlight html %}
+<a class="cta-btn" href="http://www.ebay.com">
+    <span class="cta-btn__cell">
+        <span>Button with a lot of text</span>
+        <svg aria-hidden="true" class="cta-btn__icon" focusable="false" height="8" width="8">
+            <use xlink:href="#icon-arrow-right-bold"></use>
+        </svg>
+    </span>
+</a>
+        {% endhighlight %}
+    </div>
+
 
     <h3 id="button-secondary">Fake Button</h3>
     <p>For hyperlinks that <em>look</em> like primary or secondary buttons, use the fake-btn base class.</p>

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -187,9 +187,9 @@
 </a>
         {% endhighlight %}
     </div>
-    
+
     <h4>Long text with overflow</h4>
-    
+
     <div class="demo">
         <div class="demo__inner" style="max-width: 200px">
             <a class="cta-btn" href="http://www.ebay.com">

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -91,6 +91,7 @@ a.cta-btn {
   height: 40px;
   line-height: 40px;
   margin: 0;
+  max-width: 100%;
   padding: 0 16px;
   text-align: center;
   vertical-align: middle;
@@ -291,6 +292,16 @@ a.cta-btn--fluid {
   display: -ms-flexbox;
   display: flex;
   height: 100%;
+  width: 100%;
+}
+.btn__cell > span,
+.fake-btn__cell > span,
+.cta-btn__cell > span,
+.expand-btn__cell > span {
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   width: 100%;
 }
 .btn__cell,

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -15,6 +15,7 @@ a.cta-btn {
     height: 40px;
     line-height: 40px;
     margin: 0; // Remove the button margin in Firefox and Safari */
+    max-width: 100%;
     padding: 0 16px;
     text-align: center;
     vertical-align: middle;
@@ -258,6 +259,14 @@ a.cta-btn--fluid {
     display: flex;
     height: 100%;
     width: 100%;
+
+    > span {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 100%;
+    }
 }
 
 .btn__cell,


### PR DESCRIPTION
## Description

The current CTA button does not wrap properly when long text is applied to it.

**Note: this fixes overflow of all buttons that use the `__cell` container BEM modifier.**

### Example code

```html
  <p>
    <button class="btn btn--secondary">
      <span class="btn__cell">
        <span>long text on a button</span>
      </span>
    </button>
  <p>

  <p>
    <a class="cta-btn" href="http://www.ebay.com">
      <span class="cta-btn__cell">
          <span>long text on a button</span>
          <svg aria-hidden="true" class="cta-btn__icon" focusable="false" height="8" width="8">
              <use xlink:href="#icon-arrow-right-bold"></use>
          </svg>
      </span>
    </a>
  </p>
```

Some experimentation I did to find the solution: https://codepen.io/seangates/pen/LmZKgj

### Current DS6 multiline button

![DS6 multiline button](https://user-images.githubusercontent.com/105656/38261144-a6b1556a-3726-11e8-8897-9800e19443a2.png)

## References

Closes #122 

## Screenshots

### Before

![improper wrapping](https://user-images.githubusercontent.com/105656/39288625-f7097b84-48e5-11e8-9967-7bf9ab364020.png)

### After

![wrapping with ellipsis](https://user-images.githubusercontent.com/105656/39288645-11bafa20-48e6-11e8-9479-56943cf95d12.png)
