### PR TITLE
Radio: refactor the custom icon and colour use cases

### DIFF
--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -5,8 +5,7 @@
   font-size: 1rem;
   vertical-align: text-bottom;
 }
-.radio__control[type="radio"],
-.radio__custom-control[type="radio"] {
+.radio__control[type="radio"] {
   font-size: 100%;
   height: 1.125em;
   opacity: 0;
@@ -14,11 +13,11 @@
   width: 1.125em;
   z-index: 1;
 }
-.radio__custom-control[type="radio"]:not([disabled]) {
-  cursor: pointer;
+.radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__checked {
+  display: none;
 }
-.radio__control[type="radio"]:checked + .radio__icon use {
-  fill: #10299c;
+.radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__unchecked {
+  display: inline-block;
 }
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
@@ -29,11 +28,11 @@
   height: 18px;
   width: 18px;
 }
-.radio__control[type="radio"] + .radio__icon--inherit {
-  color: inherit;
+.radio__control[type="radio"]:checked + .radio__icon svg.radio__checked {
+  display: inline-block;
 }
-.radio__control[type="radio"]:checked + .radio__icon--inherit use {
-  fill: inherit;
+.radio__control[type="radio"]:checked + .radio__icon svg.radio__unchecked {
+  display: none;
 }
 .radio__control[type="radio"]:focus + .radio__icon {
   outline: 1px dotted #767676;
@@ -41,41 +40,8 @@
 .radio__control[type="radio"][disabled] + .radio__icon {
   opacity: 0.5;
 }
-.radio__control[type="radio"]:not(:checked) + .radio__icon .radio__checked {
-  display: none;
-}
-.radio__control[type="radio"]:not(:checked) + .radio__icon .radio__unchecked {
-  display: inline-block;
-}
-.radio__control[type="radio"]:checked + .radio__icon .radio__checked {
-  display: inline-block;
-}
-.radio__control[type="radio"]:checked + .radio__icon .radio__unchecked {
-  display: none;
-}
-.radio__custom-control[type="radio"] + .radio__icon[hidden] {
-  color: currentColor;
-}
-.radio__custom-control[type="radio"]:not(:checked) + .radio__icon .radio__checked {
-  display: none;
-}
-.radio__custom-control[type="radio"]:not(:checked) + .radio__icon .radio__unchecked {
-  display: inline-block;
-}
-.radio__custom-control[type="radio"]:checked + .radio__icon .radio__checked {
-  display: inline-block;
-}
-.radio__custom-control[type="radio"]:checked + .radio__icon .radio__unchecked {
-  display: none;
-}
-.radio__custom-control[type="radio"]:focus + .radio__icon {
-  outline: 1px dotted #767676;
-}
-.radio__custom-control[type="radio"][disabled] + .radio__icon {
-  opacity: 0.5;
-}
 .radio__icon {
-  color: #c7c7c7;
+  color: #111820;
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -87,18 +53,6 @@
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
-.radio__icon svg[aria-hidden="true"] {
-  display: inline-block;
-  fill: currentColor;
-  height: 1.125rem;
-  stroke: currentColor;
-  stroke-width: 0;
-  vertical-align: middle;
-  width: 1.125rem;
-}
-.radio__control + .radio__icon use {
-  fill: currentColor;
-}
 .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -107,4 +61,16 @@
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNiIvPjwvZGVmcz48dXNlIGZpbGw9IiMwMDAiIHhsaW5rOmhyZWY9IiNhIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48L3N2Zz4=');
   height: 18px;
   width: 18px;
+}
+.radio__icon svg {
+  display: inline-block;
+  fill: currentColor;
+  height: 1.125rem;
+  stroke: currentColor;
+  stroke-width: 0;
+  vertical-align: middle;
+  width: 1.125rem;
+}
+.radio__icon--inherit {
+  color: inherit;
 }

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -41,7 +41,7 @@
   opacity: 0.5;
 }
 .radio__icon {
-  color: #111820;
+  color: inherit;
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -70,7 +70,4 @@
   stroke-width: 0;
   vertical-align: middle;
   width: 1.125rem;
-}
-.radio__icon--inherit {
-  color: inherit;
 }

--- a/docs/_includes/ds6/radio.html
+++ b/docs/_includes/ds6/radio.html
@@ -102,13 +102,12 @@
 
     <h3 id="radio-color">Custom Colour Radio</h3>
     <p>The default radio shown above uses an SVG background image, and therefore has a fixed colour. Inline SVG, while slightly more verbose, honours the CSS cascade, thus allowing any possible colour for the radio icon.</p>
-    <p>The <span class="highlight">radio__icon</span> element requires the <span class="highlight">radio__icon--inherit</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="radio" style="color: #71c63e">
                 <input aria-label="Custom colour radio example" class="radio__control" name="radio-custom-colour" type="radio" />
-                <span class="radio__icon radio__icon--inherit" hidden>
+                <span class="radio__icon" hidden>
                     <svg aria-hidden="true" class="radio__unchecked" focusable="false">
                         <use xlink:href="#icon-radio-unchecked"></use>
                     </svg>
@@ -123,7 +122,7 @@
     {% highlight html %}
 <span class="radio" style="color: #71c63e">
     <input class="radio__control" type="radio" />
-    <span class="radio__icon radio__icon--inherit" hidden>
+    <span class="radio__icon" hidden>
         <svg aria-hidden="true" class="radio__unchecked" focusable="false">
             <use xlink:href="#icon-radio-unchecked"></use>
         </svg>
@@ -144,7 +143,7 @@
         <div class="demo__inner">
             <span class="field__control radio" style="color: #ff5151">
                 <input aria-label="Custom icon radio example" class="radio__control" name="radio-custom-icon" type="radio" />
-                <span class="radio__icon radio__icon--inherit" hidden>
+                <span class="radio__icon" hidden>
                     <svg aria-hidden="true" class="radio__unchecked" focusable="false">
                         <use xlink:href="#icon-save"></use>
                     </svg>
@@ -159,7 +158,7 @@
     {% highlight html %}
 <span class="field__control radio" style="color: #ff5151">
     <input class="radio__control" type="radio" />
-    <span class="radio__icon radio__icon--inherit" hidden>
+    <span class="radio__icon" hidden>
         <svg aria-hidden="true" class="radio__unchecked" focusable="false">
             <use xlink:href="#icon-radio-unchecked"></use>
         </svg>

--- a/docs/_includes/ds6/radio.html
+++ b/docs/_includes/ds6/radio.html
@@ -1,6 +1,6 @@
 <div id="radio">
     <h2><span class="secondary-text">@ebay/skin/</span>radio</h2>
-    <p>A radio button is a form control thats allow a user to select a single option from a group of choices.</p>
+    <p>A radio button is a form control that allows a user to select a single option from a group of choices.</p>
     <p>The purpose of a radio button is to collect form data. Therefore, radio buttons should always be used in conjunction with a form, label and submit button.</p>
 
     <h3>Default Radio</h3>
@@ -9,7 +9,7 @@
     <div class="demo">
         <div class="demo__inner">
             <span class="radio">
-                <input aria-label="Default radio example" class="radio__control" type="radio" />
+                <input aria-label="Default radio example" class="radio__control" name="radio-default" type="radio" />
                 <span class="radio__icon"></span>
             </span>
         </div>
@@ -27,7 +27,7 @@
     <div class="demo">
         <div class="demo__inner">
             <span class="radio">
-                <input aria-label="Default radio example" class="radio__control" disabled type="radio" />
+                <input aria-label="Default radio example" class="radio__control" name="radio-disabled" type="radio" checked disabled />
                 <span class="radio__icon"></span>
             </span>
         </div>
@@ -35,7 +35,7 @@
 
     {% highlight html %}
 <span class="radio">
-    <input class="radio__control" disabled type="radio" />
+    <input class="radio__control" type="radio" checked disabled />
     <span class="radio__icon"></span>
 </span>
     {% endhighlight %}
@@ -107,7 +107,7 @@
     <div class="demo">
         <div class="demo__inner">
             <span class="radio" style="color: #71c63e">
-                <input aria-label="Default radio example" class="radio__control" type="radio" />
+                <input aria-label="Custom colour radio example" class="radio__control" name="radio-custom-colour" type="radio" />
                 <span class="radio__icon radio__icon--inherit" hidden>
                     <svg aria-hidden="true" class="radio__unchecked" focusable="false">
                         <use xlink:href="#icon-radio-unchecked"></use>
@@ -122,7 +122,7 @@
 
     {% highlight html %}
 <span class="radio" style="color: #71c63e">
-    <input aria-label="Default radio example" class="radio__control" type="radio" />
+    <input class="radio__control" type="radio" />
     <span class="radio__icon radio__icon--inherit" hidden>
         <svg aria-hidden="true" class="radio__unchecked" focusable="false">
             <use xlink:href="#icon-radio-unchecked"></use>
@@ -137,19 +137,19 @@
     <p><strong>NOTE:</strong> The <span class="highlight">hidden</span> attribute ensures that the SVG icon is not visible if the page is in a non-CSS state; it also helps prevent a flash of unstyled content (FOUC).</p>
 
     <h3 id="radio-custom">Custom Icon Radio</h3>
-    <p>Use the <span class="highlight">radio__custom-control</span> element class to create a custom styled radio that can use any inline SVG for it's checked and unchecked states.</p>
+    <p>The radio module can use any inline SVG for it's checked and unchecked states.</p>
     <p>Be careful when using a custom radio; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <span class="field__control radio" style="color: #71c63e">
-                <input aria-label="Custom radio example" class="radio__custom-control" id="custom-radio-1" type="radio" value="1" name="radio-custom" />
+            <span class="field__control radio" style="color: #ff5151">
+                <input aria-label="Custom icon radio example" class="radio__control" name="radio-custom-icon" type="radio" />
                 <span class="radio__icon radio__icon--inherit" hidden>
                     <svg aria-hidden="true" class="radio__unchecked" focusable="false">
-                        <use xlink:href="#icon-radio-unchecked"></use>
+                        <use xlink:href="#icon-save"></use>
                     </svg>
                     <svg aria-hidden="true" class="radio__checked" focusable="false">
-                        <use xlink:href="#icon-confirmation"></use>
+                        <use xlink:href="#icon-save-selected"></use>
                     </svg>
                 </span>
             </span>
@@ -157,8 +157,8 @@
     </div>
 
     {% highlight html %}
-<span class="field__control radio" style="color: #71c63e">
-    <input class="radio__custom-control" id="custom-radio-1" type="radio" value="1" name="radio-custom" />
+<span class="field__control radio" style="color: #ff5151">
+    <input class="radio__control" type="radio" />
     <span class="radio__icon radio__icon--inherit" hidden>
         <svg aria-hidden="true" class="radio__unchecked" focusable="false">
             <use xlink:href="#icon-radio-unchecked"></use>

--- a/docs/_includes/radio.html
+++ b/docs/_includes/radio.html
@@ -1,6 +1,6 @@
 <div id="radio">
     <h2>Radio</h2>
-    <p>A radio button is a form control thats allow a user to select a single option from a group of choices.</p>
+    <p>A radio button is a form control that allows a user to select a single option from a group of choices.</p>
     <p>The purpose of a radio button is to collect form data; therefore radios should always be used in conjunction with a form, label and submit button.</p>
 
     <ul class="module-toc cols">

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1827,8 +1827,7 @@ span.inline-notice {
   font-size: 1rem;
   vertical-align: text-bottom;
 }
-.radio__control[type="radio"],
-.radio__custom-control[type="radio"] {
+.radio__control[type="radio"] {
   font-size: 100%;
   height: 1.125em;
   opacity: 0;
@@ -1836,11 +1835,11 @@ span.inline-notice {
   width: 1.125em;
   z-index: 1;
 }
-.radio__custom-control[type="radio"]:not([disabled]) {
-  cursor: pointer;
+.radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__checked {
+  display: none;
 }
-.radio__control[type="radio"]:checked + .radio__icon use {
-  fill: #10299c;
+.radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__unchecked {
+  display: inline-block;
 }
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
@@ -1851,11 +1850,11 @@ span.inline-notice {
   height: 18px;
   width: 18px;
 }
-.radio__control[type="radio"] + .radio__icon--inherit {
-  color: inherit;
+.radio__control[type="radio"]:checked + .radio__icon svg.radio__checked {
+  display: inline-block;
 }
-.radio__control[type="radio"]:checked + .radio__icon--inherit use {
-  fill: inherit;
+.radio__control[type="radio"]:checked + .radio__icon svg.radio__unchecked {
+  display: none;
 }
 .radio__control[type="radio"]:focus + .radio__icon {
   outline: 1px dotted #767676;
@@ -1863,41 +1862,8 @@ span.inline-notice {
 .radio__control[type="radio"][disabled] + .radio__icon {
   opacity: 0.5;
 }
-.radio__control[type="radio"]:not(:checked) + .radio__icon .radio__checked {
-  display: none;
-}
-.radio__control[type="radio"]:not(:checked) + .radio__icon .radio__unchecked {
-  display: inline-block;
-}
-.radio__control[type="radio"]:checked + .radio__icon .radio__checked {
-  display: inline-block;
-}
-.radio__control[type="radio"]:checked + .radio__icon .radio__unchecked {
-  display: none;
-}
-.radio__custom-control[type="radio"] + .radio__icon[hidden] {
-  color: currentColor;
-}
-.radio__custom-control[type="radio"]:not(:checked) + .radio__icon .radio__checked {
-  display: none;
-}
-.radio__custom-control[type="radio"]:not(:checked) + .radio__icon .radio__unchecked {
-  display: inline-block;
-}
-.radio__custom-control[type="radio"]:checked + .radio__icon .radio__checked {
-  display: inline-block;
-}
-.radio__custom-control[type="radio"]:checked + .radio__icon .radio__unchecked {
-  display: none;
-}
-.radio__custom-control[type="radio"]:focus + .radio__icon {
-  outline: 1px dotted #767676;
-}
-.radio__custom-control[type="radio"][disabled] + .radio__icon {
-  opacity: 0.5;
-}
 .radio__icon {
-  color: #c7c7c7;
+  color: #111820;
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -1909,18 +1875,6 @@ span.inline-notice {
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
-.radio__icon svg[aria-hidden="true"] {
-  display: inline-block;
-  fill: currentColor;
-  height: 1.125rem;
-  stroke: currentColor;
-  stroke-width: 0;
-  vertical-align: middle;
-  width: 1.125rem;
-}
-.radio__control + .radio__icon use {
-  fill: currentColor;
-}
 .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -1929,6 +1883,18 @@ span.inline-notice {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNiIvPjwvZGVmcz48dXNlIGZpbGw9IiMwMDAiIHhsaW5rOmhyZWY9IiNhIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48L3N2Zz4=');
   height: 18px;
   width: 18px;
+}
+.radio__icon svg {
+  display: inline-block;
+  fill: currentColor;
+  height: 1.125rem;
+  stroke: currentColor;
+  stroke-width: 0;
+  vertical-align: middle;
+  width: 1.125rem;
+}
+.radio__icon--inherit {
+  color: inherit;
 }
 .select {
   display: inline-block;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1863,7 +1863,7 @@ span.inline-notice {
   opacity: 0.5;
 }
 .radio__icon {
-  color: #111820;
+  color: inherit;
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -1892,9 +1892,6 @@ span.inline-notice {
   stroke-width: 0;
   vertical-align: middle;
   width: 1.125rem;
-}
-.radio__icon--inherit {
-  color: inherit;
 }
 .select {
   display: inline-block;

--- a/src/less/radio/ds6/radio-base.less
+++ b/src/less/radio/ds6/radio-base.less
@@ -47,7 +47,7 @@
 }
 
 .radio__icon {
-    color: @ds6-color-g206-gray;
+    color: inherit;
     display: inline-flex;
     font-size: 1em;
     outline-offset: 1px;
@@ -65,8 +65,4 @@
     & svg {
         .inline-icon-base(1.125rem, 1.125rem);
     }
-}
-
-.radio__icon--inherit {
-    color: inherit;
 }

--- a/src/less/radio/ds6/radio-base.less
+++ b/src/less/radio/ds6/radio-base.less
@@ -4,88 +4,35 @@
     vertical-align: text-bottom;
 }
 
-.radio__control[type="radio"],
-.radio__custom-control[type="radio"] {
+.radio__control[type="radio"] {
     font-size: 100%;
     height: 1.125em;
     opacity: 0;
     position: absolute;
     width: 1.125em;
     z-index: 1;
-}
-
-.radio__custom-control[type="radio"]:not([disabled]) {
-    cursor: pointer;
-}
-
-.radio__control[type="radio"] {
-    &:checked + .radio__icon use {
-        fill: @ds6-color-p003-blue;
-    }
-
-    &:checked + .radio__icon:not([hidden]) {
-        .background-icon-base;
-        .icon-radio-checked();
-    }
-
-    + .radio__icon--inherit {
-        color: inherit;
-    }
-
-    &:checked + .radio__icon--inherit use {
-        fill: inherit;
-    }
-
-    &:focus + .radio__icon {
-        outline: @outline-dotted;
-    }
-
-    &[disabled] + .radio__icon {
-        opacity: 0.5;
-    }
 
     &:not(:checked) {
-        & + .radio__icon .radio__checked {
+        & + .radio__icon svg.radio__checked {
             display: none;
         }
 
-        & + .radio__icon .radio__unchecked {
+        & + .radio__icon svg.radio__unchecked {
             display: inline-block;
         }
     }
 
     &:checked {
-        & + .radio__icon .radio__checked {
+        & + .radio__icon:not([hidden]) {
+            .background-icon-base;
+            .icon-radio-checked();
+        }
+
+        & + .radio__icon svg.radio__checked {
             display: inline-block;
         }
 
-        & + .radio__icon .radio__unchecked {
-            display: none;
-        }
-    }
-}
-
-.radio__custom-control[type="radio"] {
-    & + .radio__icon[hidden] {
-        color: currentColor;
-    }
-
-    &:not(:checked) {
-        & + .radio__icon .radio__checked {
-            display: none;
-        }
-
-        & + .radio__icon .radio__unchecked {
-            display: inline-block;
-        }
-    }
-
-    &:checked {
-        & + .radio__icon .radio__checked {
-            display: inline-block;
-        }
-
-        & + .radio__icon .radio__unchecked {
+        & + .radio__icon svg.radio__unchecked {
             display: none;
         }
     }
@@ -100,26 +47,26 @@
 }
 
 .radio__icon {
-    color: @ds6-color-g204-gray;
+    color: @ds6-color-g206-gray;
     display: inline-flex;
     font-size: 1em;
     outline-offset: 1px;
+
+    // progressive enhancement - override hidden SVG
+    &[hidden] {
+        display: inline-flex;
+    }
+
+    &:not([hidden]) {
+        .background-icon-base;
+        .icon-radio-unchecked();
+    }
+
+    & svg {
+        .inline-icon-base(1.125rem, 1.125rem);
+    }
 }
 
-// progressive enhancement - over-ride hidden SVG
-.radio__icon[hidden] {
-    display: inline-flex;
-}
-
-.radio__icon svg[aria-hidden="true"] {
-    .inline-icon-base(1.125rem, 1.125rem);
-}
-
-.radio__control + .radio__icon use {
-    fill: currentColor;
-}
-
-.radio__icon:not([hidden]) {
-    .background-icon-base;
-    .icon-radio-unchecked();
+.radio__icon--inherit {
+    color: inherit;
 }


### PR DESCRIPTION
So, when we first moved over to SVG in DS4, we used inline SVG for everything (i.e. no background SVG). In an effort back then to simply the default radio/checkbox use case, to use a single SVG symbol instead of two (for checked and unchecked states), I created special merged versions of the inline checkbox and radio symbols, like so:

```svg
<symbol id="svg-icon-radio" viewBox="0 0 32 32">
     <path class="unchecked" fill="currentColor" d="M16 31.6c-8.667 0-15.719-6.999-15.719-15.6s7.052-15.6 15.719-15.6 15.719 6.999 15.719 15.6c0 8.604-7.052 15.6-15.719 15.6zM16 2.178c-7.687 0-13.941 6.201-13.941 13.822s6.254 13.822 13.941 13.822 13.941-6.201 13.941-13.822-6.254-13.822-13.941-13.822z"></path>
     <path class="checked-outer" d="M16 31.6c-8.667 0-15.719-6.997-15.719-15.6 0-8.601 7.052-15.6 15.719-15.6s15.719 6.999 15.719 15.6c0 8.604-7.052 15.6-15.719 15.6zM16 2.178c-7.687 0-13.941 6.201-13.941 13.822s6.254 13.822 13.941 13.822 13.941-6.201 13.941-13.822-6.254-13.822-13.941-13.822z"></path>
     <path class="checked-inner" d="M24.139 15.803c0 4.406-3.715 7.979-8.299 7.979s-8.299-3.572-8.299-7.979c0-4.407 3.715-7.979 8.299-7.979s8.299 3.572 8.299 7.979z"></path>
</symbol>
```

There was some clever CSS going on, using the cascade of currentColour to switch between the paths (no doubt taken from CSS tricks or the like). We couldn't use this technique for the custom icon and custom color though (two separate symbols were needed for those) and therefore we had to create a new class `radio__custom-control` as a hook.

Anyhow, later on we discovered we could just use background SVG for the default case. Much simpler all round. This means we can now do away with the `radio__custom-control` hook, as inline SVG always now requires two separate symbols.
