### PR TITLE
Adding the pseudo selectors that was causing the color issue

### DIFF
--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -93,6 +93,8 @@
   text-decoration: none;
   vertical-align: middle;
 }
+.pagination__item:active,
+.pagination__item:link,
 .pagination__item:visited {
   color: #111820;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1782,6 +1782,8 @@ span.inline-notice {
   text-decoration: none;
   vertical-align: middle;
 }
+.pagination__item:active,
+.pagination__item:link,
 .pagination__item:visited {
   color: #111820;
 }

--- a/src/less/pagination/ds6/pagination-base.less
+++ b/src/less/pagination/ds6/pagination-base.less
@@ -104,6 +104,8 @@
     text-decoration: none;
     vertical-align: middle;
 
+    &:active,
+    &:link,
     &:visited {
         color: @ds6-color-text-default;
     }


### PR DESCRIPTION
## Description
The changes fix the issue that an unvisited link (page number) was showing up with DS4 color because of the global header.

## Context
Added the pseudo selectors `:link` and `:active` 

## References
Fixes issue #188 

## Screenshots
<img width="961" alt="screen shot 2018-05-08 at 11 18 07 pm" src="https://user-images.githubusercontent.com/6751429/39798618-1ba46d3e-5316-11e8-8fbd-afff73bdb718.png">

