### PR TITLE
Add dialog--no-mask modifier.

### DIFF
--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -10,6 +10,9 @@
   will-change: background-color;
   z-index: 1000;
 }
+.dialog--no-mask[role="dialog"] {
+  background-color: transparent;
+}
 .dialog__window {
   left: 0;
   margin: auto;

--- a/docs/_includes/ds6/dialog.html
+++ b/docs/_includes/ds6/dialog.html
@@ -167,10 +167,11 @@
 
     <h3>Fullscreen Panel Dialog</h3>
     <p>Apply the <span class="highlight">dialog__window--full</span> modifier to have the dialog take up the entire viewport.</p>
+    <p>Having a mask on a fullscreen dialog doesn't typically make sense and can cause the animations to look a bit strange. You can disable the default background mask of the dialog by applying the <span class="highlight">dialog--no-mask</span> modifier on the <span class="highlight">dialog</span> element.</p>
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
+            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
                 <div class="dialog__window dialog__window--full" role="document">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <span></span>
@@ -187,7 +188,7 @@
             </div>
         </div>
         {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
+<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
     <div class="dialog__window dialog__window--full" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <span></span>
@@ -291,7 +292,7 @@ closeBtnEl.addEventListener("click", () => {
             </div>
 
             <button class="btn btn--primary dialog-button" type="button">Fullscreen</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade" hidden>
+            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
                 <div class="dialog__window dialog__window--full dialog__window--fade" role="document">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <span></span>
@@ -309,7 +310,7 @@ closeBtnEl.addEventListener("click", () => {
         </div>
         {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade" hidden>
-    <div class="dialog__window dialog__window--full" role="document">
+    <div class="dialog__window dialog__window--fade" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <span></span>
         </button>
@@ -319,12 +320,14 @@ closeBtnEl.addEventListener("click", () => {
                 magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
                 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>
+                <a href="http://www.ebay.com">www.ebay.com</a>
+            </p>
         </div>
     </div>
 </div>
 
-<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade" hidden>
+<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
     <div class="dialog__window dialog__window--full dialog__window--fade" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <span></span>

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -410,6 +410,9 @@ span.expand-btn__icon:only-child {
   will-change: background-color;
   z-index: 1000;
 }
+.dialog--no-mask[role="dialog"] {
+  background-color: transparent;
+}
 .dialog__window {
   left: 0;
   margin: auto;

--- a/src/less/dialog/ds6/dialog-base.less
+++ b/src/less/dialog/ds6/dialog-base.less
@@ -33,6 +33,12 @@
         z-index: 1000;
     }
 
+    // MODIFIERS
+    //-----------------------------
+    &--no-mask[role="dialog"] {
+        background-color: transparent;
+    }
+
     // ELEMENTS
     //-----------------------------
 


### PR DESCRIPTION
## Description
This PR adds a new modifier for the dialog element `dialog--no-mask` to allow users to remove the default background-color from the dialog.

## Context
In some cases (full screen dialogs) the animation looks a bit odd with the mask enabled.

## Screenshots
<img width="350" alt="image" src="https://user-images.githubusercontent.com/4985201/39836957-e77190b8-5389-11e8-8e8e-f4d18625d6cc.png">
<img width="939" alt="image" src="https://user-images.githubusercontent.com/4985201/39836972-f064ef08-5389-11e8-962b-269e48602105.png">

