### PR TITLE
Text Links: New DS6 Pattern #66

### DIFF
--- a/dist/link/ds6/link.css
+++ b/dist/link/ds6/link.css
@@ -1,0 +1,23 @@
+a.nav-link,
+a.action-link {
+  text-decoration: none;
+}
+a.nav-link:hover,
+a.action-link:hover {
+  text-decoration: underline;
+}
+a.nav-link {
+  color: #111820;
+}
+a.nav-link:visited {
+  color: #111820;
+}
+a.nav-link:hover {
+  color: #006efc;
+}
+a.action-link {
+  color: #006efc;
+}
+a.action-link:visited {
+  color: #6a4fcc;
+}

--- a/docs/_includes/ds6/link.html
+++ b/docs/_includes/ds6/link.html
@@ -1,0 +1,55 @@
+<div id="link">
+    <h2><span class="secondary-text">@ebay/skin/</span>link</h2>
+    <p>The link module is a bit unusual in that it has no base class; this is because all anchor tags are styled, by default, by the <a href="#global">global</a> module.</p>
+    <p>The default link is used inline, amongst sentences and paragraphs of text. The underline gives visual affordance that this selection of text is a <em>hyperlink</em>. Color alone is not sufficient affordance in this context and therefore the underline is <strong>required</strong> and must not be removed.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod <a href="#">tempor incididunt</a> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation <a href="#">ullamco laboris</a> nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in <a href="#">voluptate velit esse cillum</a> dolore eu fugiat nulla pariatur.</p>
+        </div>
+        {% highlight html %}
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod <a href="#">tempor incididunt</a> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation <a href="#">ullamco laboris</a> nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in <a href="#">voluptate velit esse cillum</a> dolore eu fugiat nulla pariatur.</p>
+        {% endhighlight %}
+    </div>
+
+    <h3>Action Link</h3>
+    <p>Action links remove the default underline, and therefore clickability <strong>must</strong> clearly and easily be perceivable via other visual affordances (e.g. call to action text, placement, or other such contextual clues).</p>
+    <p>Action links are commonly used within item tiles and provide a means to drill-down into additional aspects such as seller page and reviews.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <a class="action-link" href="https://www.ebay.com/urw/ZTE-AXON-7-Mini-32GB-Ion-Gold-Unlocked-Smartphone/product-reviews/230215749?_itm=222972816761">See all 17 Reviews</a>
+        </div>
+        {% highlight html %}
+<a class="action-link" href="https://www.ebay.com">See all 17 Reviews</a>
+        {% endhighlight %}
+    </div>
+
+    <h3>Nav Link</h3>
+    <p>Nav links remove the default underline <em>and</em> colour. Again, clickability <strong>must</strong> clearly and easily be perceivable via other visual affordances (e.g. headings, spacing or other such contextual clues).</p>
+    <p>Nav links are typically used in blocks of navigation within sidebars, allowing the user to navigate the site hierarchy.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <ul style="list-style-type: none; margin: 0; padding: 0;">
+                <li><a class="nav-link" href="#">Item 1</a></li>
+                <li><a class="nav-link" href="#">Item 2</a></li>
+                <li><a class="nav-link" href="#">Item 3</a></li>
+                <li><a class="nav-link" href="#">Item 4</a></li>
+                <li><a class="nav-link" href="#">Item 5</a></li>
+            </ul>
+        </div>
+        {% highlight html %}
+<ul style="list-style-type: none; margin: 0; padding: 0;">
+    <li><a class="nav-link" href="#">Item 1</a></li>
+    <li><a class="nav-link" href="#">Item 2</a></li>
+    <li><a class="nav-link" href="#">Item 3</a></li>
+    <li><a class="nav-link" href="#">Item 4</a></li>
+    <li><a class="nav-link" href="#">Item 5</a></li>
+</ul>
+        {% endhighlight %}
+    </div>
+
+
+
+</div>

--- a/docs/_includes/ds6/link.html
+++ b/docs/_includes/ds6/link.html
@@ -25,28 +25,34 @@
         {% endhighlight %}
     </div>
 
-    <h3>Nav Link</h3>
+    <h3 id="link-nav">Nav Link</h3>
     <p>Nav links remove the default underline <em>and</em> colour. Again, clickability <strong>must</strong> clearly and easily be perceivable via other visual affordances (e.g. headings, spacing or other such contextual clues).</p>
     <p>Nav links are typically used in blocks of navigation within sidebars, allowing the user to navigate the site hierarchy.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <ul style="list-style-type: none; margin: 0; padding: 0;">
-                <li><a class="nav-link" href="#">Item 1</a></li>
-                <li><a class="nav-link" href="#">Item 2</a></li>
-                <li><a class="nav-link" href="#">Item 3</a></li>
-                <li><a class="nav-link" href="#">Item 4</a></li>
-                <li><a class="nav-link" href="#">Item 5</a></li>
-            </ul>
+            <nav aria-labelledby="nav-link-heading" role="navigation">
+                <h4 id="nav-link-heading" style="margin: 0 0 8px 0">Navigation</h4>
+                <ul style="list-style-type: none; margin: 0; padding: 0;">
+                    <li><a class="nav-link" href="#">Item 1</a></li>
+                    <li><a class="nav-link" href="#">Item 2</a></li>
+                    <li><a class="nav-link" href="#">Item 3</a></li>
+                    <li><a class="nav-link" href="#">Item 4</a></li>
+                    <li><a class="nav-link" href="#">Item 5</a></li>
+                </ul>
+            </nav>
         </div>
         {% highlight html %}
-<ul style="list-style-type: none; margin: 0; padding: 0;">
-    <li><a class="nav-link" href="#">Item 1</a></li>
-    <li><a class="nav-link" href="#">Item 2</a></li>
-    <li><a class="nav-link" href="#">Item 3</a></li>
-    <li><a class="nav-link" href="#">Item 4</a></li>
-    <li><a class="nav-link" href="#">Item 5</a></li>
-</ul>
+<nav aria-labelledby="nav-link-heading" role="navigation">
+    <h2 id="nav-link-heading">Navigation</h2>
+    <ul>
+        <li><a class="nav-link" href="#">Item 1</a></li>
+        <li><a class="nav-link" href="#">Item 2</a></li>
+        <li><a class="nav-link" href="#">Item 3</a></li>
+        <li><a class="nav-link" href="#">Item 4</a></li>
+        <li><a class="nav-link" href="#">Item 5</a></li>
+    </ul>
+</nav>
         {% endhighlight %}
     </div>
 

--- a/docs/_layouts/ds6/default.html
+++ b/docs/_layouts/ds6/default.html
@@ -52,6 +52,7 @@
                     <li><a href="#combobox">combobox</a></li>
                     <li><a href="#dialog">dialog</a></li>
                     <li><a href="#icon">icon</a></li>
+                    <li><a href="#link">link</a></li>
                     <li><a href="#menu">menu</a></li>
                     <li><a href="#notice">notice</a></li>
                     <li><a href="#pagination">pagination</a></li>

--- a/docs/ds6/index.html
+++ b/docs/ds6/index.html
@@ -234,6 +234,7 @@ title: Skin DS6
     {% include ds6/combobox.html %}
     {% include ds6/dialog.html %}
     {% include ds6/icon.html %}
+    {% include ds6/link.html %}
     {% include ds6/menu.html %}
     {% include ds6/notice.html %}
     {% include ds6/pagination.html %}

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1579,6 +1579,29 @@ span.combobox__icon {
   background-color: transparent;
   border-color: transparent;
 }
+a.nav-link,
+a.action-link {
+  text-decoration: none;
+}
+a.nav-link:hover,
+a.action-link:hover {
+  text-decoration: underline;
+}
+a.nav-link {
+  color: #111820;
+}
+a.nav-link:visited {
+  color: #111820;
+}
+a.nav-link:hover {
+  color: #006efc;
+}
+a.action-link {
+  color: #006efc;
+}
+a.action-link:visited {
+  color: #6a4fcc;
+}
 .page-notice {
   -webkit-box-align: stretch;
       -ms-flex-align: stretch;

--- a/link.browser.json
+++ b/link.browser.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": [
+        {
+            "path": "./dist/link/ds6/link.css",
+            "if-flag": "skin-ds6"
+        }
+    ]
+}

--- a/src/less/bundles/skin/ds6/skin.less
+++ b/src/less/bundles/skin/ds6/skin.less
@@ -9,6 +9,7 @@
 @import "../../../dialog/ds6/dialog.less";
 @import "../../../icon/ds6/icon.less";
 @import "../../../dropdown/ds6/dropdown.less";
+@import "../../../link/ds6/link.less";
 @import "../../../notice/ds6/notice.less";
 @import "../../../pagination/ds6/pagination.less";
 @import "../../../radio/ds6/radio.less";

--- a/src/less/link/ds6/link-base.less
+++ b/src/less/link/ds6/link-base.less
@@ -1,0 +1,30 @@
+a {
+    &.nav-link,
+    &.action-link {
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    &.nav-link {
+        color: @ds6-color-g206-gray;
+
+        &:visited {
+            color: @ds6-color-g206-gray;
+        }
+
+        &:hover {
+            color: @ds6-color-link-default;
+        }
+    }
+
+    &.action-link {
+        color: @ds6-color-link-default;
+
+        &:visited {
+            color: @ds6-color-link-visited;
+        }
+    }
+}

--- a/src/less/link/ds6/link-mixin.less
+++ b/src/less/link/ds6/link-mixin.less
@@ -1,0 +1,3 @@
+.link-mixin() {
+    @import "../../../../dist/link/ds6/link.css";
+}

--- a/src/less/link/ds6/link.less
+++ b/src/less/link/ds6/link.less
@@ -1,0 +1,3 @@
+@import "../../less/ds6/variables.less";
+
+@import "link-base.less";


### PR DESCRIPTION
Addresses Nav Link and Action Link parts of issue #66.

Closes #66 

I think it's still a little unclear whether we are going with black text & blue underline for inline links, so I have left that part out for now (not a big fan of it personally, whatever the implementation).

I am on PTO this week and so may not be able to address comments until I get back. Just wanted to clear this off my plate :-)

<img width="1208" alt="screen shot 2018-05-29 at 12 50 17 pm" src="https://user-images.githubusercontent.com/38065/40681779-f665365a-633e-11e8-8f7b-3a6745b38514.png">