### PR TITLE
Adding select.browser.json for use on it's own

### DIFF
--- a/select.browser.json
+++ b/select.browser.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "./dist/select/ds6/select.css"
+    ]
+}


### PR DESCRIPTION
## Description
In order to use the select on it's own, it needs it's own `*.brower.json`.

## Context
This supports the split of the `ebay-select` and `ebay-combobox` in the `ebayui-core` components.

## References
Related to https://github.com/eBay/ebayui-core/issues/63.
