### PR TITLE
Issue 213: Adding vertical align-items to pagination parent

### DIFF
--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -1,4 +1,7 @@
 .pagination {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -25,6 +28,7 @@
 .pagination__next,
 .pagination__previous {
   color: #555;
+  display: inherit;
   padding: 8px 8px 8px 0;
 }
 .pagination__next:visited,

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -2060,6 +2060,9 @@ button.page-notice__close span {
   display: block;
 }
 .pagination {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -2086,6 +2089,7 @@ button.page-notice__close span {
 .pagination__next,
 .pagination__previous {
   color: #555;
+  display: inherit;
   padding: 8px 8px 8px 0;
 }
 .pagination__next:visited,

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -2060,6 +2060,9 @@ button.page-notice__close span {
   display: block;
 }
 .pagination {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -2086,6 +2089,7 @@ button.page-notice__close span {
 .pagination__next,
 .pagination__previous {
   color: #555;
+  display: inherit;
   padding: 8px 8px 8px 0;
 }
 .pagination__next:visited,

--- a/src/less/pagination/ds4/pagination.less
+++ b/src/less/pagination/ds4/pagination.less
@@ -4,6 +4,7 @@
 // blocks
 
 .pagination {
+    align-items: center;
     display: flex;
     margin: 8px 0;
 
@@ -25,6 +26,7 @@
 .pagination__next,
 .pagination__previous {
     color: @color-icon-actionable-default;
+    display: inherit;
     padding: 8px 8px 8px 0;
 
     &:visited {


### PR DESCRIPTION
## Description
This PR adds `align-items: center;` to the `.pagination` parent class in the ds4 css. It also adds `display: inherit;` to the previous & next anchor links to better line up the spacing with the chevron svg icons inside them.

**Note:** I'm not sure if all of these static documentation files should be included, but they aren't in the .gitignore so I'm thinking yes. Let me know if I should build the project any differently, but I can tell the documentation is updated with my changes.

## Context
The ds4 style for pagination uses display: flex, but does not use flex centering. This works until any extra padding is added to the child items. In the ds6 styles some extra padding is added to the previous & next buttons and this problem becomes obvious. Adding `align-items: center;` seems to be a natural addition when using `display: flex;`.

I also added the `display: inherit;` to the previous & next anchor tags to better align the svg icon in ds4. When using ds6 this is overwritten and makes no impact.

## References
https://github.com/eBay/skin/issues/213
https://github.com/eBay/ebayui-core/issues/205

## Screenshots
See: https://github.com/eBay/ebayui-core/issues/205
