### PR TITLE
Fixing alignment and font; add another example;

### DIFF
--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -11,7 +11,7 @@
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjEuNiIgaGVpZ2h0PSIxMi41OCIgdmlld0JveD0iMS4zNSA1LjcgMjEuNiAxMi41OCI+PHBhdGggZD0iTTEyLjE4NiAxOC4yODVjLS40NTEtLjAwOS0uODA5LS4xNjctMS4wNzUtLjQ0MWwtOS4zMzctOS42YTEuNTI3IDEuNTI3IDAgMCAxLS40MjQtLjk5OXYtLjEwOGMuMDE1LS4zODYuMTY2LS43NDEuNDI0LTEuMDA4LjU2LS41NzMgMS41MjktLjU3IDIuMDgyIDBsOC4yOTQgOC41MyA4LjI5Mi04LjUzMmMuNTU4LS41NyAxLjUyNi0uNTcgMi4wOCAwIC4yNjUuMjcuNDE2LjYyOS40MjggMS4wMXYuMDg3Yy0uMDEyLjM5MS0uMTY1Ljc1LS40MjcgMS4wMmwtOS4zMzMgOS42YTEuNDQzIDEuNDQzIDAgMCAxLTEuMDA0LjQ0MSIvPjwvc3ZnPg==');
   height: 40px;
   width: 9px;
-  background-position: right center;
+  background-position: right calc(50% - 1px);
   content: "";
   margin-left: 8px;
   pointer-events: none;
@@ -26,10 +26,11 @@
   background-color: #fff;
   border: 1px solid #c7c7c7;
   border-radius: 0;
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 16px;
   height: 40px;
+  margin-top: -1px;
   padding: 8px 30px 8px 16px;
-  vertical-align: top;
 }
 .select > select:focus {
   border-color: #4295ff;

--- a/docs/_includes/ds6/select.html
+++ b/docs/_includes/ds6/select.html
@@ -57,31 +57,12 @@
                 </select>
             </span>
         </div>
-        <div class="demo__inner">
-            <label for="quantity">Quantity</label>
-            <span class="select select--borderless">
-                <select name="quantity" id="quantity">
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                </select>
-            </span>
-        </div>
         {% highlight html %}
 <span class="select select--borderless">
     <select name="options">
         <option value="item1">Option 1</option>
         <option value="item2" selected="">Option 2</option>
         <option value="item3">Option 3</option>
-    </select>
-</span>
-
-<label for="quantity">Quantity</label>
-<span class="select select--borderless">
-    <select name="quantity" id="quantity">
-        <option value="1">1</option>
-        <option value="2">2</option>
-        <option value="3">3</option>
     </select>
 </span>
         {% endhighlight %}

--- a/docs/_includes/ds6/select.html
+++ b/docs/_includes/ds6/select.html
@@ -30,7 +30,7 @@
             <span class="select">
                 <select name="options">
                     <option value="item1">Option 1</option>
-                    <option value="item2" selected="">Option 2</option>
+                    <option value="item2" selected>Option 2</option>
                     <option value="item3">Option 3</option>
                 </select>
             </span>
@@ -39,7 +39,7 @@
 <span class="select">
     <select name="options">
         <option value="item1">Option 1</option>
-        <option value="item2" selected="">Option 2</option>
+        <option value="item2" selected>Option 2</option>
         <option value="item3">Option 3</option>
     </select>
 </span>
@@ -52,16 +52,16 @@
             <span class="select select--borderless">
                 <select name="options" id="options">
                     <option value="1">Option 1</option>
-                    <option value="2">Option 2</option>
+                    <option value="2" selected>Option 2</option>
                     <option value="3">Option 3</option>
                 </select>
             </span>
         </div>
         {% highlight html %}
 <span class="select select--borderless">
-    <select name="options">
+    <select name="options" id="options">
         <option value="item1">Option 1</option>
-        <option value="item2" selected="">Option 2</option>
+        <option value="item2" selected>Option 2</option>
         <option value="item3">Option 3</option>
     </select>
 </span>

--- a/docs/_includes/ds6/select.html
+++ b/docs/_includes/ds6/select.html
@@ -50,10 +50,20 @@
     <div class="demo">
         <div class="demo__inner">
             <span class="select select--borderless">
-                <select name="options">
-                    <option value="item1">Option 1</option>
-                    <option value="item2" selected="">Option 2</option>
-                    <option value="item3">Option 3</option>
+                <select name="options" id="options">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                    <option value="3">Option 3</option>
+                </select>
+            </span>
+        </div>
+        <div class="demo__inner">
+            <label for="quantity">Quantity</label>
+            <span class="select select--borderless">
+                <select name="quantity" id="quantity">
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
                 </select>
             </span>
         </div>
@@ -63,6 +73,15 @@
         <option value="item1">Option 1</option>
         <option value="item2" selected="">Option 2</option>
         <option value="item3">Option 3</option>
+    </select>
+</span>
+
+<label for="quantity">Quantity</label>
+<span class="select select--borderless">
+    <select name="quantity" id="quantity">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
     </select>
 </span>
         {% endhighlight %}

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1989,7 +1989,7 @@ span.inline-notice {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjEuNiIgaGVpZ2h0PSIxMi41OCIgdmlld0JveD0iMS4zNSA1LjcgMjEuNiAxMi41OCI+PHBhdGggZD0iTTEyLjE4NiAxOC4yODVjLS40NTEtLjAwOS0uODA5LS4xNjctMS4wNzUtLjQ0MWwtOS4zMzctOS42YTEuNTI3IDEuNTI3IDAgMCAxLS40MjQtLjk5OXYtLjEwOGMuMDE1LS4zODYuMTY2LS43NDEuNDI0LTEuMDA4LjU2LS41NzMgMS41MjktLjU3IDIuMDgyIDBsOC4yOTQgOC41MyA4LjI5Mi04LjUzMmMuNTU4LS41NyAxLjUyNi0uNTcgMi4wOCAwIC4yNjUuMjcuNDE2LjYyOS40MjggMS4wMXYuMDg3Yy0uMDEyLjM5MS0uMTY1Ljc1LS40MjcgMS4wMmwtOS4zMzMgOS42YTEuNDQzIDEuNDQzIDAgMCAxLTEuMDA0LjQ0MSIvPjwvc3ZnPg==');
   height: 40px;
   width: 9px;
-  background-position: right center;
+  background-position: right calc(50% - 1px);
   content: "";
   margin-left: 8px;
   pointer-events: none;
@@ -2004,10 +2004,11 @@ span.inline-notice {
   background-color: #fff;
   border: 1px solid #c7c7c7;
   border-radius: 0;
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 16px;
   height: 40px;
+  margin-top: -1px;
   padding: 8px 30px 8px 16px;
-  vertical-align: top;
 }
 .select > select:focus {
   border-color: #4295ff;

--- a/src/less/select/ds6/select-base.less
+++ b/src/less/select/ds6/select-base.less
@@ -27,7 +27,7 @@
     height: 40px;
     margin-top: -1px; // account for the border
     padding: 8px 30px 8px 16px;
-    
+
     &:focus {
         border-color: @ds6-color-p004-blue;
         outline: none;

--- a/src/less/select/ds6/select-base.less
+++ b/src/less/select/ds6/select-base.less
@@ -7,7 +7,7 @@
         .background-icon-base;
         .icon-chevron-down-bold(9px, 40px);
 
-        background-position: right center;
+        background-position: right calc(50% ~"-" 1px);
         content: "";
         margin-left: 8px;
         pointer-events: none;
@@ -22,11 +22,12 @@
     background-color: #fff;
     border: 1px solid #c7c7c7;
     border-radius: 0;
+    font-family: @ds6-font-family-custom; // for some reason this needs to be explicitly set
     font-size: 16px;
     height: 40px;
+    margin-top: -1px; // account for the border
     padding: 8px 30px 8px 16px;
-    vertical-align: top;
-
+    
     &:focus {
         border-color: @ds6-color-p004-blue;
         outline: none;


### PR DESCRIPTION
## Description
This fixes some styles related to the inline view of the select component. <strike>It also adds a `--small` modifier for when the select needs to match the default font size.</strike>

## Context
When placed inline with text, spans, or other inline content the select would position itself incorrectly.

## References
Fixes #194 

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/105656/39826462-00063f9c-5372-11e8-98ce-4241a270e110.png)

### After
![image](https://user-images.githubusercontent.com/105656/39830469-c7eed486-537e-11e8-9f30-32a676df72af.png)
