### PR TITLE
Issue 231: Support inline SVG for expand button in DS6

### DIFF
--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -254,13 +254,20 @@ a.cta-btn--fluid {
 .expand-btn__icon:last-child {
   margin-left: 8px;
 }
-svg.cta-btn__icon {
+svg.cta-btn__icon,
+svg.expand-btn__icon {
   color: inherit;
   fill: currentColor;
-  height: 10px;
   stroke: currentColor;
   stroke-width: 0;
+}
+svg.cta-btn__icon {
   width: 9.75px;
+  height: 10px;
+}
+svg.expand-btn__icon {
+  width: 9px;
+  height: 5.2px;
 }
 span.expand-btn__icon {
   background-repeat: no-repeat;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -262,12 +262,12 @@ svg.expand-btn__icon {
   stroke-width: 0;
 }
 svg.cta-btn__icon {
-  width: 9.75px;
   height: 10px;
+  width: 9.75px;
 }
 svg.expand-btn__icon {
-  width: 9px;
   height: 5.2px;
+  width: 9px;
 }
 span.expand-btn__icon {
   background-repeat: no-repeat;

--- a/docs/_includes/ds6/menu.html
+++ b/docs/_includes/ds6/menu.html
@@ -313,4 +313,42 @@
 </span>
         {% endhighlight %}
     </div>
+
+    <h3 id="menu-custom">Custom Menu</h3>
+    <p>For <em>custom</em> background and foreground colours, please replace the icon's span element with an inline SVG element:</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="menu">
+                <button class="expand-btn" aria-expanded="false" aria-haspopup="true" style="background-color: #6a29b9; color: white" type="button">
+                    <span class="expand-btn__cell">
+                        <span>Custom Menu</span>
+                        <svg aria-hidden="true" class="expand-btn__icon" focusable="false">
+                            <use xlink:href="#icon-chevron-down-bold"></use>
+                        </svg>
+                    </span>
+                </button>
+                <div class="menu__items" role="menu">
+                    <div class="menu__item" role="menuitem"><span>Menu item 1</span></div>
+                    <div class="menu__item" role="menuitem"><span>Menu item 2</span></div>
+                    <div class="menu__item" role="menuitem"><span>Menu item 3</span></div>
+                </div>
+            </span>
+        </div>
+
+        {% highlight html %}
+<span class="menu">
+    <button class="expand-btn" aria-expanded="false" aria-haspopup="true" style="background-color: #6a29b9; color: white" type="button">
+        <span class="expand-btn__cell">
+            <span>Custom Menu</span>
+            <svg aria-hidden="true" class="expand-btn__icon" focusable="false">
+                <use xlink:href="#icon-chevron-down-bold"></use>
+            </svg>
+        </span>
+    </button>
+</span>
+        {% endhighlight %}
+
+    </div>
+
 </div>

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -341,13 +341,20 @@ a.cta-btn--fluid {
 .expand-btn__icon:last-child {
   margin-left: 8px;
 }
-svg.cta-btn__icon {
+svg.cta-btn__icon,
+svg.expand-btn__icon {
   color: inherit;
   fill: currentColor;
-  height: 10px;
   stroke: currentColor;
   stroke-width: 0;
+}
+svg.cta-btn__icon {
   width: 9.75px;
+  height: 10px;
+}
+svg.expand-btn__icon {
+  width: 9px;
+  height: 5.2px;
 }
 span.expand-btn__icon {
   background-repeat: no-repeat;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -349,12 +349,12 @@ svg.expand-btn__icon {
   stroke-width: 0;
 }
 svg.cta-btn__icon {
-  width: 9.75px;
   height: 10px;
+  width: 9.75px;
 }
 svg.expand-btn__icon {
-  width: 9px;
   height: 5.2px;
+  width: 9px;
 }
 span.expand-btn__icon {
   background-repeat: no-repeat;

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -295,13 +295,22 @@ a.cta-btn--fluid {
     }
 }
 
-svg.cta-btn__icon {
+svg.cta-btn__icon,
+svg.expand-btn__icon {
     color: inherit;
     fill: currentColor;
-    height: 10px;
     stroke: currentColor;
     stroke-width: 0;
+}
+
+svg.cta-btn__icon {
     width: 9.75px;
+    height: 10px;
+}
+
+svg.expand-btn__icon {
+    width: 9px;
+    height: 5.2px;
 }
 
 span.expand-btn__icon {

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -304,13 +304,13 @@ svg.expand-btn__icon {
 }
 
 svg.cta-btn__icon {
-    width: 9.75px;
     height: 10px;
+    width: 9.75px;
 }
 
 svg.expand-btn__icon {
-    width: 9px;
     height: 5.2px;
+    width: 9px;
 }
 
 span.expand-btn__icon {


### PR DESCRIPTION

## Description

Added `svg.expand-btn__icon` style to DS 6, sharing from the existing style `svg.cta-btn__icon`.

Made `svg.expand-btn__icon` height/width the same as `span.expand-btn__icon`. Otherwise the icons will be larger than non SVG ones.

## References
[EBAYUI-102](https://jirap.corp.ebay.com/browse/EBAYUI-102)

## Screenshots
![screen shot 2018-06-27 at 12 15 01 pm](https://user-images.githubusercontent.com/40370947/41994597-cab648d8-7a03-11e8-8ff3-32683d949dae.png)
