### PR TITLE
Menu: Add primary modifier #235

### DIFF
--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -32,6 +32,29 @@ a.cta-btn:hover {
 a.cta-btn:focus {
   outline: 0 none;
 }
+button.expand-btn {
+  background-color: #fff;
+  border-color: #c7c7c7;
+  color: #111820;
+}
+button.expand-btn:active {
+  border-color: #111820;
+}
+button.expand-btn[aria-expanded="true"] .expand-btn__icon {
+  -webkit-transform: rotate(180deg);
+          transform: rotate(180deg);
+}
+button.expand-btn[disabled],
+button.expand-btn[aria-disabled="true"] {
+  border-color: #c7c7c7;
+  color: #c7c7c7;
+}
+button.expand-btn[disabled] span.expand-btn__icon,
+button.expand-btn[aria-disabled="true"] span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMSIgaGVpZ2h0PSIxMiIgZmlsbD0iI2M3YzdjNyI+PHBhdGggZD0iTTE5LjAwNi4zNTFMMTAuNSA5LjEwNCAxLjk5Mi4zNWExLjE0OSAxLjE0OSAwIDAgMC0xLjY1MSAwQTEuMjI2IDEuMjI2IDAgMCAwIDAgMS4xNTJ2LjA5NmMuMDEyLjI5MS4xMjYuNTc5LjM0LjgwMWw5LjMzNSA5LjZjLjIyLjIyNy41MDguMzQ0Ljc5Ni4zNTFoLjA1N2MuMjg4LS4wMDguNTc2LS4xMjQuNzk3LS4zNTFsOS4zMzMtOS42YTEuMjEgMS4yMSAwIDAgMCAuMzQyLS44MXYtLjA3OGExLjIxIDEuMjEgMCAwIDAtLjM0Mi0uODEgMS4xNDggMS4xNDggMCAwIDAtMS42NTIgMHoiLz48L3N2Zz4=');
+  height: 100%;
+  width: 9px;
+}
 button.btn--small,
 button.expand-btn--small,
 a.fake-btn--small {
@@ -47,6 +70,7 @@ a.cta-btn--large {
   line-height: 48px;
 }
 button.btn--primary,
+button.expand-btn--primary,
 a.fake-btn--primary {
   background-color: #006efc;
   border-color: #006efc;
@@ -54,16 +78,21 @@ a.fake-btn--primary {
   font-weight: bold;
 }
 button.btn--primary:focus,
+button.expand-btn--primary:focus,
 a.fake-btn--primary:focus,
-button.btn--primary:hover,
-a.fake-btn--primary:hover,
+button.btn--primary:hover:not([disabled]):not([aria-disabled="true"]),
+button.expand-btn--primary:hover:not([disabled]):not([aria-disabled="true"]),
+a.fake-btn--primary:hover:not([disabled]):not([aria-disabled="true"]),
 button.btn--primary:active,
+button.expand-btn--primary:active,
 a.fake-btn--primary:active {
   background-color: #10299c;
   border-color: #10299c;
 }
 button.btn--primary[disabled],
-button.btn--primary[aria-disabled="true"] {
+button.expand-btn--primary[disabled],
+button.btn--primary[aria-disabled="true"],
+button.expand-btn--primary[aria-disabled="true"] {
   background-color: #c7c7c7;
   border-color: #c7c7c7;
   color: #fff;
@@ -78,41 +107,26 @@ a.fake-btn--primary[aria-disabled="true"] {
   color: #fff;
 }
 button.btn--secondary,
+button.expand-btn--secondary,
 a.fake-btn--secondary {
   background-color: #fff;
   border-color: #006efc;
   color: #006efc;
 }
 button.btn--secondary:focus,
+button.expand-btn--secondary:focus,
 a.fake-btn--secondary:focus,
-button.btn--secondary:hover,
-a.fake-btn--secondary:hover,
+button.btn--secondary:hover:not([disabled]):not([aria-disabled="true"]),
+button.expand-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]),
+a.fake-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]),
 button.btn--secondary:active,
+button.expand-btn--secondary:active,
 a.fake-btn--secondary:active {
   border-color: #10299c;
   color: #10299c;
 }
-button.expand-btn {
-  background-color: #fff;
-  border-color: #c7c7c7;
-  color: #111820;
-}
-button.expand-btn:active {
-  border-color: #111820;
-}
-button.expand-btn[aria-expanded="true"] .expand-btn__icon {
-  -webkit-transform: rotate(180deg);
-          transform: rotate(180deg);
-}
-button.expand-btn[disabled] span.expand-btn__icon {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMSIgaGVpZ2h0PSIxMiIgZmlsbD0iI2M3YzdjNyI+PHBhdGggZD0iTTE5LjAwNi4zNTFMMTAuNSA5LjEwNCAxLjk5Mi4zNWExLjE0OSAxLjE0OSAwIDAgMC0xLjY1MSAwQTEuMjI2IDEuMjI2IDAgMCAwIDAgMS4xNTJ2LjA5NmMuMDEyLjI5MS4xMjYuNTc5LjM0LjgwMWw5LjMzNSA5LjZjLjIyLjIyNy41MDguMzQ0Ljc5Ni4zNTFoLjA1N2MuMjg4LS4wMDguNTc2LS4xMjQuNzk3LS4zNTFsOS4zMzMtOS42YTEuMjEgMS4yMSAwIDAgMCAuMzQyLS44MXYtLjA3OGExLjIxIDEuMjEgMCAwIDAtLjM0Mi0uODEgMS4xNDggMS4xNDggMCAwIDAtMS42NTIgMHoiLz48L3N2Zz4=');
-  height: 100%;
-  width: 9px;
-}
 button.btn--secondary[disabled],
-button.expand-btn[disabled],
-button.btn--secondary[aria-disabled="true"],
-button.expand-btn[aria-disabled="true"] {
+button.btn--secondary[aria-disabled="true"] {
   border-color: #c7c7c7;
   color: #c7c7c7;
 }
@@ -287,4 +301,16 @@ span.expand-btn__icon:only-child {
   display: -ms-flexbox;
   display: flex;
   margin: 0;
+}
+button.expand-btn--primary span.expand-btn__icon,
+button.expand-btn--primary[disabled] span.expand-btn__icon,
+button.expand-btn--primary[aria-disabled="true"] span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjEuNiIgaGVpZ2h0PSIxMi41OCIgdmlld0JveD0iMS4zNSA1LjcgMjEuNiAxMi41OCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyLjE4NiAxOC4yODVjLS40NTEtLjAwOS0uODA5LS4xNjctMS4wNzUtLjQ0MWwtOS4zMzctOS42YTEuNTI3IDEuNTI3IDAgMCAxLS40MjQtLjk5OXYtLjEwOGMuMDE1LS4zODYuMTY2LS43NDEuNDI0LTEuMDA4LjU2LS41NzMgMS41MjktLjU3IDIuMDgyIDBsOC4yOTQgOC41MyA4LjI5Mi04LjUzMmMuNTU4LS41NyAxLjUyNi0uNTcgMi4wOCAwIC4yNjUuMjcuNDE2LjYyOS40MjggMS4wMXYuMDg3Yy0uMDEyLjM5MS0uMTY1Ljc1LS40MjcgMS4wMmwtOS4zMzMgOS42YTEuNDQzIDEuNDQzIDAgMCAxLTEuMDA0LjQ0MSIvPjwvc3ZnPg==');
+}
+button.expand-btn--secondary span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjIxLjYiIGhlaWdodD0iMTIuNTgiIHZpZXdCb3g9IjEuMzUgNS43IDIxLjYgMTIuNTgiPjxwYXRoIGZpbGw9IiMwMDZlZmMiIGQ9Ik0xMi4xODYgMTguMjg1Yy0uNDUxLS4wMDktLjgwOS0uMTY3LTEuMDc1LS40NDFsLTkuMzM3LTkuNmExLjUyNyAxLjUyNyAwIDAgMS0uNDI0LS45OTl2LS4xMDhjLjAxNS0uMzg2LjE2Ni0uNzQxLjQyNC0xLjAwOC41Ni0uNTczIDEuNTI5LS41NyAyLjA4MiAwbDguMjk0IDguNTMgOC4yOTItOC41MzJjLjU1OC0uNTcgMS41MjYtLjU3IDIuMDggMCAuMjY1LjI3LjQxNi42MjkuNDI4IDEuMDF2LjA4N2MtLjAxMi4zOTEtLjE2NS43NS0uNDI3IDEuMDJsLTkuMzMzIDkuNmExLjQ0MyAxLjQ0MyAwIDAgMS0xLjAwNC40NDEiLz48L3N2Zz4=');
+}
+button.expand-btn--secondary:focus span.expand-btn__icon,
+button.expand-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]) span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjIxLjYiIGhlaWdodD0iMTIuNTgiIHZpZXdCb3g9IjEuMzUgNS43IDIxLjYgMTIuNTgiPjxwYXRoIGZpbGw9IiMxMDI5OWMiIGQ9Ik0xMi4xODYgMTguMjg1Yy0uNDUxLS4wMDktLjgwOS0uMTY3LTEuMDc1LS40NDFsLTkuMzM3LTkuNmExLjUyNyAxLjUyNyAwIDAgMS0uNDI0LS45OTl2LS4xMDhjLjAxNS0uMzg2LjE2Ni0uNzQxLjQyNC0xLjAwOC41Ni0uNTczIDEuNTI5LS41NyAyLjA4MiAwbDguMjk0IDguNTMgOC4yOTItOC41MzJjLjU1OC0uNTcgMS41MjYtLjU3IDIuMDggMCAuMjY1LjI3LjQxNi42MjkuNDI4IDEuMDF2LjA4N2MtLjAxMi4zOTEtLjE2NS43NS0uNDI3IDEuMDJsLTkuMzMzIDkuNmExLjQ0MyAxLjQ0MyAwIDAgMS0xLjAwNC40NDEiLz48L3N2Zz4=');
 }

--- a/docs/_includes/ds6/menu.html
+++ b/docs/_includes/ds6/menu.html
@@ -315,6 +315,62 @@
     </div>
 
     <h3 id="menu-custom">Custom Menu</h3>
+
+    <p>Any menu can use any kind of button hierarchy as defined in the <a href="#button">button</a> module (e.g. <span class="highlight">.expand-btn--primary</span>).</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="menu">
+                <button class="expand-btn expand-btn--primary" aria-expanded="false" aria-haspopup="true" type="button">
+                    <span class="expand-btn__cell">
+                        <span>Primary Menu</span>
+                        <span class="expand-btn__icon"></span>
+                    </span>
+                </button>
+                <div class="menu__items" role="menu">
+                    <div class="menu__item" role="menuitem"><span>Menu item 1</span></div>
+                    <div class="menu__item" role="menuitem"><span>Menu item 2</span></div>
+                    <div class="menu__item" role="menuitem"><span>Menu item 3</span></div>
+                </div>
+            </span>
+            <span class="menu">
+                <button class="expand-btn expand-btn--secondary" aria-expanded="false" aria-haspopup="true" type="button">
+                    <span class="expand-btn__cell">
+                        <span>Secondary Menu</span>
+                        <span class="expand-btn__icon"></span>
+                    </span>
+                </button>
+                <div class="menu__items" role="menu">
+                    <div class="menu__item" role="menuitem"><span>Menu item 1</span></div>
+                    <div class="menu__item" role="menuitem"><span>Menu item 2</span></div>
+                    <div class="menu__item" role="menuitem"><span>Menu item 3</span></div>
+                </div>
+            </span>
+        </div>
+    </div>
+
+    {% highlight html %}
+<span class="menu">
+    <button class="expand-btn expand-btn--primary" aria-expanded="false" aria-haspopup="true" type="button">
+        <span class="expand-btn__cell">
+            <span>Primary Menu</span>
+            <span class="expand-btn__icon"></span>
+        </span>
+    </button>
+    <!-- menu items omitted from example code -->
+</span>
+
+<span class="menu">
+    <button class="expand-btn expand-btn--secondary" aria-expanded="false" aria-haspopup="true" type="button">
+        <span class="expand-btn__cell">
+            <span>Secondary Menu</span>
+            <span class="expand-btn__icon"></span>
+        </span>
+    </button>
+    <!-- menu items omitted from example code -->
+</span>
+    {% endhighlight %}
+    
     <p>For <em>custom</em> background and foreground colours, please replace the icon's span element with an inline SVG element:</p>
 
     <div class="demo">

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -119,6 +119,29 @@ a.cta-btn:hover {
 a.cta-btn:focus {
   outline: 0 none;
 }
+button.expand-btn {
+  background-color: #fff;
+  border-color: #c7c7c7;
+  color: #111820;
+}
+button.expand-btn:active {
+  border-color: #111820;
+}
+button.expand-btn[aria-expanded="true"] .expand-btn__icon {
+  -webkit-transform: rotate(180deg);
+          transform: rotate(180deg);
+}
+button.expand-btn[disabled],
+button.expand-btn[aria-disabled="true"] {
+  border-color: #c7c7c7;
+  color: #c7c7c7;
+}
+button.expand-btn[disabled] span.expand-btn__icon,
+button.expand-btn[aria-disabled="true"] span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMSIgaGVpZ2h0PSIxMiIgZmlsbD0iI2M3YzdjNyI+PHBhdGggZD0iTTE5LjAwNi4zNTFMMTAuNSA5LjEwNCAxLjk5Mi4zNWExLjE0OSAxLjE0OSAwIDAgMC0xLjY1MSAwQTEuMjI2IDEuMjI2IDAgMCAwIDAgMS4xNTJ2LjA5NmMuMDEyLjI5MS4xMjYuNTc5LjM0LjgwMWw5LjMzNSA5LjZjLjIyLjIyNy41MDguMzQ0Ljc5Ni4zNTFoLjA1N2MuMjg4LS4wMDguNTc2LS4xMjQuNzk3LS4zNTFsOS4zMzMtOS42YTEuMjEgMS4yMSAwIDAgMCAuMzQyLS44MXYtLjA3OGExLjIxIDEuMjEgMCAwIDAtLjM0Mi0uODEgMS4xNDggMS4xNDggMCAwIDAtMS42NTIgMHoiLz48L3N2Zz4=');
+  height: 100%;
+  width: 9px;
+}
 button.btn--small,
 button.expand-btn--small,
 a.fake-btn--small {
@@ -134,6 +157,7 @@ a.cta-btn--large {
   line-height: 48px;
 }
 button.btn--primary,
+button.expand-btn--primary,
 a.fake-btn--primary {
   background-color: #006efc;
   border-color: #006efc;
@@ -141,16 +165,21 @@ a.fake-btn--primary {
   font-weight: bold;
 }
 button.btn--primary:focus,
+button.expand-btn--primary:focus,
 a.fake-btn--primary:focus,
-button.btn--primary:hover,
-a.fake-btn--primary:hover,
+button.btn--primary:hover:not([disabled]):not([aria-disabled="true"]),
+button.expand-btn--primary:hover:not([disabled]):not([aria-disabled="true"]),
+a.fake-btn--primary:hover:not([disabled]):not([aria-disabled="true"]),
 button.btn--primary:active,
+button.expand-btn--primary:active,
 a.fake-btn--primary:active {
   background-color: #10299c;
   border-color: #10299c;
 }
 button.btn--primary[disabled],
-button.btn--primary[aria-disabled="true"] {
+button.expand-btn--primary[disabled],
+button.btn--primary[aria-disabled="true"],
+button.expand-btn--primary[aria-disabled="true"] {
   background-color: #c7c7c7;
   border-color: #c7c7c7;
   color: #fff;
@@ -165,41 +194,26 @@ a.fake-btn--primary[aria-disabled="true"] {
   color: #fff;
 }
 button.btn--secondary,
+button.expand-btn--secondary,
 a.fake-btn--secondary {
   background-color: #fff;
   border-color: #006efc;
   color: #006efc;
 }
 button.btn--secondary:focus,
+button.expand-btn--secondary:focus,
 a.fake-btn--secondary:focus,
-button.btn--secondary:hover,
-a.fake-btn--secondary:hover,
+button.btn--secondary:hover:not([disabled]):not([aria-disabled="true"]),
+button.expand-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]),
+a.fake-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]),
 button.btn--secondary:active,
+button.expand-btn--secondary:active,
 a.fake-btn--secondary:active {
   border-color: #10299c;
   color: #10299c;
 }
-button.expand-btn {
-  background-color: #fff;
-  border-color: #c7c7c7;
-  color: #111820;
-}
-button.expand-btn:active {
-  border-color: #111820;
-}
-button.expand-btn[aria-expanded="true"] .expand-btn__icon {
-  -webkit-transform: rotate(180deg);
-          transform: rotate(180deg);
-}
-button.expand-btn[disabled] span.expand-btn__icon {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMSIgaGVpZ2h0PSIxMiIgZmlsbD0iI2M3YzdjNyI+PHBhdGggZD0iTTE5LjAwNi4zNTFMMTAuNSA5LjEwNCAxLjk5Mi4zNWExLjE0OSAxLjE0OSAwIDAgMC0xLjY1MSAwQTEuMjI2IDEuMjI2IDAgMCAwIDAgMS4xNTJ2LjA5NmMuMDEyLjI5MS4xMjYuNTc5LjM0LjgwMWw5LjMzNSA5LjZjLjIyLjIyNy41MDguMzQ0Ljc5Ni4zNTFoLjA1N2MuMjg4LS4wMDguNTc2LS4xMjQuNzk3LS4zNTFsOS4zMzMtOS42YTEuMjEgMS4yMSAwIDAgMCAuMzQyLS44MXYtLjA3OGExLjIxIDEuMjEgMCAwIDAtLjM0Mi0uODEgMS4xNDggMS4xNDggMCAwIDAtMS42NTIgMHoiLz48L3N2Zz4=');
-  height: 100%;
-  width: 9px;
-}
 button.btn--secondary[disabled],
-button.expand-btn[disabled],
-button.btn--secondary[aria-disabled="true"],
-button.expand-btn[aria-disabled="true"] {
+button.btn--secondary[aria-disabled="true"] {
   border-color: #c7c7c7;
   color: #c7c7c7;
 }
@@ -374,6 +388,18 @@ span.expand-btn__icon:only-child {
   display: -ms-flexbox;
   display: flex;
   margin: 0;
+}
+button.expand-btn--primary span.expand-btn__icon,
+button.expand-btn--primary[disabled] span.expand-btn__icon,
+button.expand-btn--primary[aria-disabled="true"] span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjEuNiIgaGVpZ2h0PSIxMi41OCIgdmlld0JveD0iMS4zNSA1LjcgMjEuNiAxMi41OCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyLjE4NiAxOC4yODVjLS40NTEtLjAwOS0uODA5LS4xNjctMS4wNzUtLjQ0MWwtOS4zMzctOS42YTEuNTI3IDEuNTI3IDAgMCAxLS40MjQtLjk5OXYtLjEwOGMuMDE1LS4zODYuMTY2LS43NDEuNDI0LTEuMDA4LjU2LS41NzMgMS41MjktLjU3IDIuMDgyIDBsOC4yOTQgOC41MyA4LjI5Mi04LjUzMmMuNTU4LS41NyAxLjUyNi0uNTcgMi4wOCAwIC4yNjUuMjcuNDE2LjYyOS40MjggMS4wMXYuMDg3Yy0uMDEyLjM5MS0uMTY1Ljc1LS40MjcgMS4wMmwtOS4zMzMgOS42YTEuNDQzIDEuNDQzIDAgMCAxLTEuMDA0LjQ0MSIvPjwvc3ZnPg==');
+}
+button.expand-btn--secondary span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjIxLjYiIGhlaWdodD0iMTIuNTgiIHZpZXdCb3g9IjEuMzUgNS43IDIxLjYgMTIuNTgiPjxwYXRoIGZpbGw9IiMwMDZlZmMiIGQ9Ik0xMi4xODYgMTguMjg1Yy0uNDUxLS4wMDktLjgwOS0uMTY3LTEuMDc1LS40NDFsLTkuMzM3LTkuNmExLjUyNyAxLjUyNyAwIDAgMS0uNDI0LS45OTl2LS4xMDhjLjAxNS0uMzg2LjE2Ni0uNzQxLjQyNC0xLjAwOC41Ni0uNTczIDEuNTI5LS41NyAyLjA4MiAwbDguMjk0IDguNTMgOC4yOTItOC41MzJjLjU1OC0uNTcgMS41MjYtLjU3IDIuMDggMCAuMjY1LjI3LjQxNi42MjkuNDI4IDEuMDF2LjA4N2MtLjAxMi4zOTEtLjE2NS43NS0uNDI3IDEuMDJsLTkuMzMzIDkuNmExLjQ0MyAxLjQ0MyAwIDAgMS0xLjAwNC40NDEiLz48L3N2Zz4=');
+}
+button.expand-btn--secondary:focus span.expand-btn__icon,
+button.expand-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]) span.expand-btn__icon {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjIxLjYiIGhlaWdodD0iMTIuNTgiIHZpZXdCb3g9IjEuMzUgNS43IDIxLjYgMTIuNTgiPjxwYXRoIGZpbGw9IiMxMDI5OWMiIGQ9Ik0xMi4xODYgMTguMjg1Yy0uNDUxLS4wMDktLjgwOS0uMTY3LTEuMDc1LS40NDFsLTkuMzM3LTkuNmExLjUyNyAxLjUyNyAwIDAgMS0uNDI0LS45OTl2LS4xMDhjLjAxNS0uMzg2LjE2Ni0uNzQxLjQyNC0xLjAwOC41Ni0uNTczIDEuNTI5LS41NyAyLjA4MiAwbDguMjk0IDguNTMgOC4yOTItOC41MzJjLjU1OC0uNTcgMS41MjYtLjU3IDIuMDggMCAuMjY1LjI3LjQxNi42MjkuNDI4IDEuMDF2LjA4N2MtLjAxMi4zOTEtLjE2NS43NS0uNDI3IDEuMDJsLTkuMzMzIDkuNmExLjQ0MyAxLjQ0MyAwIDAgMS0xLjAwNC40NDEiLz48L3N2Zz4=');
 }
 .checkbox {
   display: -webkit-inline-box;

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -45,6 +45,32 @@ a.cta-btn {
     }
 }
 
+button.expand-btn {
+    background-color: @ds6-color-g201-gray;
+    border-color: @ds6-color-g204-gray;
+    color: @ds6-color-g206-gray;
+
+    &:active {
+        border-color: @ds6-color-g206-gray;
+    }
+
+    &[aria-expanded="true"] {
+        .expand-btn__icon {
+            transform: rotate(180deg);
+        }
+    }
+
+    &[disabled],
+    &[aria-disabled="true"] {
+        border-color: @ds6-color-disabled;
+        color: @ds6-color-disabled;
+
+        span.expand-btn__icon {
+            .icon-chevron-down-disabled(9px, 100%);
+        }
+    }
+}
+
 // BEM block mods
 
 button.btn--small,
@@ -64,6 +90,7 @@ a.cta-btn--large {
 }
 
 button.btn--primary,
+button.expand-btn--primary,
 a.fake-btn--primary {
     background-color: @ds6-color-p002-blue;
     border-color: @ds6-color-p002-blue;
@@ -71,14 +98,15 @@ a.fake-btn--primary {
     font-weight: bold;
 
     &:focus,
-    &:hover,
+    &:hover:not([disabled]):not([aria-disabled="true"]),
     &:active {
         background-color: @ds6-color-p003-blue;
         border-color: @ds6-color-p003-blue;
     }
 }
 
-button.btn--primary {
+button.btn--primary,
+button.expand-btn--primary {
     &[disabled],
     &[aria-disabled="true"] {
         background-color: @ds6-color-disabled;
@@ -101,43 +129,21 @@ a.fake-btn--primary {
 }
 
 button.btn--secondary,
+button.expand-btn--secondary,
 a.fake-btn--secondary {
     background-color: @ds6-color-g201-gray;
     border-color: @ds6-color-p002-blue;
     color: @ds6-color-p002-blue;
 
     &:focus,
-    &:hover,
+    &:hover:not([disabled]):not([aria-disabled="true"]),
     &:active {
         border-color: @ds6-color-p003-blue;
         color: @ds6-color-p003-blue;
     }
 }
 
-button.expand-btn {
-    background-color: @ds6-color-g201-gray;
-    border-color: @ds6-color-g204-gray;
-    color: @ds6-color-g206-gray;
-
-    &:active {
-        border-color: @ds6-color-g206-gray;
-    }
-
-    &[aria-expanded="true"] {
-        .expand-btn__icon {
-            transform: rotate(180deg);
-        }
-    }
-
-    &[disabled] {
-        span.expand-btn__icon {
-            .icon-chevron-down-disabled(9px, 100%);
-        }
-    }
-}
-
-button.btn--secondary,
-button.expand-btn {
+button.btn--secondary {
     &[disabled],
     &[aria-disabled="true"] {
         border-color: @ds6-color-disabled;
@@ -324,5 +330,26 @@ span.expand-btn__icon {
     &:only-child {
         display: flex;
         margin: 0;
+    }
+}
+
+button.expand-btn--primary,
+button.expand-btn--primary[disabled],
+button.expand-btn--primary[aria-disabled="true"] {
+    span.expand-btn__icon {
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjEuNiIgaGVpZ2h0PSIxMi41OCIgdmlld0JveD0iMS4zNSA1LjcgMjEuNiAxMi41OCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyLjE4NiAxOC4yODVjLS40NTEtLjAwOS0uODA5LS4xNjctMS4wNzUtLjQ0MWwtOS4zMzctOS42YTEuNTI3IDEuNTI3IDAgMCAxLS40MjQtLjk5OXYtLjEwOGMuMDE1LS4zODYuMTY2LS43NDEuNDI0LTEuMDA4LjU2LS41NzMgMS41MjktLjU3IDIuMDgyIDBsOC4yOTQgOC41MyA4LjI5Mi04LjUzMmMuNTU4LS41NyAxLjUyNi0uNTcgMi4wOCAwIC4yNjUuMjcuNDE2LjYyOS40MjggMS4wMXYuMDg3Yy0uMDEyLjM5MS0uMTY1Ljc1LS40MjcgMS4wMmwtOS4zMzMgOS42YTEuNDQzIDEuNDQzIDAgMCAxLTEuMDA0LjQ0MSIvPjwvc3ZnPg==');
+    }
+}
+
+button.expand-btn--secondary {
+    span.expand-btn__icon {
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjIxLjYiIGhlaWdodD0iMTIuNTgiIHZpZXdCb3g9IjEuMzUgNS43IDIxLjYgMTIuNTgiPjxwYXRoIGZpbGw9IiMwMDZlZmMiIGQ9Ik0xMi4xODYgMTguMjg1Yy0uNDUxLS4wMDktLjgwOS0uMTY3LTEuMDc1LS40NDFsLTkuMzM3LTkuNmExLjUyNyAxLjUyNyAwIDAgMS0uNDI0LS45OTl2LS4xMDhjLjAxNS0uMzg2LjE2Ni0uNzQxLjQyNC0xLjAwOC41Ni0uNTczIDEuNTI5LS41NyAyLjA4MiAwbDguMjk0IDguNTMgOC4yOTItOC41MzJjLjU1OC0uNTcgMS41MjYtLjU3IDIuMDggMCAuMjY1LjI3LjQxNi42MjkuNDI4IDEuMDF2LjA4N2MtLjAxMi4zOTEtLjE2NS43NS0uNDI3IDEuMDJsLTkuMzMzIDkuNmExLjQ0MyAxLjQ0MyAwIDAgMS0xLjAwNC40NDEiLz48L3N2Zz4=');
+    }
+
+    &:focus,
+    &:hover:not([disabled]):not([aria-disabled="true"]) {
+        span.expand-btn__icon {
+            background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjIxLjYiIGhlaWdodD0iMTIuNTgiIHZpZXdCb3g9IjEuMzUgNS43IDIxLjYgMTIuNTgiPjxwYXRoIGZpbGw9IiMxMDI5OWMiIGQ9Ik0xMi4xODYgMTguMjg1Yy0uNDUxLS4wMDktLjgwOS0uMTY3LTEuMDc1LS40NDFsLTkuMzM3LTkuNmExLjUyNyAxLjUyNyAwIDAgMS0uNDI0LS45OTl2LS4xMDhjLjAxNS0uMzg2LjE2Ni0uNzQxLjQyNC0xLjAwOC41Ni0uNTczIDEuNTI5LS41NyAyLjA4MiAwbDguMjk0IDguNTMgOC4yOTItOC41MzJjLjU1OC0uNTcgMS41MjYtLjU3IDIuMDggMCAuMjY1LjI3LjQxNi42MjkuNDI4IDEuMDF2LjA4N2MtLjAxMi4zOTEtLjE2NS43NS0uNDI3IDEuMDJsLTkuMzMzIDkuNmExLjQ0MyAxLjQ0MyAwIDAgMS0xLjAwNC40NDEiLz48L3N2Zz4=');
+        }
     }
 }


### PR DESCRIPTION
Fixes #235 

Menu button / expand button now supports primary and secondary modifiers (and all disabled/hover/etc states)

Note that I had to change the source order of the `.expand-btn` block class for cascade reasons.

<img width="1038" alt="screen shot 2018-06-27 at 4 23 06 pm" src="https://user-images.githubusercontent.com/38065/42005770-12a3d9c2-7a2b-11e8-81e4-27b3e83f2d94.png">
 
Please pull and test locally.