### PR TITLE
Fix for combobox second click;

### DIFF
--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -46,6 +46,16 @@
 .combobox__control > input::selection {
   background: #fff;
 }
+.combobox__control::after {
+  content: '';
+  background-color: transparent;
+  display: inline-block;
+  height: 40px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
 span.combobox__icon {
   background-repeat: no-repeat;
   background-size: contain;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -47,8 +47,8 @@
   background: #fff;
 }
 .combobox__control::after {
-  content: '';
   background-color: transparent;
+  content: '';
   display: inline-block;
   height: 40px;
   left: 0;

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -244,8 +244,8 @@ span.fake-menu__status {
   background: #fff;
 }
 .combobox__control::after {
-  content: '';
   background-color: transparent;
+  content: '';
   display: inline-block;
   height: 40px;
   left: 0;

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -243,6 +243,16 @@ span.fake-menu__status {
 .combobox__control > input::selection {
   background: #fff;
 }
+.combobox__control::after {
+  content: '';
+  background-color: transparent;
+  display: inline-block;
+  height: 40px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
 span.combobox__icon {
   background-repeat: no-repeat;
   background-size: contain;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1656,8 +1656,8 @@ span.fake-menu__status {
   background: #fff;
 }
 .combobox__control::after {
-  content: '';
   background-color: transparent;
+  content: '';
   display: inline-block;
   height: 40px;
   left: 0;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1655,6 +1655,16 @@ span.fake-menu__status {
 .combobox__control > input::selection {
   background: #fff;
 }
+.combobox__control::after {
+  content: '';
+  background-color: transparent;
+  display: inline-block;
+  height: 40px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
 span.combobox__icon {
   background-repeat: no-repeat;
   background-size: contain;

--- a/src/less/combobox/ds6/combobox-base.less
+++ b/src/less/combobox/ds6/combobox-base.less
@@ -54,6 +54,18 @@
     }
 }
 
+// Bug #229 in ebayui-core: adding a pseudo-element fixes the second click/touch to close the menu
+.combobox__control::after {
+    content: '';
+    background-color: transparent;
+    display: inline-block;
+    height: @combobox-height;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+
 span.combobox__icon {
     .background-icon-base;
     .icon-chevron-down-bold(9px, @combobox-height);

--- a/src/less/combobox/ds6/combobox-base.less
+++ b/src/less/combobox/ds6/combobox-base.less
@@ -56,8 +56,8 @@
 
 // Bug #229 in ebayui-core: adding a pseudo-element fixes the second click/touch to close the menu
 .combobox__control::after {
-    content: '';
     background-color: transparent;
+    content: '';
     display: inline-block;
     height: @combobox-height;
     left: 0;


### PR DESCRIPTION
## Description
This change adds a pseudo-element to the `combobox__control` which provides a clickable area. This might not be desirable when the combobox is editable in the future, but fixes the problem of the second click for the combobox at this juncture.

## References
Fixes this eBayUI bug: https://github.com/eBay/ebayui-core/issues/229