### PR TITLE
Button: replace line-height based alignment with flexbox

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -1,20 +1,28 @@
 button.btn,
 button.expand-btn,
 a.fake-btn {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   background-color: #fff;
   border-color: #ccc;
   border-radius: 3px;
   border-style: solid;
   border-width: 1px;
   color: #0654ba;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-family: inherit;
   font-size: 14px;
   font-weight: normal;
   height: 40px;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   margin: 0;
   padding: 0 48px;
   text-align: center;
-  vertical-align: middle;
 }
 button.btn:hover,
 button.expand-btn:hover,
@@ -28,10 +36,6 @@ button.btn:active,
 button.expand-btn:active,
 a.fake-btn:active {
   border-color: #555;
-}
-button.btn,
-button.expand-btn {
-  line-height: 1.15;
 }
 button.btn[disabled],
 button.expand-btn[disabled],
@@ -65,8 +69,6 @@ button[aria-disabled="true"].expand-btn {
 }
 a.fake-btn {
   box-sizing: border-box;
-  display: inline-block;
-  line-height: 40px;
   text-decoration: none;
 }
 a.fake-btn:not([href]),
@@ -255,18 +257,12 @@ a.fake-btn--medium {
   height: 40px;
   padding: 0 48px;
 }
-a.fake-btn--medium {
-  line-height: 40px;
-}
 button.btn--small,
 button.expand-btn--small,
 a.fake-btn--small {
   font-size: 12px;
   height: 32px;
   padding: 0 32px;
-}
-a.fake-btn--small {
-  line-height: 32px;
 }
 button.btn--large,
 button.expand-btn--large,
@@ -275,18 +271,12 @@ a.fake-btn--large {
   height: 48px;
   padding: 0 80px;
 }
-a.fake-btn--large {
-  line-height: 48px;
-}
 button.btn--extra-large,
 button.expand-btn--extra-large,
 a.fake-btn--extra-large {
   font-size: 18px;
   height: 56px;
   padding: 0 112px;
-}
-a.fake-btn--extra-large {
-  line-height: 56px;
 }
 button.expand-btn--small,
 button.expand-btn--large,
@@ -315,7 +305,6 @@ button.expand-btn--extra-large {
   -ms-flex-item-align: center;
       -ms-grid-row-align: center;
       align-self: center;
-  line-height: normal;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -2,21 +2,27 @@ button.btn,
 button.expand-btn,
 a.fake-btn,
 a.cta-btn {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border: 1px solid;
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-family: inherit;
   font-size: 16px;
   height: 40px;
-  line-height: 40px;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   margin: 0;
   max-width: 100%;
   padding: 0 16px;
   text-align: center;
-  vertical-align: middle;
 }
 a.fake-btn,
 a.cta-btn {
-  box-sizing: border-box;
-  display: inline-block;
   text-decoration: none;
 }
 a.cta-btn {
@@ -60,14 +66,12 @@ button.expand-btn--small,
 a.fake-btn--small {
   font-size: 14px;
   height: 32px;
-  line-height: 32px;
 }
 button.btn--large,
 button.expand-btn--large,
 a.fake-btn--large,
 a.cta-btn--large {
   height: 48px;
-  line-height: 48px;
 }
 button.btn--primary,
 button.expand-btn--primary,
@@ -219,6 +223,9 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell,
 .expand-btn__cell {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -254,7 +261,6 @@ a.cta-btn--fluid {
   -ms-flex-item-align: center;
       -ms-grid-row-align: center;
       align-self: center;
-  line-height: normal;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,

--- a/dist/listbox/ds4/listbox.css
+++ b/dist/listbox/ds4/listbox.css
@@ -16,7 +16,6 @@ select.listbox__control {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: inherit;
   height: 40px;
-  line-height: 1.15;
   margin: 0;
   padding: 0 40px 0 16px;
 }

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -17,7 +17,7 @@
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 0;
+  top: 1px;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .select::after {
@@ -34,8 +34,8 @@
   font-family: "Market Sans", Arial, sans-serif;
   font-size: 16px;
   height: 40px;
-  margin-top: -1px;
-  padding: 8px 30px 8px 16px;
+  margin: 0;
+  padding: 0 30px 0 16px;
 }
 .select > select:focus {
   border-color: #4295ff;

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -17,7 +17,6 @@ textarea.textbox__control {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: inherit;
   height: 40px;
-  line-height: 1.15;
   margin: 0;
   padding: 0 16px 0 16px;
 }

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -14,9 +14,8 @@ textarea.textbox__control {
   box-sizing: border-box;
   color: #111820;
   font-family: inherit;
-  font-size: inherit;
+  font-size: 16px;
   height: 40px;
-  line-height: 1.5;
   margin: 0;
   padding: 0 16px 0 16px;
 }

--- a/docs/_layouts/ds6/test.html
+++ b/docs/_layouts/ds6/test.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>{{ page.title }}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <link rel="stylesheet" type="text/css" href="../../../static/ds6/skin.css">
+        <link rel="stylesheet" type="text/css" href="../../../static/ds4/test.css">
+    </head>
+    <body>
+        <header>
+            <h1>{{ page.title }}</h1>
+        </header>
+        <div role="main">
+            {{ content }}
+        </div>
+    </body>
+</html>

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -220,20 +220,28 @@ button.img-btn:not([disabled]):active {
 button.btn,
 button.expand-btn,
 a.fake-btn {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   background-color: #fff;
   border-color: #ccc;
   border-radius: 3px;
   border-style: solid;
   border-width: 1px;
   color: #0654ba;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-family: inherit;
   font-size: 14px;
   font-weight: normal;
   height: 40px;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   margin: 0;
   padding: 0 48px;
   text-align: center;
-  vertical-align: middle;
 }
 button.btn:hover,
 button.expand-btn:hover,
@@ -247,10 +255,6 @@ button.btn:active,
 button.expand-btn:active,
 a.fake-btn:active {
   border-color: #555;
-}
-button.btn,
-button.expand-btn {
-  line-height: 1.15;
 }
 button.btn[disabled],
 button.expand-btn[disabled],
@@ -284,8 +288,6 @@ button[aria-disabled="true"].expand-btn {
 }
 a.fake-btn {
   box-sizing: border-box;
-  display: inline-block;
-  line-height: 40px;
   text-decoration: none;
 }
 a.fake-btn:not([href]),
@@ -474,18 +476,12 @@ a.fake-btn--medium {
   height: 40px;
   padding: 0 48px;
 }
-a.fake-btn--medium {
-  line-height: 40px;
-}
 button.btn--small,
 button.expand-btn--small,
 a.fake-btn--small {
   font-size: 12px;
   height: 32px;
   padding: 0 32px;
-}
-a.fake-btn--small {
-  line-height: 32px;
 }
 button.btn--large,
 button.expand-btn--large,
@@ -494,18 +490,12 @@ a.fake-btn--large {
   height: 48px;
   padding: 0 80px;
 }
-a.fake-btn--large {
-  line-height: 48px;
-}
 button.btn--extra-large,
 button.expand-btn--extra-large,
 a.fake-btn--extra-large {
   font-size: 18px;
   height: 56px;
   padding: 0 112px;
-}
-a.fake-btn--extra-large {
-  line-height: 56px;
 }
 button.expand-btn--small,
 button.expand-btn--large,
@@ -534,7 +524,6 @@ button.expand-btn--extra-large {
   -ms-flex-item-align: center;
       -ms-grid-row-align: center;
       align-self: center;
-  line-height: normal;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -1430,7 +1419,6 @@ select.listbox__control {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: inherit;
   height: 40px;
-  line-height: 1.15;
   margin: 0;
   padding: 0 40px 0 16px;
 }
@@ -2507,7 +2495,6 @@ textarea.textbox__control {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: inherit;
   height: 40px;
-  line-height: 1.15;
   margin: 0;
   padding: 0 16px 0 16px;
 }

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -220,20 +220,28 @@ button.img-btn:not([disabled]):active {
 button.btn,
 button.expand-btn,
 a.fake-btn {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   background-color: #fff;
   border-color: #ccc;
   border-radius: 3px;
   border-style: solid;
   border-width: 1px;
   color: #0654ba;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-family: inherit;
   font-size: 14px;
   font-weight: normal;
   height: 40px;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   margin: 0;
   padding: 0 48px;
   text-align: center;
-  vertical-align: middle;
 }
 button.btn:hover,
 button.expand-btn:hover,
@@ -247,10 +255,6 @@ button.btn:active,
 button.expand-btn:active,
 a.fake-btn:active {
   border-color: #555;
-}
-button.btn,
-button.expand-btn {
-  line-height: 1.15;
 }
 button.btn[disabled],
 button.expand-btn[disabled],
@@ -284,8 +288,6 @@ button[aria-disabled="true"].expand-btn {
 }
 a.fake-btn {
   box-sizing: border-box;
-  display: inline-block;
-  line-height: 40px;
   text-decoration: none;
 }
 a.fake-btn:not([href]),
@@ -474,18 +476,12 @@ a.fake-btn--medium {
   height: 40px;
   padding: 0 48px;
 }
-a.fake-btn--medium {
-  line-height: 40px;
-}
 button.btn--small,
 button.expand-btn--small,
 a.fake-btn--small {
   font-size: 12px;
   height: 32px;
   padding: 0 32px;
-}
-a.fake-btn--small {
-  line-height: 32px;
 }
 button.btn--large,
 button.expand-btn--large,
@@ -494,18 +490,12 @@ a.fake-btn--large {
   height: 48px;
   padding: 0 80px;
 }
-a.fake-btn--large {
-  line-height: 48px;
-}
 button.btn--extra-large,
 button.expand-btn--extra-large,
 a.fake-btn--extra-large {
   font-size: 18px;
   height: 56px;
   padding: 0 112px;
-}
-a.fake-btn--extra-large {
-  line-height: 56px;
 }
 button.expand-btn--small,
 button.expand-btn--large,
@@ -534,7 +524,6 @@ button.expand-btn--extra-large {
   -ms-flex-item-align: center;
       -ms-grid-row-align: center;
       align-self: center;
-  line-height: normal;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -1430,7 +1419,6 @@ select.listbox__control {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: inherit;
   height: 40px;
-  line-height: 1.15;
   margin: 0;
   padding: 0 40px 0 16px;
 }
@@ -2507,7 +2495,6 @@ textarea.textbox__control {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: inherit;
   height: 40px;
-  line-height: 1.15;
   margin: 0;
   padding: 0 16px 0 16px;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -94,21 +94,27 @@ button.btn,
 button.expand-btn,
 a.fake-btn,
 a.cta-btn {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border: 1px solid;
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-family: inherit;
   font-size: 16px;
   height: 40px;
-  line-height: 40px;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   margin: 0;
   max-width: 100%;
   padding: 0 16px;
   text-align: center;
-  vertical-align: middle;
 }
 a.fake-btn,
 a.cta-btn {
-  box-sizing: border-box;
-  display: inline-block;
   text-decoration: none;
 }
 a.cta-btn {
@@ -152,14 +158,12 @@ button.expand-btn--small,
 a.fake-btn--small {
   font-size: 14px;
   height: 32px;
-  line-height: 32px;
 }
 button.btn--large,
 button.expand-btn--large,
 a.fake-btn--large,
 a.cta-btn--large {
   height: 48px;
-  line-height: 48px;
 }
 button.btn--primary,
 button.expand-btn--primary,
@@ -311,6 +315,9 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell,
 .expand-btn__cell {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -346,7 +353,6 @@ a.cta-btn--fluid {
   -ms-flex-item-align: center;
       -ms-grid-row-align: center;
       align-self: center;
-  line-height: normal;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -2117,7 +2123,7 @@ span.inline-notice {
   pointer-events: none;
   position: absolute;
   right: 16px;
-  top: 0;
+  top: 1px;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .select::after {
@@ -2134,8 +2140,8 @@ span.inline-notice {
   font-family: "Market Sans", Arial, sans-serif;
   font-size: 16px;
   height: 40px;
-  margin-top: -1px;
-  padding: 8px 30px 8px 16px;
+  margin: 0;
+  padding: 0 30px 0 16px;
 }
 .select > select:focus {
   border-color: #4295ff;
@@ -2167,9 +2173,8 @@ textarea.textbox__control {
   box-sizing: border-box;
   color: #111820;
   font-family: inherit;
-  font-size: inherit;
+  font-size: 16px;
   height: 40px;
-  line-height: 1.5;
   margin: 0;
   padding: 0 16px 0 16px;
 }

--- a/docs/test/misc/ds4/alignment-controls-inline.html
+++ b/docs/test/misc/ds4/alignment-controls-inline.html
@@ -10,7 +10,7 @@ title: Inline Alignment of Textbox, Listbox, Button &amp; Link
 </svg>
 
 <h2>Small</h2>
-<div class="test children-middle">
+<div class="test">
     <span class="textbox textbox--small">
         <input class="textbox__control" placeholder="placeholder text" type="text" />
     </span>
@@ -31,7 +31,7 @@ title: Inline Alignment of Textbox, Listbox, Button &amp; Link
 </div>
 
 <h2>Medium</h2>
-<div class="test children-middle">
+<div class="test">
     <span class="textbox">
         <input class="textbox__control" placeholder="placeholder text" type="text" />
     </span>
@@ -52,7 +52,7 @@ title: Inline Alignment of Textbox, Listbox, Button &amp; Link
 </div>
 
 <h2>Large</h2>
-<div class="test children-middle">
+<div class="test">
     <span class="textbox textbox--large">
         <input class="textbox__control" placeholder="placeholder text" type="text" />
     </span>
@@ -73,7 +73,7 @@ title: Inline Alignment of Textbox, Listbox, Button &amp; Link
 </div>
 
 <h2>Extra Large</h2>
-<div class="test children-middle">
+<div class="test">
     <span class="textbox textbox--extra-large">
         <input class="textbox__control" placeholder="placeholder text" type="text" />
     </span>

--- a/docs/test/misc/ds6/alignment-controls-inline.html
+++ b/docs/test/misc/ds6/alignment-controls-inline.html
@@ -1,0 +1,20 @@
+---
+layout: ds6/test
+title: Inline Alignment of Textbox, Select, Button &amp; Fake Button
+---
+
+<h2>Medium</h2>
+<div class="test" style="padding: 1px">
+    <span class="textbox">
+        <input class="textbox__control" placeholder="placeholder text" type="text" />
+    </span>
+    <span class="select">
+        <select class="select__control">
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+        </select>
+    </span>
+    <button type="button" class="btn btn--primary btn--medium">Button</button>
+    <a class="fake-btn fake-btn--primary fake-btn--medium" href="#">Fake Button</a>
+</div>

--- a/src/less/button/ds4/button-base.less
+++ b/src/less/button/ds4/button-base.less
@@ -7,20 +7,22 @@
 button.btn,
 button.expand-btn,
 a.fake-btn {
+    align-items: center;
     background-color: @color-core-white;
     border-color: @color-core-gray-silver;
     border-radius: 3px;
     border-style: solid;
     border-width: 1px;
     color: @color-interface-cta;
+    display: inline-flex;
     font-family: inherit;
     font-size: 14px;
     font-weight: normal;
     height: @height-control-medium;
+    justify-content: center;
     margin: 0; // Remove the button margin in Firefox and Safari */
     padding: 0 48px;
     text-align: center;
-    vertical-align: middle; // align buttons and faux buttons on same line
 
     &:hover,
     &:focus {
@@ -34,8 +36,6 @@ a.fake-btn {
 
 button.btn,
 button.expand-btn {
-    line-height: 1.15;
-
     &[disabled],
     &[aria-disabled="true"] {
         background-color: @color-core-gray-silver;
@@ -62,8 +62,6 @@ button[aria-disabled="true"] {
 
 a.fake-btn {
     box-sizing: border-box;
-    display: inline-block;
-    line-height: 40px;
     text-decoration: none;
 
     &:not([href]),
@@ -238,20 +236,12 @@ a.fake-btn--medium {
     padding: 0 48px;
 }
 
-a.fake-btn--medium {
-    line-height: @height-control-medium;
-}
-
 button.btn--small,
 button.expand-btn--small,
 a.fake-btn--small {
     font-size: 12px;
     height: @height-control-small;
     padding: 0 32px;
-}
-
-a.fake-btn--small {
-    line-height: @height-control-small;
 }
 
 button.btn--large,
@@ -262,20 +252,12 @@ a.fake-btn--large {
     padding: 0 80px;
 }
 
-a.fake-btn--large {
-    line-height: @height-control-large;
-}
-
 button.btn--extra-large,
 button.expand-btn--extra-large,
 a.fake-btn--extra-large {
     font-size: 18px;
     height: @height-control-extra-large;
     padding: 0 112px;
-}
-
-a.fake-btn--extra-large {
-    line-height: @height-control-extra-large;
 }
 
 button.expand-btn--small,
@@ -302,7 +284,6 @@ button.expand-btn--extra-large {
 .fake-btn__icon,
 .expand-btn__icon {
     align-self: center;
-    line-height: normal;
 
     &:first-child {
         margin-right: 8px;

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -9,22 +9,22 @@ button.btn,
 button.expand-btn,
 a.fake-btn,
 a.cta-btn {
+    align-items: center;
     border: 1px solid;
+    box-sizing: border-box;
+    display: inline-flex;
     font-family: inherit;
     font-size: 16px;
     height: 40px;
-    line-height: 40px;
+    justify-content: center;
     margin: 0; // Remove the button margin in Firefox and Safari */
     max-width: 100%;
     padding: 0 16px;
     text-align: center;
-    vertical-align: middle;
 }
 
 a.fake-btn,
 a.cta-btn {
-    box-sizing: border-box;
-    display: inline-block;
     text-decoration: none;
 }
 
@@ -78,7 +78,6 @@ button.expand-btn--small,
 a.fake-btn--small {
     font-size: 14px;
     height: 32px;
-    line-height: 32px;
 }
 
 button.btn--large,
@@ -86,7 +85,6 @@ button.expand-btn--large,
 a.fake-btn--large,
 a.cta-btn--large {
     height: 48px;
-    line-height: 48px;
 }
 
 button.btn--primary,
@@ -262,6 +260,7 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell,
 .expand-btn__cell {
+    align-items: center;
     display: flex;
     height: 100%;
     width: 100%;
@@ -290,7 +289,6 @@ a.cta-btn--fluid {
 .cta-btn__icon,
 .expand-btn__icon {
     align-self: center;
-    line-height: normal;
 
     &:first-child {
         margin-right: 8px;

--- a/src/less/listbox/ds4/listbox-base.less
+++ b/src/less/listbox/ds4/listbox-base.less
@@ -24,7 +24,6 @@ select.listbox__control {
     font-family: @font-family-base;
     font-size: inherit;
     height: @height-control-medium;
-    line-height: 1.15; // normalized line-height
     margin: 0;
     padding: 0 40px 0 16px;
 

--- a/src/less/select/ds6/select-base.less
+++ b/src/less/select/ds6/select-base.less
@@ -13,7 +13,7 @@
         pointer-events: none;
         position: absolute;
         right: 16px;
-        top: 0;
+        top: 1px;
     }
 }
 
@@ -31,8 +31,8 @@
     font-family: @ds6-font-family-custom; // for some reason this needs to be explicitly set
     font-size: 16px;
     height: 40px;
-    margin-top: -1px; // account for the border
-    padding: 8px 30px 8px 16px;
+    margin: 0; // Remove the margin in Firefox and Safari.
+    padding: 0 30px 0 16px;
 
     &:focus {
         border-color: @ds6-color-p004-blue;

--- a/src/less/textbox/ds4/textbox-base.less
+++ b/src/less/textbox/ds4/textbox-base.less
@@ -21,7 +21,6 @@ textarea.textbox__control {
     font-family: @font-family-base;
     font-size: inherit;
     height: @height-control-medium;
-    line-height: 1.15; // normalized line-height
     margin: 0; // Remove the margin in Firefox and Safari.
     padding: 0 16px 0 16px;
 

--- a/src/less/textbox/ds6/textbox-base.less
+++ b/src/less/textbox/ds6/textbox-base.less
@@ -18,9 +18,8 @@ textarea.textbox__control {
     box-sizing: border-box;
     color: @ds6-color-g206-gray;
     font-family: inherit;
-    font-size: inherit;
+    font-size: 16px; // for Market Sans to align with buttons and select, it needs same font-size
     height: 40px;
-    line-height: 1.5;
     margin: 0; // Remove the margin in Firefox and Safari.
     padding: 0 16px 0 16px;
 


### PR DESCRIPTION
Removes the line-height based rules which addressed alignment issues in IE9 and IE10, but were difficult to reason with and felt brittle.

This change will also make it easier to allow buttons to wrap when they have a fixed width (i.e. we will just need to override height rules, not all the different line-heights too).

Overall, this change simplifies the CSS, at the expense of IE9 and 10 support.

Existing DS4 tests continue to work (except for the aforementioned IE9 and IE10).

<img width="937" alt="screen shot 2018-07-03 at 4 30 56 pm" src="https://user-images.githubusercontent.com/38065/42249580-f25d1f4c-7ee0-11e8-91da-ca8dde56cddf.png">

Also added a quick DS6 test page:

<img width="964" alt="screen shot 2018-07-03 at 4 39 29 pm" src="https://user-images.githubusercontent.com/38065/42249582-f57cfb02-7ee0-11e8-8ebe-3ea39979bd68.png">
