### PR TITLE
Docs: fix custom checkbox inclusion

### DIFF
--- a/docs/_includes/ds4/checkbox-custom.html
+++ b/docs/_includes/ds4/checkbox-custom.html
@@ -66,5 +66,3 @@
     {% endhighlight %}
 
     <p>Be careful when using a custom checkbox; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
-
-</div>

--- a/docs/_includes/ds6/checkbox-custom.html
+++ b/docs/_includes/ds6/checkbox-custom.html
@@ -66,5 +66,3 @@
     {% endhighlight %}
 
     <p>Be careful when using a custom checkbox; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
-
-</div>


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
Quick fix, removes invalid markup that was destroying the ds6 docs (though it wasn't problematic in the ds4 docs).

## References
Accidentally caused by https://github.com/eBay/skin/pull/253

## Screenshots
<!-- Upload screenshots if appropriate-->
Issue:
<img width="996" alt="screen shot 2018-07-09 at 1 29 45 pm" src="https://user-images.githubusercontent.com/3595986/42474428-6665322c-837c-11e8-9a04-5c40334dc5fb.png">
