### PR TITLE
Button: apply only-child styling to svg icon

### DIFF
--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -302,7 +302,8 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
-span.expand-btn__icon:only-child {
+span.expand-btn__icon:only-child,
+svg.expand-btn__icon:only-child {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -254,10 +254,21 @@
             <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
                 <span class="expand-btn__icon"></span>
             </button>
+            <button aria-expanded="false" class="expand-btn expand-btn-example" aria-label="Expand/Collapse">
+                <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
+                    <use xlink:href="#icon-chevron-down-bold"></use>
+                </svg>
+            </button>
         </div>
         {% highlight html %}
 <button aria-expanded="false" class="expand-btn" aria-label="Expand/Collapse">
     <span class="expand-btn__icon"></span>
+</button>
+
+<button aria-expanded="false" class="expand-btn" aria-label="Expand/Collapse">
+    <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
+        <use xlink:href="#icon-chevron-down-bold"></use>
+    </svg>
 </button>
         {% endhighlight %}
     </div>

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -394,7 +394,8 @@ span.expand-btn__icon {
       flex-shrink: 0;
   margin-left: 8px;
 }
-span.expand-btn__icon:only-child {
+span.expand-btn__icon:only-child,
+svg.expand-btn__icon:only-child {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -324,7 +324,10 @@ span.expand-btn__icon {
     background-position-y: center;
     flex-shrink: 0;
     margin-left: 8px;
+}
 
+span.expand-btn__icon,
+svg.expand-btn__icon {
     &:only-child {
         display: flex;
         margin: 0;


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- adds rule for `svg.expand-btn__icon:only-child` alongside `span.expand-btn__icon:only-child`
- adds second example to button docs

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Questions:
1) Is `display: flex` supposed to only apply to `span`? I wasn't able to tell from https://github.com/eBay/skin/pull/157
2) Should the docs example be under Menu instead?

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Fixes #258 

## Screenshots
<!-- Upload screenshots if appropriate-->
<img width="749" alt="screen shot 2018-07-10 at 9 56 10 am" src="https://user-images.githubusercontent.com/3595986/42525252-87888bb0-8427-11e8-992f-147ea586bda6.png">

