### PR TITLE
pagination alignment fix

### DIFF
--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -3,6 +3,9 @@
   display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 .pagination svg {
   display: inline-block;
@@ -13,9 +16,6 @@
   width: 1em;
 }
 .pagination__items {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;


### PR DESCRIPTION
## Description
css change to move an align-items: center style from the .pagination__items to the .pagination class to fix vertical alignment between arrows and page numbers
