### PR TITLE
Checkbox & Radio: added DS6 test pages

### DIFF
--- a/docs/_layouts/ds6/test.html
+++ b/docs/_layouts/ds6/test.html
@@ -6,7 +6,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <link rel="stylesheet" type="text/css" href="../../../static/ds6/skin.css">
-        <link rel="stylesheet" type="text/css" href="../../../static/ds4/test.css">
     </head>
     <body>
         <header>

--- a/docs/test/checkbox/ds4/index.html
+++ b/docs/test/checkbox/ds4/index.html
@@ -28,7 +28,7 @@ title: Checkbox
 <h2>Background, Disabled</h2>
 <div class="test">
     <span class="checkbox">
-        <input aria-label="Disabled checkbox example" class="checkbox__control" disabled type="checkbox" value="1" name="test1b" />
+        <input aria-label="Disabled checkbox example" class="checkbox__control" checked disabled type="checkbox" value="1" name="test1b" />
         <span class="checkbox__icon"></span>
     </span>
 </div>

--- a/docs/test/checkbox/ds6/index.html
+++ b/docs/test/checkbox/ds6/index.html
@@ -1,0 +1,127 @@
+---
+layout: ds6/test
+title: Checkbox
+---
+
+<svg hidden>
+    <symbol id="icon-checkbox-unchecked" viewBox="4.12 4.1 15.77 15.8">
+        <path fill-rule="evenodd" d="M18.56 5.25H5.44a.19.19 0 0 0-.19.187v13.126a.19.19 0 0 0 .19.187h13.12a.19.19 0 0 0 .19-.187V5.437a.19.19 0 0 0-.19-.187zM4.116 19.9h15.768V4.1H4.116v15.8z"/>
+    </symbol>
+    <symbol id="icon-checkbox-checked" viewBox="4.12 4.1 15.77 15.8">
+        <path d="M4.116 19.9V4.1h15.768v15.8H4.116zm4.28-7.782a.725.725 0 0 0-1.06 0 .816.816 0 0 0 0 1.114l2.998 3.013a.725.725 0 0 0 1.061 0l6.001-6.3a.816.816 0 0 0 0-1.114.725.725 0 0 0-1.06 0l-5.471 5.744-2.469-2.457z"/>
+    </symbol>
+    <symbol id="icon-save-bold" viewBox="1.2 1.95 22 21">
+        <path d="M7.275 4.675c-1.924 0-3.375 1.47-3.375 3.419 0 2.925 3.219 5.893 8.1 10.37 4.881-4.475 8.099-7.444 8.099-10.37 0-1.949-1.45-3.419-3.374-3.419-1.5 0-2.954.972-3.458 2.313l-.072.195h-2.379l-.073-.193c-.513-1.341-1.971-2.315-3.468-2.315zM12 22.156l-1.725-1.578C4.793 15.537 1.2 12.234 1.2 8.094c0-3.446 2.669-6.144 6.075-6.144 1.763 0 3.502.768 4.725 2.07 1.221-1.302 2.963-2.07 4.725-2.07 3.406 0 6.075 2.698 6.075 6.144 0 4.146-3.605 7.455-9.062 12.46L12 22.156z"/>
+    </symbol>
+    <symbol id="icon-save-selected" viewBox="1.2 1.95 22 21">
+        <path d="M12 22.156l-1.725-1.578C4.793 15.537 1.2 12.234 1.2 8.094c0-3.446 2.669-6.144 6.075-6.144 1.763 0 3.502.768 4.725 2.07 1.221-1.302 2.963-2.07 4.725-2.07 3.406 0 6.075 2.698 6.075 6.144 0 4.146-3.605 7.455-9.062 12.46L12 22.156z"/>
+    </symbol>
+</svg>
+
+<h2>Background</h2>
+<div class="test">
+    <span class="checkbox">
+        <input aria-label="Default checkbox example" class="checkbox__control" type="checkbox" value="1" name="test1a" />
+        <span class="checkbox__icon"></span>
+    </span>
+</div>
+
+
+<h2>Background, Disabled</h2>
+<div class="test">
+    <span class="checkbox">
+        <input aria-label="Disabled checkbox example" class="checkbox__control" disabled type="checkbox" value="1" name="test1b" />
+        <span class="checkbox__icon"></span>
+    </span>
+</div>
+
+<h2>Foreground</h2>
+<div class="test">
+    <span class="checkbox">
+        <input aria-label="Inline SVG checkbox example" class="checkbox__control" type="checkbox" value="1" name="test2a" />
+        <span class="checkbox__icon" hidden>
+            <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
+                <use xlink:href="#icon-checkbox-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="checkbox__checked" focusable="false">
+                <use xlink:href="#icon-checkbox-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+
+<h2>Foreground, Disabled</h2>
+<div class="test">
+    <span class="checkbox">
+        <input aria-label="Disabled Inline SVG checkbox example" class="checkbox__control" disabled checked type="checkbox" value="1" name="test2b" />
+        <span class="checkbox__icon" hidden>
+            <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
+                <use xlink:href="#icon-checkbox-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="checkbox__checked" focusable="false">
+                <use xlink:href="#icon-checkbox-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Colour</h2>
+<div class="test">
+    <span class="checkbox" style="color: #5ba71b">
+        <input aria-label="Inline SVG checkbox example" class="checkbox__control" type="checkbox" />
+        <span class="checkbox__icon" hidden>
+            <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
+                <use xlink:href="#icon-checkbox-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="checkbox__checked" focusable="false">
+                <use xlink:href="#icon-checkbox-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Colour, Disabled</h2>
+<div class="test">
+    <span class="checkbox" style="color: #5ba71b">
+        <input aria-label="Inline SVG checkbox example" class="checkbox__control" disabled checked type="checkbox" />
+        <span class="checkbox__icon" hidden>
+            <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
+                <use xlink:href="#icon-checkbox-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="checkbox__checked" focusable="false">
+                <use xlink:href="#icon-checkbox-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Icon</h2>
+<div class="test">
+    <span class="checkbox" style="color: #5ba71b">
+        <input aria-label="Custom checkbox example" class="checkbox__control" type="checkbox" value="1" name="test3a" />
+        <span class="checkbox__icon" hidden>
+            <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
+                <use xlink:href="#icon-save-bold"></use>
+            </svg>
+            <svg aria-hidden="true" class="checkbox__checked" focusable="false">
+                <use xlink:href="#icon-save-selected"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Icon, Disabled</h2>
+<div class="test">
+    <span class="checkbox" style="color: #5ba71b">
+        <input aria-label="Default checkbox example" class="checkbox__control" disabled checked type="checkbox" value="1" name="test3b" />
+        <span class="checkbox__icon" hidden>
+            <svg aria-hidden="true" class="checkbox__unchecked" focusable="false">
+                <use xlink:href="#icon-save-bold"></use>
+            </svg>
+            <svg aria-hidden="true" class="checkbox__checked" focusable="false">
+                <use xlink:href="#icon-save-selected"></use>
+            </svg>
+        </span>
+    </span>
+</div>

--- a/docs/test/checkbox/ds6/index.html
+++ b/docs/test/checkbox/ds6/index.html
@@ -30,7 +30,7 @@ title: Checkbox
 <h2>Background, Disabled</h2>
 <div class="test">
     <span class="checkbox">
-        <input aria-label="Disabled checkbox example" class="checkbox__control" disabled type="checkbox" value="1" name="test1b" />
+        <input aria-label="Disabled checkbox example" class="checkbox__control" checked disabled type="checkbox" value="1" name="test1b" />
         <span class="checkbox__icon"></span>
     </span>
 </div>

--- a/docs/test/radio/ds4/index.html
+++ b/docs/test/radio/ds4/index.html
@@ -28,7 +28,7 @@ title: Radio
 <h2>Background, Disabled</h2>
 <div class="test">
     <span class="radio">
-        <input aria-label="Disabled radio example" class="radio__control" disabled type="radio" value="1" name="test1b" />
+        <input aria-label="Disabled radio example" class="radio__control" checked disabled type="radio" value="1" name="test1b" />
         <span class="radio__icon"></span>
     </span>
 </div>

--- a/docs/test/radio/ds6/index.html
+++ b/docs/test/radio/ds6/index.html
@@ -1,0 +1,124 @@
+---
+layout: ds6/test
+title: Radio
+---
+<svg hidden>
+    <symbol id="icon-radio-unchecked" viewBox="3 3 18 18">
+        <path d="M12 3a9 9 0 1 0 9 9 9 9 0 0 0-9-9m0 1.059c4.38 0 7.941 3.563 7.941 7.941S16.38 19.941 12 19.941 4.059 16.378 4.059 12 7.62 4.059 12 4.059"/>
+    </symbol>
+    <symbol id="icon-radio-checked" viewBox="3 3 18 18">
+        <path d="M12 3a9 9 0 1 0 9 9 9 9 0 0 0-9-9m0 1.059c4.38 0 7.941 3.563 7.941 7.941S16.38 19.941 12 19.941 4.059 16.378 4.059 12 7.62 4.059 12 4.059zm0 13.191a5.25 5.25 0 1 0 0-10.5 5.25 5.25 0 0 0 0 10.5z"/>
+    </symbol>
+    <symbol id="icon-confirmation" viewBox="0 0 32 32">
+        <path fill="#5ba71b" d="M16.009 32c-8.842 0-16.009-7.168-16.009-16.009s7.168-16.009 16.009-16.009c8.842 0 16.009 7.168 16.009 16.009 0 0.007 0 0.013 0 0.020-0.011 8.833-7.174 15.99-16.009 15.99 0 0 0 0 0 0zM16.009 2.319c0 0 0 0 0 0-7.561 0-13.69 6.129-13.69 13.69s6.129 13.69 13.69 13.69c7.561 0 13.69-6.129 13.69-13.69s-6.129-13.69-13.69-13.69z"></path>
+        <path fill="#5ba71b" d="M14.841 23.448c-0.001 0-0.003 0-0.004 0-0.247 0-0.473-0.091-0.646-0.242l-6.232-5.305c-0.213-0.182-0.347-0.451-0.347-0.751 0-0.545 0.442-0.987 0.987-0.987 0.245 0 0.469 0.089 0.641 0.237l5.434 4.637 8.181-10.741c0.183-0.238 0.468-0.39 0.788-0.39 0.548 0 0.992 0.444 0.992 0.992 0 0.228-0.077 0.438-0.206 0.605l-8.81 11.573c-0.137 0.199-0.39 0.358-0.682 0.389l-0.116 0z"></path>
+    </symbol>
+</svg>
+
+<h2>Background</h2>
+<div class="test">
+    <span class="radio">
+        <input aria-label="Default radio example" class="radio__control" type="radio" value="1" name="test1a" />
+        <span class="radio__icon"></span>
+    </span>
+</div>
+
+
+<h2>Background, Disabled</h2>
+<div class="test">
+    <span class="radio">
+        <input aria-label="Disabled radio example" class="radio__control" disabled type="radio" value="1" name="test1b" />
+        <span class="radio__icon"></span>
+    </span>
+</div>
+
+<h2>Foreground</h2>
+<div class="test">
+    <span class="radio">
+        <input aria-label="Inline SVG radio example" class="radio__control" type="radio" value="1" name="test2a" />
+        <span class="radio__icon" hidden>
+            <svg aria-hidden="true" class="radio__unchecked" focusable="false">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="radio__checked" focusable="false">
+                <use xlink:href="#icon-radio-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+
+<h2>Foreground, Disabled</h2>
+<div class="test">
+    <span class="radio">
+        <input aria-label="Disabled Inline SVG radio example" class="radio__control" disabled checked type="radio" value="1" name="test2b" />
+        <span class="radio__icon" hidden>
+            <svg aria-hidden="true" class="radio__unchecked" focusable="false">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="radio__checked" focusable="false">
+                <use xlink:href="#icon-radio-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Colour</h2>
+<div class="test">
+    <span class="radio" style="color: #5ba71b">
+        <input aria-label="Inline SVG radio example" class="radio__control" type="radio" />
+        <span class="radio__icon" hidden>
+            <svg aria-hidden="true" class="radio__unchecked" focusable="false">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="radio__checked" focusable="false">
+                <use xlink:href="#icon-radio-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Colour, Disabled</h2>
+<div class="test">
+    <span class="radio" style="color: #5ba71b">
+        <input aria-label="Inline SVG radio example" class="radio__control" disabled checked type="radio" />
+        <span class="radio__icon" hidden>
+            <svg aria-hidden="true" class="radio__unchecked" focusable="false">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="radio__checked" focusable="false">
+                <use xlink:href="#icon-radio-checked"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Icon</h2>
+<div class="test">
+    <span class="radio" style="color: #5ba71b">
+        <input aria-label="Custom radio example" class="radio__control" type="radio" value="1" name="test3a" />
+        <span class="radio__icon" hidden>
+            <svg aria-hidden="true" class="radio__unchecked" focusable="false">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="radio__checked" focusable="false">
+                <use xlink:href="#icon-confirmation"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+
+<h2>Custom Icon, Disabled</h2>
+<div class="test">
+    <span class="radio" style="color: #5ba71b">
+        <input aria-label="Default radio example" class="radio__control" disabled checked type="radio" value="1" name="test3b" />
+        <span class="radio__icon" hidden>
+            <svg aria-hidden="true" class="radio__unchecked" focusable="false">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg aria-hidden="true" class="radio__checked" focusable="false">
+                <use xlink:href="#icon-confirmation"></use>
+            </svg>
+        </span>
+    </span>
+</div>

--- a/docs/test/radio/ds6/index.html
+++ b/docs/test/radio/ds6/index.html
@@ -27,7 +27,7 @@ title: Radio
 <h2>Background, Disabled</h2>
 <div class="test">
     <span class="radio">
-        <input aria-label="Disabled radio example" class="radio__control" disabled type="radio" value="1" name="test1b" />
+        <input aria-label="Disabled radio example" class="radio__control" checked disabled type="radio" value="1" name="test1b" />
         <span class="radio__icon"></span>
     </span>
 </div>


### PR DESCRIPTION
A small PR that adds a DS6 test page for checkbox and radio that matches DS4 cases. We can cleanup and maybe reduce some duplication between the DS4 and DS6 test pages later, but for now this is a stop gap. 

Note: I intentionally removed the `ds4/test.css` in order to create a completely unstyled test page. The ds4 black/grey test pages were intended to make it easy to view the margin around an element, but they look a bit awful, so we will also remove those for ds4 at some point.

Also, we should update both ds4 and ds6 page to have test cases for checked state when non-disabled (I missed this, but we can add it later).

<img width="307" alt="screen shot 2018-07-17 at 5 05 53 pm" src="https://user-images.githubusercontent.com/38065/42856767-88efe424-89fb-11e8-8f60-9013b9a43859.png">

<img width="293" alt="screen shot 2018-07-17 at 5 06 02 pm" src="https://user-images.githubusercontent.com/38065/42856770-8c095726-89fb-11e8-9553-8321aef2aaba.png">