### PR TITLE
Checkbox: fixed "no-descending-specificity" LESS violations

### DIFF
--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -48,6 +48,12 @@
 .checkbox__control[type="checkbox"]:not(:checked) + .checkbox__icon svg.checkbox__unchecked {
   display: inline-block;
 }
+.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
+  outline: 1px dotted #767676;
+}
+.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
+  opacity: 0.5;
+}
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -60,27 +66,21 @@
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon svg.checkbox__unchecked {
   display: none;
 }
-.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
-  outline: 1px dotted #767676;
-}
-.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
-  opacity: 0.5;
+.checkbox__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
+  height: 18px;
+  width: 18px;
 }
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzA2NTRiYSIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.checkbox__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
-  }
   .checkbox__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
+  }
+  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
   }
 }

--- a/dist/checkbox/ds6/checkbox.css
+++ b/dist/checkbox/ds6/checkbox.css
@@ -48,6 +48,12 @@
 .checkbox__control[type="checkbox"]:not(:checked) + .checkbox__icon svg.checkbox__unchecked {
   display: inline-block;
 }
+.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
+  outline: 1px dotted #767676;
+}
+.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
+  opacity: 0.5;
+}
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -60,27 +66,21 @@
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon svg.checkbox__unchecked {
   display: none;
 }
-.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
-  outline: 1px dotted #767676;
-}
-.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
-  opacity: 0.5;
+.checkbox__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTUuNzciIGhlaWdodD0iMTUuOCIgdmlld0JveD0iNC4xMiA0LjEgMTUuNzcgMTUuOCI+PHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTguNTYgNS4yNUg1LjQ0YS4xOS4xOSAwIDAgMC0uMTkuMTg3djEzLjEyNmEuMTkuMTkgMCAwIDAgLjE5LjE4N2gxMy4xMmEuMTkuMTkgMCAwIDAgLjE5LS4xODdWNS40MzdhLjE5LjE5IDAgMCAwLS4xOS0uMTg3ek00LjExNiAxOS45aDE1Ljc2OFY0LjFINC4xMTZ2MTUuOHoiLz48L3N2Zz4=');
+  height: 18px;
+  width: 18px;
 }
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNC4xMTYgMTkuOVY0LjFoMTUuNzY4djE1LjhINC4xMTZ6bTQuMjgtNy43ODJhLjcyNS43MjUgMCAwIDAtMS4wNiAwIC44MTYuODE2IDAgMCAwIDAgMS4xMTRsMi45OTggMy4wMTNhLjcyNS43MjUgMCAwIDAgMS4wNjEgMGw2LjAwMS02LjNhLjgxNi44MTYgMCAwIDAgMC0xLjExNC43MjUuNzI1IDAgMCAwLTEuMDYgMGwtNS40NzEgNS43NDQtMi40NjktMi40NTd6Ii8+PC9kZWZzPjx1c2UgZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNCAtNCkiIHhsaW5rOmhyZWY9IiNhIi8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.checkbox__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTUuNzciIGhlaWdodD0iMTUuOCIgdmlld0JveD0iNC4xMiA0LjEgMTUuNzcgMTUuOCI+PHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTguNTYgNS4yNUg1LjQ0YS4xOS4xOSAwIDAgMC0uMTkuMTg3djEzLjEyNmEuMTkuMTkgMCAwIDAgLjE5LjE4N2gxMy4xMmEuMTkuMTkgMCAwIDAgLjE5LS4xODdWNS40MzdhLjE5LjE5IDAgMCAwLS4xOS0uMTg3ek00LjExNiAxOS45aDE1Ljc2OFY0LjFINC4xMTZ2MTUuOHoiLz48L3N2Zz4=');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE1Ljc3IiBoZWlnaHQ9IjE1LjgiIHZpZXdCb3g9IjQuMTIgNC4xIDE1Ljc3IDE1LjgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik00LjExNiAxOS45VjQuMWgxNS43Njh2MTUuOEg0LjExNnptNC4yOC03Ljc4MmEuNzI1LjcyNSAwIDAgMC0xLjA2IDAgLjgxNi44MTYgMCAwIDAgMCAxLjExNGwyLjk5OCAzLjAxM2EuNzI1LjcyNSAwIDAgMCAxLjA2MSAwbDYuMDAxLTYuM2EuODE2LjgxNiAwIDAgMCAwLTEuMTE0LjcyNS43MjUgMCAwIDAtMS4wNiAwbC01LjQ3MSA1Ljc0NC0yLjQ2OS0yLjQ1N3oiLz48L3N2Zz4=');
-  }
   .checkbox__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE1Ljc3IiBoZWlnaHQ9IjE1LjgiIHZpZXdCb3g9IjQuMTIgNC4xIDE1Ljc3IDE1LjgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xOC41NiA1LjI1SDUuNDRhLjE5LjE5IDAgMCAwLS4xOS4xODd2MTMuMTI2YS4xOS4xOSAwIDAgMCAuMTkuMTg3aDEzLjEyYS4xOS4xOSAwIDAgMCAuMTktLjE4N1Y1LjQzN2EuMTkuMTkgMCAwIDAtLjE5LS4xODd6TTQuMTE2IDE5LjloMTUuNzY4VjQuMUg0LjExNnYxNS44eiIvPjwvc3ZnPg==');
+  }
+  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE1Ljc3IiBoZWlnaHQ9IjE1LjgiIHZpZXdCb3g9IjQuMTIgNC4xIDE1Ljc3IDE1LjgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik00LjExNiAxOS45VjQuMWgxNS43Njh2MTUuOEg0LjExNnptNC4yOC03Ljc4MmEuNzI1LjcyNSAwIDAgMC0xLjA2IDAgLjgxNi44MTYgMCAwIDAgMCAxLjExNGwyLjk5OCAzLjAxM2EuNzI1LjcyNSAwIDAgMCAxLjA2MSAwbDYuMDAxLTYuM2EuODE2LjgxNiAwIDAgMCAwLTEuMTE0LjcyNS43MjUgMCAwIDAtMS4wNiAwbC01LjQ3MSA1Ljc0NC0yLjQ2OS0yLjQ1N3oiLz48L3N2Zz4=');
   }
 }

--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -48,6 +48,12 @@
 .radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__unchecked {
   display: inline-block;
 }
+.radio__control[type="radio"]:focus + .radio__icon {
+  outline: 1px dotted #767676;
+}
+.radio__control[type="radio"][disabled] + .radio__icon {
+  opacity: 0.5;
+}
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -60,27 +66,21 @@
 .radio__control[type="radio"]:checked + .radio__icon svg.radio__unchecked {
   display: none;
 }
-.radio__control[type="radio"]:focus + .radio__icon {
-  outline: 1px dotted #767676;
-}
-.radio__control[type="radio"][disabled] + .radio__icon {
-  opacity: 0.5;
+.radio__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
+  height: 18px;
+  width: 18px;
 }
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzA2NTRiYSIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.radio__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
-  }
   .radio__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
+  }
+  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
   }
 }

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -48,6 +48,12 @@
 .radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__unchecked {
   display: inline-block;
 }
+.radio__control[type="radio"]:focus + .radio__icon {
+  outline: 1px dotted #767676;
+}
+.radio__control[type="radio"][disabled] + .radio__icon {
+  opacity: 0.5;
+}
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -60,27 +66,21 @@
 .radio__control[type="radio"]:checked + .radio__icon svg.radio__unchecked {
   display: none;
 }
-.radio__control[type="radio"]:focus + .radio__icon {
-  outline: 1px dotted #767676;
-}
-.radio__control[type="radio"][disabled] + .radio__icon {
-  opacity: 0.5;
+.radio__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNiIvPjwvZGVmcz48dXNlIGZpbGw9IiMwMDAiIHhsaW5rOmhyZWY9IiNhIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48L3N2Zz4=');
+  height: 18px;
+  width: 18px;
 }
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNnpNNiA5LjVhMy41IDMuNSAwIDEgMCAwLTcgMy41IDMuNSAwIDAgMCAwIDd6Ii8+PC9kZWZzPjx1c2UgZmlsbD0iIzAwMCIgeGxpbms6aHJlZj0iI2EiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg==');
   height: 18px;
   width: 18px;
 }
-.radio__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNiIvPjwvZGVmcz48dXNlIGZpbGw9IiMwMDAiIHhsaW5rOmhyZWY9IiNhIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48L3N2Zz4=');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiB2aWV3Qm94PSIzIDMgMTggMTgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xMiAzYTkgOSAwIDEgMCA5IDkgOSA5IDAgMCAwLTktOW0wIDEuMDU5YzQuMzggMCA3Ljk0MSAzLjU2MyA3Ljk0MSA3Ljk0MVMxNi4zOCAxOS45NDEgMTIgMTkuOTQxIDQuMDU5IDE2LjM3OCA0LjA1OSAxMiA3LjYyIDQuMDU5IDEyIDQuMDU5em0wIDEzLjE5MWE1LjI1IDUuMjUgMCAxIDAgMC0xMC41IDUuMjUgNS4yNSAwIDAgMCAwIDEwLjV6Ii8+PC9zdmc+');
-  }
   .radio__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiB2aWV3Qm94PSIzIDMgMTggMTgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xMiAzYTkgOSAwIDEgMCA5IDkgOSA5IDAgMCAwLTktOW0wIDEuMDU5YzQuMzggMCA3Ljk0MSAzLjU2MyA3Ljk0MSA3Ljk0MVMxNi4zOCAxOS45NDEgMTIgMTkuOTQxIDQuMDU5IDE2LjM3OCA0LjA1OSAxMiA3LjYyIDQuMDU5IDEyIDQuMDU5Ii8+PC9zdmc+');
+  }
+  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiB2aWV3Qm94PSIzIDMgMTggMTgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xMiAzYTkgOSAwIDEgMCA5IDkgOSA5IDAgMCAwLTktOW0wIDEuMDU5YzQuMzggMCA3Ljk0MSAzLjU2MyA3Ljk0MSA3Ljk0MVMxNi4zOCAxOS45NDEgMTIgMTkuOTQxIDQuMDU5IDE2LjM3OCA0LjA1OSAxMiA3LjYyIDQuMDU5IDEyIDQuMDU5em0wIDEzLjE5MWE1LjI1IDUuMjUgMCAxIDAgMC0xMC41IDUuMjUgNS4yNSAwIDAgMCAwIDEwLjV6Ii8+PC9zdmc+');
   }
 }

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -652,6 +652,12 @@ body .grid .card {
 .checkbox__control[type="checkbox"]:not(:checked) + .checkbox__icon svg.checkbox__unchecked {
   display: inline-block;
 }
+.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
+  outline: 1px dotted #767676;
+}
+.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
+  opacity: 0.5;
+}
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -664,28 +670,22 @@ body .grid .card {
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon svg.checkbox__unchecked {
   display: none;
 }
-.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
-  outline: 1px dotted #767676;
-}
-.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
-  opacity: 0.5;
+.checkbox__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
+  height: 18px;
+  width: 18px;
 }
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzA2NTRiYSIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.checkbox__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
-  }
   .checkbox__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
+  }
+  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
   }
 }
 .dialog {
@@ -2673,6 +2673,12 @@ a.pagination__item {
 .radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__unchecked {
   display: inline-block;
 }
+.radio__control[type="radio"]:focus + .radio__icon {
+  outline: 1px dotted #767676;
+}
+.radio__control[type="radio"][disabled] + .radio__icon {
+  opacity: 0.5;
+}
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -2685,28 +2691,22 @@ a.pagination__item {
 .radio__control[type="radio"]:checked + .radio__icon svg.radio__unchecked {
   display: none;
 }
-.radio__control[type="radio"]:focus + .radio__icon {
-  outline: 1px dotted #767676;
-}
-.radio__control[type="radio"][disabled] + .radio__icon {
-  opacity: 0.5;
+.radio__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
+  height: 18px;
+  width: 18px;
 }
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzA2NTRiYSIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.radio__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
-  }
   .radio__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
+  }
+  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
   }
 }
 .select {

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -652,6 +652,12 @@ body .grid .card {
 .checkbox__control[type="checkbox"]:not(:checked) + .checkbox__icon svg.checkbox__unchecked {
   display: inline-block;
 }
+.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
+  outline: 1px dotted #767676;
+}
+.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
+  opacity: 0.5;
+}
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -664,28 +670,22 @@ body .grid .card {
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon svg.checkbox__unchecked {
   display: none;
 }
-.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
-  outline: 1px dotted #767676;
-}
-.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
-  opacity: 0.5;
+.checkbox__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
+  height: 18px;
+  width: 18px;
 }
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzA2NTRiYSIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.checkbox__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
-  }
   .checkbox__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTE4LjM2MSAyNC4wNDZINC43MDFBNC43MDUgNC43MDUgMCAwIDEgMCAxOS4zNDhWNC43MDFBNC43MDcgNC43MDcgMCAwIDEgNC43MDEgMGgxMy42NmE0LjcwNyA0LjcwNyAwIDAgMSA0LjcwMSA0LjcwMXYxNC42NDdhNC43MDYgNC43MDYgMCAwIDEtNC43MDEgNC42OTh6TTQuNzAxIDEuNDExQTMuMjkyIDMuMjkyIDAgMCAwIDEuNDEyIDQuN3YxNC42NDdhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODkgMy4yODdoMTMuNjZhMy4yOTEgMy4yOTEgMCAwIDAgMy4yODktMy4yODdWNC43YTMuMjkyIDMuMjkyIDAgMCAwLTMuMjg5LTMuMjg5SDQuNzAxeiIvPjwvc3ZnPg==');
+  }
+  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMyAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgNC4yMzVBNC4yMzcgNC4yMzcgMCAwIDEgNC4yMzcgMGgxNC40ODJhNC4yMjggNC4yMjggMCAwIDEgNC4yMzcgNC4yMzV2MTUuNTI5YTQuMjM3IDQuMjM3IDAgMCAxLTQuMjM3IDQuMjM1SDQuMjM3QTQuMjI4IDQuMjI4IDAgMCAxIDAgMTkuNzY0VjQuMjM1em0zLjU3NyA4Ljk1NWw1LjI3OSA1LjEyOUwxOS4yMjkgOC4yNGwtMS45NzctMS45MjEtOC4xOTcgNy45NjUtMy4zMzItMy4yMzctMi4xNDYgMi4xNDN6Ii8+PC9zdmc+');
   }
 }
 .dialog {
@@ -2673,6 +2673,12 @@ a.pagination__item {
 .radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__unchecked {
   display: inline-block;
 }
+.radio__control[type="radio"]:focus + .radio__icon {
+  outline: 1px dotted #767676;
+}
+.radio__control[type="radio"][disabled] + .radio__icon {
+  opacity: 0.5;
+}
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -2685,28 +2691,22 @@ a.pagination__item {
 .radio__control[type="radio"]:checked + .radio__icon svg.radio__unchecked {
   display: none;
 }
-.radio__control[type="radio"]:focus + .radio__icon {
-  outline: 1px dotted #767676;
-}
-.radio__control[type="radio"][disabled] + .radio__icon {
-  opacity: 0.5;
+.radio__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
+  height: 18px;
+  width: 18px;
 }
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzA2NTRiYSIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.radio__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iIzc2NzY3NiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
-  }
   .radio__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTEgMCAxMS43UzUuMjg5IDAgMTEuNzg5IDBzMTEuNzg5IDUuMjQ5IDExLjc4OSAxMS43YzAgNi40NTMtNS4yODkgMTEuNy0xMS43ODkgMTEuN3ptMC0yMi4wNjdDNi4wMjQgMS4zMzMgMS4zMzMgNS45ODQgMS4zMzMgMTEuN2MwIDUuNzE2IDQuNjkxIDEwLjM2NyAxMC40NTYgMTAuMzY3UzIyLjI0NSAxNy40MTYgMjIuMjQ1IDExLjdjMC01LjcxNi00LjY5MS0xMC4zNjctMTAuNDU2LTEwLjM2N3oiLz48L3N2Zz4=');
+  }
+  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExLjc4OSAyMy40QzUuMjg5IDIzLjQgMCAxOC4xNTIgMCAxMS43IDAgNS4yNDkgNS4yODkgMCAxMS43ODkgMHMxMS43ODkgNS4yNDkgMTEuNzg5IDExLjdjMCA2LjQ1My01LjI4OSAxMS43LTExLjc4OSAxMS43em0wLTIyLjA2N0M2LjAyNCAxLjMzMyAxLjMzMyA1Ljk4NCAxLjMzMyAxMS43YzAgNS43MTYgNC42OTEgMTAuMzY3IDEwLjQ1NiAxMC4zNjdTMjIuMjQ1IDE3LjQxNiAyMi4yNDUgMTEuN2MwLTUuNzE2LTQuNjkxLTEwLjM2Ny0xMC40NTYtMTAuMzY3em02LjEwNCAxMC4yMTljMCAzLjMwNS0yLjc4NyA1Ljk4NC02LjIyNCA1Ljk4NC0zLjQzNyAwLTYuMjI0LTIuNjc5LTYuMjI0LTUuOTg0czIuNzg3LTUuOTg0IDYuMjI0LTUuOTg0YzMuNDM3IDAgNi4yMjQgMi42NzkgNi4yMjQgNS45ODR6Ii8+PC9zdmc+');
   }
 }
 .select {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -468,6 +468,12 @@ button.expand-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]) s
 .checkbox__control[type="checkbox"]:not(:checked) + .checkbox__icon svg.checkbox__unchecked {
   display: inline-block;
 }
+.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
+  outline: 1px dotted #767676;
+}
+.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
+  opacity: 0.5;
+}
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -480,28 +486,22 @@ button.expand-btn--secondary:hover:not([disabled]):not([aria-disabled="true"]) s
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon svg.checkbox__unchecked {
   display: none;
 }
-.checkbox__control[type="checkbox"]:focus + .checkbox__icon {
-  outline: 1px dotted #767676;
-}
-.checkbox__control[type="checkbox"][disabled] + .checkbox__icon {
-  opacity: 0.5;
+.checkbox__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTUuNzciIGhlaWdodD0iMTUuOCIgdmlld0JveD0iNC4xMiA0LjEgMTUuNzcgMTUuOCI+PHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTguNTYgNS4yNUg1LjQ0YS4xOS4xOSAwIDAgMC0uMTkuMTg3djEzLjEyNmEuMTkuMTkgMCAwIDAgLjE5LjE4N2gxMy4xMmEuMTkuMTkgMCAwIDAgLjE5LS4xODdWNS40MzdhLjE5LjE5IDAgMCAwLS4xOS0uMTg3ek00LjExNiAxOS45aDE1Ljc2OFY0LjFINC4xMTZ2MTUuOHoiLz48L3N2Zz4=');
+  height: 18px;
+  width: 18px;
 }
 .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNC4xMTYgMTkuOVY0LjFoMTUuNzY4djE1LjhINC4xMTZ6bTQuMjgtNy43ODJhLjcyNS43MjUgMCAwIDAtMS4wNiAwIC44MTYuODE2IDAgMCAwIDAgMS4xMTRsMi45OTggMy4wMTNhLjcyNS43MjUgMCAwIDAgMS4wNjEgMGw2LjAwMS02LjNhLjgxNi44MTYgMCAwIDAgMC0xLjExNC43MjUuNzI1IDAgMCAwLTEuMDYgMGwtNS40NzEgNS43NDQtMi40NjktMi40NTd6Ii8+PC9kZWZzPjx1c2UgZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNCAtNCkiIHhsaW5rOmhyZWY9IiNhIi8+PC9zdmc+');
   height: 18px;
   width: 18px;
 }
-.checkbox__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTUuNzciIGhlaWdodD0iMTUuOCIgdmlld0JveD0iNC4xMiA0LjEgMTUuNzcgMTUuOCI+PHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTguNTYgNS4yNUg1LjQ0YS4xOS4xOSAwIDAgMC0uMTkuMTg3djEzLjEyNmEuMTkuMTkgMCAwIDAgLjE5LjE4N2gxMy4xMmEuMTkuMTkgMCAwIDAgLjE5LS4xODdWNS40MzdhLjE5LjE5IDAgMCAwLS4xOS0uMTg3ek00LjExNiAxOS45aDE1Ljc2OFY0LjFINC4xMTZ2MTUuOHoiLz48L3N2Zz4=');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE1Ljc3IiBoZWlnaHQ9IjE1LjgiIHZpZXdCb3g9IjQuMTIgNC4xIDE1Ljc3IDE1LjgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik00LjExNiAxOS45VjQuMWgxNS43Njh2MTUuOEg0LjExNnptNC4yOC03Ljc4MmEuNzI1LjcyNSAwIDAgMC0xLjA2IDAgLjgxNi44MTYgMCAwIDAgMCAxLjExNGwyLjk5OCAzLjAxM2EuNzI1LjcyNSAwIDAgMCAxLjA2MSAwbDYuMDAxLTYuM2EuODE2LjgxNiAwIDAgMCAwLTEuMTE0LjcyNS43MjUgMCAwIDAtMS4wNiAwbC01LjQ3MSA1Ljc0NC0yLjQ2OS0yLjQ1N3oiLz48L3N2Zz4=');
-  }
   .checkbox__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE1Ljc3IiBoZWlnaHQ9IjE1LjgiIHZpZXdCb3g9IjQuMTIgNC4xIDE1Ljc3IDE1LjgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xOC41NiA1LjI1SDUuNDRhLjE5LjE5IDAgMCAwLS4xOS4xODd2MTMuMTI2YS4xOS4xOSAwIDAgMCAuMTkuMTg3aDEzLjEyYS4xOS4xOSAwIDAgMCAuMTktLjE4N1Y1LjQzN2EuMTkuMTkgMCAwIDAtLjE5LS4xODd6TTQuMTE2IDE5LjloMTUuNzY4VjQuMUg0LjExNnYxNS44eiIvPjwvc3ZnPg==');
+  }
+  .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE1Ljc3IiBoZWlnaHQ9IjE1LjgiIHZpZXdCb3g9IjQuMTIgNC4xIDE1Ljc3IDE1LjgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik00LjExNiAxOS45VjQuMWgxNS43Njh2MTUuOEg0LjExNnptNC4yOC03Ljc4MmEuNzI1LjcyNSAwIDAgMC0xLjA2IDAgLjgxNi44MTYgMCAwIDAgMCAxLjExNGwyLjk5OCAzLjAxM2EuNzI1LjcyNSAwIDAgMCAxLjA2MSAwbDYuMDAxLTYuM2EuODE2LjgxNiAwIDAgMCAwLTEuMTE0LjcyNS43MjUgMCAwIDAtMS4wNiAwbC01LjQ3MSA1Ljc0NC0yLjQ2OS0yLjQ1N3oiLz48L3N2Zz4=');
   }
 }
 .color-text-default {
@@ -2077,6 +2077,12 @@ span.inline-notice {
 .radio__control[type="radio"]:not(:checked) + .radio__icon svg.radio__unchecked {
   display: inline-block;
 }
+.radio__control[type="radio"]:focus + .radio__icon {
+  outline: 1px dotted #767676;
+}
+.radio__control[type="radio"][disabled] + .radio__icon {
+  opacity: 0.5;
+}
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-repeat: no-repeat;
   background-size: contain;
@@ -2089,28 +2095,22 @@ span.inline-notice {
 .radio__control[type="radio"]:checked + .radio__icon svg.radio__unchecked {
   display: none;
 }
-.radio__control[type="radio"]:focus + .radio__icon {
-  outline: 1px dotted #767676;
-}
-.radio__control[type="radio"][disabled] + .radio__icon {
-  opacity: 0.5;
+.radio__icon:not([hidden]) {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNiIvPjwvZGVmcz48dXNlIGZpbGw9IiMwMDAiIHhsaW5rOmhyZWY9IiNhIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48L3N2Zz4=');
+  height: 18px;
+  width: 18px;
 }
 .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNnpNNiA5LjVhMy41IDMuNSAwIDEgMCAwLTcgMy41IDMuNSAwIDAgMCAwIDd6Ii8+PC9kZWZzPjx1c2UgZmlsbD0iIzAwMCIgeGxpbms6aHJlZj0iI2EiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg==');
   height: 18px;
   width: 18px;
 }
-.radio__icon:not([hidden]) {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNNiAwYTYgNiAwIDEgMCAwIDEyQTYgNiAwIDAgMCA2IDBtMCAuNzA2QTUuMyA1LjMgMCAwIDEgMTEuMjk0IDYgNS4zIDUuMyAwIDAgMSA2IDExLjI5NCA1LjMgNS4zIDAgMCAxIC43MDYgNiA1LjMgNS4zIDAgMCAxIDYgLjcwNiIvPjwvZGVmcz48dXNlIGZpbGw9IiMwMDAiIHhsaW5rOmhyZWY9IiNhIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz48L3N2Zz4=');
-  height: 18px;
-  width: 18px;
-}
 @media screen and (-ms-high-contrast: white-on-black) {
-  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiB2aWV3Qm94PSIzIDMgMTggMTgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xMiAzYTkgOSAwIDEgMCA5IDkgOSA5IDAgMCAwLTktOW0wIDEuMDU5YzQuMzggMCA3Ljk0MSAzLjU2MyA3Ljk0MSA3Ljk0MVMxNi4zOCAxOS45NDEgMTIgMTkuOTQxIDQuMDU5IDE2LjM3OCA0LjA1OSAxMiA3LjYyIDQuMDU5IDEyIDQuMDU5em0wIDEzLjE5MWE1LjI1IDUuMjUgMCAxIDAgMC0xMC41IDUuMjUgNS4yNSAwIDAgMCAwIDEwLjV6Ii8+PC9zdmc+');
-  }
   .radio__icon:not([hidden]) {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiB2aWV3Qm94PSIzIDMgMTggMTgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xMiAzYTkgOSAwIDEgMCA5IDkgOSA5IDAgMCAwLTktOW0wIDEuMDU5YzQuMzggMCA3Ljk0MSAzLjU2MyA3Ljk0MSA3Ljk0MVMxNi4zOCAxOS45NDEgMTIgMTkuOTQxIDQuMDU5IDE2LjM3OCA0LjA1OSAxMiA3LjYyIDQuMDU5IDEyIDQuMDU5Ii8+PC9zdmc+');
+  }
+  .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiANCiAgd2lkdGg9IjE4IiBoZWlnaHQ9IjE4IiB2aWV3Qm94PSIzIDMgMTggMTgiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xMiAzYTkgOSAwIDEgMCA5IDkgOSA5IDAgMCAwLTktOW0wIDEuMDU5YzQuMzggMCA3Ljk0MSAzLjU2MyA3Ljk0MSA3Ljk0MVMxNi4zOCAxOS45NDEgMTIgMTkuOTQxIDQuMDU5IDE2LjM3OCA0LjA1OSAxMiA3LjYyIDQuMDU5IDEyIDQuMDU5em0wIDEzLjE5MWE1LjI1IDUuMjUgMCAxIDAgMC0xMC41IDUuMjUgNS4yNSAwIDAgMCAwIDEwLjV6Ii8+PC9zdmc+');
   }
 }
 .select {

--- a/src/less/checkbox/base/checkbox.less
+++ b/src/less/checkbox/base/checkbox.less
@@ -46,6 +46,14 @@
         }
     }
 
+    &:focus + .checkbox__icon {
+        outline: 1px dotted #767676;
+    }
+
+    &[disabled] + .checkbox__icon {
+        opacity: 0.5;
+    }
+
     &:checked {
         & + .checkbox__icon:not([hidden]) {
             .background-icon-base;
@@ -58,13 +66,5 @@
         & + .checkbox__icon svg.checkbox__unchecked {
             display: none;
         }
-    }
-
-    &:focus + .checkbox__icon {
-        outline: 1px dotted #767676;
-    }
-
-    &[disabled] + .checkbox__icon {
-        opacity: 0.5;
     }
 }

--- a/src/less/checkbox/ds4/checkbox.less
+++ b/src/less/checkbox/ds4/checkbox.less
@@ -3,6 +3,12 @@
 
 @import "../base/checkbox.less";
 
+.checkbox__icon {
+    &:not([hidden]) {
+        .ds4-icon-checkbox-unchecked(18px, 18px);
+    }
+}
+
 .checkbox__control[type="checkbox"] {
     &:checked {
         & + .checkbox__icon:not([hidden]) {
@@ -11,18 +17,12 @@
     }
 }
 
-.checkbox__icon {
-    &:not([hidden]) {
-        .ds4-icon-checkbox-unchecked(18px, 18px);
-    }
-}
-
 @media screen and (-ms-high-contrast: white-on-black) {
-    .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
-        background-image: url('data:image/svg+xml;base64,@{ds4-icon-checkbox-checked-base64-light}');
-    }
-
     .checkbox__icon:not([hidden]) {
         background-image: url('data:image/svg+xml;base64,@{ds4-icon-checkbox-unchecked-base64-light}');
+    }
+
+    .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
+        background-image: url('data:image/svg+xml;base64,@{ds4-icon-checkbox-checked-base64-light}');
     }
 }

--- a/src/less/checkbox/ds6/checkbox.less
+++ b/src/less/checkbox/ds6/checkbox.less
@@ -3,6 +3,12 @@
 
 @import "../base/checkbox.less";
 
+.checkbox__icon {
+    &:not([hidden]) {
+        .ds6-icon-checkbox-unchecked(18px, 18px);
+    }
+}
+
 .checkbox__control[type="checkbox"] {
     &:checked {
         & + .checkbox__icon:not([hidden]) {
@@ -11,18 +17,12 @@
     }
 }
 
-.checkbox__icon {
-    &:not([hidden]) {
-        .ds6-icon-checkbox-unchecked(18px, 18px);
-    }
-}
-
 @media screen and (-ms-high-contrast: white-on-black) {
-    .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
-        background-image: url('data:image/svg+xml;base64,@{ds6-icon-checkbox-checked-base64-light}');
-    }
-
     .checkbox__icon:not([hidden]) {
         background-image: url('data:image/svg+xml;base64,@{ds6-icon-checkbox-unchecked-base64-light}');
+    }
+
+    .checkbox__control[type="checkbox"]:checked + .checkbox__icon:not([hidden]) {
+        background-image: url('data:image/svg+xml;base64,@{ds6-icon-checkbox-checked-base64-light}');
     }
 }

--- a/src/less/radio/base/radio.less
+++ b/src/less/radio/base/radio.less
@@ -46,6 +46,14 @@
         }
     }
 
+    &:focus + .radio__icon {
+        outline: 1px dotted #767676;
+    }
+
+    &[disabled] + .radio__icon {
+        opacity: 0.5;
+    }
+
     &:checked {
         & + .radio__icon:not([hidden]) {
             .background-icon-base;
@@ -58,13 +66,5 @@
         & + .radio__icon svg.radio__unchecked {
             display: none;
         }
-    }
-
-    &:focus + .radio__icon {
-        outline: 1px dotted #767676;
-    }
-
-    &[disabled] + .radio__icon {
-        opacity: 0.5;
     }
 }

--- a/src/less/radio/ds4/radio.less
+++ b/src/less/radio/ds4/radio.less
@@ -3,6 +3,12 @@
 
 @import "../base/radio.less";
 
+.radio__icon {
+    &:not([hidden]) {
+        .ds4-icon-radio-unchecked(18px, 18px);
+    }
+}
+
 .radio__control[type="radio"] {
     &:checked {
         & + .radio__icon:not([hidden]) {
@@ -11,18 +17,12 @@
     }
 }
 
-.radio__icon {
-    &:not([hidden]) {
-        .ds4-icon-radio-unchecked(18px, 18px);
-    }
-}
-
 @media screen and (-ms-high-contrast: white-on-black) {
-    .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
-        background-image: url('data:image/svg+xml;base64,@{ds4-icon-radio-checked-base64-light}');
-    }
-
     .radio__icon:not([hidden]) {
         background-image: url('data:image/svg+xml;base64,@{ds4-icon-radio-unchecked-base64-light}');
+    }
+
+    .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
+        background-image: url('data:image/svg+xml;base64,@{ds4-icon-radio-checked-base64-light}');
     }
 }

--- a/src/less/radio/ds6/radio.less
+++ b/src/less/radio/ds6/radio.less
@@ -3,6 +3,12 @@
 
 @import "../base/radio.less";
 
+.radio__icon {
+    &:not([hidden]) {
+        .ds6-icon-radio-unchecked(18px, 18px);
+    }
+}
+
 .radio__control[type="radio"] {
     &:checked {
         & + .radio__icon:not([hidden]) {
@@ -11,18 +17,12 @@
     }
 }
 
-.radio__icon {
-    &:not([hidden]) {
-        .ds6-icon-radio-unchecked(18px, 18px);
-    }
-}
-
 @media screen and (-ms-high-contrast: white-on-black) {
-    .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
-        background-image: url('data:image/svg+xml;base64,@{ds6-icon-radio-checked-base64-light}');
-    }
-
     .radio__icon:not([hidden]) {
         background-image: url('data:image/svg+xml;base64,@{ds6-icon-radio-unchecked-base64-light}');
+    }
+
+    .radio__control[type="radio"]:checked + .radio__icon:not([hidden]) {
+        background-image: url('data:image/svg+xml;base64,@{ds6-icon-radio-checked-base64-light}');
     }
 }


### PR DESCRIPTION
## Description

As part of cleanup of LESS files I temporarily removed the "no-descending-specificity" stylelint rule and fixed all violations for checkbox and radio. I then put the rule back in place (until we've fixed all modules).

I tested this locally and nothing seems to break.

## Scope

No properties are changed. Only certain rules are re-orderded to achieve an ascending specificity.

## Context

Trying to match the default, out of the box settings of stylelint where it makes sense.

## References

#180.

## Notes

We cannot currently disable this rule for CSS, due to the way the delta CSS is appended to the base CSS. But maybe in future we could use something like PostCSS/CSSComb to reorder the compiled CSS.

## Screenshots

The LESS violations:

<img width="1194" alt="screen shot 2018-07-19 at 3 52 29 pm" src="https://user-images.githubusercontent.com/38065/42974758-79bf9c6a-8b6d-11e8-882b-3acb364fe2d9.png">

<img width="1091" alt="screen shot 2018-07-19 at 3 52 43 pm" src="https://user-images.githubusercontent.com/38065/42974759-79d8cc3a-8b6d-11e8-8f7d-338da318626a.png">
