### PR TITLE
Select: fixed "no-descending-specificity" LESS violations

### DIFF
--- a/dist/select/ds4/select.css
+++ b/dist/select/ds4/select.css
@@ -12,17 +12,11 @@ span.select {
   font-size: inherit;
   height: 40px;
 }
-.select > select:focus {
-  outline: 0;
-}
-.select > select[disabled] {
-  border: 0;
-}
-.select > select[disabled] + .select__icon {
-  opacity: 0.5;
-}
 .select > select::-ms-expand {
   display: none;
+}
+.select > select:focus {
+  outline: 0;
 }
 .select__icon {
   display: inline;
@@ -53,6 +47,12 @@ svg.select__icon {
   position: absolute;
   right: 16px;
   top: 0;
+}
+.select > select[disabled] {
+  border: 0;
+}
+.select > select[disabled] + .select__icon {
+  opacity: 0.5;
 }
 .select.fluid,
 .select.select--fluid {
@@ -91,9 +91,6 @@ span.select__icon {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   padding: 0 40px 0 16px;
 }
-.select > select:focus {
-  border-color: #0654ba;
-}
 .select > select[disabled] {
   background-color: #eee;
   color: #ccc;
@@ -124,13 +121,16 @@ span.select__icon {
 .select--extra-large > select {
   height: 56px;
 }
-.select.select--borderless > select {
-  padding-left: 0;
-}
-.select.select--borderless > select:focus {
+.select > select:focus {
   border-color: #0654ba;
 }
 .select[dir="rtl"] > select {
   padding-left: 40px;
   padding-right: 16px;
+}
+.select.select--borderless > select {
+  padding-left: 0;
+}
+.select.select--borderless > select:focus {
+  border-color: #0654ba;
 }

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -12,17 +12,11 @@ span.select {
   font-size: inherit;
   height: 40px;
 }
-.select > select:focus {
-  outline: 0;
-}
-.select > select[disabled] {
-  border: 0;
-}
-.select > select[disabled] + .select__icon {
-  opacity: 0.5;
-}
 .select > select::-ms-expand {
   display: none;
+}
+.select > select:focus {
+  outline: 0;
 }
 .select__icon {
   display: inline;
@@ -53,6 +47,12 @@ svg.select__icon {
   position: absolute;
   right: 16px;
   top: 0;
+}
+.select > select[disabled] {
+  border: 0;
+}
+.select > select[disabled] + .select__icon {
+  opacity: 0.5;
 }
 .select.fluid,
 .select.select--fluid {
@@ -98,14 +98,14 @@ span.select__icon {
   background-color: #e5e5e5;
   color: #c7c7c7;
 }
+.select[dir="rtl"] > select {
+  padding-left: 30px;
+  padding-right: 16px;
+}
 .select.select--borderless > select:focus {
   border-color: #4295ff;
 }
 .select.select--borderless > select[disabled] {
   background-color: #fff;
   color: #c7c7c7;
-}
-.select[dir="rtl"] > select {
-  padding-left: 30px;
-  padding-right: 16px;
 }

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -2723,17 +2723,11 @@ span.select {
   font-size: inherit;
   height: 40px;
 }
-.select > select:focus {
-  outline: 0;
-}
-.select > select[disabled] {
-  border: 0;
-}
-.select > select[disabled] + .select__icon {
-  opacity: 0.5;
-}
 .select > select::-ms-expand {
   display: none;
+}
+.select > select:focus {
+  outline: 0;
 }
 .select__icon {
   display: inline;
@@ -2764,6 +2758,12 @@ svg.select__icon {
   position: absolute;
   right: 16px;
   top: 0;
+}
+.select > select[disabled] {
+  border: 0;
+}
+.select > select[disabled] + .select__icon {
+  opacity: 0.5;
 }
 .select.fluid,
 .select.select--fluid {
@@ -2802,9 +2802,6 @@ span.select__icon {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   padding: 0 40px 0 16px;
 }
-.select > select:focus {
-  border-color: #0654ba;
-}
 .select > select[disabled] {
   background-color: #eee;
   color: #ccc;
@@ -2835,15 +2832,18 @@ span.select__icon {
 .select--extra-large > select {
   height: 56px;
 }
-.select.select--borderless > select {
-  padding-left: 0;
-}
-.select.select--borderless > select:focus {
+.select > select:focus {
   border-color: #0654ba;
 }
 .select[dir="rtl"] > select {
   padding-left: 40px;
   padding-right: 16px;
+}
+.select.select--borderless > select {
+  padding-left: 0;
+}
+.select.select--borderless > select:focus {
+  border-color: #0654ba;
 }
 .spinner[role="img"][aria-label] {
   -webkit-animation: spin 600ms linear infinite;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -2723,17 +2723,11 @@ span.select {
   font-size: inherit;
   height: 40px;
 }
-.select > select:focus {
-  outline: 0;
-}
-.select > select[disabled] {
-  border: 0;
-}
-.select > select[disabled] + .select__icon {
-  opacity: 0.5;
-}
 .select > select::-ms-expand {
   display: none;
+}
+.select > select:focus {
+  outline: 0;
 }
 .select__icon {
   display: inline;
@@ -2764,6 +2758,12 @@ svg.select__icon {
   position: absolute;
   right: 16px;
   top: 0;
+}
+.select > select[disabled] {
+  border: 0;
+}
+.select > select[disabled] + .select__icon {
+  opacity: 0.5;
 }
 .select.fluid,
 .select.select--fluid {
@@ -2802,9 +2802,6 @@ span.select__icon {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   padding: 0 40px 0 16px;
 }
-.select > select:focus {
-  border-color: #0654ba;
-}
 .select > select[disabled] {
   background-color: #eee;
   color: #ccc;
@@ -2835,15 +2832,18 @@ span.select__icon {
 .select--extra-large > select {
   height: 56px;
 }
-.select.select--borderless > select {
-  padding-left: 0;
-}
-.select.select--borderless > select:focus {
+.select > select:focus {
   border-color: #0654ba;
 }
 .select[dir="rtl"] > select {
   padding-left: 40px;
   padding-right: 16px;
+}
+.select.select--borderless > select {
+  padding-left: 0;
+}
+.select.select--borderless > select:focus {
+  border-color: #0654ba;
 }
 .spinner[role="img"][aria-label] {
   -webkit-animation: spin 600ms linear infinite;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2127,17 +2127,11 @@ span.select {
   font-size: inherit;
   height: 40px;
 }
-.select > select:focus {
-  outline: 0;
-}
-.select > select[disabled] {
-  border: 0;
-}
-.select > select[disabled] + .select__icon {
-  opacity: 0.5;
-}
 .select > select::-ms-expand {
   display: none;
+}
+.select > select:focus {
+  outline: 0;
 }
 .select__icon {
   display: inline;
@@ -2168,6 +2162,12 @@ svg.select__icon {
   position: absolute;
   right: 16px;
   top: 0;
+}
+.select > select[disabled] {
+  border: 0;
+}
+.select > select[disabled] + .select__icon {
+  opacity: 0.5;
 }
 .select.fluid,
 .select.select--fluid {
@@ -2213,16 +2213,16 @@ span.select__icon {
   background-color: #e5e5e5;
   color: #c7c7c7;
 }
+.select[dir="rtl"] > select {
+  padding-left: 30px;
+  padding-right: 16px;
+}
 .select.select--borderless > select:focus {
   border-color: #4295ff;
 }
 .select.select--borderless > select[disabled] {
   background-color: #fff;
   color: #c7c7c7;
-}
-.select[dir="rtl"] > select {
-  padding-left: 30px;
-  padding-right: 16px;
 }
 .textbox {
   position: relative;

--- a/src/less/select/base/select.less
+++ b/src/less/select/base/select.less
@@ -12,21 +12,13 @@ span.select {
     font-size: inherit;
     height: 40px;
 
-    &:focus {
-        outline: 0;
-    }
-
-    &[disabled] {
-        border: 0;
-
-        + .select__icon {
-            opacity: 0.5;
-        }
-    }
-
     // custom IE pseudo selector for the arrow
     &::-ms-expand {
         display: none;
+    }
+
+    &:focus {
+        outline: 0;
     }
 }
 
@@ -54,6 +46,14 @@ span.select {
         position: absolute;
         right: 16px;
         top: 0;
+    }
+}
+
+.select > select[disabled] {
+    border: 0;
+
+    + .select__icon {
+        opacity: 0.5;
     }
 }
 

--- a/src/less/select/ds4/select.less
+++ b/src/less/select/ds4/select.less
@@ -21,10 +21,6 @@ span.select__icon {
     font-family: @font-family-base;
     padding: 0 40px 0 16px;
 
-    &:focus {
-        border-color: @color-core-blue;
-    }
-
     &[disabled] {
         background-color: @color-core-gray-light;
         color: @color-core-gray-silver;
@@ -65,17 +61,21 @@ span.select__icon {
     }
 }
 
-.select.select--borderless > select {
-    padding-left: 0;
-
-    &:focus {
-        border-color: @color-core-blue;
-    }
+.select > select:focus {
+    border-color: @color-core-blue;
 }
 
 [dir="rtl"] {
     .select& > select {
         padding-left: 40px;
         padding-right: 16px;
+    }
+}
+
+.select.select--borderless > select {
+    padding-left: 0;
+
+    &:focus {
+        border-color: @color-core-blue;
     }
 }

--- a/src/less/select/ds6/select.less
+++ b/src/less/select/ds6/select.less
@@ -31,6 +31,13 @@ span.select__icon {
     }
 }
 
+[dir="rtl"] {
+    .select& > select {
+        padding-left: 30px;
+        padding-right: 16px;
+    }
+}
+
 .select.select--borderless > select {
     &:focus {
         border-color: @ds6-color-p004-blue;
@@ -39,12 +46,5 @@ span.select__icon {
     &[disabled] {
         background-color: @ds6-color-g201-gray;
         color: @ds6-color-g204-gray;
-    }
-}
-
-[dir="rtl"] {
-    .select& > select {
-        padding-left: 30px;
-        padding-right: 16px;
     }
 }


### PR DESCRIPTION
## Description

As part of cleanup of LESS files I temporarily removed the "no-descending-specificity" stylelint rule and fixed all violations for **select**. I then put the rule back in place (until we've fixed all modules).

I tested this locally and nothing seems to break.

## Context

Trying to match the default, out of the box settings of stylelint where it makes sense.

## References

#180.

## Notes

We cannot currently disable this rule for CSS, due to the way the delta CSS is appended to the base CSS. But maybe in future we could use something like PostCSS/CSSComb to reorder the compiled CSS.

## Screenshots

The LESS violations:

![image](https://user-images.githubusercontent.com/105656/42974944-bd73227a-8b76-11e8-931d-a4d2a738e580.png)
