### PR TITLE
fix DS6 30px font size

### DIFF
--- a/src/less/less/ds6/variables.less
+++ b/src/less/less/ds6/variables.less
@@ -59,7 +59,7 @@
 @ds6-font-size-24: 1.5rem;
 @ds6-font-size-26: 1.625rem;
 @ds6-font-size-28: 1.75rem;
-@ds6-font-size-30: 1.8625rem;
+@ds6-font-size-30: 1.875rem;
 @ds6-font-size-36: 2.25rem;
 
 @ds6-font-size-giant-2: @ds6-font-size-36;


### PR DESCRIPTION
## Description
Change DS6 font size for 30px from `1.8625rem` to the correct `1.875rem`

## References
Fixes https://github.com/eBay/skin/issues/298
