### PR TITLE
298 ds6 fontsize

### DIFF
--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -4,7 +4,7 @@ a.fake-btn,
 a.cta-btn {
   border: 1px solid;
   font-family: inherit;
-  font-size: 16px;
+  font-size: 14px;
   height: 40px;
   line-height: 40px;
   margin: 0;
@@ -55,17 +55,14 @@ button.expand-btn[aria-disabled="true"] span.expand-btn__icon {
   height: 100%;
   width: 9px;
 }
-button.btn--small,
-button.expand-btn--small,
-a.fake-btn--small {
-  font-size: 14px;
-  height: 32px;
-  line-height: 32px;
-}
 button.btn--large,
 button.expand-btn--large,
 a.fake-btn--large,
-a.cta-btn--large {
+a.cta-btn--large,
+button.btn--extra-large,
+button.expand-btn--extra-large,
+a.fake-btn--extra-large {
+  font-size: 18px;
   height: 48px;
   line-height: 48px;
 }

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -14,7 +14,7 @@
   color: transparent;
   cursor: default;
   font-family: inherit;
-  font-size: 16px;
+  font-size: 14px;
   height: 40px;
   padding: 0 16px;
   text-shadow: 0 0 0 #111820;

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -211,7 +211,7 @@ span.fake-menu__status {
   color: transparent;
   cursor: default;
   font-family: inherit;
-  font-size: 16px;
+  font-size: 14px;
   height: 40px;
   padding: 0 16px;
   text-shadow: 0 0 0 #111820;

--- a/dist/less/ds6/variables.less
+++ b/dist/less/ds6/variables.less
@@ -59,7 +59,7 @@
 @ds6-font-size-24: 1.5rem;
 @ds6-font-size-26: 1.625rem;
 @ds6-font-size-28: 1.75rem;
-@ds6-font-size-30: 1.8625rem;
+@ds6-font-size-30: 1.875rem;
 @ds6-font-size-36: 2.25rem;
 
 @ds6-font-size-giant-2: @ds6-font-size-36;

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -32,7 +32,7 @@
   border: 1px solid #c7c7c7;
   border-radius: 0;
   font-family: "Market Sans", Arial, sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   height: 40px;
   margin-top: -1px;
   padding: 8px 30px 8px 16px;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -15,11 +15,12 @@ textarea.textbox__control {
   box-sizing: border-box;
   color: #111820;
   font-family: inherit;
-  font-size: inherit;
+  font-size: 14px;
   height: 40px;
   line-height: 1.5;
   margin: 0;
   padding: 0 16px 0 16px;
+  vertical-align: middle;
 }
 input.textbox__control::-webkit-input-placeholder,
 textarea.textbox__control::-webkit-input-placeholder {
@@ -149,18 +150,14 @@ span.textbox__icon:first-child + textarea.textbox__control,
 .textbox--icon-end .textbox__icon:last-child {
   right: 17px;
 }
-.textbox--small {
-  font-size: 12px;
-}
-.textbox--small input.textbox__control,
-.textbox--small textarea.textbox__control {
-  height: 32px;
-}
-.textbox--large {
-  font-size: 16px;
+.textbox--large,
+.textbox--extra-large {
+  font-size: 18px;
 }
 .textbox--large input.textbox__control,
-.textbox--large textarea.textbox__control {
+.textbox--extra-large input.textbox__control,
+.textbox--large textarea.textbox__control,
+.textbox--extra-large textarea.textbox__control {
   height: 48px;
 }
 .textbox__control--fluid {

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -4,7 +4,7 @@
   line-height: 46px;
 }
 .giant-text-1 {
-  font-size: 1.8625rem;
+  font-size: 1.875rem;
   font-weight: 700;
   line-height: 40px;
 }

--- a/docs/_includes/ds6/button.html
+++ b/docs/_includes/ds6/button.html
@@ -65,16 +65,6 @@
         {% endhighlight %}
     </div>
 
-    <h3 id="button-small">Small Button</h3>
-    <div class="demo">
-        <div class="demo__inner">
-            <button class="btn btn--primary btn--small">Button</button>
-        </div>
-        {% highlight html %}
-<button class="btn btn--primary btn--small">Button</button>
-        {% endhighlight %}
-    </div>
-
     <h3 id="button-large">Large Button</h3>
     <div class="demo">
         <div class="demo__inner">

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -96,7 +96,7 @@ a.fake-btn,
 a.cta-btn {
   border: 1px solid;
   font-family: inherit;
-  font-size: 16px;
+  font-size: 14px;
   height: 40px;
   line-height: 40px;
   margin: 0;
@@ -147,17 +147,14 @@ button.expand-btn[aria-disabled="true"] span.expand-btn__icon {
   height: 100%;
   width: 9px;
 }
-button.btn--small,
-button.expand-btn--small,
-a.fake-btn--small {
-  font-size: 14px;
-  height: 32px;
-  line-height: 32px;
-}
 button.btn--large,
 button.expand-btn--large,
 a.fake-btn--large,
-a.cta-btn--large {
+a.cta-btn--large,
+button.btn--extra-large,
+button.expand-btn--extra-large,
+a.fake-btn--extra-large {
+  font-size: 18px;
   height: 48px;
   line-height: 48px;
 }
@@ -1623,7 +1620,7 @@ span.fake-menu__status {
   color: transparent;
   cursor: default;
   font-family: inherit;
-  font-size: 16px;
+  font-size: 14px;
   height: 40px;
   padding: 0 16px;
   text-shadow: 0 0 0 #111820;
@@ -2132,7 +2129,7 @@ span.inline-notice {
   border: 1px solid #c7c7c7;
   border-radius: 0;
   font-family: "Market Sans", Arial, sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   height: 40px;
   margin-top: -1px;
   padding: 8px 30px 8px 16px;
@@ -2168,11 +2165,12 @@ textarea.textbox__control {
   box-sizing: border-box;
   color: #111820;
   font-family: inherit;
-  font-size: inherit;
+  font-size: 14px;
   height: 40px;
   line-height: 1.5;
   margin: 0;
   padding: 0 16px 0 16px;
+  vertical-align: middle;
 }
 input.textbox__control::-webkit-input-placeholder,
 textarea.textbox__control::-webkit-input-placeholder {
@@ -2302,18 +2300,14 @@ span.textbox__icon:first-child + textarea.textbox__control,
 .textbox--icon-end .textbox__icon:last-child {
   right: 17px;
 }
-.textbox--small {
-  font-size: 12px;
-}
-.textbox--small input.textbox__control,
-.textbox--small textarea.textbox__control {
-  height: 32px;
-}
-.textbox--large {
-  font-size: 16px;
+.textbox--large,
+.textbox--extra-large {
+  font-size: 18px;
 }
 .textbox--large input.textbox__control,
-.textbox--large textarea.textbox__control {
+.textbox--extra-large input.textbox__control,
+.textbox--large textarea.textbox__control,
+.textbox--extra-large textarea.textbox__control {
   height: 48px;
 }
 .textbox__control--fluid {
@@ -2347,7 +2341,7 @@ span.textbox__icon:first-child + textarea.textbox__control,
   line-height: 46px;
 }
 .giant-text-1 {
-  font-size: 1.8625rem;
+  font-size: 1.875rem;
   font-weight: 700;
   line-height: 40px;
 }

--- a/src/less/button/ds6/button-base.less
+++ b/src/less/button/ds6/button-base.less
@@ -11,7 +11,7 @@ a.fake-btn,
 a.cta-btn {
     border: 1px solid;
     font-family: inherit;
-    font-size: 16px;
+    font-size: 14px;
     height: 40px;
     line-height: 40px;
     margin: 0; // Remove the button margin in Firefox and Safari */
@@ -73,18 +73,14 @@ button.expand-btn {
 
 // BEM block mods
 
-button.btn--small,
-button.expand-btn--small,
-a.fake-btn--small {
-    font-size: 14px;
-    height: 32px;
-    line-height: 32px;
-}
-
 button.btn--large,
 button.expand-btn--large,
 a.fake-btn--large,
-a.cta-btn--large {
+a.cta-btn--large,
+button.btn--extra-large, // BACKWARDS COMPATIBILITY FOR DS4
+button.expand-btn--extra-large, // BACKWARDS COMPATIBILITY FOR DS4
+a.fake-btn--extra-large { // BACKWARDS COMPATIBILITY FOR DS4
+    font-size: 18px;
     height: 48px;
     line-height: 48px;
 }

--- a/src/less/combobox/ds6/combobox-base.less
+++ b/src/less/combobox/ds6/combobox-base.less
@@ -16,7 +16,7 @@
     color: transparent;
     cursor: default;
     font-family: inherit;
-    font-size: 16px;
+    font-size: 14px;
     height: @combobox-height;
     padding: 0 16px;
     // fixes the cursor in firefox (2 of 2)

--- a/src/less/less/ds6/variables.less
+++ b/src/less/less/ds6/variables.less
@@ -59,7 +59,7 @@
 @ds6-font-size-24: 1.5rem;
 @ds6-font-size-26: 1.625rem;
 @ds6-font-size-28: 1.75rem;
-@ds6-font-size-30: 1.8625rem;
+@ds6-font-size-30: 1.875rem;
 @ds6-font-size-36: 2.25rem;
 
 @ds6-font-size-giant-2: @ds6-font-size-36;

--- a/src/less/select/ds6/select-base.less
+++ b/src/less/select/ds6/select-base.less
@@ -29,7 +29,7 @@
     border: 1px solid #c7c7c7;
     border-radius: 0;
     font-family: @ds6-font-family-custom; // for some reason this needs to be explicitly set
-    font-size: 16px;
+    font-size: 14px;
     height: 40px;
     margin-top: -1px; // account for the border
     padding: 8px 30px 8px 16px;

--- a/src/less/textbox/ds6/textbox-base.less
+++ b/src/less/textbox/ds6/textbox-base.less
@@ -19,11 +19,12 @@ textarea.textbox__control {
     box-sizing: border-box;
     color: @ds6-color-g206-gray;
     font-family: inherit;
-    font-size: inherit;
+    font-size: 14px;
     height: 40px;
     line-height: 1.5;
     margin: 0; // Remove the margin in Firefox and Safari.
     padding: 0 16px 0 16px;
+    vertical-align: middle;
 
     &[disabled] {
         .placeholder-disabled;
@@ -117,17 +118,9 @@ span.textbox__icon:first-child,
     }
 }
 
-.textbox--small {
-    font-size: 12px;
-
-    input.textbox__control,
-    textarea.textbox__control {
-        height: 32px;
-    }
-}
-
-.textbox--large {
-    font-size: 16px;
+.textbox--large,
+.textbox--extra-large { // BACKWARDS COMPATIBILITY FOR DS4
+    font-size: 18px;
 
     input.textbox__control,
     textarea.textbox__control {


### PR DESCRIPTION
## Description
Standardized font sizes for button, combobox, dropdown, select, and textbox to small 14px or large 18px.

## Context
Design guidelines updated.
Fixed a one pixel alignment issue on the textbox by adding vertical-align:middle.
Added backwards compatibility with DS4 for:
`.btn--extra-large`
`.textbox--extra-large`

## References
Fixes https://github.com/eBay/skin/issues/298

## Screenshots
### Before
![screen shot 2018-08-15 at 5 18 58 pm](https://user-images.githubusercontent.com/1562843/44180088-5d4f5000-a0af-11e8-9c43-546b69d95d20.png)

![screen shot 2018-08-15 at 5 20 05 pm](https://user-images.githubusercontent.com/1562843/44180108-8243c300-a0af-11e8-97de-efd2573d8377.png)

![screen shot 2018-08-15 at 5 20 52 pm](https://user-images.githubusercontent.com/1562843/44180120-9a1b4700-a0af-11e8-9686-378ab7fba046.png)

### After
![screen shot 2018-08-15 at 5 18 47 pm](https://user-images.githubusercontent.com/1562843/44180090-63453100-a0af-11e8-951e-5f1a5d44313d.png)

![screen shot 2018-08-15 at 5 20 12 pm](https://user-images.githubusercontent.com/1562843/44180110-87a10d80-a0af-11e8-855c-5a0797cde583.png)

![screen shot 2018-08-15 at 5 20 58 pm](https://user-images.githubusercontent.com/1562843/44180122-9e476480-a0af-11e8-8bc4-6fb43292a172.png)

