### PR TITLE
fixing pagination link focus

### DIFF
--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -125,7 +125,9 @@
 }
 .pagination--fluid .pagination__items {
   height: 48px;
+  margin: -4px 0;
   max-width: 512px;
+  padding: 4px 4px 4px 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2146,7 +2146,9 @@ button.page-notice__close span {
 }
 .pagination--fluid .pagination__items {
   height: 48px;
+  margin: -4px 0;
   max-width: 512px;
+  padding: 4px 4px 4px 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {

--- a/src/less/pagination/ds6/pagination.less
+++ b/src/less/pagination/ds6/pagination.less
@@ -86,7 +86,9 @@
 
 .pagination--fluid .pagination__items {
     height: 48px;
+    margin: -4px 0;
     max-width: 512px;
+    padding: 4px 4px 4px 0;
 }
 
 @media screen and (-ms-high-contrast: white-on-black) {


### PR DESCRIPTION
## Description
Gave more room for the pagination focus for fluid pagination

## Context
Found that it was only happening in the fluid pagination due to the `overflow:hidden`.  But it was happening in other browsers (Chrome), not just safari.

Added padding to the `<ol>` to make sure it was visible, but used negative margins to keep the original height.

## References
Fixes https://github.com/eBay/skin/issues/153

## Screenshots
![screen shot 2018-08-16 at 6 05 19 pm](https://user-images.githubusercontent.com/1562843/44242667-a5d63e80-a17f-11e8-924f-0d7ea919c986.png)

