### PR TITLE
Switch: clear default margin

### DIFF
--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -45,6 +45,7 @@ span.switch__button::after {
 input.switch__control {
   height: 24px;
   left: 0;
+  margin: 0;
   opacity: 0;
   padding: 0;
   position: absolute;

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -45,6 +45,7 @@ span.switch__button::after {
 input.switch__control {
   height: 24px;
   left: 0;
+  margin: 0;
   opacity: 0;
   padding: 0;
   position: absolute;

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -3386,6 +3386,7 @@ span.switch__button::after {
 input.switch__control {
   height: 24px;
   left: 0;
+  margin: 0;
   opacity: 0;
   padding: 0;
   position: absolute;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -3386,6 +3386,7 @@ span.switch__button::after {
 input.switch__control {
   height: 24px;
   left: 0;
+  margin: 0;
   opacity: 0;
   padding: 0;
   position: absolute;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2453,6 +2453,7 @@ span.switch__button::after {
 input.switch__control {
   height: 24px;
   left: 0;
+  margin: 0;
   opacity: 0;
   padding: 0;
   position: absolute;

--- a/src/less/switch/base/switch.less
+++ b/src/less/switch/base/switch.less
@@ -46,6 +46,7 @@ span.switch__button {
 input.switch__control {
     height: 24px;
     left: 0;
+    margin: 0;
     opacity: 0;
     padding: 0;
     position: absolute;


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- adds `margin: 0` to switch `input`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Margin causes offset issues which can lead to event bugs.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Fixes https://github.com/eBay/ebayui-core/issues/359
Follow up to https://github.com/eBay/skin/pull/208

## Screenshots
<!-- Upload screenshots if appropriate-->

Before:
<img width="231" alt="screen shot 2018-08-22 at 10 27 19 am" src="https://user-images.githubusercontent.com/3595986/44469831-56b46180-a5f6-11e8-9344-cdfd08e372e5.png">

After:
<img width="247" alt="screen shot 2018-08-22 at 10 27 27 am" src="https://user-images.githubusercontent.com/3595986/44469827-54ea9e00-a5f6-11e8-86ce-44f4dd29200a.png">

