### PR TITLE
supporting expand button for small buttons

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -366,7 +366,12 @@ a.fake-btn--extra-large {
   font-size: 18px;
   padding: 0 112px;
 }
-button.expand-btn--small,
+button.expand-btn--small {
+  padding: 0 12px 0 16px;
+}
+button.expand-btn--small.expand-btn--no-text {
+  padding: 0 12px;
+}
 button.expand-btn--large,
 button.expand-btn--extra-large {
   padding: 0 16px;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -322,6 +322,12 @@ button.expand-btn--legacy,
 a.fake-btn--legacy {
   height: 32px;
 }
+button.expand-btn--legacy {
+  padding: 0 12px 0 16px;
+}
+button.expand-btn--legacy.expand-btn--no-text {
+  padding: 0 12px;
+}
 svg.btn__icon,
 svg.fake-btn__icon {
   display: inline-block;

--- a/docs/_includes/common/button.html
+++ b/docs/_includes/common/button.html
@@ -225,30 +225,7 @@
 </button>
     {% endhighlight %}
 
-    <h3 id="button-expand">Expand Button</h3>
-    <p>Use the <span class="highlight">expand-btn</span> base class on a button that expands (and collapses) content.</p>
-    <div class="demo">
-        <div class="demo__inner">
-            <button aria-expanded="false" class="expand-btn expand-btn--regular expand-btn-example" type="button">
-                <span class="expand-btn__cell">
-                    <span>Expand</span>
-                    <span class="expand-btn__icon"></span>
-                </span>
-            </button>
-        </div>
-    </div>
-
-    {% highlight html %}
-<button aria-expanded="false" class="expand-btn expand-btn--regular" type="button">
-    <span class="expand-btn__cell">
-        <span>Expand</span>
-        <span class="expand-btn__icon"></span>
-    </span>
-</button>
-    {% endhighlight %}
-
-    <p>Can be used with or without a text label, with background or foreground SVG.</p>
-    <!-- Deviation! DS4 uses arrow down icon. DS6 uses a chevron icon -->
+    <!-- Deviation! DS4 uses arrow down icon. DS6 uses a chevron icon. DS6 uses legacy for small button -->
     {% include ds{{ page.ds}}/button-expand.html %}
     </div>
 

--- a/docs/_includes/ds4/button-expand.html
+++ b/docs/_includes/ds4/button-expand.html
@@ -1,9 +1,51 @@
+<h3 id="button-expand">Expand Button</h3>
+<p>Use the <span class="highlight">expand-btn</span> base class on a button that expands (and collapses) content.</p>
+<div class="demo">
+    <div class="demo__inner">
+        <button aria-expanded="false" class="expand-btn expand-btn--regular expand-btn-example" type="button">
+            <span class="expand-btn__cell">
+                <span>Expand</span>
+                <span class="expand-btn__icon"></span>
+            </span>
+        </button>
+        <button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--small expand-btn-example" type="button">
+            <span class="expand-btn__cell">
+                <span>Expand</span>
+                <span class="expand-btn__icon"></span>
+            </span>
+        </button>
+    </div>
+</div>
+
+{% highlight html %}
+<button aria-expanded="false" class="expand-btn expand-btn--regular" type="button">
+<span class="expand-btn__cell">
+    <span>Expand</span>
+    <span class="expand-btn__icon"></span>
+</span>
+</button>
+
+<button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--small" type="button">
+<span class="expand-btn__cell">
+    <span>Expand</span>
+    <span class="expand-btn__icon"></span>
+</span>
+</button>
+{% endhighlight %}
+
+<p>Can be used with or without a text label, with background or foreground SVG.</p>
+
 <div class="demo">
     <div class="demo__inner">
         <button aria-expanded="false" class="expand-btn expand-btn--secondary expand-btn-example" aria-label="Expand/Collapse">
             <span class="expand-btn__icon"></span>
         </button>
         <button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn-example" aria-label="Expand/Collapse">
+            <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
+                <use xlink:href="#icon-arrow-down"></use>
+            </svg>
+        </button>
+        <button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--small expand-btn--no-text expand-btn-example" aria-label="Expand/Collapse">
             <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
                 <use xlink:href="#icon-arrow-down"></use>
             </svg>
@@ -19,4 +61,11 @@
         <use xlink:href="#icon-arrow-down"></use>
     </svg>
 </button>
+
+<button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--small expand-btn--no-text" aria-label="Expand/Collapse">
+    <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
+        <use xlink:href="#icon-arrow-down"></use>
+    </svg>
+</button>
+
     {% endhighlight %}

--- a/docs/_includes/ds6/button-expand.html
+++ b/docs/_includes/ds6/button-expand.html
@@ -1,9 +1,51 @@
+<h3 id="button-expand">Expand Button</h3>
+<p>Use the <span class="highlight">expand-btn</span> base class on a button that expands (and collapses) content.</p>
+<div class="demo">
+    <div class="demo__inner">
+        <button aria-expanded="false" class="expand-btn expand-btn--regular expand-btn-example" type="button">
+            <span class="expand-btn__cell">
+                <span>Expand</span>
+                <span class="expand-btn__icon"></span>
+            </span>
+        </button>
+        <button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--legacy expand-btn-example" type="button">
+            <span class="expand-btn__cell">
+                <span>Expand</span>
+                <span class="expand-btn__icon"></span>
+            </span>
+        </button>
+    </div>
+</div>
+
+{% highlight html %}
+<button aria-expanded="false" class="expand-btn expand-btn--regular" type="button">
+<span class="expand-btn__cell">
+    <span>Expand</span>
+    <span class="expand-btn__icon"></span>
+</span>
+</button>
+
+<button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--legacy" type="button">
+<span class="expand-btn__cell">
+    <span>Expand</span>
+    <span class="expand-btn__icon"></span>
+</span>
+</button>
+{% endhighlight %}
+
+<p>Can be used with or without a text label, with background or foreground SVG.</p>
+
 <div class="demo">
     <div class="demo__inner">
         <button aria-expanded="false" class="expand-btn expand-btn--secondary expand-btn-example" aria-label="Expand/Collapse">
             <span class="expand-btn__icon"></span>
         </button>
         <button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn-example" aria-label="Expand/Collapse">
+            <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
+                <use xlink:href="#icon-chevron-down"></use>
+            </svg>
+        </button>
+        <button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--legacy expand-btn--no-text  expand-btn-example" aria-label="Expand/Collapse">
             <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
                 <use xlink:href="#icon-chevron-down"></use>
             </svg>
@@ -19,4 +61,11 @@
         <use xlink:href="#icon-chevron-down"></use>
     </svg>
 </button>
+
+<button aria-expanded="false" class="expand-btn expand-btn--primary expand-btn--legacy expand-btn--no-text" aria-label="Expand/Collapse">
+    <svg aria-hidden="true" class="expand-btn__icon" focusable="false" height="8" width="8">
+        <use xlink:href="#icon-chevron-down"></use>
+    </svg>
+</button>
+
     {% endhighlight %}

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -609,7 +609,12 @@ a.fake-btn--extra-large {
   font-size: 18px;
   padding: 0 112px;
 }
-button.expand-btn--small,
+button.expand-btn--small {
+  padding: 0 12px 0 16px;
+}
+button.expand-btn--small.expand-btn--no-text {
+  padding: 0 12px;
+}
 button.expand-btn--large,
 button.expand-btn--extra-large {
   padding: 0 16px;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -609,7 +609,12 @@ a.fake-btn--extra-large {
   font-size: 18px;
   padding: 0 112px;
 }
-button.expand-btn--small,
+button.expand-btn--small {
+  padding: 0 12px 0 16px;
+}
+button.expand-btn--small.expand-btn--no-text {
+  padding: 0 12px;
+}
 button.expand-btn--large,
 button.expand-btn--extra-large {
   padding: 0 16px;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -416,6 +416,12 @@ button.expand-btn--legacy,
 a.fake-btn--legacy {
   height: 32px;
 }
+button.expand-btn--legacy {
+  padding: 0 12px 0 16px;
+}
+button.expand-btn--legacy.expand-btn--no-text {
+  padding: 0 12px;
+}
 svg.btn__icon,
 svg.fake-btn__icon {
   display: inline-block;

--- a/src/less/button/ds4/button-sizes.less
+++ b/src/less/button/ds4/button-sizes.less
@@ -26,7 +26,14 @@ a.fake-btn--extra-large {
     padding: 0 112px;
 }
 
-button.expand-btn--small,
+button.expand-btn--small {
+    padding: 0 12px 0 16px;
+
+    &.expand-btn--no-text {
+        padding: 0 12px;
+    }
+}
+
 button.expand-btn--large,
 button.expand-btn--extra-large {
     padding: 0 16px;

--- a/src/less/button/ds6/button-legacy.less
+++ b/src/less/button/ds6/button-legacy.less
@@ -5,3 +5,11 @@ button.expand-btn--legacy,
 a.fake-btn--legacy {
     height: 32px;
 }
+
+button.expand-btn--legacy {
+    padding: 0 12px 0 16px;
+
+    &.expand-btn--no-text {
+        padding: 0 12px;
+    }
+}


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
Added different padding for expand buttons, with a variation when there is not text using the "expand-btn--no-text" class.

## Context
It only added one extra CSS declaration to support the no-text case.  It was better than trying to restructure the html.

## References
Fixes https://github.com/eBay/skin/issues/244

## Screenshots
### DS4
![screen shot 2018-08-22 at 10 21 00 am](https://user-images.githubusercontent.com/1562843/44479334-23bd9e00-a5f5-11e8-9467-6378e05e0edd.png)
![screen shot 2018-08-22 at 10 21 05 am](https://user-images.githubusercontent.com/1562843/44479338-291ae880-a5f5-11e8-8fb6-7fffa271c1c1.png)

### DS6
![screen shot 2018-08-22 at 10 21 47 am](https://user-images.githubusercontent.com/1562843/44479361-4059d600-a5f5-11e8-891d-6ee7d7413ae9.png)
![screen shot 2018-08-22 at 10 21 52 am](https://user-images.githubusercontent.com/1562843/44479367-43ed5d00-a5f5-11e8-8b0c-252cf355d2d4.png)

