### PR TITLE
Card dialog fixes;

### DIFF
--- a/dist/dialog/ds4/dialog.css
+++ b/dist/dialog/ds4/dialog.css
@@ -216,10 +216,11 @@
 }
 .dialog__body {
   font-size: 0.875rem;
-  padding-top: calc(1.125rem + 8px);
+  padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
   background-color: #fff;
+  border-bottom: 1px solid #eee;
   box-sizing: border-box;
   font-size: 1.125rem;
   font-weight: 400;
@@ -248,6 +249,14 @@
 }
 .dialog--hide-close-button .dialog__close {
   display: none;
+}
+.dialog .card {
+  margin: 16px 0;
+}
+.dialog .card.card--primary {
+  margin-left: -16px;
+  margin-right: -16px;
+  margin-top: -16px;
 }
 @media (min-width: 601px) {
   .dialog__window:not(.dialog__window--full) {

--- a/docs/_includes/ds4/card.html
+++ b/docs/_includes/ds4/card.html
@@ -143,15 +143,11 @@
             <button class="btn btn--primary btn--small dialog-button" type="button" data-jquery-dialog-button-for="dialog-card">Dialog with Cards</button>
             <div role="dialog" class="dialog" id="dialog-card" aria-labelledby="dialog-card-title" hidden data-jquery-dialog-transition-out-duration="175">
                 <div class="dialog__window" role="document">
-                    <header class="dialog__header">
-                        <h2 class="dialog__title" id="dialog-card-title">Dialog with Cards</h2>
-                        <button aria-label="Close dialog" class="dialog__close" type="button">
-                            <svg aria-hidden="true" focusable="false">
-                                <use xlink:href="#icon-close"></use>
-                            </svg>
-                        </button>
-                    </header>
+                    <button aria-label="Close dialog" class="dialog__close" type="button">
+                        <span></span>
+                    </button>
                     <div class="dialog__body">
+                        <h2 id="dialog-card-title">Dialog with Cards</h2>
                         <div class="card card--primary">
                             <div class="card__cell">
                                 <h2>Title</h2>
@@ -171,7 +167,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="dialog__mask"></div>
             </div>
         </div>
     </div>

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -1328,10 +1328,11 @@ span.combobox__icon {
 }
 .dialog__body {
   font-size: 0.875rem;
-  padding-top: calc(1.125rem + 8px);
+  padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
   background-color: #fff;
+  border-bottom: 1px solid #eee;
   box-sizing: border-box;
   font-size: 1.125rem;
   font-weight: 400;
@@ -1360,6 +1361,14 @@ span.combobox__icon {
 }
 .dialog--hide-close-button .dialog__close {
   display: none;
+}
+.dialog .card {
+  margin: 16px 0;
+}
+.dialog .card.card--primary {
+  margin-left: -16px;
+  margin-right: -16px;
+  margin-top: -16px;
 }
 @media (min-width: 601px) {
   .dialog__window:not(.dialog__window--full) {

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -1328,10 +1328,11 @@ span.combobox__icon {
 }
 .dialog__body {
   font-size: 0.875rem;
-  padding-top: calc(1.125rem + 8px);
+  padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
   background-color: #fff;
+  border-bottom: 1px solid #eee;
   box-sizing: border-box;
   font-size: 1.125rem;
   font-weight: 400;
@@ -1360,6 +1361,14 @@ span.combobox__icon {
 }
 .dialog--hide-close-button .dialog__close {
   display: none;
+}
+.dialog .card {
+  margin: 16px 0;
+}
+.dialog .card.card--primary {
+  margin-left: -16px;
+  margin-right: -16px;
+  margin-top: -16px;
 }
 @media (min-width: 601px) {
   .dialog__window:not(.dialog__window--full) {

--- a/src/less/dialog/ds4/dialog.less
+++ b/src/less/dialog/ds4/dialog.less
@@ -112,7 +112,6 @@
         display: none;
     }
 
-    // temp fix for cards example
     .card {
         margin: 16px 0;
 

--- a/src/less/dialog/ds4/dialog.less
+++ b/src/less/dialog/ds4/dialog.less
@@ -59,10 +59,11 @@
 
     &__body {
         font-size: @ds4-font-size-14;
-        padding-top: calc(1.125rem ~"+" 8px);
+        padding-top: calc(1.125rem ~"+" 12px);
 
         h2:first-of-type {
             background-color: @ds4-color-core-white;
+            border-bottom: 1px solid @ds4-color-core-gray-light;
             box-sizing: border-box;
             font-size: @ds4-font-size-18;
             font-weight: 400;
@@ -109,6 +110,17 @@
 
     &--hide-close-button &__close {
         display: none;
+    }
+
+    // temp fix for cards example
+    .card {
+        margin: 16px 0;
+
+        &.card--primary {
+            margin-left: -16px;
+            margin-right: -16px;
+            margin-top: -16px;
+        }
     }
 }
 


### PR DESCRIPTION
## Description
- fixes the dialog HTML in the cards example
- adds some (albeit, tightly coupled) CSS because the dialog body now has default margins
- minor fix for the heading margin in DS4 (since it's a fake heading using the first H2, it needs 4px more)

## Context
Fixing the example for the docs.

## References
Fixes #320 

## Screenshots

**Before**
![image](https://user-images.githubusercontent.com/105656/44290795-a7fbd400-a237-11e8-891d-64380f078b10.png)

**After**
![image](https://user-images.githubusercontent.com/105656/44549725-390ef700-a6df-11e8-8438-928beeb5de55.png)
