### PR TITLE
Fix for Borderless select in DS4 #272

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 npm-debug.log*
 yarn-error.log*
 .DS_Store
+.history

--- a/dist/select/ds4/select.css
+++ b/dist/select/ds4/select.css
@@ -64,10 +64,12 @@ svg.select__icon {
 }
 .select.select--borderless > select {
   background-color: transparent;
-  border-color: transparent;
+  border: 0;
+  padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border: 1px solid;
+  text-decoration: underline;
 }
 [dir="rtl"] span.select__icon {
   left: 16px;
@@ -129,8 +131,11 @@ span.select__icon {
   padding-right: 16px;
 }
 .select.select--borderless > select {
+  background-color: transparent;
+  border: 0;
   padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border-color: #0654ba;
+  text-decoration: underline;
 }

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -64,10 +64,12 @@ svg.select__icon {
 }
 .select.select--borderless > select {
   background-color: transparent;
-  border-color: transparent;
+  border: 0;
+  padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border: 1px solid;
+  text-decoration: underline;
 }
 [dir="rtl"] span.select__icon {
   left: 16px;

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -3253,10 +3253,12 @@ svg.select__icon {
 }
 .select.select--borderless > select {
   background-color: transparent;
-  border-color: transparent;
+  border: 0;
+  padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border: 1px solid;
+  text-decoration: underline;
 }
 [dir="rtl"] span.select__icon {
   left: 16px;
@@ -3318,10 +3320,13 @@ span.select__icon {
   padding-right: 16px;
 }
 .select.select--borderless > select {
+  background-color: transparent;
+  border: 0;
   padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border-color: #0654ba;
+  text-decoration: underline;
 }
 .spinner[role="img"][aria-label] {
   -webkit-animation: spin 600ms linear infinite;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -3253,10 +3253,12 @@ svg.select__icon {
 }
 .select.select--borderless > select {
   background-color: transparent;
-  border-color: transparent;
+  border: 0;
+  padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border: 1px solid;
+  text-decoration: underline;
 }
 [dir="rtl"] span.select__icon {
   left: 16px;
@@ -3318,10 +3320,13 @@ span.select__icon {
   padding-right: 16px;
 }
 .select.select--borderless > select {
+  background-color: transparent;
+  border: 0;
   padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border-color: #0654ba;
+  text-decoration: underline;
 }
 .spinner[role="img"][aria-label] {
   -webkit-animation: spin 600ms linear infinite;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2375,10 +2375,12 @@ svg.select__icon {
 }
 .select.select--borderless > select {
   background-color: transparent;
-  border-color: transparent;
+  border: 0;
+  padding-left: 0;
+  width: auto;
 }
 .select.select--borderless > select:focus {
-  border: 1px solid;
+  text-decoration: underline;
 }
 [dir="rtl"] span.select__icon {
   left: 16px;

--- a/src/less/select/base/select.less
+++ b/src/less/select/base/select.less
@@ -68,10 +68,12 @@ span.select {
 
 .select.select--borderless > select {
     background-color: transparent;
-    border-color: transparent;
+    border: 0;
+    padding-left: 0;
+    width: auto;
 
     &:focus {
-        border: 1px solid;
+        text-decoration: underline;
     }
 }
 

--- a/src/less/select/ds4/select.less
+++ b/src/less/select/ds4/select.less
@@ -73,9 +73,12 @@ span.select__icon {
 }
 
 .select.select--borderless > select {
+    background-color: transparent;
+    border: 0;
     padding-left: 0;
+    width: auto;
 
     &:focus {
-        border-color: @ds4-color-core-blue;
+        text-decoration: underline;
     }
 }


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
1. removed border onFocus for borderless select in Ds4 & Ds6 (similar to borderless listbox)
2. Removed background-color for borderless-disabled select & made it transparent in Ds4 & Ds6
3. updated .gitignore file to ignore history 
 
## Context
Since we have set padding-left: 0 and onFocus we have set the border, content seems to be overlapping with the border.  For eg:
<img width="279" alt="screen shot 2018-08-23 at 2 18 15 pm" src="https://user-images.githubusercontent.com/16012151/44552931-b850fa80-a6e0-11e8-85f5-6c620ad277db.png">

## References
#272 

## Screenshots
Before:
--Borderless select DS4--
<img width="279" alt="screen shot 2018-08-23 at 2 18 15 pm" src="https://user-images.githubusercontent.com/16012151/44552990-f2220100-a6e0-11e8-8e69-7336e7ff07a3.png">

--Borderless Disabled select DS4 --
<img width="324" alt="screen shot 2018-08-23 at 2 18 20 pm" src="https://user-images.githubusercontent.com/16012151/44552991-f4845b00-a6e0-11e8-964a-0f7d9b3bdd03.png">

--Boderless select DS6--
<img width="331" alt="screen shot 2018-08-23 at 2 17 53 pm" src="https://user-images.githubusercontent.com/16012151/44553073-3b725080-a6e1-11e8-9dd1-31baf4040252.png">

After:

--Borderless select DS4--
<img width="230" alt="screen shot 2018-08-23 at 2 19 02 pm" src="https://user-images.githubusercontent.com/16012151/44553021-0c5bdf00-a6e1-11e8-90eb-74ab1a47eb92.png">


--Borderless Disabled select DS4--
<img width="323" alt="screen shot 2018-08-23 at 2 19 08 pm" src="https://user-images.githubusercontent.com/16012151/44553037-1847a100-a6e1-11e8-8ec7-444984fab0ad.png">

--Borderless select DS6--
<img width="242" alt="screen shot 2018-08-23 at 2 18 49 pm" src="https://user-images.githubusercontent.com/16012151/44553102-4b8a3000-a6e1-11e8-96d1-a6e68d5d287d.png">

