### PR TITLE
Aligns all the borderless versions of select, menu and combobox;

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -13,6 +13,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {
@@ -144,10 +150,6 @@ span.fake-menu__status {
 .fake-menu__items--reverse {
   right: 0;
 }
-.menu button.expand-btn--borderless,
-.fake-menu button.expand-btn--borderless {
-  background-color: transparent;
-}
 .menu__items[role="menu"],
 .combobox__options[role="listbox"],
 .fake-menu__items {
@@ -247,6 +249,12 @@ span.combobox__icon {
 .combobox .combobox__control--borderless > input {
   background-color: transparent;
   border-color: transparent;
+  padding-left: 0;
+}
+.combobox .combobox__control--borderless > input:focus {
+  border-color: transparent;
+  outline: none;
+  text-decoration: underline;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.combobox__icon {

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -13,6 +13,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {
@@ -266,6 +272,12 @@ span.combobox__icon {
 .combobox .combobox__control--borderless > input {
   background-color: transparent;
   border-color: transparent;
+  padding-left: 0;
+}
+.combobox .combobox__control--borderless > input:focus {
+  border-color: transparent;
+  outline: none;
+  text-decoration: underline;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.combobox__icon {

--- a/dist/dropdown/ds4/dropdown.css
+++ b/dist/dropdown/ds4/dropdown.css
@@ -13,6 +13,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {
@@ -143,10 +149,6 @@ span.fake-menu__status {
 .combobox__options--reverse[role="listbox"],
 .fake-menu__items--reverse {
   right: 0;
-}
-.menu button.expand-btn--borderless,
-.fake-menu button.expand-btn--borderless {
-  background-color: transparent;
 }
 .menu__items[role="menu"],
 .combobox__options[role="listbox"],

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -13,6 +13,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -13,6 +13,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {
@@ -143,10 +149,6 @@ span.fake-menu__status {
 .combobox__options--reverse[role="listbox"],
 .fake-menu__items--reverse {
   right: 0;
-}
-.menu button.expand-btn--borderless,
-.fake-menu button.expand-btn--borderless {
-  background-color: transparent;
 }
 .menu__items[role="menu"],
 .combobox__options[role="listbox"],

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -13,6 +13,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -816,6 +816,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {
@@ -947,10 +953,6 @@ span.fake-menu__status {
 .fake-menu__items--reverse {
   right: 0;
 }
-.menu button.expand-btn--borderless,
-.fake-menu button.expand-btn--borderless {
-  background-color: transparent;
-}
 .menu__items[role="menu"],
 .combobox__options[role="listbox"],
 .fake-menu__items {
@@ -1050,6 +1052,12 @@ span.combobox__icon {
 .combobox .combobox__control--borderless > input {
   background-color: transparent;
   border-color: transparent;
+  padding-left: 0;
+}
+.combobox .combobox__control--borderless > input:focus {
+  border-color: transparent;
+  outline: none;
+  text-decoration: underline;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.combobox__icon {

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -816,6 +816,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {
@@ -947,10 +953,6 @@ span.fake-menu__status {
 .fake-menu__items--reverse {
   right: 0;
 }
-.menu button.expand-btn--borderless,
-.fake-menu button.expand-btn--borderless {
-  background-color: transparent;
-}
 .menu__items[role="menu"],
 .combobox__options[role="listbox"],
 .fake-menu__items {
@@ -1050,6 +1052,12 @@ span.combobox__icon {
 .combobox .combobox__control--borderless > input {
   background-color: transparent;
   border-color: transparent;
+  padding-left: 0;
+}
+.combobox .combobox__control--borderless > input:focus {
+  border-color: transparent;
+  outline: none;
+  text-decoration: underline;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.combobox__icon {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -605,6 +605,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
   vertical-align: initial;
+  padding-left: 0;
+}
+.menu button.expand-btn--borderless:focus,
+.fake-menu button.expand-btn--borderless:focus {
+  outline: none;
+  text-decoration: underline;
 }
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"] {
@@ -858,6 +864,12 @@ span.combobox__icon {
 .combobox .combobox__control--borderless > input {
   background-color: transparent;
   border-color: transparent;
+  padding-left: 0;
+}
+.combobox .combobox__control--borderless > input:focus {
+  border-color: transparent;
+  outline: none;
+  text-decoration: underline;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.combobox__icon {

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -48,6 +48,13 @@ span.combobox__icon {
 .combobox .combobox__control--borderless > input {
     background-color: transparent;
     border-color: transparent;
+    padding-left: 0;
+
+    &:focus {
+        border-color: transparent;
+        outline: none;
+        text-decoration: underline;
+    }
 }
 
 @media screen and (-ms-high-contrast: white-on-black) {

--- a/src/less/dropdown/base/dropdown.less
+++ b/src/less/dropdown/base/dropdown.less
@@ -19,6 +19,12 @@ span.combobox {
 .fake-menu button.expand-btn--borderless {
     border-color: transparent;
     vertical-align: initial;
+    padding-left: 0;
+
+    &:focus {
+        outline: none;
+        text-decoration: underline;
+    }
 }
 
 .menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu__items[role="menu"],

--- a/src/less/dropdown/ds4/dropdown.less
+++ b/src/less/dropdown/ds4/dropdown.less
@@ -3,11 +3,6 @@
 
 @import "../base/dropdown.less";
 
-.menu button.expand-btn--borderless,
-.fake-menu button.expand-btn--borderless {
-    background-color: transparent;
-}
-
 .menu__items[role="menu"],
 .combobox__options[role="listbox"],
 .fake-menu__items {


### PR DESCRIPTION
## Description
- updates CSS to align borderless modifiers for menu and combobox with the recent changes to select
- removes a dupe selector in the DS4 version

## Context
The current borderless versions were incorrect, given that they were all slightly different. This PR aligns them all together.

## References
Fixes #343 
Fixes #344 

## Screenshots

>**These screenshots are generalized for both menu and combobox.**

### DS4

**Before:**
_Closed with focus_
![image](https://user-images.githubusercontent.com/105656/44564691-a04d9b00-a721-11e8-8837-a4b321efd80d.png)

_Open_
![image](https://user-images.githubusercontent.com/105656/44564716-bc513c80-a721-11e8-8d74-8dd5376680cc.png)

**After:**

_Closed with focus_
![image](https://user-images.githubusercontent.com/105656/44564819-59ac7080-a722-11e8-934a-e1caa165c5b5.png)

_Open_
![image](https://user-images.githubusercontent.com/105656/44564918-c1fb5200-a722-11e8-8b26-7a454d709377.png)

### DS6

**Before:**
_Closed with focus_
![image](https://user-images.githubusercontent.com/105656/44564967-00910c80-a723-11e8-988b-b698aa263079.png)

_Open_
![image](https://user-images.githubusercontent.com/105656/44564981-130b4600-a723-11e8-8cae-3bbf7a1d55ce.png)

**After**

_Closed with focus_
![image](https://user-images.githubusercontent.com/105656/44565003-29b19d00-a723-11e8-98b5-5fe1db113d47.png)

_Open_
![image](https://user-images.githubusercontent.com/105656/44565062-69788480-a723-11e8-8724-9e941dafdd13.png)
