### PR TITLE
updated some pagination styles regarding flex and max-width

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/dropdown/ds4/dropdown.css
+++ b/dist/dropdown/ds4/dropdown.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -1,5 +1,6 @@
 .pagination {
   font-size: 0;
+  max-width: 100%;
   min-width: 400px;
 }
 .pagination__items {
@@ -58,8 +59,6 @@
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
   min-width: 288px;
   overflow: hidden;
 }
@@ -131,6 +130,8 @@
   width: 10px;
 }
 .pagination--fluid .pagination__items {
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   width: 100%;
 }
 @media screen and (-ms-high-contrast: white-on-black) {

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -1,5 +1,6 @@
 .pagination {
   font-size: 0;
+  max-width: 100%;
   min-width: 400px;
 }
 .pagination__items {
@@ -58,8 +59,6 @@
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
   min-width: 288px;
   overflow: hidden;
 }
@@ -140,10 +139,15 @@
   height: 3rem;
   margin: -4px 0;
   max-width: 512px;
-  padding: 4px 4px 4px 0;
+  padding: 4px 0 4px 8px;
 }
 .pagination--fluid .pagination__items > li {
   line-height: 3rem;
+}
+.pagination--fluid .pagination__next,
+.pagination--fluid .pagination__previous {
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -136,9 +136,10 @@
   width: 17px;
 }
 .pagination--fluid .pagination__items {
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
   height: 3rem;
-  margin: -4px 0;
-  max-width: 512px;
   padding: 4px 0 4px 8px;
 }
 .pagination--fluid .pagination__items > li {
@@ -146,6 +147,9 @@
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
+  -webkit-box-flex: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
   -ms-flex-negative: 0;
       flex-shrink: 0;
 }

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -140,6 +140,7 @@
       -ms-flex-positive: 1;
           flex-grow: 1;
   height: 3rem;
+  max-width: 512px;
   padding: 4px 0 4px 8px;
 }
 .pagination--fluid .pagination__items > li {

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -815,8 +815,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {
@@ -2971,6 +2971,7 @@ button.page-notice__close span {
 }
 .pagination {
   font-size: 0;
+  max-width: 100%;
   min-width: 400px;
 }
 .pagination__items {
@@ -3029,8 +3030,6 @@ button.page-notice__close span {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
   min-width: 288px;
   overflow: hidden;
 }
@@ -3102,6 +3101,8 @@ button.page-notice__close span {
   width: 10px;
 }
 .pagination--fluid .pagination__items {
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   width: 100%;
 }
 @media screen and (-ms-high-contrast: white-on-black) {

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -815,8 +815,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {
@@ -2971,6 +2971,7 @@ button.page-notice__close span {
 }
 .pagination {
   font-size: 0;
+  max-width: 100%;
   min-width: 400px;
 }
 .pagination__items {
@@ -3029,8 +3030,6 @@ button.page-notice__close span {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
   min-width: 288px;
   overflow: hidden;
 }
@@ -3102,6 +3101,8 @@ button.page-notice__close span {
   width: 10px;
 }
 .pagination--fluid .pagination__items {
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   width: 100%;
 }
 @media screen and (-ms-high-contrast: white-on-black) {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2208,6 +2208,7 @@ button.page-notice__close span {
       -ms-flex-positive: 1;
           flex-grow: 1;
   height: 3rem;
+  max-width: 512px;
   padding: 4px 0 4px 8px;
 }
 .pagination--fluid .pagination__items > li {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2204,9 +2204,10 @@ button.page-notice__close span {
   width: 17px;
 }
 .pagination--fluid .pagination__items {
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
   height: 3rem;
-  margin: -4px 0;
-  max-width: 512px;
   padding: 4px 0 4px 8px;
 }
 .pagination--fluid .pagination__items > li {
@@ -2214,6 +2215,9 @@ button.page-notice__close span {
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
+  -webkit-box-flex: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
   -ms-flex-negative: 0;
       flex-shrink: 0;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -604,8 +604,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {
@@ -2068,6 +2068,7 @@ button.page-notice__close span {
 }
 .pagination {
   font-size: 0;
+  max-width: 100%;
   min-width: 400px;
 }
 .pagination__items {
@@ -2126,8 +2127,6 @@ button.page-notice__close span {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
   min-width: 288px;
   overflow: hidden;
 }
@@ -2208,10 +2207,15 @@ button.page-notice__close span {
   height: 3rem;
   margin: -4px 0;
   max-width: 512px;
-  padding: 4px 4px 4px 0;
+  padding: 4px 0 4px 8px;
 }
 .pagination--fluid .pagination__items > li {
   line-height: 3rem;
+}
+.pagination--fluid .pagination__next,
+.pagination--fluid .pagination__previous {
+  -ms-flex-negative: 0;
+      flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {

--- a/src/less/dropdown/base/dropdown.less
+++ b/src/less/dropdown/base/dropdown.less
@@ -18,8 +18,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
     border-color: transparent;
-    vertical-align: initial;
     padding-left: 0;
+    vertical-align: initial;
 
     &:focus {
         outline: none;

--- a/src/less/pagination/base/pagination.less
+++ b/src/less/pagination/base/pagination.less
@@ -1,5 +1,6 @@
 .pagination {
     font-size: 0;
+    max-width: 100%;
     min-width: 400px;
 }
 
@@ -56,7 +57,6 @@
 
     .pagination__items {
         display: flex;
-        flex-wrap: wrap;
         min-width: 288px;
         overflow: hidden;
 

--- a/src/less/pagination/ds4/pagination.less
+++ b/src/less/pagination/ds4/pagination.less
@@ -79,6 +79,7 @@
 }
 
 .pagination--fluid .pagination__items {
+    flex-wrap: wrap;
     width: 100%;
 }
 

--- a/src/less/pagination/ds6/pagination.less
+++ b/src/less/pagination/ds6/pagination.less
@@ -89,6 +89,7 @@
     .pagination__items {
         flex-grow: 1;
         height: 3rem; // a11y: needs to be relative to the text zoom level
+        max-width: 512px;
         padding: 4px 0 4px 8px;
 
         > li {

--- a/src/less/pagination/ds6/pagination.less
+++ b/src/less/pagination/ds6/pagination.less
@@ -87,9 +87,8 @@
 
 .pagination--fluid {
     .pagination__items {
+        flex-grow: 1;
         height: 3rem; // a11y: needs to be relative to the text zoom level
-        margin: -4px 0;
-        max-width: 512px;
         padding: 4px 0 4px 8px;
 
         > li {
@@ -99,6 +98,7 @@
 
     .pagination__next,
     .pagination__previous {
+        flex-grow: 0;
         flex-shrink: 0;
     }
 }

--- a/src/less/pagination/ds6/pagination.less
+++ b/src/less/pagination/ds6/pagination.less
@@ -85,14 +85,21 @@
     }
 }
 
-.pagination--fluid .pagination__items {
-    height: 3rem; // a11y: needs to be relative to the text zoom level
-    margin: -4px 0;
-    max-width: 512px;
-    padding: 4px 4px 4px 0;
+.pagination--fluid {
+    .pagination__items {
+        height: 3rem; // a11y: needs to be relative to the text zoom level
+        margin: -4px 0;
+        max-width: 512px;
+        padding: 4px 0 4px 8px;
 
-    > li {
-        line-height: 3rem; // a11y: needs to be relative to the text zoom level
+        > li {
+            line-height: 3rem; // a11y: needs to be relative to the text zoom level
+        }
+    }
+
+    .pagination__next,
+    .pagination__previous {
+        flex-shrink: 0;
     }
 }
 


### PR DESCRIPTION
## Description
added flex-shrink: 0 to next previous buttons in pagination--fluid.
added a max-width: 100% to the container to prevent pushing over content.
removed flex-wrap: wrap from pagination/base.less and into ds4 as it was not needed for ds6.

## Context
fixes to make the ebayui-core pagination component work as expected.

## References
it was for this issue
https://github.com/eBay/skin/issues/347
which appears the widths issue was already fixed. But this PR contains the rest of the fixes for ebayui-core pagination to work as expected.
