### PR TITLE
Tabs: support wrapping

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/dropdown/ds4/dropdown.css
+++ b/dist/dropdown/ds4/dropdown.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -12,8 +12,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/dist/tab/ds4/tab.css
+++ b/dist/tab/ds4/tab.css
@@ -25,22 +25,30 @@ ul.hijax-tabs__items {
 }
 div.tabs__item[role="tab"],
 li.hijax-tabs__item[role="tab"] {
+  border-bottom: 2px solid transparent;
   box-sizing: border-box;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  height: 40px;
-  line-height: 40px;
   margin: 0 2px;
+  min-height: 40px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
   cursor: default;
 }
 div.tabs__item[role="tab"] > span {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }
@@ -51,29 +59,46 @@ div.tabs__item[role="tab"][aria-selected="true"] > span {
   color: #333;
 }
 li.fake-tabs__item {
+  border-bottom: 2px solid transparent;
   box-sizing: border-box;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  height: 40px;
-  line-height: 40px;
   margin: 0 2px;
+  min-height: 40px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
 }
 li.fake-tabs__item > a {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }
 li.hijax-tabs__item[role="tab"] > a[role="presentation"] {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }

--- a/dist/tab/ds4/tab.css
+++ b/dist/tab/ds4/tab.css
@@ -25,8 +25,14 @@ ul.hijax-tabs__items {
 }
 div.tabs__item[role="tab"],
 li.hijax-tabs__item[role="tab"] {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -36,19 +42,18 @@ li.hijax-tabs__item[role="tab"] {
   cursor: default;
 }
 div.tabs__item[role="tab"] > span {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }
@@ -59,8 +64,14 @@ div.tabs__item[role="tab"][aria-selected="true"] > span {
   color: #333;
 }
 li.fake-tabs__item {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -69,36 +80,34 @@ li.fake-tabs__item {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
 }
 li.fake-tabs__item > a {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }
 li.hijax-tabs__item[role="tab"] > a[role="presentation"] {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }

--- a/docs/_includes/ds4/tab.html
+++ b/docs/_includes/ds4/tab.html
@@ -12,7 +12,7 @@
             <div class="tabs">
                 <div class="tabs__items">
                     <div class="tabs__item">
-                        <span>Tab 1</span>
+                        <span>Tab 1 with lots of text that could easily take up several lines</span>
                     </div>
                     <div class="tabs__item">
                         <span>Tab 2</span>

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -3483,22 +3483,30 @@ ul.hijax-tabs__items {
 }
 div.tabs__item[role="tab"],
 li.hijax-tabs__item[role="tab"] {
+  border-bottom: 2px solid transparent;
   box-sizing: border-box;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  height: 40px;
-  line-height: 40px;
   margin: 0 2px;
+  min-height: 40px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
   cursor: default;
 }
 div.tabs__item[role="tab"] > span {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }
@@ -3509,29 +3517,46 @@ div.tabs__item[role="tab"][aria-selected="true"] > span {
   color: #333;
 }
 li.fake-tabs__item {
+  border-bottom: 2px solid transparent;
   box-sizing: border-box;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  height: 40px;
-  line-height: 40px;
   margin: 0 2px;
+  min-height: 40px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
 }
 li.fake-tabs__item > a {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }
 li.hijax-tabs__item[role="tab"] > a[role="presentation"] {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -815,8 +815,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {
@@ -3483,8 +3483,14 @@ ul.hijax-tabs__items {
 }
 div.tabs__item[role="tab"],
 li.hijax-tabs__item[role="tab"] {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -3494,19 +3500,18 @@ li.hijax-tabs__item[role="tab"] {
   cursor: default;
 }
 div.tabs__item[role="tab"] > span {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }
@@ -3517,8 +3522,14 @@ div.tabs__item[role="tab"][aria-selected="true"] > span {
   color: #333;
 }
 li.fake-tabs__item {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -3527,36 +3538,34 @@ li.fake-tabs__item {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
 }
 li.fake-tabs__item > a {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }
 li.hijax-tabs__item[role="tab"] > a[role="presentation"] {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -3483,22 +3483,30 @@ ul.hijax-tabs__items {
 }
 div.tabs__item[role="tab"],
 li.hijax-tabs__item[role="tab"] {
+  border-bottom: 2px solid transparent;
   box-sizing: border-box;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  height: 40px;
-  line-height: 40px;
   margin: 0 2px;
+  min-height: 40px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
   cursor: default;
 }
 div.tabs__item[role="tab"] > span {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }
@@ -3509,29 +3517,46 @@ div.tabs__item[role="tab"][aria-selected="true"] > span {
   color: #333;
 }
 li.fake-tabs__item {
+  border-bottom: 2px solid transparent;
   box-sizing: border-box;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  height: 40px;
-  line-height: 40px;
   margin: 0 2px;
+  min-height: 40px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
-  white-space: nowrap;
 }
 li.fake-tabs__item > a {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }
 li.hijax-tabs__item[role="tab"] > a[role="presentation"] {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #767676;
-  display: block;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 14px;
   height: 100%;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  padding: 0 16px;
   text-align: center;
   text-decoration: none;
 }

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -815,8 +815,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {
@@ -3483,8 +3483,14 @@ ul.hijax-tabs__items {
 }
 div.tabs__item[role="tab"],
 li.hijax-tabs__item[role="tab"] {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -3494,19 +3500,18 @@ li.hijax-tabs__item[role="tab"] {
   cursor: default;
 }
 div.tabs__item[role="tab"] > span {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }
@@ -3517,8 +3522,14 @@ div.tabs__item[role="tab"][aria-selected="true"] > span {
   color: #333;
 }
 li.fake-tabs__item {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -3527,36 +3538,34 @@ li.fake-tabs__item {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0.15);
 }
 li.fake-tabs__item > a {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }
 li.hijax-tabs__item[role="tab"] > a[role="presentation"] {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
   color: #767676;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  height: 100%;
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 16px;
+  padding: 8px 16px;
   text-align: center;
   text-decoration: none;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -604,8 +604,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
   border-color: transparent;
-  vertical-align: initial;
   padding-left: 0;
+  vertical-align: initial;
 }
 .menu button.expand-btn--borderless:focus,
 .fake-menu button.expand-btn--borderless:focus {

--- a/src/less/dropdown/base/dropdown.less
+++ b/src/less/dropdown/base/dropdown.less
@@ -18,8 +18,8 @@ span.combobox {
 .menu button.expand-btn--borderless,
 .fake-menu button.expand-btn--borderless {
     border-color: transparent;
-    vertical-align: initial;
     padding-left: 0;
+    vertical-align: initial;
 
     &:focus {
         outline: none;

--- a/src/less/tab/ds4/tab-mixins.less
+++ b/src/less/tab/ds4/tab-mixins.less
@@ -1,6 +1,8 @@
 .tab-outer() {
+    align-items: center;
     border-bottom: 2px solid transparent;
     box-sizing: border-box;
+    display: flex;
     flex: 1;
     margin: 0 2px;
     min-height: 40px;
@@ -8,13 +10,12 @@
 }
 
 .tab-inner() {
-    align-items: center;
     color: @ds4-color-core-gray-dim;
     display: flex;
+    flex: 1;
     font-size: 14px; // font-size should not scale with REM
-    height: 100%;
     justify-content: center;
-    padding: 0 16px;
+    padding: 8px 16px;
     text-align: center;
     text-decoration: none;
 }

--- a/src/less/tab/ds4/tab-mixins.less
+++ b/src/less/tab/ds4/tab-mixins.less
@@ -1,18 +1,20 @@
 .tab-outer() {
+    border-bottom: 2px solid transparent;
     box-sizing: border-box;
     flex: 1;
-    height: 40px;
-    line-height: 40px;
     margin: 0 2px;
+    min-height: 40px;
     -webkit-tap-highlight-color: @ds4-color-transparent-gray-gainsboro;
-    white-space: nowrap;
 }
 
 .tab-inner() {
+    align-items: center;
     color: @ds4-color-core-gray-dim;
-    display: block;
+    display: flex;
     font-size: 14px; // font-size should not scale with REM
     height: 100%;
+    justify-content: center;
+    padding: 0 16px;
     text-align: center;
     text-decoration: none;
 }


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- adjusts `tab` to allow wrapping

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Tab is still DS4-only in Skin, but I did add padding and wrapping as designated in the DS6 design specs. Wrapping is achieved by making the children themselves `flex`. Verified across Chrome, Firefox, Safari, IE11.

Note: the Skin DS4 demo page has `break-all`, which might make the wrapping look funny at various sizes.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
DS6 Design: https://ebay.invisionapp.com/share/CWN9X1JF6MA#/screens/278353515_Tabs
Closes #302 
Fixes #329 

## Screenshots
<!-- Upload screenshots if appropriate-->
<img width="779" alt="screen shot 2018-08-27 at 7 49 20 am" src="https://user-images.githubusercontent.com/3595986/44666686-cd25da80-a9cd-11e8-9d1c-0a4c40fb6507.png">
