### PR TITLE
Icon: copy arrow-down to chevron-down-bold for DS4 Menu

### DIFF
--- a/dist/svg/ds4/icons.svg
+++ b/dist/svg/ds4/icons.svg
@@ -6,6 +6,9 @@
     <symbol id="icon-arrow-down" viewBox="0 0 24 13">
         <path d="M11.604 12.921L0 0h23.215l-5.807 6.462z"/>
     </symbol>
+    <symbol id="icon-chevron-down-bold" viewBox="0 0 24 13">
+        <path d="M11.604 12.921L0 0h23.215l-5.807 6.462z"/>
+    </symbol>
     <symbol id="icon-arrow-down-disabled" viewBox="0 0 24 13">
         <path fill="#ccc" d="M11.604 12.921L0 0h23.215l-5.807 6.462z"/>
     </symbol>

--- a/src/svg/ds4/icons.svg
+++ b/src/svg/ds4/icons.svg
@@ -6,6 +6,9 @@
     <symbol id="icon-arrow-down" viewBox="0 0 24 13">
         <path d="M11.604 12.921L0 0h23.215l-5.807 6.462z"/>
     </symbol>
+    <symbol id="icon-chevron-down-bold" viewBox="0 0 24 13">
+        <path d="M11.604 12.921L0 0h23.215l-5.807 6.462z"/>
+    </symbol>
     <symbol id="icon-arrow-down-disabled" viewBox="0 0 24 13">
         <path fill="#ccc" d="M11.604 12.921L0 0h23.215l-5.807 6.462z"/>
     </symbol>


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
- creates a new `chevron-down-bold` DS4 icon as a copy of `arrow-down`

## Context
<!--- Why did you make these changes, and why in this particular way? -->
This is a one-off fix. The eBayUI Menu component tries to use `chevron-down-bold` for the toggle icon, which doesn't exist in DS4. The DS4 Menu is supposed to use `arrow-down`. It's difficult to have logic to conditionally use different types of icons based on DS in eBayUI, so one other solution is to make an internal map. So when it looks for `chevron-down-bold` in DS4, it will just get `arrow-down`. I'm leaving this out of DS4 documentation, since it's really only meant for internal usage.

This will need a follow up PR in eBayUI to import the new mapping.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
Fixes https://github.com/eBay/ebayui-core/issues/378
