### PR TITLE
Fixing the background color of disabled secondary buttons;

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -304,7 +304,7 @@ button.btn--secondary[disabled],
 button.expand-btn--secondary[disabled],
 button.btn--secondary[aria-disabled="true"],
 button.expand-btn--secondary[aria-disabled="true"] {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
   color: #555;
 }
@@ -322,12 +322,12 @@ button.btn--secondary[disabled]:focus,
 button.expand-btn--secondary[disabled]:focus,
 button.btn--secondary[aria-disabled="true"]:focus,
 button.expand-btn--secondary[aria-disabled="true"]:focus {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
 }
 a.fake-btn--secondary:not([href]),
 a.fake-btn--secondary[aria-disabled="true"] {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
   color: #555;
 }
@@ -339,7 +339,7 @@ a.fake-btn--secondary:not([href]):hover,
 a.fake-btn--secondary[aria-disabled="true"]:hover,
 a.fake-btn--secondary:not([href]):focus,
 a.fake-btn--secondary[aria-disabled="true"]:focus {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
 }
 button.btn--small,

--- a/dist/grid/ds4/grid-full.css
+++ b/dist/grid/ds4/grid-full.css
@@ -1,5 +1,5 @@
 /*!
-Skin v6.0.0-3
+Skin v6.0.0-2
 Copyright 2017 eBay! Inc. All rights reserved.
 Licensed under the BSD License.
 https://github.com/eBay/skin/blob/master/LICENSE.txt"

--- a/docs/static/ds4/grid-full.css
+++ b/docs/static/ds4/grid-full.css
@@ -1,5 +1,5 @@
 /*!
-Skin v6.0.0-3
+Skin v6.0.0-2
 Copyright 2017 eBay! Inc. All rights reserved.
 Licensed under the BSD License.
 https://github.com/eBay/skin/blob/master/LICENSE.txt"

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -1,5 +1,5 @@
 /*!
-Skin v6.0.0-3
+Skin v6.0.0-2
 Copyright 2017 eBay! Inc. All rights reserved.
 Licensed under the BSD License.
 https://github.com/eBay/skin/blob/master/LICENSE.txt"
@@ -559,7 +559,7 @@ button.btn--secondary[disabled],
 button.expand-btn--secondary[disabled],
 button.btn--secondary[aria-disabled="true"],
 button.expand-btn--secondary[aria-disabled="true"] {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
   color: #555;
 }
@@ -577,12 +577,12 @@ button.btn--secondary[disabled]:focus,
 button.expand-btn--secondary[disabled]:focus,
 button.btn--secondary[aria-disabled="true"]:focus,
 button.expand-btn--secondary[aria-disabled="true"]:focus {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
 }
 a.fake-btn--secondary:not([href]),
 a.fake-btn--secondary[aria-disabled="true"] {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
   color: #555;
 }
@@ -594,7 +594,7 @@ a.fake-btn--secondary:not([href]):hover,
 a.fake-btn--secondary[aria-disabled="true"]:hover,
 a.fake-btn--secondary:not([href]):focus,
 a.fake-btn--secondary[aria-disabled="true"]:focus {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
 }
 button.btn--small,

--- a/docs/static/ds4/skin-large.css
+++ b/docs/static/ds4/skin-large.css
@@ -1,5 +1,5 @@
 /*!
-Skin v6.0.0-3
+Skin v6.0.0-2
 Copyright 2017 eBay! Inc. All rights reserved.
 Licensed under the BSD License.
 https://github.com/eBay/skin/blob/master/LICENSE.txt"

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -1,5 +1,5 @@
 /*!
-Skin v6.0.0-3
+Skin v6.0.0-2
 Copyright 2017 eBay! Inc. All rights reserved.
 Licensed under the BSD License.
 https://github.com/eBay/skin/blob/master/LICENSE.txt"
@@ -559,7 +559,7 @@ button.btn--secondary[disabled],
 button.expand-btn--secondary[disabled],
 button.btn--secondary[aria-disabled="true"],
 button.expand-btn--secondary[aria-disabled="true"] {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
   color: #555;
 }
@@ -577,12 +577,12 @@ button.btn--secondary[disabled]:focus,
 button.expand-btn--secondary[disabled]:focus,
 button.btn--secondary[aria-disabled="true"]:focus,
 button.expand-btn--secondary[aria-disabled="true"]:focus {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
 }
 a.fake-btn--secondary:not([href]),
 a.fake-btn--secondary[aria-disabled="true"] {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
   color: #555;
 }
@@ -594,7 +594,7 @@ a.fake-btn--secondary:not([href]):hover,
 a.fake-btn--secondary[aria-disabled="true"]:hover,
 a.fake-btn--secondary:not([href]):focus,
 a.fake-btn--secondary[aria-disabled="true"]:focus {
-  background-color: rgba(240, 238, 236, 0.5);
+  background-color: #ccc;
   border-color: #999;
 }
 button.btn--small,

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1,5 +1,5 @@
 /*!
-Skin v6.0.0-3
+Skin v6.0.0-2
 Copyright 2017 eBay! Inc. All rights reserved.
 Licensed under the BSD License.
 https://github.com/eBay/skin/blob/master/LICENSE.txt"

--- a/src/less/button/ds4/button-secondary.less
+++ b/src/less/button/ds4/button-secondary.less
@@ -29,7 +29,7 @@ button.btn--secondary[disabled],
 button.expand-btn--secondary[disabled],
 button.btn--secondary[aria-disabled="true"],
 button.expand-btn--secondary[aria-disabled="true"] {
-    background-color: fade(@ds4-color-interface-view-background, 50%);
+    background-color: @ds4-color-core-gray-silver;
     border-color: @ds4-color-text-disabled;
     color: @ds4-color-core-gray-davys;
 
@@ -39,14 +39,14 @@ button.expand-btn--secondary[aria-disabled="true"] {
 
     &:hover,
     &:focus {
-        background-color: fade(@ds4-color-interface-view-background, 50%);
+        background-color: @ds4-color-core-gray-silver;
         border-color: @ds4-color-text-disabled;
     }
 }
 
 a.fake-btn--secondary:not([href]),
 a.fake-btn--secondary[aria-disabled="true"] {
-    background-color: fade(@ds4-color-interface-view-background, 50%);
+    background-color: @ds4-color-core-gray-silver;
     border-color: @ds4-color-text-disabled;
     color: @ds4-color-core-gray-davys;
 
@@ -56,7 +56,7 @@ a.fake-btn--secondary[aria-disabled="true"] {
 
     &:hover,
     &:focus {
-        background-color: fade(@ds4-color-interface-view-background, 50%);
+        background-color: @ds4-color-core-gray-silver;
         border-color: @ds4-color-text-disabled;
     }
 }


### PR DESCRIPTION
## Description
- fixes the DS4 background color for disabled secondary buttons

## Context
The current disabled secondary button background color was wrong (and was based on a LESS computation) and needed to be fixed.

## References
Fixes https://github.com/eBay/ebayui-core/issues/380

## Screenshots

**Before**
![image](https://user-images.githubusercontent.com/105656/44741109-6251cd80-aab9-11e8-9a3a-6d94076e9275.png)

**After**
![image](https://user-images.githubusercontent.com/105656/44741133-785f8e00-aab9-11e8-96f6-fa028962d2ee.png)
