### PR TITLE
fix ds4 breadcrumb style

### DIFF
--- a/dist/breadcrumb/ds4/breadcrumb.css
+++ b/dist/breadcrumb/ds4/breadcrumb.css
@@ -39,13 +39,21 @@
 .breadcrumb button {
   color: #333;
 }
+.breadcrumb a:focus,
+.breadcrumb button:focus,
+.breadcrumb a:visited,
+.breadcrumb button:visited {
+  color: #333;
+}
 .breadcrumb a:hover,
 .breadcrumb button:hover {
   color: #0654ba;
+  text-decoration: underline;
 }
 .breadcrumb a[aria-current],
 .breadcrumb button[aria-current] {
   color: #767676;
+  text-decoration: none;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .breadcrumb li:not(:last-of-type)::after {

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -240,13 +240,21 @@ button.img-btn:not([disabled]):active {
 .breadcrumb button {
   color: #333;
 }
+.breadcrumb a:focus,
+.breadcrumb button:focus,
+.breadcrumb a:visited,
+.breadcrumb button:visited {
+  color: #333;
+}
 .breadcrumb a:hover,
 .breadcrumb button:hover {
   color: #0654ba;
+  text-decoration: underline;
 }
 .breadcrumb a[aria-current],
 .breadcrumb button[aria-current] {
   color: #767676;
+  text-decoration: none;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .breadcrumb li:not(:last-of-type)::after {

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -240,13 +240,21 @@ button.img-btn:not([disabled]):active {
 .breadcrumb button {
   color: #333;
 }
+.breadcrumb a:focus,
+.breadcrumb button:focus,
+.breadcrumb a:visited,
+.breadcrumb button:visited {
+  color: #333;
+}
 .breadcrumb a:hover,
 .breadcrumb button:hover {
   color: #0654ba;
+  text-decoration: underline;
 }
 .breadcrumb a[aria-current],
 .breadcrumb button[aria-current] {
   color: #767676;
+  text-decoration: none;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .breadcrumb li:not(:last-of-type)::after {

--- a/src/less/breadcrumb/ds4/breadcrumb.less
+++ b/src/less/breadcrumb/ds4/breadcrumb.less
@@ -14,12 +14,19 @@
     button {
         color: @ds4-color-text-default;
 
+        &:focus,
+        &:visited {
+            color: @ds4-color-text-default;
+        }
+
         &:hover {
             color: @ds4-color-core-blue;
+            text-decoration: underline;
         }
 
         &[aria-current] {
             color: @ds4-color-core-gray-dim;
+            text-decoration: none;
         }
     }
 }


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
Added text-decoration and color to active and visited states.
Fixes https://github.com/eBay/skin/issues/355

## Context
There was no official design in skin DS4 so I used the browse use case, as the DS6 design docs suggested.

## References
https://ebay.invisionapp.com/share/CWN9X1JF6MA#/screens/274338884

## Screenshots
![screen shot 2018-08-28 at 3 27 06 pm](https://user-images.githubusercontent.com/1562843/44754562-32b1be00-aad7-11e8-9acc-b948dd0f31d5.png)

