### PR TITLE
Fixing left margin for checkmark when in tight spaces;

### DIFF
--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -221,6 +221,7 @@ span.fake-menu__status {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTMuNSIgaGVpZ2h0PSIxMC4xMiIgdmlld0JveD0iNiA2LjQ1IDEzLjUgMTAuMTIiPjxwYXRoIGQ9Ik03LjY0NiAxMC45NzJhLjkzMi45MzIgMCAwIDAtMS4zNjQgMCAxLjA0OSAxLjA0OSAwIDAgMCAwIDEuNDMybDMuODU2IDMuODc0YS45MzIuOTMyIDAgMCAwIDEuMzY0IDBsNy43MTYtOC4xYTEuMDQ5IDEuMDQ5IDAgMCAwIDAtMS40MzEuOTMyLjkzMiAwIDAgMC0xLjM2NCAwTDEwLjgyIDE0LjEzbC0zLjE3NC0zLjE1OXoiLz48L3N2Zz4=');
   height: 9px;
   width: 9px;
+  margin-left: 8px;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.menu__status,

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -221,6 +221,7 @@ span.fake-menu__status {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTMuNSIgaGVpZ2h0PSIxMC4xMiIgdmlld0JveD0iNiA2LjQ1IDEzLjUgMTAuMTIiPjxwYXRoIGQ9Ik03LjY0NiAxMC45NzJhLjkzMi45MzIgMCAwIDAtMS4zNjQgMCAxLjA0OSAxLjA0OSAwIDAgMCAwIDEuNDMybDMuODU2IDMuODc0YS45MzIuOTMyIDAgMCAwIDEuMzY0IDBsNy43MTYtOC4xYTEuMDQ5IDEuMDQ5IDAgMCAwIDAtMS40MzEuOTMyLjkzMiAwIDAgMC0xLjM2NCAwTDEwLjgyIDE0LjEzbC0zLjE3NC0zLjE1OXoiLz48L3N2Zz4=');
   height: 9px;
   width: 9px;
+  margin-left: 8px;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.menu__status,

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -221,6 +221,7 @@ span.fake-menu__status {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTMuNSIgaGVpZ2h0PSIxMC4xMiIgdmlld0JveD0iNiA2LjQ1IDEzLjUgMTAuMTIiPjxwYXRoIGQ9Ik03LjY0NiAxMC45NzJhLjkzMi45MzIgMCAwIDAtMS4zNjQgMCAxLjA0OSAxLjA0OSAwIDAgMCAwIDEuNDMybDMuODU2IDMuODc0YS45MzIuOTMyIDAgMCAwIDEuMzY0IDBsNy43MTYtOC4xYTEuMDQ5IDEuMDQ5IDAgMCAwIDAtMS40MzEuOTMyLjkzMiAwIDAgMC0xLjM2NCAwTDEwLjgyIDE0LjEzbC0zLjE3NC0zLjE1OXoiLz48L3N2Zz4=');
   height: 9px;
   width: 9px;
+  margin-left: 8px;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.menu__status,

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -825,6 +825,7 @@ span.fake-menu__status {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTMuNSIgaGVpZ2h0PSIxMC4xMiIgdmlld0JveD0iNiA2LjQ1IDEzLjUgMTAuMTIiPjxwYXRoIGQ9Ik03LjY0NiAxMC45NzJhLjkzMi45MzIgMCAwIDAtMS4zNjQgMCAxLjA0OSAxLjA0OSAwIDAgMCAwIDEuNDMybDMuODU2IDMuODc0YS45MzIuOTMyIDAgMCAwIDEuMzY0IDBsNy43MTYtOC4xYTEuMDQ5IDEuMDQ5IDAgMCAwIDAtMS40MzEuOTMyLjkzMiAwIDAgMC0xLjM2NCAwTDEwLjgyIDE0LjEzbC0zLjE3NC0zLjE1OXoiLz48L3N2Zz4=');
   height: 9px;
   width: 9px;
+  margin-left: 8px;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.menu__status,

--- a/src/less/dropdown/ds6/dropdown.less
+++ b/src/less/dropdown/ds6/dropdown.less
@@ -65,6 +65,8 @@ span.menu__status,
 span.combobox__status,
 span.fake-menu__status {
     .icon-tick(9px, 9px);
+
+    margin-left: 8px;
 }
 
 @media screen and (-ms-high-contrast: white-on-black) {


### PR DESCRIPTION
## Description
- adds left margin for check mark

## Context
When the menu or combobox have small widths it can cause the check mark to be too close to the text.

## References
None

## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/105656/44802581-59c0cc00-ab79-11e8-9b2f-2139e9a2c0ff.png)

**After**
![image](https://user-images.githubusercontent.com/105656/44802606-6c3b0580-ab79-11e8-8ce8-542e26593305.png)
