### PR TITLE
Add pointer events none for icons to allow click events to work.

### DIFF
--- a/dist/icon/ds6/icon.css
+++ b/dist/icon/ds6/icon.css
@@ -1,4 +1,5 @@
 svg.icon {
+  pointer-events: none;
   display: inline-block;
   fill: currentColor;
   height: 1rem;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -1202,6 +1202,7 @@ label.floating-label__label--animate {
   transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 svg.icon {
+  pointer-events: none;
   display: inline-block;
   fill: currentColor;
   height: 1rem;

--- a/src/less/icon/ds6/icon.less
+++ b/src/less/icon/ds6/icon.less
@@ -4,6 +4,7 @@
 
 .icon {
     svg& {
+        pointer-events: none;
         .foreground-icon-base;
     }
 


### PR DESCRIPTION
## Description
Currently when you click on an inline svg in IE it does not propagate click events for the `<use>` tag. This adds `pointer-events: none` to all inline svgs so that we skip the click event for the svg entirely.

## References
Fixes https://github.com/eBay/ebayui-core/issues/396

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15727705/
