### PR TITLE
moving display:inline-flex from ds6 to base

### DIFF
--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -1,4 +1,7 @@
 .pagination {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -1,4 +1,7 @@
 .pagination {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
@@ -72,9 +75,6 @@
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   min-width: 376px;
 }
 .pagination a,

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -3002,6 +3002,9 @@ button.page-notice__close span {
   display: block;
 }
 .pagination {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -3002,6 +3002,9 @@ button.page-notice__close span {
   display: block;
 }
 .pagination {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2089,6 +2089,9 @@ button.page-notice__close span {
   }
 }
 .pagination {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
@@ -2162,9 +2165,6 @@ button.page-notice__close span {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   min-width: 376px;
 }
 .pagination a,

--- a/src/less/pagination/base/pagination.less
+++ b/src/less/pagination/base/pagination.less
@@ -1,4 +1,5 @@
 .pagination {
+    display: inline-flex;
     font-size: 0;
     max-width: 100%;
 }

--- a/src/less/pagination/ds6/pagination.less
+++ b/src/less/pagination/ds6/pagination.less
@@ -5,7 +5,6 @@
 
 .pagination {
     align-items: center;
-    display: inline-flex;
     min-width: 376px;
 }
 


### PR DESCRIPTION
## Description
Moved `display: inline-flex` in pagination from DS6 to base so it will effect DS4 also.
Fixes: 

## Context
It looks like this isn't strictly needed for skin, but it fixes a DS4 pagination issue for ebayui-core.

## References
https://github.com/eBay/skin/issues/369

## Screenshots
### Doesn't appear to effect skin
![screen shot 2018-08-30 at 6 56 16 pm](https://user-images.githubusercontent.com/1562843/44888605-ec02c600-ac86-11e8-8d50-d581e3abf024.png)
![screen shot 2018-08-30 at 6 56 28 pm](https://user-images.githubusercontent.com/1562843/44888606-ec02c600-ac86-11e8-8c24-0953c96a3474.png)

### Fixes DS4 ebayUI
![screen shot 2018-08-30 at 7 00 39 pm](https://user-images.githubusercontent.com/1562843/44888637-076dd100-ac87-11e8-8d3e-7958e803237b.png)

