### PR TITLE
SVG click event fix for DS4

### DIFF
--- a/dist/icon/ds4/icon.css
+++ b/dist/icon/ds4/icon.css
@@ -1,4 +1,5 @@
 svg.icon {
+  pointer-events: none;
   display: inline-block;
   fill: currentColor;
   height: 1rem;

--- a/docs/_includes/ds4/icon.html
+++ b/docs/_includes/ds4/icon.html
@@ -11,6 +11,7 @@
     </ul>
 
     <p><strong>NOTE:</strong> Skin is in the midst of a transition from a font-based icon system to an SVG-based icon system. All icons listed below are being converted to <a href="#svg">SVG</a> on a per-need basis.</p>
+    <p><strong>IMPORTANT:</strong> Skin removes all mouse and touch events on our SVG icons due to a bug in IE. To add events to these icons you should wrap them in another element and attach your events there.</p>
 
     <h3>Core Icons</h3>
     <div class="demo">

--- a/docs/_includes/ds6/icon.html
+++ b/docs/_includes/ds6/icon.html
@@ -5,6 +5,7 @@
     <h3>Inline SVG</h3>
     <p>Inline SVGs can inherit their colour via the CSS cascade; this behaviour can be useful when crafting custom buttons and controls.</p>
     <p>To avoid gigantic icons when in a non-CSS (edge-case) state, we use the SVG width and height attributes to override the browser's default 300x150 size.</p>
+    <p><strong>IMPORTANT:</strong> Skin removes all mouse and touch events on our SVG icons due to a bug in IE. To add events to these icons you should wrap them in another element and attach your events there.</p>
 
     <div class="demo">
         <div class="demo__inner">

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -1518,6 +1518,7 @@ div.field__description {
   color: #dd1e31;
 }
 svg.icon {
+  pointer-events: none;
   display: inline-block;
   fill: currentColor;
   height: 1rem;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -1518,6 +1518,7 @@ div.field__description {
   color: #dd1e31;
 }
 svg.icon {
+  pointer-events: none;
   display: inline-block;
   fill: currentColor;
   height: 1rem;

--- a/src/less/icon/ds4/icon.less
+++ b/src/less/icon/ds4/icon.less
@@ -3,6 +3,7 @@
 
 .icon {
     svg& {
+        pointer-events: none;
         .foreground-icon-base;
     }
 


### PR DESCRIPTION
## Description
Added change from DS6 icon style to DS4 icon style to remove mouse and touch events.
Added documentation.
Fixes https://github.com/eBay/skin/issues/373

## Context
Same fix as https://github.com/eBay/skin/pull/366 made for DS6

## Screenshots
<img width="1331" alt="screen shot 2018-08-31 at 12 46 41 pm" src="https://user-images.githubusercontent.com/1562843/44932985-50239980-ad1c-11e8-8f74-f041bdcd2fb2.png">

