### PR TITLE
hotfix for select dropdown icon in IE

### DIFF
--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -77,9 +77,10 @@ svg.select__icon {
 }
 span.select__icon {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjEuNiIgaGVpZ2h0PSIxMi41OCIgdmlld0JveD0iMS4zNSA1LjcgMjEuNiAxMi41OCI+PHBhdGggZD0iTTEyLjE4NiAxOC4yODVjLS40NTEtLjAwOS0uODA5LS4xNjctMS4wNzUtLjQ0MWwtOS4zMzctOS42YTEuNTI3IDEuNTI3IDAgMCAxLS40MjQtLjk5OXYtLjEwOGMuMDE1LS4zODYuMTY2LS43NDEuNDI0LTEuMDA4LjU2LS41NzMgMS41MjktLjU3IDIuMDgyIDBsOC4yOTQgOC41MyA4LjI5Mi04LjUzMmMuNTU4LS41NyAxLjUyNi0uNTcgMi4wOCAwIC4yNjUuMjcuNDE2LjYyOS40MjggMS4wMXYuMDg3Yy0uMDEyLjM5MS0uMTY1Ljc1LS40MjcgMS4wMmwtOS4zMzMgOS42YTEuNDQzIDEuNDQzIDAgMCAxLTEuMDA0LjQ0MSIvPjwvc3ZnPg==');
-  height: 100%;
+  height: 5.2px;
   width: 9px;
-  background-size: 9px 100%;
+  background-size: 9px 5.2px;
+  top: calc(50% - 2.6px);
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.select__icon {

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2472,9 +2472,10 @@ svg.select__icon {
 }
 span.select__icon {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjEuNiIgaGVpZ2h0PSIxMi41OCIgdmlld0JveD0iMS4zNSA1LjcgMjEuNiAxMi41OCI+PHBhdGggZD0iTTEyLjE4NiAxOC4yODVjLS40NTEtLjAwOS0uODA5LS4xNjctMS4wNzUtLjQ0MWwtOS4zMzctOS42YTEuNTI3IDEuNTI3IDAgMCAxLS40MjQtLjk5OXYtLjEwOGMuMDE1LS4zODYuMTY2LS43NDEuNDI0LTEuMDA4LjU2LS41NzMgMS41MjktLjU3IDIuMDgyIDBsOC4yOTQgOC41MyA4LjI5Mi04LjUzMmMuNTU4LS41NyAxLjUyNi0uNTcgMi4wOCAwIC4yNjUuMjcuNDE2LjYyOS40MjggMS4wMXYuMDg3Yy0uMDEyLjM5MS0uMTY1Ljc1LS40MjcgMS4wMmwtOS4zMzMgOS42YTEuNDQzIDEuNDQzIDAgMCAxLTEuMDA0LjQ0MSIvPjwvc3ZnPg==');
-  height: 100%;
+  height: 5.2px;
   width: 9px;
-  background-size: 9px 100%;
+  background-size: 9px 5.2px;
+  top: calc(50% - 2.6px);
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   span.select__icon {

--- a/src/less/select/ds6/select.less
+++ b/src/less/select/ds6/select.less
@@ -4,7 +4,9 @@
 @import "../base/select.less";
 
 span.select__icon {
-    .icon-chevron-down-bold(9px, 100%);
+    .icon-chevron-down-bold(9px, 5.2px);
+
+    top: calc(50% - 2.6px);
 }
 
 @media screen and (-ms-high-contrast: white-on-black) {


### PR DESCRIPTION
## Description
Changing select icon height from 100% to a fixed height.

## Context
Firefox and IE had UI issues when the background image was sized to 100% height.

## Screenshots
### Previous
![screen shot 2018-09-12 at 4 47 25 pm](https://user-images.githubusercontent.com/1562843/45459163-e4daaf80-b6ab-11e8-9818-d2d5d9f2db4f.png)

### Fixed
![screen shot 2018-09-12 at 4 43 43 pm](https://user-images.githubusercontent.com/1562843/45459169-ed32ea80-b6ab-11e8-8355-90a32ae0cd89.png)

