### PR TITLE
Adding missing combobox file;

### DIFF
--- a/src/less/combobox/ds6/combobox-mixin.less
+++ b/src/less/combobox/ds6/combobox-mixin.less
@@ -1,0 +1,3 @@
+.combobox-mixin() {
+    @import "../../../../dist/combobox/ds6/combobox.css";
+}


### PR DESCRIPTION
## Description
Reported bug that the combobox mixin was missing for the `gh.browser.json` LESS import.

## References
Fixes #393 
