### PR TITLE
Build: Adding npm version hook to pick up generated files;

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "lint:less": "stylelint src/less --config .stylelintrc-less",
     "lint:css": "stylelint dist --config .stylelintrc-css",
     "copy:lessToDist": "node_modules/mkdirp/bin/cmd.js dist/less && ncp src/less/less dist/less",
-    "copy:svgToDist": "node_modules/mkdirp/bin/cmd.js dist/svg && ncp src/svg dist/svg"
+    "copy:svgToDist": "node_modules/mkdirp/bin/cmd.js dist/svg && ncp src/svg dist/svg",
+    "version": "npm run build && git add -A dist docs"
   },
   "devDependencies": {
     "browser-sync": "^2",


### PR DESCRIPTION
## Description
- adds a `version` hook which runs the build before making the actual version commit

## Context
_Brilliant._ This helps us make sure the correct build files are in the same commit as the version bump, but without having to do any extra-special steps before or after the version commit.