### PR TITLE
Fix primary button a11y issue

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -216,7 +216,7 @@ button.btn--primary:focus,
 button.expand-btn--primary:focus,
 a.fake-btn--primary:focus {
   border-color: #0654ba;
-  opacity: 0.7;
+  opacity: 0.8;
 }
 button.btn--primary:active,
 button.expand-btn--primary:active,

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -542,7 +542,7 @@ button.btn--primary:focus,
 button.expand-btn--primary:focus,
 a.fake-btn--primary:focus {
   border-color: #0654ba;
-  opacity: 0.7;
+  opacity: 0.8;
 }
 button.btn--primary:active,
 button.expand-btn--primary:active,

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -542,7 +542,7 @@ button.btn--primary:focus,
 button.expand-btn--primary:focus,
 a.fake-btn--primary:focus {
   border-color: #0654ba;
-  opacity: 0.7;
+  opacity: 0.8;
 }
 button.btn--primary:active,
 button.expand-btn--primary:active,

--- a/src/less/button/ds4/button-primary.less
+++ b/src/less/button/ds4/button-primary.less
@@ -13,7 +13,7 @@ a.fake-btn--primary {
     &:hover,
     &:focus {
         border-color: @ds4-color-interface-cta;
-        opacity: 0.7;
+        opacity: 0.8;
     }
 
     &:active {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3087,94 +3087,6 @@ jekyll@^3.0.0-beta1:
   version "3.0.0-beta1"
   resolved "https://registry.yarnpkg.com/jekyll/-/jekyll-3.0.0-beta1.tgz#32749f03004cff217bf29988f6e4420606479ff9"
 
-jquery-active-descendant@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-active-descendant/-/jquery-active-descendant-1.0.1.tgz#577c2437a509915716636c2ed3bcce851e480243"
-
-jquery-click-flyout@~0.0:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/jquery-click-flyout/-/jquery-click-flyout-0.0.10.tgz#6764249fe239ddd19485588f19a23ba0ce6f7183"
-
-jquery-common-keydown@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-common-keydown/-/jquery-common-keydown-1.0.1.tgz#4b6d99dae5c20ffa9bc937b1652fb4620ca9f1f6"
-
-jquery-dialog@~0.5:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/jquery-dialog/-/jquery-dialog-0.5.2.tgz#42479fe140752346f10cd6f7465f864d11ee4087"
-
-jquery-focus-exit@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-focus-exit/-/jquery-focus-exit-1.0.1.tgz#76b5686bb464d07f9be45ef3888216305ced8046"
-
-jquery-focus-flyout@~0.0:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/jquery-focus-flyout/-/jquery-focus-flyout-0.0.5.tgz#ccc031d75ba4edcee3fceb5ef8180edba94643d6"
-
-jquery-focusable@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-focusable/-/jquery-focusable-1.0.1.tgz#a8fe7062ccf01a0c1cf7818cfb2f41ac0dd55a79"
-
-jquery-grid-navigation@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-grid-navigation/-/jquery-grid-navigation-1.0.1.tgz#210b971ef14f90c61a9309b89c2cb9e92747bc95"
-
-jquery-hijax-button@~0.0:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/jquery-hijax-button/-/jquery-hijax-button-0.0.2.tgz#465cac80ed8929f0a005274bc31eb0f7f2610dec"
-
-jquery-hover-flyout@~0.0:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/jquery-hover-flyout/-/jquery-hover-flyout-0.0.5.tgz#f39db3e66f716053920e6b7ccf03706b5bd4a16b"
-
-jquery-keyboard-trap@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-keyboard-trap/-/jquery-keyboard-trap-1.0.1.tgz#f3802972953aef1c787fe5ee1fe833b393e7c30f"
-
-jquery-linear-navigation@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-linear-navigation/-/jquery-linear-navigation-1.0.1.tgz#3c0626bf09cbe543eb26c8b57c30010cebc0cadc"
-
-jquery-menu@~0.7:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/jquery-menu/-/jquery-menu-0.7.3.tgz#85e56e668cc8851a25f82dc4b22c60556b44a1af"
-
-jquery-mouse-exit@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-mouse-exit/-/jquery-mouse-exit-1.0.1.tgz#010226c4065a52eda618ce9f450e42bd5dc38fe2"
-
-jquery-next-id@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-next-id/-/jquery-next-id-1.0.1.tgz#26541a06be9cb44186470716bc2ab7870cfd7936"
-
-jquery-prevent-scroll-keys@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-prevent-scroll-keys/-/jquery-prevent-scroll-keys-1.0.1.tgz#4ee4ac3b59bee96c3f77cf814c88c947d9a2228d"
-
-jquery-roving-tabindex@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-roving-tabindex/-/jquery-roving-tabindex-1.0.1.tgz#e32544212d874da306b5448639acb25106c7c0d5"
-
-jquery-screenreader-trap@^1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jquery-screenreader-trap/-/jquery-screenreader-trap-1.0.1.tgz#4933c189ab8af200b6575579b290d891d64f04cc"
-
-jquery-skip-to@~0.0:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/jquery-skip-to/-/jquery-skip-to-0.0.2.tgz#1a3240dfd67a99ad9951db10ebce18abe8933070"
-
-jquery-tabs@~0.5:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/jquery-tabs/-/jquery-tabs-0.5.1.tgz#90cc5fbcd30066f8f6b2d9927892ded1a9181a49"
-
-jquery-tooltip@~0.2:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/jquery-tooltip/-/jquery-tooltip-0.2.1.tgz#ef0492cf04add960cf1f7ed394d70cca3fc7fe94"
-
-jquery@>=1.11:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
-
 jquery@^3:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
@@ -3800,33 +3712,6 @@ makeup-floating-label@~0.0.2:
 makeup-focusables@~0.0, makeup-focusables@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/makeup-focusables/-/makeup-focusables-0.0.3.tgz#e30f36a99beb7c5166daafb8f823fefcc7a551fa"
-
-makeup-jquery@~0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/makeup-jquery/-/makeup-jquery-0.0.1.tgz#c48449a987956b401ff9f448dee0cd9f3d50e06e"
-  dependencies:
-    jquery ">=1.11"
-    jquery-active-descendant "^1"
-    jquery-click-flyout "~0.0"
-    jquery-common-keydown "^1"
-    jquery-dialog "~0.5"
-    jquery-focus-exit "^1"
-    jquery-focus-flyout "~0.0"
-    jquery-focusable "^1"
-    jquery-grid-navigation "^1"
-    jquery-hijax-button "~0.0"
-    jquery-hover-flyout "~0.0"
-    jquery-keyboard-trap "^1"
-    jquery-linear-navigation "^1"
-    jquery-menu "~0.7"
-    jquery-mouse-exit "^1"
-    jquery-next-id "^1"
-    jquery-prevent-scroll-keys "^1"
-    jquery-roving-tabindex "^1"
-    jquery-screenreader-trap "^1"
-    jquery-skip-to "~0.0"
-    jquery-tabs "~0.5"
-    jquery-tooltip "~0.2"
 
 makeup-key-emitter@~0.0, makeup-key-emitter@~0.0.3:
   version "0.0.3"


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
Override to the style for DS4 primary button hover/focus state. Changing the opacity to 0.8 from 0.7 for better color contrast.

Fixes https://github.com/eBay/skin/issues/421

## Context
Minimal change to meet a11y requirements.

## Screenshots
![screen shot 2018-10-19 at 11 01 51 am](https://user-images.githubusercontent.com/1562843/47235605-69e17480-d38e-11e8-9456-2cf7d3fc4ba6.png)

