### PR TITLE
Badge: some refactoring of classes based on feedback

### DIFF
--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -67,10 +67,12 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
 }
-.icon-btn--badged {
+.icon-btn--badged,
+.icon-link--badged {
   position: relative;
 }
-.icon-btn--badged .badge {
+.icon-btn--badged .badge,
+.icon-link--badged .badge {
   border: 2px solid;
   border-color: #fff;
   font-size: 0.75rem;

--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -67,3 +67,18 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
 }
+.icon-btn--badged {
+  position: relative;
+}
+.icon-btn--badged .badge {
+  border: 2px solid;
+  border-color: #fff;
+  font-size: 0.75rem;
+  height: 24px;
+  left: 12px;
+  margin: auto;
+  min-width: 24px;
+  position: absolute;
+  top: -8px;
+  z-index: 1;
+}

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -17,10 +17,12 @@
   vertical-align: middle;
   width: 1rem;
 }
-.icon-btn--badged {
+.icon-btn--badged,
+.icon-link--badged {
   position: relative;
 }
-.icon-btn--badged .badge {
+.icon-btn--badged .badge,
+.icon-link--badged .badge {
   border: 2px solid;
   border-color: #fff;
   font-size: 0.75rem;

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -17,3 +17,18 @@
   vertical-align: middle;
   width: 1rem;
 }
+.icon-btn--badged {
+  position: relative;
+}
+.icon-btn--badged .badge {
+  border: 2px solid;
+  border-color: #fff;
+  font-size: 0.75rem;
+  height: 24px;
+  left: 12px;
+  margin: auto;
+  min-width: 24px;
+  position: absolute;
+  top: -8px;
+  z-index: 1;
+}

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,5 +1,4 @@
-.badge,
-.menu-badge {
+.badge {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
@@ -20,43 +19,7 @@
   position: relative;
   top: calc(50% - 20px);
 }
-.menu-badge {
-  margin-left: 8px;
-}
-.icon-badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  border-radius: 20px;
-  box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  padding: 0 7px;
-  vertical-align: middle;
-  white-space: nowrap;
-  border: 2px solid;
-  height: 24px;
-  left: 12px;
-  margin: auto;
-  min-width: 24px;
-  position: absolute;
-  top: -8px;
-  z-index: 1;
-}
-.icon-badge-container {
-  position: relative;
-}
-.badge,
-.menu-badge,
-.icon-badge {
+.badge {
   background-color: #dd1e31;
   color: #fff;
-}
-.icon-badge {
-  border-color: #fff;
-  font-size: 0.75rem;
 }

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,5 +1,4 @@
-.badge,
-.menu-badge {
+.badge {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
@@ -20,43 +19,7 @@
   position: relative;
   top: calc(50% - 20px);
 }
-.menu-badge {
-  margin-left: 8px;
-}
-.icon-badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  border-radius: 20px;
-  box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  padding: 0 7px;
-  vertical-align: middle;
-  white-space: nowrap;
-  border: 2px solid;
-  height: 24px;
-  left: 12px;
-  margin: auto;
-  min-width: 24px;
-  position: absolute;
-  top: -8px;
-  z-index: 1;
-}
-.icon-badge-container {
-  position: relative;
-}
-.badge,
-.menu-badge,
-.icon-badge {
+.badge {
   background-color: #e62048;
   color: #fff;
-}
-.icon-badge {
-  border-color: #fff;
-  font-size: 0.75rem;
 }

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -264,3 +264,6 @@ span.fake-menu__status {
 .expand_btn ~ .fake-menu__items--static {
   position: static;
 }
+.menu__item .badge {
+  margin-left: 8px;
+}

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -292,3 +292,6 @@ span.fake-menu__status {
 .expand_btn ~ .fake-menu__items--static {
   position: static;
 }
+.menu__item .badge {
+  margin-left: 8px;
+}

--- a/docs/_includes/common/badge.html
+++ b/docs/_includes/common/badge.html
@@ -1,8 +1,9 @@
 <div id="badge">
     <h2><span class="secondary-text">@ebay/skin/</span>badge</h2>
-    <p>A badge is a visual indicator added to an element to convey quantity, newness or both. Badges are intended to remind a user of previous actions taken or alert them to new actions that they should consider.</p>
+    <p>A badge is a visual indicator added to an element to convey quantity, newness or both. Badges are intended to remind a user of previous actions taken, or to alert them of new actions that they should consider.</p>
 
     <h3 id="badge-default">Default Badge</h3>
+    <p>The default badge contains the basic, base styles. A <span class="highlight">role</span> and <span class="highlight">aria-label</span> are added for assistive technology.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -14,13 +15,14 @@
     {% endhighlight %}
 
     <h3 id="badge-menu">Menu Badge</h3>
+    <p>A badge can be placed inside of a menu item and it will receive the appropriate margin. Note that the <span class="highlight">aria-label</span> is now moved to the menuitem role.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="menu">
                 <div class="menu__items" role="menu">
-                    <div aria-label="Item 1 (3 notifications)" class="menu__item" role="menuitem"><span aria-hidden="true">Item 1<span class="menu-badge">3</span></span></div>
-                    <div aria-label="Item 2 (77 notifications)" class="menu__item" role="menuitem"><span aria-hidden="true">Item 2<span class="menu-badge">77</span></span></div>
+                    <div aria-label="Item 1 (3 notifications)" class="menu__item" role="menuitem"><span aria-hidden="true">Item 1<span class="badge">3</span></span></div>
+                    <div aria-label="Item 2 (77 notifications)" class="menu__item" role="menuitem"><span aria-hidden="true">Item 2<span class="badge">77</span></span></div>
                     <div class="menu__item" role="menuitem"><span>Item 3</span></div>
                 </div>
             </span>
@@ -30,10 +32,10 @@
 <span class="menu">
     <div class="menu__items" role="menu">
         <div aria-label="Item 1 (3 notifications)" class="menu__item" role="menuitem">
-            <span aria-hidden="true">Item 1<span class="menu-badge">3</span></span>
+            <span aria-hidden="true">Item 1<span class="badge">3</span></span>
         </div>
         <div aria-label="Item 2 (77 notifications)" class="menu__item" role="menuitem">
-            <span aria-hidden="true">Item 2<span class="menu-badge">77</span></span>
+            <span aria-hidden="true">Item 2<span class="badge">77</span></span>
         </div>
         <div class="menu__item" role="menuitem">
             <span>Item 3</span>
@@ -42,25 +44,26 @@
 </span>
     {% endhighlight %}
 
-    <h3 id="badge-icon">Icon Badge</h3>
+    <h3 id="badge-icon-button">Icon Button Badge</h3>
+    <p>A badge can be placed inside of an icon button and it will receive the appropriate positioning. Note that the <span class="highlight">aria-label</span> is now moved to the button role.</p>
+    <p>The button element requires an additional <span class="highlight">icon-btn--badged</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <button aria-label="Menu (4 notifications)" class="icon-btn icon-badge-container" type="button">
+            <button aria-label="Menu (4 notifications)" class="icon-btn icon-btn--badged" type="button">
                 <svg aria-hidden="true" focusable="false" width="16" height="16">
                     <use xlink:href="#icon-menu"></use>
                 </svg>
-                <span aria-hidden="true" class="icon-badge">4</span>
+                <span aria-hidden="true" class="badge">4</span>
             </button>
         </div>
     </div>
     {% highlight html %}
-<button aria-label="Menu (4 notifications)" class="icon-btn icon-badge-container" type="button">
+<button aria-label="Menu (4 notifications)" class="icon-btn icon-btn--badged" type="button">
     <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-    <span aria-hidden="true" class="icon-badge">4</span>
+    <span aria-hidden="true" class="badge">4</span>
 </button>
-
     {% endhighlight %}
 </div>

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -199,8 +199,22 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
 }
-.badge,
-.menu-badge {
+.icon-btn--badged {
+  position: relative;
+}
+.icon-btn--badged .badge {
+  border: 2px solid;
+  border-color: #fff;
+  font-size: 0.75rem;
+  height: 24px;
+  left: 12px;
+  margin: auto;
+  min-width: 24px;
+  position: absolute;
+  top: -8px;
+  z-index: 1;
+}
+.badge {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
@@ -221,45 +235,9 @@ button.img-btn:not([disabled]):active {
   position: relative;
   top: calc(50% - 20px);
 }
-.menu-badge {
-  margin-left: 8px;
-}
-.icon-badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  border-radius: 20px;
-  box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  padding: 0 7px;
-  vertical-align: middle;
-  white-space: nowrap;
-  border: 2px solid;
-  height: 24px;
-  left: 12px;
-  margin: auto;
-  min-width: 24px;
-  position: absolute;
-  top: -8px;
-  z-index: 1;
-}
-.icon-badge-container {
-  position: relative;
-}
-.badge,
-.menu-badge,
-.icon-badge {
+.badge {
   background-color: #dd1e31;
   color: #fff;
-}
-.icon-badge {
-  border-color: #fff;
-  font-size: 0.75rem;
 }
 .breadcrumb {
   margin: 16px 0;
@@ -2606,6 +2584,9 @@ span.fake-menu__status {
 .expand-btn ~ .menu__items--static[role="menu"],
 .expand_btn ~ .fake-menu__items--static {
   position: static;
+}
+.menu__item .badge {
+  margin-left: 8px;
 }
 .page-notice {
   -webkit-box-align: stretch;

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -199,10 +199,12 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
 }
-.icon-btn--badged {
+.icon-btn--badged,
+.icon-link--badged {
   position: relative;
 }
-.icon-btn--badged .badge {
+.icon-btn--badged .badge,
+.icon-link--badged .badge {
   border: 2px solid;
   border-color: #fff;
   font-size: 0.75rem;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -199,8 +199,22 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
 }
-.badge,
-.menu-badge {
+.icon-btn--badged {
+  position: relative;
+}
+.icon-btn--badged .badge {
+  border: 2px solid;
+  border-color: #fff;
+  font-size: 0.75rem;
+  height: 24px;
+  left: 12px;
+  margin: auto;
+  min-width: 24px;
+  position: absolute;
+  top: -8px;
+  z-index: 1;
+}
+.badge {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
@@ -221,45 +235,9 @@ button.img-btn:not([disabled]):active {
   position: relative;
   top: calc(50% - 20px);
 }
-.menu-badge {
-  margin-left: 8px;
-}
-.icon-badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  border-radius: 20px;
-  box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  padding: 0 7px;
-  vertical-align: middle;
-  white-space: nowrap;
-  border: 2px solid;
-  height: 24px;
-  left: 12px;
-  margin: auto;
-  min-width: 24px;
-  position: absolute;
-  top: -8px;
-  z-index: 1;
-}
-.icon-badge-container {
-  position: relative;
-}
-.badge,
-.menu-badge,
-.icon-badge {
+.badge {
   background-color: #dd1e31;
   color: #fff;
-}
-.icon-badge {
-  border-color: #fff;
-  font-size: 0.75rem;
 }
 .breadcrumb {
   margin: 16px 0;
@@ -2606,6 +2584,9 @@ span.fake-menu__status {
 .expand-btn ~ .menu__items--static[role="menu"],
 .expand_btn ~ .fake-menu__items--static {
   position: static;
+}
+.menu__item .badge {
+  margin-left: 8px;
 }
 .page-notice {
   -webkit-box-align: stretch;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -199,10 +199,12 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
 }
-.icon-btn--badged {
+.icon-btn--badged,
+.icon-link--badged {
   position: relative;
 }
-.icon-btn--badged .badge {
+.icon-btn--badged .badge,
+.icon-link--badged .badge {
   border: 2px solid;
   border-color: #fff;
   font-size: 0.75rem;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -50,8 +50,41 @@ legend {
 body {
   font-family: "Market Sans", Arial, sans-serif;
 }
-.badge,
-.menu-badge {
+.icon-btn,
+.icon-link {
+  background-color: transparent;
+  border: 0 none;
+  font-size: 24px;
+  min-height: 32px;
+  min-width: 32px;
+  padding: 0;
+}
+.icon-btn svg,
+.icon-link svg {
+  display: inline-block;
+  fill: currentColor;
+  height: 1rem;
+  stroke: currentColor;
+  stroke-width: 0;
+  vertical-align: middle;
+  width: 1rem;
+}
+.icon-btn--badged {
+  position: relative;
+}
+.icon-btn--badged .badge {
+  border: 2px solid;
+  border-color: #fff;
+  font-size: 0.75rem;
+  height: 24px;
+  left: 12px;
+  margin: auto;
+  min-width: 24px;
+  position: absolute;
+  top: -8px;
+  z-index: 1;
+}
+.badge {
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
@@ -72,45 +105,9 @@ body {
   position: relative;
   top: calc(50% - 20px);
 }
-.menu-badge {
-  margin-left: 8px;
-}
-.icon-badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  border-radius: 20px;
-  box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  padding: 0 7px;
-  vertical-align: middle;
-  white-space: nowrap;
-  border: 2px solid;
-  height: 24px;
-  left: 12px;
-  margin: auto;
-  min-width: 24px;
-  position: absolute;
-  top: -8px;
-  z-index: 1;
-}
-.icon-badge-container {
-  position: relative;
-}
-.badge,
-.menu-badge,
-.icon-badge {
+.badge {
   background-color: #e62048;
   color: #fff;
-}
-.icon-badge {
-  border-color: #fff;
-  font-size: 0.75rem;
 }
 .breadcrumb {
   margin: 16px 0;
@@ -2071,6 +2068,9 @@ span.fake-menu__status {
 .expand-btn ~ .menu__items--static[role="menu"],
 .expand_btn ~ .fake-menu__items--static {
   position: static;
+}
+.menu__item .badge {
+  margin-left: 8px;
 }
 .page-notice {
   -webkit-box-align: stretch;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -69,10 +69,12 @@ body {
   vertical-align: middle;
   width: 1rem;
 }
-.icon-btn--badged {
+.icon-btn--badged,
+.icon-link--badged {
   position: relative;
 }
-.icon-btn--badged .badge {
+.icon-btn--badged .badge,
+.icon-link--badged .badge {
   border: 2px solid;
   border-color: #fff;
   font-size: 0.75rem;

--- a/docs/test/badge/ds4/index.html
+++ b/docs/test/badge/ds4/index.html
@@ -38,7 +38,7 @@ title: Badge
 <div class="test">
     <span class="menu">
         <span class="menu__items" role="menu">
-            <div class="menu__item" role="menuitem"><span>Button 1<span class="menu-badge">1</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 1<span class="badge">1</span></span></div>
             <div class="menu__item" role="menuitem"><span>Button 2</span></div>
             <div class="menu__item" role="menuitem"><span>Button 3</span></div>
         </span>
@@ -46,197 +46,197 @@ title: Badge
     <span class="menu">
         <span class="menu__items" role="menu">
             <div class="menu__item" role="menuitem"><span>Button 1</span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">2</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">2</span></span></div>
             <div class="menu__item" role="menuitem"><span>Button 3</span></div>
         </span>
     </span>
     <span class="menu">
         <span class="menu__items" role="menu">
             <div class="menu__item" role="menuitem"><span>Button 1</span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">3</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">3</span></span></div>
             <div class="menu__item" role="menuitem"><span>Button 3</span></div>
         </span>
     </span>
     <span class="menu">
         <span class="menu__items" role="menu">
-            <div class="menu__item" role="menuitem"><span>Button 1<span class="menu-badge">4</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">6</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 3<span class="menu-badge">55</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 1<span class="badge">4</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">6</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 3<span class="badge">55</span></span></div>
         </span>
     </span>
     <span class="menu">
         <span class="menu__items" role="menu">
-            <div class="menu__item" role="menuitem"><span>Button 1<span class="menu-badge">155</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">555</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 3<span class="menu-badge">55+</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 1<span class="badge">155</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">555</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 3<span class="badge">55+</span></span></div>
         </span>
     </span>
 </div>
 
 <h2>Badge Icon</h2>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">1</span></span>
+        <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">1</span></span>
     </button>
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">4</span></span>
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">4</span></span>
     </button>
 </div>
 <h2>Badge Multi</h2>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">5</span></span>
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">5</span></span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">44</span></span>
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">44</span></span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">55</span></span>
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">55</span></span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">55+</span></span>
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">55+</span></span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <span aria-label="Font Icon" role="img" class="icon icon--menu">
 
-            <span class="icon-badge">100</span>
+            <span class="badge">100</span>
         </span>
     </button>
 </div>
 
 <h2>Badge Fake anchor</h2>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">5</span></span>
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">5</span></span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">44</span></span>
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">44</span></span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">55</span></span>
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">55</span></span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
-        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="icon-badge">55+</span></span>
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
+        <span aria-label="Font Icon" role="img" class="icon icon--menu">      <span class="badge">55+</span></span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <span aria-label="Font Icon" role="img" class="icon icon--menu">
-            <span class="icon-badge">100</span>
+            <span class="badge">100</span>
         </span>
     </a>
 </div>
 
 <h2>Badge Icon SVG</h2>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">1</span>
+      <span class="badge">1</span>
     </button>
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">4</span>
+      <span class="badge">4</span>
     </button>
 </div>
 <h2>Badge Multi</h2>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">5</span>
+      <span class="badge">5</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
             <use xlink:href="#icon-menu"></use>
         </svg>
-      <span class="icon-badge">44</span>
+      <span class="badge">44</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">55</span>
+      <span class="badge">55</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">55+</span>
+      <span class="badge">55+</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
        <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-    <span class="icon-badge">100</span>
+    <span class="badge">100</span>
     </button>
 </div>
 
 <h2>Badge Fake SVG anchor</h2>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
             <use xlink:href="#icon-menu"></use>
         </svg>
-      <span class="icon-badge">5</span>
+      <span class="badge">5</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">44</span>
+      <span class="badge">44</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">55</span>
+      <span class="badge">55</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
 
-      <span class="icon-badge">55+</span>
+      <span class="badge">55+</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
             <use xlink:href="#icon-menu"></use>
         </svg>
-        <span class="icon-badge">100</span>
+        <span class="badge">100</span>
     </a>
 </div>

--- a/docs/test/badge/ds6/index.html
+++ b/docs/test/badge/ds6/index.html
@@ -39,7 +39,7 @@ title: Badge
 <div class="test">
     <span class="menu">
         <span class="menu__items" role="menu">
-            <div class="menu__item" role="menuitem"><span>Button 1<span class="menu-badge">1</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 1<span class="badge">1</span></span></div>
             <div class="menu__item" role="menuitem"><span>Button 2</span></div>
             <div class="menu__item" role="menuitem"><span>Button 3</span></div>
         </span>
@@ -47,129 +47,129 @@ title: Badge
     <span class="menu">
         <span class="menu__items" role="menu">
             <div class="menu__item" role="menuitem"><span>Button 1</span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">2</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">2</span></span></div>
             <div class="menu__item" role="menuitem"><span>Button 3</span></div>
         </span>
     </span>
     <span class="menu">
         <span class="menu__items" role="menu">
             <div class="menu__item" role="menuitem"><span>Button 1</span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">3</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">3</span></span></div>
             <div class="menu__item" role="menuitem"><span>Button 3</span></div>
         </span>
     </span>
     <span class="menu">
         <span class="menu__items" role="menu">
-            <div class="menu__item" role="menuitem"><span>Button 1<span class="menu-badge">4</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">6</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 3<span class="menu-badge">55</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 1<span class="badge">4</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">6</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 3<span class="badge">55</span></span></div>
         </span>
     </span>
     <span class="menu">
         <span class="menu__items" role="menu">
-            <div class="menu__item" role="menuitem"><span>Button 1<span class="menu-badge">155</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 2<span class="menu-badge">555</span></span></div>
-            <div class="menu__item" role="menuitem"><span>Button 3<span class="menu-badge">55+</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 1<span class="badge">155</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">555</span></span></div>
+            <div class="menu__item" role="menuitem"><span>Button 3<span class="badge">55+</span></span></div>
         </span>
     </span>
 </div>
 
 <h2>Badge Icon</h2>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">1</span>
+      <span class="badge">1</span>
     </button>
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">4</span>
+      <span class="badge">4</span>
     </button>
 </div>
 <h2>Badge Multi</h2>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">5</span>
+      <span class="badge">5</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
             <use xlink:href="#icon-menu"></use>
         </svg>
-      <span class="icon-badge">44</span>
+      <span class="badge">44</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">55</span>
+      <span class="badge">55</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">55+</span>
+      <span class="badge">55+</span>
     </button>
 </div>
 <div class="test">
-    <button aria-label="Menu" class="icon-btn icon-badge-container" type="button">
+    <button aria-label="Menu" class="icon-btn icon-btn--badged" type="button">
        <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-    <span class="icon-badge">100</span>
+    <span class="badge">100</span>
     </button>
 </div>
 
 <h2>Badge Fake anchor</h2>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
             <use xlink:href="#icon-menu"></use>
         </svg>
-      <span class="icon-badge">5</span>
+      <span class="badge">5</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">44</span>
+      <span class="badge">44</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
-      <span class="icon-badge">55</span>
+      <span class="badge">55</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
         <use xlink:href="#icon-menu"></use>
     </svg>
 
-      <span class="icon-badge">55+</span>
+      <span class="badge">55+</span>
     </a>
 </div>
 <div class="test">
-    <a aria-label="Settings" class="icon-link icon-badge-container" href="http://www.ebay.com">
+    <a aria-label="Settings" class="icon-link icon-link--badged" href="http://www.ebay.com">
         <svg aria-hidden="true" focusable="false" width="16" height="16">
             <use xlink:href="#icon-menu"></use>
         </svg>
-        <span class="icon-badge">100</span>
+        <span class="badge">100</span>
     </a>
 </div>

--- a/src/less/actionable/ds4/actionable-base.less
+++ b/src/less/actionable/ds4/actionable-base.less
@@ -84,3 +84,20 @@ button.img-btn {
         }
     }
 }
+
+.icon-btn--badged {
+    position: relative;
+
+    .badge {
+        border: 2px solid;
+        border-color: @ds4-color-core-white;
+        font-size: @ds4-font-size-12;
+        height: 24px;
+        left: 12px;
+        margin: auto;
+        min-width: 24px;
+        position: absolute;
+        top: -8px;
+        z-index: 1;
+    }
+}

--- a/src/less/actionable/ds4/actionable-base.less
+++ b/src/less/actionable/ds4/actionable-base.less
@@ -85,7 +85,8 @@ button.img-btn {
     }
 }
 
-.icon-btn--badged {
+.icon-btn--badged,
+.icon-link--badged {
     position: relative;
 
     .badge {

--- a/src/less/actionable/ds6/actionable.less
+++ b/src/less/actionable/ds6/actionable.less
@@ -14,7 +14,8 @@
     }
 }
 
-.icon-btn--badged {
+.icon-btn--badged,
+.icon-link--badged {
     position: relative;
 
     .badge {

--- a/src/less/actionable/ds6/actionable.less
+++ b/src/less/actionable/ds6/actionable.less
@@ -13,3 +13,20 @@
         .foreground-icon-base;
     }
 }
+
+.icon-btn--badged {
+    position: relative;
+
+    .badge {
+        border: 2px solid;
+        border-color: @ds6-color-badge-text;
+        font-size: @ds6-font-size-12;
+        height: 24px;
+        left: 12px;
+        margin: auto;
+        min-width: 24px;
+        position: absolute;
+        top: -8px;
+        z-index: 1;
+    }
+}

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -12,8 +12,7 @@
     white-space: nowrap;
 }
 
-.badge,
-.menu-badge {
+.badge {
     .badge-base();
 
     font-size: 0.75em;
@@ -21,25 +20,4 @@
     min-width: 20px;
     position: relative;
     top: calc(50% - 20px);
-}
-
-.menu-badge {
-    margin-left: 8px;
-}
-
-.icon-badge {
-    .badge-base();
-
-    border: 2px solid;
-    height: 24px;
-    left: 12px;
-    margin: auto;
-    min-width: 24px;
-    position: absolute;
-    top: -8px;
-    z-index: 1;
-
-    &-container {
-        position: relative;
-    }
 }

--- a/src/less/badge/ds4/badge.less
+++ b/src/less/badge/ds4/badge.less
@@ -2,14 +2,7 @@
 @import "../../less/ds4/variables.less";
 @import "../../less/ds4/mixins.less";
 
-.badge,
-.menu-badge,
-.icon-badge {
+.badge {
     background-color: @ds4-color-core-red;
     color: @ds4-color-core-white;
-}
-
-.icon-badge {
-    border-color: @ds4-color-core-white;
-    font-size: @ds4-font-size-12;
 }

--- a/src/less/badge/ds6/badge.less
+++ b/src/less/badge/ds6/badge.less
@@ -2,14 +2,7 @@
 @import "../../less/ds6/variables.less";
 @import "../../less/ds6/mixins.less";
 
-.badge,
-.menu-badge,
-.icon-badge {
+.badge {
     background-color: @ds6-color-badge-background;
     color: @ds6-color-badge-text;
-}
-
-.icon-badge {
-    border-color: @ds6-color-badge-text;
-    font-size: @ds6-font-size-12;
 }

--- a/src/less/bundles/skin/ds6/skin.less
+++ b/src/less/bundles/skin/ds6/skin.less
@@ -2,6 +2,7 @@
 
 @import "../../../marketsans/marketsans.less";
 @import "../../../global/ds6/global-static.less";
+@import "../../../actionable/ds6/actionable.less";
 @import "../../../badge/ds6/badge.less";
 @import "../../../breadcrumb/ds6/breadcrumb.less";
 @import "../../../button/ds6/button.less";

--- a/src/less/menu/base/menu.less
+++ b/src/less/menu/base/menu.less
@@ -27,3 +27,7 @@ span.fake-menu__status {
 .expand_btn ~ .fake-menu__items--static {
     position: static;
 }
+
+.menu__item .badge {
+    margin-left: 8px;
+}


### PR DESCRIPTION
## Description

Refactored the badge classnames.

1. `menu-badge` renamed to just `badge` (margin left is now applied via menu module)
1. `icon-badge` renamed to just `badge` (positioning properties now applied via actionable module)
1. `icon-badge-container` renamed to `icon-btn--badged` (as above)
1. Missing `actionable` module added to DS6 less bundle

## Context

Changes are based on sprint review feedback.

The badge module now essentially just contains the base properties for a badge. Any instance specific styles have been moved out to the respective module (e.g. menu and actionable).

## Not Addressed / Out of Scope

1. Existing alignment issue
1. Un-normalized folder structure of actionable module

## References

#80

## Screenshots

![screen shot 2018-10-24 at 1 50 55 pm](https://user-images.githubusercontent.com/38065/47460770-0e4f2680-d794-11e8-9db2-d62bcde1c0bb.png)
