### PR TITLE
Updates to get pixel perfect font alignment in the badge;

### DIFF
--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -78,8 +78,10 @@ button.img-btn:not([disabled]):active {
   font-size: 0.75rem;
   height: 24px;
   left: 12px;
+  line-height: 1rem;
   margin: auto;
   min-width: 24px;
+  padding-top: 0;
   position: absolute;
   top: -8px;
   z-index: 1;

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -28,8 +28,10 @@
   font-size: 0.75rem;
   height: 24px;
   left: 12px;
+  line-height: 1rem;
   margin: auto;
   min-width: 24px;
+  padding-top: 0;
   position: absolute;
   top: -8px;
   z-index: 1;

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -10,7 +10,7 @@
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 7px;
+  padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
   font-size: 0.75em;

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -10,7 +10,7 @@
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 7px;
+  padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
   font-size: 0.75em;

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -210,8 +210,10 @@ button.img-btn:not([disabled]):active {
   font-size: 0.75rem;
   height: 24px;
   left: 12px;
+  line-height: 1rem;
   margin: auto;
   min-width: 24px;
+  padding-top: 0;
   position: absolute;
   top: -8px;
   z-index: 1;
@@ -228,7 +230,7 @@ button.img-btn:not([disabled]):active {
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 7px;
+  padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
   font-size: 0.75em;

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -210,8 +210,10 @@ button.img-btn:not([disabled]):active {
   font-size: 0.75rem;
   height: 24px;
   left: 12px;
+  line-height: 1rem;
   margin: auto;
   min-width: 24px;
+  padding-top: 0;
   position: absolute;
   top: -8px;
   z-index: 1;
@@ -228,7 +230,7 @@ button.img-btn:not([disabled]):active {
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 7px;
+  padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
   font-size: 0.75em;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -80,8 +80,10 @@ body {
   font-size: 0.75rem;
   height: 24px;
   left: 12px;
+  line-height: 1rem;
   margin: auto;
   min-width: 24px;
+  padding-top: 0;
   position: absolute;
   top: -8px;
   z-index: 1;
@@ -98,7 +100,7 @@ body {
   -webkit-box-pack: center;
       -ms-flex-pack: center;
           justify-content: center;
-  padding: 0 7px;
+  padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
   font-size: 0.75em;

--- a/src/less/actionable/ds4/actionable-base.less
+++ b/src/less/actionable/ds4/actionable-base.less
@@ -95,8 +95,10 @@ button.img-btn {
         font-size: @ds4-font-size-12;
         height: 24px;
         left: 12px;
+        line-height: 1rem;
         margin: auto;
         min-width: 24px;
+        padding-top: 0;
         position: absolute;
         top: -8px;
         z-index: 1;

--- a/src/less/actionable/ds6/actionable.less
+++ b/src/less/actionable/ds6/actionable.less
@@ -24,8 +24,10 @@
         font-size: @ds6-font-size-12;
         height: 24px;
         left: 12px;
+        line-height: 1rem;
         margin: auto;
         min-width: 24px;
+        padding-top: 0;
         position: absolute;
         top: -8px;
         z-index: 1;

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -7,7 +7,7 @@
     box-sizing: border-box;
     display: inline-flex;
     justify-content: center;
-    padding: 0 7px;
+    padding: 1px 7px 0;
     vertical-align: middle;
     white-space: nowrap;
 }


### PR DESCRIPTION
## Description
- base `.badge` class now has a `1px` top padding
- actionable `.badge` resets the line height to `1rem;`

## Context
The font looked misaligned across all the browsers. This creates a pixel-perfect version they all appear to like.

## References
Fixes #441.

## Screenshots

### Before

![badge - before](https://user-images.githubusercontent.com/105656/47583930-0f0fc600-d916-11e8-8a80-099a367dde61.png)

### After

![badge - after](https://user-images.githubusercontent.com/105656/47583951-1505a700-d916-11e8-823f-4269e68529f6.png)

>Yay 400% zoom.
