### PR TITLE
Fixed docs: Unwanted double quotes in lasso-page flags for DS6

### DIFF
--- a/docs/_includes/ds6/install.html
+++ b/docs/_includes/ds6/install.html
@@ -46,7 +46,7 @@ myLasso.lassoPage({
     <p>Or, alternatively, using the Marko Taglib.</p>
 
     {% highlight html %}
-<lasso-page flags="['skin-ds6']">
+<lasso-page flags=['skin-ds6']>
    ...
 </lasso-page>
     {% endhighlight %}

--- a/docs/archive/v5.0/ds6/index.html
+++ b/docs/archive/v5.0/ds6/index.html
@@ -329,7 +329,7 @@
 
     <p>Or, alternatively, using the Marko Taglib.</p>
 
-    <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;lasso-page</span> <span class="na">flags=</span><span class="s">"['skin-ds6']"</span><span class="nt">&gt;</span>
+    <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;lasso-page</span> <span class="na">flags=</span><span class="s">['skin-ds6']</span><span class="nt">&gt;</span>
    ...
 <span class="nt">&lt;/lasso-page&gt;</span>
     </code></pre></figure>

--- a/docs/archive/v5.1.2/ds6/index.html
+++ b/docs/archive/v5.1.2/ds6/index.html
@@ -332,7 +332,7 @@
 
     <p>Or, alternatively, using the Marko Taglib.</p>
 
-    <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;lasso-page</span> <span class="na">flags=</span><span class="s">"['skin-ds6']"</span><span class="nt">&gt;</span>
+    <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;lasso-page</span> <span class="na">flags=</span><span class="s">['skin-ds6']</span><span class="nt">&gt;</span>
    ...
 <span class="nt">&lt;/lasso-page&gt;</span>
     </code></pre></figure>
@@ -3287,7 +3287,7 @@
     <span class="c">&lt;!-- menu items omitted from example code --&gt;</span>
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
-    
+
     <p>For <em>custom</em> background and foreground colours, please replace the icon's span element with an inline SVG element:</p>
 
     <div class="demo">

--- a/docs/archive/v5.1/ds6/index.html
+++ b/docs/archive/v5.1/ds6/index.html
@@ -332,7 +332,7 @@
 
     <p>Or, alternatively, using the Marko Taglib.</p>
 
-    <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;lasso-page</span> <span class="na">flags=</span><span class="s">"['skin-ds6']"</span><span class="nt">&gt;</span>
+    <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;lasso-page</span> <span class="na">flags=</span><span class="s">['skin-ds6']</span><span class="nt">&gt;</span>
    ...
 <span class="nt">&lt;/lasso-page&gt;</span>
     </code></pre></figure>
@@ -3287,7 +3287,7 @@
     <span class="c">&lt;!-- menu items omitted from example code --&gt;</span>
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
-    
+
     <p>For <em>custom</em> background and foreground colours, please replace the icon's span element with an inline SVG element:</p>
 
     <div class="demo">


### PR DESCRIPTION

## Description
lasso-page flags attribute should take actual array rather than array enclosed in double quotes.

@seangates 

