### PR TITLE
Allow an flag in combo.browser.json to opt out of icon modules

### DIFF
--- a/combo.browser.json
+++ b/combo.browser.json
@@ -4,7 +4,10 @@
         "@ebay/skin/dialog",
         "@ebay/skin/form",
         "@ebay/skin/iconfont",
-        "@ebay/skin/icon",
-        "@ebay/skin/spinner"
+        "@ebay/skin/spinner",
+        {
+            "if-not-flag": "icon-opt-out",
+            "path": "@ebay/skin/icon"
+        }
     ]
 }

--- a/combo.browser.json
+++ b/combo.browser.json
@@ -3,11 +3,13 @@
         "@ebay/skin/core",
         "@ebay/skin/dialog",
         "@ebay/skin/form",
-        "@ebay/skin/iconfont",
-        "@ebay/skin/spinner",
         {
             "if-not-flag": "icon-opt-out",
-            "path": "@ebay/skin/icon"
+            "dependencies": [
+                "@ebay/skin/iconfont",
+                "@ebay/skin/icon",
+                "@ebay/skin/spinner"
+            ]
         }
     ]
 }

--- a/combo.browser.json
+++ b/combo.browser.json
@@ -3,12 +3,12 @@
         "@ebay/skin/core",
         "@ebay/skin/dialog",
         "@ebay/skin/form",
+        "@ebay/skin/spinner",
         {
-            "if-not-flag": "icon-opt-out",
+            "if-not-flag": "skin-icon-opt-out",
             "dependencies": [
                 "@ebay/skin/iconfont",
-                "@ebay/skin/icon",
-                "@ebay/skin/spinner"
+                "@ebay/skin/icon"
             ]
         }
     ]


### PR DESCRIPTION
## Issue Number
#460 

## Description
Adding a flag `icon-opt-out` in `combo.browser.json` to not include `icon`, `iconfont` and `spinner` modules. 

**Note:** The DS4 [combo documentation](https://ebay.github.io/skin/#bundles_combo) is not updated to reflect this. This is anyway going to be changed in 7.0.0 with `skin-ds6` flag, hence the update would be redundant.