### PR TITLE
458 - fix padding issue with text box with icon when dir="rtl" is spe…

### DIFF
--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -82,13 +82,13 @@ span.textbox__icon:first-child + textarea.textbox__control,
 .textbox__control--fluid {
   width: 100%;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   left: auto;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-right: 40px;
 }
@@ -167,13 +167,13 @@ span.textbox__icon:first-child,
 .textbox--extra-large textarea.textbox__control {
   height: 56px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   right: 16px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-left: 16px;
 }

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -82,13 +82,13 @@ span.textbox__icon:first-child + textarea.textbox__control,
 .textbox__control--fluid {
   width: 100%;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   left: auto;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-right: 40px;
 }
@@ -181,13 +181,13 @@ span.textbox__icon:first-child,
   font-size: 1.125rem;
   height: 48px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   right: 17px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-left: 17px;
 }

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -3709,13 +3709,13 @@ span.textbox__icon:first-child + textarea.textbox__control,
 .textbox__control--fluid {
   width: 100%;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   left: auto;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-right: 40px;
 }
@@ -3794,13 +3794,13 @@ span.textbox__icon:first-child,
 .textbox--extra-large textarea.textbox__control {
   height: 56px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   right: 16px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-left: 16px;
 }

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -3709,13 +3709,13 @@ span.textbox__icon:first-child + textarea.textbox__control,
 .textbox__control--fluid {
   width: 100%;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   left: auto;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-right: 40px;
 }
@@ -3794,13 +3794,13 @@ span.textbox__icon:first-child,
 .textbox--extra-large textarea.textbox__control {
   height: 56px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   right: 16px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-left: 16px;
 }

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -2936,13 +2936,13 @@ span.textbox__icon:first-child + textarea.textbox__control,
 .textbox__control--fluid {
   width: 100%;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   left: auto;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-right: 40px;
 }
@@ -3035,13 +3035,13 @@ span.textbox__icon:first-child,
   font-size: 1.125rem;
   height: 48px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before,
+[dir="rtl"] span.textbox__icon:first-child,
 [dir="rtl"] .textbox__icon:first-child {
   right: 17px;
 }
-[dir="rtl"] span.textbox__icon:first-child::before + input.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + input.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + input.textbox__control,
-[dir="rtl"] span.textbox__icon:first-child::before + textarea.textbox__control,
+[dir="rtl"] span.textbox__icon:first-child + textarea.textbox__control,
 [dir="rtl"] .textbox__icon:first-child + textarea.textbox__control {
   padding-left: 17px;
 }

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -75,7 +75,7 @@ span.textbox__icon:first-child,
 // RTL
 
 [dir="rtl"] {
-    span.textbox__icon:first-child::before,
+    span.textbox__icon:first-child,
     .textbox__icon:first-child {
         left: auto;
 

--- a/src/less/textbox/ds4/textbox.less
+++ b/src/less/textbox/ds4/textbox.less
@@ -88,7 +88,7 @@ span.textbox__icon:first-child,
 // RTL
 
 [dir="rtl"] {
-    span.textbox__icon:first-child::before,
+    span.textbox__icon:first-child,
     .textbox__icon:first-child {
         right: 16px;
 

--- a/src/less/textbox/ds6/textbox.less
+++ b/src/less/textbox/ds6/textbox.less
@@ -81,7 +81,7 @@ span.textbox__icon:first-child,
 // RTL
 
 [dir="rtl"] {
-    span.textbox__icon:first-child::before,
+    span.textbox__icon:first-child,
     .textbox__icon:first-child {
         right: 17px;
 


### PR DESCRIPTION
## Issue No
[#458](https://github.com/eBay/skin/issues/458)

## Goals
Fix padding issue for textbox that has an icon prefix for right to left languages.

## Changes
Minor changes where made in the [dir="rtl"] section of the following files:
- base/texbox.less
- ds4/textbox.less
- ds6/textbox.less

## Tested
Safari, Firefox, Chrome

## Screenshots

### Issue:
![screen shot 2018-11-21 at 12 49 05 pm](https://user-images.githubusercontent.com/20077653/48813667-e4d1ec80-ed8b-11e8-861b-58c168ad8b8e.png)

### After issue has been fixed:
![screen shot 2018-11-21 at 12 51 12 pm](https://user-images.githubusercontent.com/20077653/48813730-2a8eb500-ed8c-11e8-841d-ba4351208c99.png)

