### PR TITLE
Upgraded autoprefixer to v8.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ From v3 onwards, please refer to our publicly visible [releases](https://github.
 
 Prior to v3, all releases and milestones can only be viewed on the old, internal repository.
 
+## Browser Support
+
+Please view our [@ebay/browserslist-config](https://github.com/eBay/browserslist-config/blob/master/index.js) to see which browsers we currently support.
+
+SPOILER: we do not support IE10 or under.
+
 ## Issues
 
 Please use our publicly visible [issues page](https://github.com/eBay/skin/issues) to ask questions, report issues or submit feature requests.

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,9 +1,19 @@
 .badge {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 20px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -11,6 +21,7 @@
   height: 20px;
   min-width: 20px;
   position: relative;
+  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,18 +1,12 @@
 .badge {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
@@ -21,7 +15,6 @@
   height: 20px;
   min-width: 20px;
   position: relative;
-  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,15 +1,9 @@
 .badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 20px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,9 +1,19 @@
 .badge {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 20px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -11,6 +21,7 @@
   height: 20px;
   min-width: 20px;
   position: relative;
+  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,18 +1,12 @@
 .badge {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
@@ -21,7 +15,6 @@
   height: 20px;
   min-width: 20px;
   position: relative;
-  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,15 +1,9 @@
 .badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 20px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;

--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -48,9 +48,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -79,12 +77,8 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -94,8 +88,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -106,10 +98,7 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
@@ -117,8 +106,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -129,24 +116,17 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
 }
 .expand-btn__cell {
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 svg.btn__icon,
@@ -163,16 +143,12 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -184,9 +160,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -200,25 +174,17 @@ button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 24px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
           flex-direction: column;
   height: 48px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   max-width: 180px;
   min-width: 80px;
@@ -470,9 +436,7 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   overflow: visible;
 }
 button.btn--small,

--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -5,7 +5,8 @@ a.cta-btn {
   background-color: transparent;
   border: 1px solid;
   border-color: inherit;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   color: inherit;
   display: inline-block;
   font-family: inherit;
@@ -47,7 +48,9 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -75,7 +78,13 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -84,6 +93,9 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -94,13 +106,19 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -111,16 +129,25 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
 }
 .expand-btn__cell {
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -136,11 +163,16 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -152,7 +184,9 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -165,13 +199,27 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 24px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column;
   height: 48px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -422,7 +470,9 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   overflow: visible;
 }
 button.btn--small,

--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -47,9 +47,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -77,11 +75,7 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
   height: 100%;
   width: 100%;
@@ -90,8 +84,6 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -102,16 +94,13 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -122,21 +111,16 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 .expand-btn__cell {
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -152,14 +136,11 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -171,9 +152,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -186,22 +165,13 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 24px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   height: 48px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -452,9 +422,7 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   overflow: visible;
 }
 button.btn--small,

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -47,9 +47,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -77,11 +75,7 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
   height: 100%;
   width: 100%;
@@ -90,8 +84,6 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -102,16 +94,13 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -122,21 +111,16 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 .expand-btn__cell {
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -152,14 +136,11 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -171,9 +152,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -186,22 +165,13 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 24px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   height: 48px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -439,9 +409,7 @@ button.btn__cell--fixed-height svg.cta-btn__icon,
 button.expand-btn__cell--fixed-height svg.cta-btn__icon,
 a.fake-btn__cell--fixed-height svg.cta-btn__icon,
 a.cta-btn__cell--fixed-height svg.cta-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   height: 1rem;
   width: 1rem;
 }
@@ -626,8 +594,7 @@ svg.fake-btn__icon {
 }
 svg.cta-btn__icon,
 svg.expand-btn__icon {
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
 }
 svg.cta-btn__icon {
   height: 10px;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -48,9 +48,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -79,12 +77,8 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -94,8 +88,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -106,10 +98,7 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
@@ -117,8 +106,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -129,24 +116,17 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
 }
 .expand-btn__cell {
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 svg.btn__icon,
@@ -163,16 +143,12 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -184,9 +160,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -200,25 +174,17 @@ button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 24px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
           flex-direction: column;
   height: 48px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   max-width: 180px;
   min-width: 80px;
@@ -457,9 +423,7 @@ button.btn__cell--fixed-height svg.cta-btn__icon,
 button.expand-btn__cell--fixed-height svg.cta-btn__icon,
 a.fake-btn__cell--fixed-height svg.cta-btn__icon,
 a.cta-btn__cell--fixed-height svg.cta-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   height: 1rem;
   width: 1rem;
 }
@@ -644,9 +608,7 @@ svg.fake-btn__icon {
 }
 svg.cta-btn__icon,
 svg.expand-btn__icon {
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
 }
 svg.cta-btn__icon {
   height: 10px;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -5,7 +5,8 @@ a.cta-btn {
   background-color: transparent;
   border: 1px solid;
   border-color: inherit;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   color: inherit;
   display: inline-block;
   font-family: inherit;
@@ -47,7 +48,9 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -75,7 +78,13 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -84,6 +93,9 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -94,13 +106,19 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -111,16 +129,25 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
 }
 .expand-btn__cell {
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -136,11 +163,16 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -152,7 +184,9 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -165,13 +199,27 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 24px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column;
   height: 48px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -409,7 +457,9 @@ button.btn__cell--fixed-height svg.cta-btn__icon,
 button.expand-btn__cell--fixed-height svg.cta-btn__icon,
 a.fake-btn__cell--fixed-height svg.cta-btn__icon,
 a.cta-btn__cell--fixed-height svg.cta-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   height: 1rem;
   width: 1rem;
 }
@@ -594,7 +644,9 @@ svg.fake-btn__icon {
 }
 svg.cta-btn__icon,
 svg.expand-btn__icon {
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
 }
 svg.cta-btn__icon {
   height: 10px;

--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -1,14 +1,23 @@
 .checkbox {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {

--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -1,23 +1,17 @@
 .checkbox {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {

--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -1,20 +1,14 @@
 .checkbox {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {

--- a/dist/checkbox/ds6/checkbox.css
+++ b/dist/checkbox/ds6/checkbox.css
@@ -1,14 +1,23 @@
 .checkbox {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {

--- a/dist/checkbox/ds6/checkbox.css
+++ b/dist/checkbox/ds6/checkbox.css
@@ -1,23 +1,17 @@
 .checkbox {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {

--- a/dist/checkbox/ds6/checkbox.css
+++ b/dist/checkbox/ds6/checkbox.css
@@ -1,20 +1,14 @@
 .checkbox {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -234,7 +247,8 @@ span.fake-menu__status {
   }
 }
 .combobox {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   display: inline-block;
 }
 .combobox__control > input {
@@ -242,7 +256,8 @@ span.fake-menu__status {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-family: inherit;
   text-align: left;
 }

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -194,12 +186,8 @@ button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -187,12 +180,8 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -180,8 +193,14 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,
@@ -258,7 +277,8 @@ span.fake-menu__status {
   }
 }
 .combobox {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   display: inline-block;
 }
 .combobox__control > input {
@@ -266,7 +286,8 @@ span.fake-menu__status {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-family: inherit;
   text-align: left;
 }

--- a/dist/dialog/ds4/dialog.css
+++ b/dist/dialog/ds4/dialog.css
@@ -21,6 +21,7 @@
   position: absolute;
   right: 0;
   top: 15%;
+  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -68,8 +69,11 @@
 }
 .dialog__window--left,
 .dialog__window--right {
+  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
+  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -81,7 +85,8 @@
   left: auto;
 }
 .dialog__body {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 16px;
   min-height: 100%;
   position: relative;
@@ -110,18 +115,22 @@
 }
 .dialog--show.dialog--mask-fade,
 .dialog--hide.dialog--mask-fade {
+  -webkit-transition: background-color 0.16s ease-out;
   transition: background-color 0.16s ease-out;
 }
 .dialog--show.dialog--mask-fade-slow,
 .dialog--hide.dialog--mask-fade-slow {
+  -webkit-transition: background-color 0.32s ease-out;
   transition: background-color 0.32s ease-out;
 }
 .dialog--show .dialog__window--fade,
 .dialog--hide .dialog__window--fade {
+  -webkit-transition: opacity 0.16s ease-out;
   transition: opacity 0.16s ease-out;
 }
 .dialog--show .dialog__window--slide,
 .dialog--hide .dialog__window--slide {
+  -webkit-transition: -webkit-transform 0.32s ease-out;
   transition: -webkit-transform 0.32s ease-out;
   transition: transform 0.32s ease-out;
   transition: transform 0.32s ease-out, -webkit-transform 0.32s ease-out;
@@ -163,20 +172,27 @@
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
+    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
+    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
+    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
+    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -228,12 +244,14 @@
 }
 .dialog__body {
   font-size: 0.875rem;
+  padding-top: -webkit-calc(1.125rem + 12px);
   padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
   background-color: #fff;
   border-bottom: 1px solid #eee;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-size: 1.125rem;
   font-weight: 400;
   left: 0;
@@ -245,6 +263,7 @@
   text-overflow: ellipsis;
   top: 0;
   white-space: nowrap;
+  width: -webkit-calc(100% + 32px);
   width: calc(100% + 32px);
 }
 .dialog--hide.dialog--mask-fade,
@@ -274,6 +293,7 @@
   .dialog__window:not(.dialog__window--full) {
     max-width: 980px;
     min-width: auto;
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
   }
   .dialog__body h2:first-of-type {

--- a/dist/dialog/ds4/dialog.css
+++ b/dist/dialog/ds4/dialog.css
@@ -21,7 +21,6 @@
   position: absolute;
   right: 0;
   top: 15%;
-  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -69,11 +68,8 @@
 }
 .dialog__window--left,
 .dialog__window--right {
-  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
-  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
-  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -172,27 +168,20 @@
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
-    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
-    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
-    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
-    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -244,7 +233,6 @@
 }
 .dialog__body {
   font-size: 0.875rem;
-  padding-top: -webkit-calc(1.125rem + 12px);
   padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
@@ -263,7 +251,6 @@
   text-overflow: ellipsis;
   top: 0;
   white-space: nowrap;
-  width: -webkit-calc(100% + 32px);
   width: calc(100% + 32px);
 }
 .dialog--hide.dialog--mask-fade,
@@ -293,7 +280,6 @@
   .dialog__window:not(.dialog__window--full) {
     max-width: 980px;
     min-width: auto;
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
   }
   .dialog__body h2:first-of-type {

--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -21,6 +21,7 @@
   position: absolute;
   right: 0;
   top: 15%;
+  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -68,8 +69,11 @@
 }
 .dialog__window--left,
 .dialog__window--right {
+  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
+  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -81,7 +85,8 @@
   left: auto;
 }
 .dialog__body {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 16px;
   min-height: 100%;
   position: relative;
@@ -110,18 +115,22 @@
 }
 .dialog--show.dialog--mask-fade,
 .dialog--hide.dialog--mask-fade {
+  -webkit-transition: background-color 0.16s ease-out;
   transition: background-color 0.16s ease-out;
 }
 .dialog--show.dialog--mask-fade-slow,
 .dialog--hide.dialog--mask-fade-slow {
+  -webkit-transition: background-color 0.32s ease-out;
   transition: background-color 0.32s ease-out;
 }
 .dialog--show .dialog__window--fade,
 .dialog--hide .dialog__window--fade {
+  -webkit-transition: opacity 0.16s ease-out;
   transition: opacity 0.16s ease-out;
 }
 .dialog--show .dialog__window--slide,
 .dialog--hide .dialog__window--slide {
+  -webkit-transition: -webkit-transform 0.32s ease-out;
   transition: -webkit-transform 0.32s ease-out;
   transition: transform 0.32s ease-out;
   transition: transform 0.32s ease-out, -webkit-transform 0.32s ease-out;
@@ -163,20 +172,27 @@
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
+    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
+    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
+    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
+    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }

--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -21,7 +21,6 @@
   position: absolute;
   right: 0;
   top: 15%;
-  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -69,11 +68,8 @@
 }
 .dialog__window--left,
 .dialog__window--right {
-  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
-  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
-  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -172,27 +168,20 @@
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
-    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
-    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
-    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
-    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }

--- a/dist/dropdown/ds4/dropdown.css
+++ b/dist/dropdown/ds4/dropdown.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/dropdown/ds4/dropdown.css
+++ b/dist/dropdown/ds4/dropdown.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/dropdown/ds4/dropdown.css
+++ b/dist/dropdown/ds4/dropdown.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -194,12 +186,8 @@ button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -187,12 +180,8 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,

--- a/dist/dropdown/ds6/dropdown.css
+++ b/dist/dropdown/ds6/dropdown.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -180,8 +193,14 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,

--- a/dist/field/ds4/field.css
+++ b/dist/field/ds4/field.css
@@ -9,8 +9,6 @@ div.field {
 }
 .field-group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -25,20 +23,14 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.field__group {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {

--- a/dist/field/ds4/field.css
+++ b/dist/field/ds4/field.css
@@ -8,6 +8,9 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -22,12 +25,20 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.field__group {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .field__label {

--- a/dist/field/ds4/field.css
+++ b/dist/field/ds4/field.css
@@ -8,8 +8,6 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -24,18 +22,12 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.field__group {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {

--- a/dist/field/ds6/field.css
+++ b/dist/field/ds6/field.css
@@ -9,8 +9,6 @@ div.field {
 }
 .field-group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -25,20 +23,14 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.field__group {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {

--- a/dist/field/ds6/field.css
+++ b/dist/field/ds6/field.css
@@ -8,6 +8,9 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -22,12 +25,20 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.field__group {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .field__label {

--- a/dist/field/ds6/field.css
+++ b/dist/field/ds6/field.css
@@ -8,8 +8,6 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -24,18 +22,12 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.field__group {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {

--- a/dist/grid/ds4/grid-core.css
+++ b/dist/grid/ds4/grid-core.css
@@ -53,12 +53,8 @@
  * This class extends .grid--gutters
  */
 .grid__group {
-  -webkit-box-align: start;
-      -ms-flex-align: start;
-          align-items: flex-start;
+  align-items: flex-start;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -86,9 +82,7 @@
   padding-right: 16px;
 }
 .grid__cell--grow {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -96,8 +90,7 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -125,65 +118,47 @@
      * commonly used fractions
      */
 .grid__cell--one-half {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -205,114 +180,82 @@
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 93.75%;
-          flex: 0 0 93.75%;
+  flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 87.5%;
-          flex: 0 0 87.5%;
+  flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 81.25%;
-          flex: 0 0 81.25%;
+  flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 68.75%;
-          flex: 0 0 68.75%;
+  flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 62.5%;
-          flex: 0 0 62.5%;
+  flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 56.25%;
-          flex: 0 0 56.25%;
+  flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 43.75%;
-          flex: 0 0 43.75%;
+  flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 37.5%;
-          flex: 0 0 37.5%;
+  flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 31.25%;
-          flex: 0 0 31.25%;
+  flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 18.75%;
-          flex: 0 0 18.75%;
+  flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 12.5%;
-          flex: 0 0 12.5%;
+  flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 6.25%;
-          flex: 0 0 6.25%;
+  flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -326,114 +269,82 @@
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 93.75%;
-            flex: 0 0 93.75%;
+    flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 81.25%;
-            flex: 0 0 81.25%;
+    flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 68.75%;
-            flex: 0 0 68.75%;
+    flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 56.25%;
-            flex: 0 0 56.25%;
+    flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 43.75%;
-            flex: 0 0 43.75%;
+    flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 31.25%;
-            flex: 0 0 31.25%;
+    flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 18.75%;
-            flex: 0 0 18.75%;
+    flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 6.25%;
-            flex: 0 0 6.25%;
+    flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }
@@ -446,58 +357,42 @@
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }

--- a/dist/grid/ds4/grid-core.css
+++ b/dist/grid/ds4/grid-core.css
@@ -13,7 +13,8 @@
  * a separate class
  */
 .grid {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-width: 1280px;
   padding-left: 0;
   padding-right: 0;
@@ -53,8 +54,15 @@
  * This class extends .grid--gutters
  */
 .grid__group {
-  align-items: flex-start;
-  box-sizing: border-box;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+      -ms-flex-align: start;
+          align-items: flex-start;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -77,12 +85,16 @@
   }
 }
 .grid__cell {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   min-height: 1px;
   padding-right: 16px;
 }
 .grid__cell--grow {
-  flex: 1 1 auto;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 1 auto;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -90,7 +102,9 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -118,47 +132,74 @@
      * commonly used fractions
      */
 .grid__cell--one-half {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -180,82 +221,130 @@
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  flex: 0 0 93.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 93.75%;
+      -ms-flex: 0 0 93.75%;
+          flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  flex: 0 0 87.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 87.5%;
+      -ms-flex: 0 0 87.5%;
+          flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  flex: 0 0 81.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 81.25%;
+      -ms-flex: 0 0 81.25%;
+          flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  flex: 0 0 68.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 68.75%;
+      -ms-flex: 0 0 68.75%;
+          flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  flex: 0 0 62.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 62.5%;
+      -ms-flex: 0 0 62.5%;
+          flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  flex: 0 0 56.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 56.25%;
+      -ms-flex: 0 0 56.25%;
+          flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  flex: 0 0 43.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 43.75%;
+      -ms-flex: 0 0 43.75%;
+          flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  flex: 0 0 37.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 37.5%;
+      -ms-flex: 0 0 37.5%;
+          flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  flex: 0 0 31.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 31.25%;
+      -ms-flex: 0 0 31.25%;
+          flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  flex: 0 0 18.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 18.75%;
+      -ms-flex: 0 0 18.75%;
+          flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  flex: 0 0 12.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 12.5%;
+      -ms-flex: 0 0 12.5%;
+          flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  flex: 0 0 6.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 6.25%;
+      -ms-flex: 0 0 6.25%;
+          flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -269,82 +358,130 @@
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    flex: 0 0 93.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 93.75%;
+        -ms-flex: 0 0 93.75%;
+            flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    flex: 0 0 81.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 81.25%;
+        -ms-flex: 0 0 81.25%;
+            flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    flex: 0 0 68.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 68.75%;
+        -ms-flex: 0 0 68.75%;
+            flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    flex: 0 0 56.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 56.25%;
+        -ms-flex: 0 0 56.25%;
+            flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    flex: 0 0 43.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 43.75%;
+        -ms-flex: 0 0 43.75%;
+            flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    flex: 0 0 31.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 31.25%;
+        -ms-flex: 0 0 31.25%;
+            flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    flex: 0 0 18.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 18.75%;
+        -ms-flex: 0 0 18.75%;
+            flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    flex: 0 0 6.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 6.25%;
+        -ms-flex: 0 0 6.25%;
+            flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }
@@ -357,42 +494,66 @@
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }

--- a/dist/grid/ds4/grid-core.css
+++ b/dist/grid/ds4/grid-core.css
@@ -55,14 +55,10 @@
  */
 .grid__group {
   -webkit-box-align: start;
-  -webkit-align-items: flex-start;
-      -ms-flex-align: start;
           align-items: flex-start;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -92,8 +88,6 @@
 }
 .grid__cell--grow {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
           flex: 1 1 auto;
 }
 /**
@@ -102,9 +96,7 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -133,72 +125,54 @@
      */
 .grid__cell--one-half {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -222,128 +196,96 @@
  */
 .grid__cell--16of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 93.75%;
-      -ms-flex: 0 0 93.75%;
           flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 87.5%;
-      -ms-flex: 0 0 87.5%;
           flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 81.25%;
-      -ms-flex: 0 0 81.25%;
           flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 68.75%;
-      -ms-flex: 0 0 68.75%;
           flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 62.5%;
-      -ms-flex: 0 0 62.5%;
           flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 56.25%;
-      -ms-flex: 0 0 56.25%;
           flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 43.75%;
-      -ms-flex: 0 0 43.75%;
           flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 37.5%;
-      -ms-flex: 0 0 37.5%;
           flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 31.25%;
-      -ms-flex: 0 0 31.25%;
           flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 18.75%;
-      -ms-flex: 0 0 18.75%;
           flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 12.5%;
-      -ms-flex: 0 0 12.5%;
           flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 6.25%;
-      -ms-flex: 0 0 6.25%;
           flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
@@ -359,128 +301,96 @@
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 93.75%;
-        -ms-flex: 0 0 93.75%;
             flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 81.25%;
-        -ms-flex: 0 0 81.25%;
             flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 68.75%;
-        -ms-flex: 0 0 68.75%;
             flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 56.25%;
-        -ms-flex: 0 0 56.25%;
             flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 43.75%;
-        -ms-flex: 0 0 43.75%;
             flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 31.25%;
-        -ms-flex: 0 0 31.25%;
             flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 18.75%;
-        -ms-flex: 0 0 18.75%;
             flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 6.25%;
-        -ms-flex: 0 0 6.25%;
             flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
@@ -495,64 +405,48 @@
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;

--- a/dist/grid/ds4/grid-full.css
+++ b/dist/grid/ds4/grid-full.css
@@ -59,12 +59,8 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * This class extends .grid--gutters
  */
 .grid__group {
-  -webkit-box-align: start;
-      -ms-flex-align: start;
-          align-items: flex-start;
+  align-items: flex-start;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -92,9 +88,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   padding-right: 16px;
 }
 .grid__cell--grow {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -102,8 +96,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * screen gets smaller
  */
 .grid__group--wrap {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -131,65 +124,47 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
      * commonly used fractions
      */
 .grid__cell--one-half {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -211,114 +186,82 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 93.75%;
-          flex: 0 0 93.75%;
+  flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 87.5%;
-          flex: 0 0 87.5%;
+  flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 81.25%;
-          flex: 0 0 81.25%;
+  flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 68.75%;
-          flex: 0 0 68.75%;
+  flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 62.5%;
-          flex: 0 0 62.5%;
+  flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 56.25%;
-          flex: 0 0 56.25%;
+  flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 43.75%;
-          flex: 0 0 43.75%;
+  flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 37.5%;
-          flex: 0 0 37.5%;
+  flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 31.25%;
-          flex: 0 0 31.25%;
+  flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 18.75%;
-          flex: 0 0 18.75%;
+  flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 12.5%;
-          flex: 0 0 12.5%;
+  flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 6.25%;
-          flex: 0 0 6.25%;
+  flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -332,114 +275,82 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 93.75%;
-            flex: 0 0 93.75%;
+    flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 81.25%;
-            flex: 0 0 81.25%;
+    flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 68.75%;
-            flex: 0 0 68.75%;
+    flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 56.25%;
-            flex: 0 0 56.25%;
+    flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 43.75%;
-            flex: 0 0 43.75%;
+    flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 31.25%;
-            flex: 0 0 31.25%;
+    flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 18.75%;
-            flex: 0 0 18.75%;
+    flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 6.25%;
-            flex: 0 0 6.25%;
+    flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }
@@ -452,58 +363,42 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -546,10 +441,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * HIGHLY EXPERIMENTAL
  */
 .grid__group--top-to-bottom {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   width: auto;
 }
 .grid__group--top-to-bottom .grid__cell {
@@ -562,9 +454,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 6.66666667%;
-          flex: 0 0 6.66666667%;
+  flex: 0 0 6.66666667%;
   max-width: 6.66666667%;
   width: 6.66666667%;
 }
@@ -572,9 +462,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 13.33333333%;
-          flex: 0 0 13.33333333%;
+  flex: 0 0 13.33333333%;
   max-width: 13.33333333%;
   width: 13.33333333%;
 }
@@ -582,9 +470,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -592,9 +478,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 26.66666667%;
-          flex: 0 0 26.66666667%;
+  flex: 0 0 26.66666667%;
   max-width: 26.66666667%;
   width: 26.66666667%;
 }
@@ -602,9 +486,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -612,9 +494,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -622,9 +502,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 46.66666667%;
-          flex: 0 0 46.66666667%;
+  flex: 0 0 46.66666667%;
   max-width: 46.66666667%;
   width: 46.66666667%;
 }
@@ -632,9 +510,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 53.33333333%;
-          flex: 0 0 53.33333333%;
+  flex: 0 0 53.33333333%;
   max-width: 53.33333333%;
   width: 53.33333333%;
 }
@@ -642,9 +518,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -652,9 +526,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -662,9 +534,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 73.33333333%;
-          flex: 0 0 73.33333333%;
+  flex: 0 0 73.33333333%;
   max-width: 73.33333333%;
   width: 73.33333333%;
 }
@@ -672,9 +542,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -682,9 +550,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 86.66666667%;
-          flex: 0 0 86.66666667%;
+  flex: 0 0 86.66666667%;
   max-width: 86.66666667%;
   width: 86.66666667%;
 }
@@ -692,9 +558,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 93.33333333%;
-          flex: 0 0 93.33333333%;
+  flex: 0 0 93.33333333%;
   max-width: 93.33333333%;
   width: 93.33333333%;
 }
@@ -702,9 +566,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--15of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -712,9 +574,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 7.14285714%;
-          flex: 0 0 7.14285714%;
+  flex: 0 0 7.14285714%;
   max-width: 7.14285714%;
   width: 7.14285714%;
 }
@@ -722,9 +582,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 14.28571429%;
-          flex: 0 0 14.28571429%;
+  flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -732,9 +590,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 21.42857143%;
-          flex: 0 0 21.42857143%;
+  flex: 0 0 21.42857143%;
   max-width: 21.42857143%;
   width: 21.42857143%;
 }
@@ -742,9 +598,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 28.57142857%;
-          flex: 0 0 28.57142857%;
+  flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -752,9 +606,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 35.71428571%;
-          flex: 0 0 35.71428571%;
+  flex: 0 0 35.71428571%;
   max-width: 35.71428571%;
   width: 35.71428571%;
 }
@@ -762,9 +614,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 42.85714286%;
-          flex: 0 0 42.85714286%;
+  flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -772,9 +622,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -782,9 +630,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 57.14285714%;
-          flex: 0 0 57.14285714%;
+  flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -792,9 +638,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 64.28571429%;
-          flex: 0 0 64.28571429%;
+  flex: 0 0 64.28571429%;
   max-width: 64.28571429%;
   width: 64.28571429%;
 }
@@ -802,9 +646,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 71.42857143%;
-          flex: 0 0 71.42857143%;
+  flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -812,9 +654,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 78.57142857%;
-          flex: 0 0 78.57142857%;
+  flex: 0 0 78.57142857%;
   max-width: 78.57142857%;
   width: 78.57142857%;
 }
@@ -822,9 +662,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 85.71428571%;
-          flex: 0 0 85.71428571%;
+  flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -832,9 +670,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 92.85714286%;
-          flex: 0 0 92.85714286%;
+  flex: 0 0 92.85714286%;
   max-width: 92.85714286%;
   width: 92.85714286%;
 }
@@ -842,9 +678,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -852,9 +686,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 7.69230769%;
-          flex: 0 0 7.69230769%;
+  flex: 0 0 7.69230769%;
   max-width: 7.69230769%;
   width: 7.69230769%;
 }
@@ -862,9 +694,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 15.38461538%;
-          flex: 0 0 15.38461538%;
+  flex: 0 0 15.38461538%;
   max-width: 15.38461538%;
   width: 15.38461538%;
 }
@@ -872,9 +702,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 23.07692308%;
-          flex: 0 0 23.07692308%;
+  flex: 0 0 23.07692308%;
   max-width: 23.07692308%;
   width: 23.07692308%;
 }
@@ -882,9 +710,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 30.76923077%;
-          flex: 0 0 30.76923077%;
+  flex: 0 0 30.76923077%;
   max-width: 30.76923077%;
   width: 30.76923077%;
 }
@@ -892,9 +718,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 38.46153846%;
-          flex: 0 0 38.46153846%;
+  flex: 0 0 38.46153846%;
   max-width: 38.46153846%;
   width: 38.46153846%;
 }
@@ -902,9 +726,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 46.15384615%;
-          flex: 0 0 46.15384615%;
+  flex: 0 0 46.15384615%;
   max-width: 46.15384615%;
   width: 46.15384615%;
 }
@@ -912,9 +734,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 53.84615385%;
-          flex: 0 0 53.84615385%;
+  flex: 0 0 53.84615385%;
   max-width: 53.84615385%;
   width: 53.84615385%;
 }
@@ -922,9 +742,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 61.53846154%;
-          flex: 0 0 61.53846154%;
+  flex: 0 0 61.53846154%;
   max-width: 61.53846154%;
   width: 61.53846154%;
 }
@@ -932,9 +750,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 69.23076923%;
-          flex: 0 0 69.23076923%;
+  flex: 0 0 69.23076923%;
   max-width: 69.23076923%;
   width: 69.23076923%;
 }
@@ -942,9 +758,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 76.92307692%;
-          flex: 0 0 76.92307692%;
+  flex: 0 0 76.92307692%;
   max-width: 76.92307692%;
   width: 76.92307692%;
 }
@@ -952,9 +766,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 84.61538462%;
-          flex: 0 0 84.61538462%;
+  flex: 0 0 84.61538462%;
   max-width: 84.61538462%;
   width: 84.61538462%;
 }
@@ -962,9 +774,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 92.30769231%;
-          flex: 0 0 92.30769231%;
+  flex: 0 0 92.30769231%;
   max-width: 92.30769231%;
   width: 92.30769231%;
 }
@@ -972,9 +782,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -982,9 +790,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 8.33333333%;
-          flex: 0 0 8.33333333%;
+  flex: 0 0 8.33333333%;
   max-width: 8.33333333%;
   width: 8.33333333%;
 }
@@ -992,9 +798,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 16.66666667%;
-          flex: 0 0 16.66666667%;
+  flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -1002,9 +806,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1012,9 +814,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1022,9 +822,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 41.66666667%;
-          flex: 0 0 41.66666667%;
+  flex: 0 0 41.66666667%;
   max-width: 41.66666667%;
   width: 41.66666667%;
 }
@@ -1032,9 +830,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1042,9 +838,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 58.33333333%;
-          flex: 0 0 58.33333333%;
+  flex: 0 0 58.33333333%;
   max-width: 58.33333333%;
   width: 58.33333333%;
 }
@@ -1052,9 +846,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1062,9 +854,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1072,9 +862,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 83.33333333%;
-          flex: 0 0 83.33333333%;
+  flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -1082,9 +870,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 91.66666667%;
-          flex: 0 0 91.66666667%;
+  flex: 0 0 91.66666667%;
   max-width: 91.66666667%;
   width: 91.66666667%;
 }
@@ -1092,9 +878,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1102,9 +886,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 9.09090909%;
-          flex: 0 0 9.09090909%;
+  flex: 0 0 9.09090909%;
   max-width: 9.09090909%;
   width: 9.09090909%;
 }
@@ -1112,9 +894,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 18.18181818%;
-          flex: 0 0 18.18181818%;
+  flex: 0 0 18.18181818%;
   max-width: 18.18181818%;
   width: 18.18181818%;
 }
@@ -1122,9 +902,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 27.27272727%;
-          flex: 0 0 27.27272727%;
+  flex: 0 0 27.27272727%;
   max-width: 27.27272727%;
   width: 27.27272727%;
 }
@@ -1132,9 +910,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 36.36363636%;
-          flex: 0 0 36.36363636%;
+  flex: 0 0 36.36363636%;
   max-width: 36.36363636%;
   width: 36.36363636%;
 }
@@ -1142,9 +918,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 45.45454545%;
-          flex: 0 0 45.45454545%;
+  flex: 0 0 45.45454545%;
   max-width: 45.45454545%;
   width: 45.45454545%;
 }
@@ -1152,9 +926,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 54.54545455%;
-          flex: 0 0 54.54545455%;
+  flex: 0 0 54.54545455%;
   max-width: 54.54545455%;
   width: 54.54545455%;
 }
@@ -1162,9 +934,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 63.63636364%;
-          flex: 0 0 63.63636364%;
+  flex: 0 0 63.63636364%;
   max-width: 63.63636364%;
   width: 63.63636364%;
 }
@@ -1172,9 +942,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 72.72727273%;
-          flex: 0 0 72.72727273%;
+  flex: 0 0 72.72727273%;
   max-width: 72.72727273%;
   width: 72.72727273%;
 }
@@ -1182,9 +950,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 81.81818182%;
-          flex: 0 0 81.81818182%;
+  flex: 0 0 81.81818182%;
   max-width: 81.81818182%;
   width: 81.81818182%;
 }
@@ -1192,9 +958,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 90.90909091%;
-          flex: 0 0 90.90909091%;
+  flex: 0 0 90.90909091%;
   max-width: 90.90909091%;
   width: 90.90909091%;
 }
@@ -1202,9 +966,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1212,9 +974,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 10%;
-          flex: 0 0 10%;
+  flex: 0 0 10%;
   max-width: 10%;
   width: 10%;
 }
@@ -1222,9 +982,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -1232,9 +990,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 30%;
-          flex: 0 0 30%;
+  flex: 0 0 30%;
   max-width: 30%;
   width: 30%;
 }
@@ -1242,9 +998,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1252,9 +1006,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1262,9 +1014,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1272,9 +1022,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 70%;
-          flex: 0 0 70%;
+  flex: 0 0 70%;
   max-width: 70%;
   width: 70%;
 }
@@ -1282,9 +1030,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1292,9 +1038,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 90%;
-          flex: 0 0 90%;
+  flex: 0 0 90%;
   max-width: 90%;
   width: 90%;
 }
@@ -1302,9 +1046,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1312,9 +1054,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 11.11111111%;
-          flex: 0 0 11.11111111%;
+  flex: 0 0 11.11111111%;
   max-width: 11.11111111%;
   width: 11.11111111%;
 }
@@ -1322,9 +1062,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 22.22222222%;
-          flex: 0 0 22.22222222%;
+  flex: 0 0 22.22222222%;
   max-width: 22.22222222%;
   width: 22.22222222%;
 }
@@ -1332,9 +1070,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1342,9 +1078,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 44.44444444%;
-          flex: 0 0 44.44444444%;
+  flex: 0 0 44.44444444%;
   max-width: 44.44444444%;
   width: 44.44444444%;
 }
@@ -1352,9 +1086,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 55.55555556%;
-          flex: 0 0 55.55555556%;
+  flex: 0 0 55.55555556%;
   max-width: 55.55555556%;
   width: 55.55555556%;
 }
@@ -1362,9 +1094,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1372,9 +1102,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 77.77777778%;
-          flex: 0 0 77.77777778%;
+  flex: 0 0 77.77777778%;
   max-width: 77.77777778%;
   width: 77.77777778%;
 }
@@ -1382,9 +1110,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 88.88888889%;
-          flex: 0 0 88.88888889%;
+  flex: 0 0 88.88888889%;
   max-width: 88.88888889%;
   width: 88.88888889%;
 }
@@ -1392,9 +1118,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1402,9 +1126,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 12.5%;
-          flex: 0 0 12.5%;
+  flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
@@ -1412,9 +1134,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1422,9 +1142,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 37.5%;
-          flex: 0 0 37.5%;
+  flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
@@ -1432,9 +1150,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1442,9 +1158,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 62.5%;
-          flex: 0 0 62.5%;
+  flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
@@ -1452,9 +1166,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1462,9 +1174,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 87.5%;
-          flex: 0 0 87.5%;
+  flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
@@ -1472,9 +1182,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1482,9 +1190,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 14.28571429%;
-          flex: 0 0 14.28571429%;
+  flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -1492,9 +1198,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 28.57142857%;
-          flex: 0 0 28.57142857%;
+  flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -1502,9 +1206,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 42.85714286%;
-          flex: 0 0 42.85714286%;
+  flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -1512,9 +1214,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 57.14285714%;
-          flex: 0 0 57.14285714%;
+  flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -1522,9 +1222,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 71.42857143%;
-          flex: 0 0 71.42857143%;
+  flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -1532,9 +1230,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 85.71428571%;
-          flex: 0 0 85.71428571%;
+  flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -1542,9 +1238,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1552,9 +1246,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 16.66666667%;
-          flex: 0 0 16.66666667%;
+  flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -1562,9 +1254,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1572,9 +1262,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1582,9 +1270,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1592,9 +1278,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 83.33333333%;
-          flex: 0 0 83.33333333%;
+  flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -1602,9 +1286,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1612,9 +1294,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -1622,9 +1302,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1632,9 +1310,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1642,9 +1318,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1652,9 +1326,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1662,9 +1334,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1672,9 +1342,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1682,9 +1350,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1692,9 +1358,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1702,9 +1366,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of3 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1712,9 +1374,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of3 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1722,9 +1382,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of3 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1732,9 +1390,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of2 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1742,9 +1398,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of2 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1752,9 +1406,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of1 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1763,9 +1415,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 6.66666667%;
-            flex: 0 0 6.66666667%;
+    flex: 0 0 6.66666667%;
     max-width: 6.66666667%;
     width: 6.66666667%;
   }
@@ -1773,9 +1423,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 13.33333333%;
-            flex: 0 0 13.33333333%;
+    flex: 0 0 13.33333333%;
     max-width: 13.33333333%;
     width: 13.33333333%;
   }
@@ -1783,9 +1431,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -1793,9 +1439,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 26.66666667%;
-            flex: 0 0 26.66666667%;
+    flex: 0 0 26.66666667%;
     max-width: 26.66666667%;
     width: 26.66666667%;
   }
@@ -1803,9 +1447,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -1813,9 +1455,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -1823,9 +1463,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 46.66666667%;
-            flex: 0 0 46.66666667%;
+    flex: 0 0 46.66666667%;
     max-width: 46.66666667%;
     width: 46.66666667%;
   }
@@ -1833,9 +1471,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 53.33333333%;
-            flex: 0 0 53.33333333%;
+    flex: 0 0 53.33333333%;
     max-width: 53.33333333%;
     width: 53.33333333%;
   }
@@ -1843,9 +1479,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -1853,9 +1487,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -1863,9 +1495,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 73.33333333%;
-            flex: 0 0 73.33333333%;
+    flex: 0 0 73.33333333%;
     max-width: 73.33333333%;
     width: 73.33333333%;
   }
@@ -1873,9 +1503,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -1883,9 +1511,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 86.66666667%;
-            flex: 0 0 86.66666667%;
+    flex: 0 0 86.66666667%;
     max-width: 86.66666667%;
     width: 86.66666667%;
   }
@@ -1893,9 +1519,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 93.33333333%;
-            flex: 0 0 93.33333333%;
+    flex: 0 0 93.33333333%;
     max-width: 93.33333333%;
     width: 93.33333333%;
   }
@@ -1903,9 +1527,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--15of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1913,9 +1535,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 7.14285714%;
-            flex: 0 0 7.14285714%;
+    flex: 0 0 7.14285714%;
     max-width: 7.14285714%;
     width: 7.14285714%;
   }
@@ -1923,9 +1543,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 14.28571429%;
-            flex: 0 0 14.28571429%;
+    flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -1933,9 +1551,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 21.42857143%;
-            flex: 0 0 21.42857143%;
+    flex: 0 0 21.42857143%;
     max-width: 21.42857143%;
     width: 21.42857143%;
   }
@@ -1943,9 +1559,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 28.57142857%;
-            flex: 0 0 28.57142857%;
+    flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -1953,9 +1567,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 35.71428571%;
-            flex: 0 0 35.71428571%;
+    flex: 0 0 35.71428571%;
     max-width: 35.71428571%;
     width: 35.71428571%;
   }
@@ -1963,9 +1575,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 42.85714286%;
-            flex: 0 0 42.85714286%;
+    flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -1973,9 +1583,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1983,9 +1591,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 57.14285714%;
-            flex: 0 0 57.14285714%;
+    flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -1993,9 +1599,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 64.28571429%;
-            flex: 0 0 64.28571429%;
+    flex: 0 0 64.28571429%;
     max-width: 64.28571429%;
     width: 64.28571429%;
   }
@@ -2003,9 +1607,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 71.42857143%;
-            flex: 0 0 71.42857143%;
+    flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2013,9 +1615,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 78.57142857%;
-            flex: 0 0 78.57142857%;
+    flex: 0 0 78.57142857%;
     max-width: 78.57142857%;
     width: 78.57142857%;
   }
@@ -2023,9 +1623,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 85.71428571%;
-            flex: 0 0 85.71428571%;
+    flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2033,9 +1631,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 92.85714286%;
-            flex: 0 0 92.85714286%;
+    flex: 0 0 92.85714286%;
     max-width: 92.85714286%;
     width: 92.85714286%;
   }
@@ -2043,9 +1639,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2053,9 +1647,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 7.69230769%;
-            flex: 0 0 7.69230769%;
+    flex: 0 0 7.69230769%;
     max-width: 7.69230769%;
     width: 7.69230769%;
   }
@@ -2063,9 +1655,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 15.38461538%;
-            flex: 0 0 15.38461538%;
+    flex: 0 0 15.38461538%;
     max-width: 15.38461538%;
     width: 15.38461538%;
   }
@@ -2073,9 +1663,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 23.07692308%;
-            flex: 0 0 23.07692308%;
+    flex: 0 0 23.07692308%;
     max-width: 23.07692308%;
     width: 23.07692308%;
   }
@@ -2083,9 +1671,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 30.76923077%;
-            flex: 0 0 30.76923077%;
+    flex: 0 0 30.76923077%;
     max-width: 30.76923077%;
     width: 30.76923077%;
   }
@@ -2093,9 +1679,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 38.46153846%;
-            flex: 0 0 38.46153846%;
+    flex: 0 0 38.46153846%;
     max-width: 38.46153846%;
     width: 38.46153846%;
   }
@@ -2103,9 +1687,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 46.15384615%;
-            flex: 0 0 46.15384615%;
+    flex: 0 0 46.15384615%;
     max-width: 46.15384615%;
     width: 46.15384615%;
   }
@@ -2113,9 +1695,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 53.84615385%;
-            flex: 0 0 53.84615385%;
+    flex: 0 0 53.84615385%;
     max-width: 53.84615385%;
     width: 53.84615385%;
   }
@@ -2123,9 +1703,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 61.53846154%;
-            flex: 0 0 61.53846154%;
+    flex: 0 0 61.53846154%;
     max-width: 61.53846154%;
     width: 61.53846154%;
   }
@@ -2133,9 +1711,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 69.23076923%;
-            flex: 0 0 69.23076923%;
+    flex: 0 0 69.23076923%;
     max-width: 69.23076923%;
     width: 69.23076923%;
   }
@@ -2143,9 +1719,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 76.92307692%;
-            flex: 0 0 76.92307692%;
+    flex: 0 0 76.92307692%;
     max-width: 76.92307692%;
     width: 76.92307692%;
   }
@@ -2153,9 +1727,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 84.61538462%;
-            flex: 0 0 84.61538462%;
+    flex: 0 0 84.61538462%;
     max-width: 84.61538462%;
     width: 84.61538462%;
   }
@@ -2163,9 +1735,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 92.30769231%;
-            flex: 0 0 92.30769231%;
+    flex: 0 0 92.30769231%;
     max-width: 92.30769231%;
     width: 92.30769231%;
   }
@@ -2173,9 +1743,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2183,9 +1751,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 8.33333333%;
-            flex: 0 0 8.33333333%;
+    flex: 0 0 8.33333333%;
     max-width: 8.33333333%;
     width: 8.33333333%;
   }
@@ -2193,9 +1759,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 16.66666667%;
-            flex: 0 0 16.66666667%;
+    flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2203,9 +1767,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2213,9 +1775,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2223,9 +1783,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 41.66666667%;
-            flex: 0 0 41.66666667%;
+    flex: 0 0 41.66666667%;
     max-width: 41.66666667%;
     width: 41.66666667%;
   }
@@ -2233,9 +1791,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2243,9 +1799,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 58.33333333%;
-            flex: 0 0 58.33333333%;
+    flex: 0 0 58.33333333%;
     max-width: 58.33333333%;
     width: 58.33333333%;
   }
@@ -2253,9 +1807,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2263,9 +1815,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2273,9 +1823,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 83.33333333%;
-            flex: 0 0 83.33333333%;
+    flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2283,9 +1831,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 91.66666667%;
-            flex: 0 0 91.66666667%;
+    flex: 0 0 91.66666667%;
     max-width: 91.66666667%;
     width: 91.66666667%;
   }
@@ -2293,9 +1839,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2303,9 +1847,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 9.09090909%;
-            flex: 0 0 9.09090909%;
+    flex: 0 0 9.09090909%;
     max-width: 9.09090909%;
     width: 9.09090909%;
   }
@@ -2313,9 +1855,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 18.18181818%;
-            flex: 0 0 18.18181818%;
+    flex: 0 0 18.18181818%;
     max-width: 18.18181818%;
     width: 18.18181818%;
   }
@@ -2323,9 +1863,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 27.27272727%;
-            flex: 0 0 27.27272727%;
+    flex: 0 0 27.27272727%;
     max-width: 27.27272727%;
     width: 27.27272727%;
   }
@@ -2333,9 +1871,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 36.36363636%;
-            flex: 0 0 36.36363636%;
+    flex: 0 0 36.36363636%;
     max-width: 36.36363636%;
     width: 36.36363636%;
   }
@@ -2343,9 +1879,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 45.45454545%;
-            flex: 0 0 45.45454545%;
+    flex: 0 0 45.45454545%;
     max-width: 45.45454545%;
     width: 45.45454545%;
   }
@@ -2353,9 +1887,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 54.54545455%;
-            flex: 0 0 54.54545455%;
+    flex: 0 0 54.54545455%;
     max-width: 54.54545455%;
     width: 54.54545455%;
   }
@@ -2363,9 +1895,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 63.63636364%;
-            flex: 0 0 63.63636364%;
+    flex: 0 0 63.63636364%;
     max-width: 63.63636364%;
     width: 63.63636364%;
   }
@@ -2373,9 +1903,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 72.72727273%;
-            flex: 0 0 72.72727273%;
+    flex: 0 0 72.72727273%;
     max-width: 72.72727273%;
     width: 72.72727273%;
   }
@@ -2383,9 +1911,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 81.81818182%;
-            flex: 0 0 81.81818182%;
+    flex: 0 0 81.81818182%;
     max-width: 81.81818182%;
     width: 81.81818182%;
   }
@@ -2393,9 +1919,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 90.90909091%;
-            flex: 0 0 90.90909091%;
+    flex: 0 0 90.90909091%;
     max-width: 90.90909091%;
     width: 90.90909091%;
   }
@@ -2403,9 +1927,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2413,9 +1935,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 10%;
-            flex: 0 0 10%;
+    flex: 0 0 10%;
     max-width: 10%;
     width: 10%;
   }
@@ -2423,9 +1943,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2433,9 +1951,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 30%;
-            flex: 0 0 30%;
+    flex: 0 0 30%;
     max-width: 30%;
     width: 30%;
   }
@@ -2443,9 +1959,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2453,9 +1967,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2463,9 +1975,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2473,9 +1983,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 70%;
-            flex: 0 0 70%;
+    flex: 0 0 70%;
     max-width: 70%;
     width: 70%;
   }
@@ -2483,9 +1991,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2493,9 +1999,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 90%;
-            flex: 0 0 90%;
+    flex: 0 0 90%;
     max-width: 90%;
     width: 90%;
   }
@@ -2503,9 +2007,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2513,9 +2015,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 11.11111111%;
-            flex: 0 0 11.11111111%;
+    flex: 0 0 11.11111111%;
     max-width: 11.11111111%;
     width: 11.11111111%;
   }
@@ -2523,9 +2023,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 22.22222222%;
-            flex: 0 0 22.22222222%;
+    flex: 0 0 22.22222222%;
     max-width: 22.22222222%;
     width: 22.22222222%;
   }
@@ -2533,9 +2031,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2543,9 +2039,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 44.44444444%;
-            flex: 0 0 44.44444444%;
+    flex: 0 0 44.44444444%;
     max-width: 44.44444444%;
     width: 44.44444444%;
   }
@@ -2553,9 +2047,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 55.55555556%;
-            flex: 0 0 55.55555556%;
+    flex: 0 0 55.55555556%;
     max-width: 55.55555556%;
     width: 55.55555556%;
   }
@@ -2563,9 +2055,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2573,9 +2063,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 77.77777778%;
-            flex: 0 0 77.77777778%;
+    flex: 0 0 77.77777778%;
     max-width: 77.77777778%;
     width: 77.77777778%;
   }
@@ -2583,9 +2071,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 88.88888889%;
-            flex: 0 0 88.88888889%;
+    flex: 0 0 88.88888889%;
     max-width: 88.88888889%;
     width: 88.88888889%;
   }
@@ -2593,9 +2079,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2603,9 +2087,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -2613,9 +2095,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2623,9 +2103,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
@@ -2633,9 +2111,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2643,9 +2119,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
@@ -2653,9 +2127,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2663,9 +2135,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
@@ -2673,9 +2143,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2683,9 +2151,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 14.28571429%;
-            flex: 0 0 14.28571429%;
+    flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2693,9 +2159,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 28.57142857%;
-            flex: 0 0 28.57142857%;
+    flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2703,9 +2167,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 42.85714286%;
-            flex: 0 0 42.85714286%;
+    flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2713,9 +2175,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 57.14285714%;
-            flex: 0 0 57.14285714%;
+    flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -2723,9 +2183,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 71.42857143%;
-            flex: 0 0 71.42857143%;
+    flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2733,9 +2191,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 85.71428571%;
-            flex: 0 0 85.71428571%;
+    flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2743,9 +2199,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2753,9 +2207,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 16.66666667%;
-            flex: 0 0 16.66666667%;
+    flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2763,9 +2215,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2773,9 +2223,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2783,9 +2231,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2793,9 +2239,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 83.33333333%;
-            flex: 0 0 83.33333333%;
+    flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2803,9 +2247,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2813,9 +2255,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2823,9 +2263,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2833,9 +2271,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2843,9 +2279,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2853,9 +2287,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2863,9 +2295,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2873,9 +2303,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2883,9 +2311,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2893,9 +2319,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2903,9 +2327,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2913,9 +2335,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2923,9 +2343,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2933,9 +2351,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2943,9 +2359,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2953,9 +2367,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2965,9 +2377,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 14.28571429%;
-            flex: 0 0 14.28571429%;
+    flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2975,9 +2385,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 28.57142857%;
-            flex: 0 0 28.57142857%;
+    flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2985,9 +2393,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 42.85714286%;
-            flex: 0 0 42.85714286%;
+    flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2995,9 +2401,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 57.14285714%;
-            flex: 0 0 57.14285714%;
+    flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -3005,9 +2409,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 71.42857143%;
-            flex: 0 0 71.42857143%;
+    flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -3015,9 +2417,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 85.71428571%;
-            flex: 0 0 85.71428571%;
+    flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -3025,9 +2425,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3035,9 +2433,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 16.66666667%;
-            flex: 0 0 16.66666667%;
+    flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -3045,9 +2441,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -3055,9 +2449,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -3065,9 +2457,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -3075,9 +2465,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 83.33333333%;
-            flex: 0 0 83.33333333%;
+    flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -3085,9 +2473,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3095,9 +2481,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -3105,9 +2489,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -3115,9 +2497,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -3125,9 +2505,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -3135,9 +2513,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3145,9 +2521,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -3155,9 +2529,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -3165,9 +2537,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -3175,9 +2545,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3185,9 +2553,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -3195,9 +2561,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -3205,9 +2569,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3215,9 +2577,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -3225,9 +2585,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3235,9 +2593,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }

--- a/dist/grid/ds4/grid-full.css
+++ b/dist/grid/ds4/grid-full.css
@@ -19,7 +19,8 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * a separate class
  */
 .grid {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-width: 1280px;
   padding-left: 0;
   padding-right: 0;
@@ -59,8 +60,15 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * This class extends .grid--gutters
  */
 .grid__group {
-  align-items: flex-start;
-  box-sizing: border-box;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+      -ms-flex-align: start;
+          align-items: flex-start;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -83,12 +91,16 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   }
 }
 .grid__cell {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   min-height: 1px;
   padding-right: 16px;
 }
 .grid__cell--grow {
-  flex: 1 1 auto;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 1 auto;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -96,7 +108,9 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * screen gets smaller
  */
 .grid__group--wrap {
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -124,47 +138,74 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
      * commonly used fractions
      */
 .grid__cell--one-half {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -186,82 +227,130 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  flex: 0 0 93.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 93.75%;
+      -ms-flex: 0 0 93.75%;
+          flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  flex: 0 0 87.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 87.5%;
+      -ms-flex: 0 0 87.5%;
+          flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  flex: 0 0 81.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 81.25%;
+      -ms-flex: 0 0 81.25%;
+          flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  flex: 0 0 68.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 68.75%;
+      -ms-flex: 0 0 68.75%;
+          flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  flex: 0 0 62.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 62.5%;
+      -ms-flex: 0 0 62.5%;
+          flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  flex: 0 0 56.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 56.25%;
+      -ms-flex: 0 0 56.25%;
+          flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  flex: 0 0 43.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 43.75%;
+      -ms-flex: 0 0 43.75%;
+          flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  flex: 0 0 37.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 37.5%;
+      -ms-flex: 0 0 37.5%;
+          flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  flex: 0 0 31.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 31.25%;
+      -ms-flex: 0 0 31.25%;
+          flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  flex: 0 0 18.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 18.75%;
+      -ms-flex: 0 0 18.75%;
+          flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  flex: 0 0 12.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 12.5%;
+      -ms-flex: 0 0 12.5%;
+          flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  flex: 0 0 6.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 6.25%;
+      -ms-flex: 0 0 6.25%;
+          flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -275,82 +364,130 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    flex: 0 0 93.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 93.75%;
+        -ms-flex: 0 0 93.75%;
+            flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    flex: 0 0 81.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 81.25%;
+        -ms-flex: 0 0 81.25%;
+            flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    flex: 0 0 68.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 68.75%;
+        -ms-flex: 0 0 68.75%;
+            flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    flex: 0 0 56.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 56.25%;
+        -ms-flex: 0 0 56.25%;
+            flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    flex: 0 0 43.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 43.75%;
+        -ms-flex: 0 0 43.75%;
+            flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    flex: 0 0 31.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 31.25%;
+        -ms-flex: 0 0 31.25%;
+            flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    flex: 0 0 18.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 18.75%;
+        -ms-flex: 0 0 18.75%;
+            flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    flex: 0 0 6.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 6.25%;
+        -ms-flex: 0 0 6.25%;
+            flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }
@@ -363,42 +500,66 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -435,13 +596,18 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   margin: 8px auto;
   position: relative;
   right: 8px;
+  width: -webkit-calc(100% - 48px);
   width: calc(100% - 48px);
 }
 /**
  * HIGHLY EXPERIMENTAL
  */
 .grid__group--top-to-bottom {
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column;
   width: auto;
 }
 .grid__group--top-to-bottom .grid__cell {
@@ -454,7 +620,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of15 {
-  flex: 0 0 6.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 6.66666667%;
+      -ms-flex: 0 0 6.66666667%;
+          flex: 0 0 6.66666667%;
   max-width: 6.66666667%;
   width: 6.66666667%;
 }
@@ -462,7 +631,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of15 {
-  flex: 0 0 13.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 13.33333333%;
+      -ms-flex: 0 0 13.33333333%;
+          flex: 0 0 13.33333333%;
   max-width: 13.33333333%;
   width: 13.33333333%;
 }
@@ -470,7 +642,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of15 {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -478,7 +653,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of15 {
-  flex: 0 0 26.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 26.66666667%;
+      -ms-flex: 0 0 26.66666667%;
+          flex: 0 0 26.66666667%;
   max-width: 26.66666667%;
   width: 26.66666667%;
 }
@@ -486,7 +664,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of15 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -494,7 +675,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of15 {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -502,7 +686,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of15 {
-  flex: 0 0 46.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 46.66666667%;
+      -ms-flex: 0 0 46.66666667%;
+          flex: 0 0 46.66666667%;
   max-width: 46.66666667%;
   width: 46.66666667%;
 }
@@ -510,7 +697,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of15 {
-  flex: 0 0 53.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 53.33333333%;
+      -ms-flex: 0 0 53.33333333%;
+          flex: 0 0 53.33333333%;
   max-width: 53.33333333%;
   width: 53.33333333%;
 }
@@ -518,7 +708,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of15 {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -526,7 +719,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of15 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -534,7 +730,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of15 {
-  flex: 0 0 73.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 73.33333333%;
+      -ms-flex: 0 0 73.33333333%;
+          flex: 0 0 73.33333333%;
   max-width: 73.33333333%;
   width: 73.33333333%;
 }
@@ -542,7 +741,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of15 {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -550,7 +752,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of15 {
-  flex: 0 0 86.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 86.66666667%;
+      -ms-flex: 0 0 86.66666667%;
+          flex: 0 0 86.66666667%;
   max-width: 86.66666667%;
   width: 86.66666667%;
 }
@@ -558,7 +763,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of15 {
-  flex: 0 0 93.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 93.33333333%;
+      -ms-flex: 0 0 93.33333333%;
+          flex: 0 0 93.33333333%;
   max-width: 93.33333333%;
   width: 93.33333333%;
 }
@@ -566,7 +774,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--15of15 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -574,7 +785,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of14 {
-  flex: 0 0 7.14285714%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 7.14285714%;
+      -ms-flex: 0 0 7.14285714%;
+          flex: 0 0 7.14285714%;
   max-width: 7.14285714%;
   width: 7.14285714%;
 }
@@ -582,7 +796,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of14 {
-  flex: 0 0 14.28571429%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 14.28571429%;
+      -ms-flex: 0 0 14.28571429%;
+          flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -590,7 +807,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of14 {
-  flex: 0 0 21.42857143%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 21.42857143%;
+      -ms-flex: 0 0 21.42857143%;
+          flex: 0 0 21.42857143%;
   max-width: 21.42857143%;
   width: 21.42857143%;
 }
@@ -598,7 +818,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of14 {
-  flex: 0 0 28.57142857%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 28.57142857%;
+      -ms-flex: 0 0 28.57142857%;
+          flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -606,7 +829,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of14 {
-  flex: 0 0 35.71428571%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 35.71428571%;
+      -ms-flex: 0 0 35.71428571%;
+          flex: 0 0 35.71428571%;
   max-width: 35.71428571%;
   width: 35.71428571%;
 }
@@ -614,7 +840,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of14 {
-  flex: 0 0 42.85714286%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 42.85714286%;
+      -ms-flex: 0 0 42.85714286%;
+          flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -622,7 +851,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of14 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -630,7 +862,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of14 {
-  flex: 0 0 57.14285714%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 57.14285714%;
+      -ms-flex: 0 0 57.14285714%;
+          flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -638,7 +873,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of14 {
-  flex: 0 0 64.28571429%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 64.28571429%;
+      -ms-flex: 0 0 64.28571429%;
+          flex: 0 0 64.28571429%;
   max-width: 64.28571429%;
   width: 64.28571429%;
 }
@@ -646,7 +884,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of14 {
-  flex: 0 0 71.42857143%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 71.42857143%;
+      -ms-flex: 0 0 71.42857143%;
+          flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -654,7 +895,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of14 {
-  flex: 0 0 78.57142857%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 78.57142857%;
+      -ms-flex: 0 0 78.57142857%;
+          flex: 0 0 78.57142857%;
   max-width: 78.57142857%;
   width: 78.57142857%;
 }
@@ -662,7 +906,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of14 {
-  flex: 0 0 85.71428571%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 85.71428571%;
+      -ms-flex: 0 0 85.71428571%;
+          flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -670,7 +917,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of14 {
-  flex: 0 0 92.85714286%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 92.85714286%;
+      -ms-flex: 0 0 92.85714286%;
+          flex: 0 0 92.85714286%;
   max-width: 92.85714286%;
   width: 92.85714286%;
 }
@@ -678,7 +928,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of14 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -686,7 +939,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of13 {
-  flex: 0 0 7.69230769%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 7.69230769%;
+      -ms-flex: 0 0 7.69230769%;
+          flex: 0 0 7.69230769%;
   max-width: 7.69230769%;
   width: 7.69230769%;
 }
@@ -694,7 +950,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of13 {
-  flex: 0 0 15.38461538%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 15.38461538%;
+      -ms-flex: 0 0 15.38461538%;
+          flex: 0 0 15.38461538%;
   max-width: 15.38461538%;
   width: 15.38461538%;
 }
@@ -702,7 +961,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of13 {
-  flex: 0 0 23.07692308%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 23.07692308%;
+      -ms-flex: 0 0 23.07692308%;
+          flex: 0 0 23.07692308%;
   max-width: 23.07692308%;
   width: 23.07692308%;
 }
@@ -710,7 +972,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of13 {
-  flex: 0 0 30.76923077%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 30.76923077%;
+      -ms-flex: 0 0 30.76923077%;
+          flex: 0 0 30.76923077%;
   max-width: 30.76923077%;
   width: 30.76923077%;
 }
@@ -718,7 +983,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of13 {
-  flex: 0 0 38.46153846%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 38.46153846%;
+      -ms-flex: 0 0 38.46153846%;
+          flex: 0 0 38.46153846%;
   max-width: 38.46153846%;
   width: 38.46153846%;
 }
@@ -726,7 +994,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of13 {
-  flex: 0 0 46.15384615%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 46.15384615%;
+      -ms-flex: 0 0 46.15384615%;
+          flex: 0 0 46.15384615%;
   max-width: 46.15384615%;
   width: 46.15384615%;
 }
@@ -734,7 +1005,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of13 {
-  flex: 0 0 53.84615385%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 53.84615385%;
+      -ms-flex: 0 0 53.84615385%;
+          flex: 0 0 53.84615385%;
   max-width: 53.84615385%;
   width: 53.84615385%;
 }
@@ -742,7 +1016,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of13 {
-  flex: 0 0 61.53846154%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 61.53846154%;
+      -ms-flex: 0 0 61.53846154%;
+          flex: 0 0 61.53846154%;
   max-width: 61.53846154%;
   width: 61.53846154%;
 }
@@ -750,7 +1027,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of13 {
-  flex: 0 0 69.23076923%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 69.23076923%;
+      -ms-flex: 0 0 69.23076923%;
+          flex: 0 0 69.23076923%;
   max-width: 69.23076923%;
   width: 69.23076923%;
 }
@@ -758,7 +1038,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of13 {
-  flex: 0 0 76.92307692%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 76.92307692%;
+      -ms-flex: 0 0 76.92307692%;
+          flex: 0 0 76.92307692%;
   max-width: 76.92307692%;
   width: 76.92307692%;
 }
@@ -766,7 +1049,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of13 {
-  flex: 0 0 84.61538462%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 84.61538462%;
+      -ms-flex: 0 0 84.61538462%;
+          flex: 0 0 84.61538462%;
   max-width: 84.61538462%;
   width: 84.61538462%;
 }
@@ -774,7 +1060,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of13 {
-  flex: 0 0 92.30769231%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 92.30769231%;
+      -ms-flex: 0 0 92.30769231%;
+          flex: 0 0 92.30769231%;
   max-width: 92.30769231%;
   width: 92.30769231%;
 }
@@ -782,7 +1071,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of13 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -790,7 +1082,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of12 {
-  flex: 0 0 8.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 8.33333333%;
+      -ms-flex: 0 0 8.33333333%;
+          flex: 0 0 8.33333333%;
   max-width: 8.33333333%;
   width: 8.33333333%;
 }
@@ -798,7 +1093,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of12 {
-  flex: 0 0 16.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 16.66666667%;
+      -ms-flex: 0 0 16.66666667%;
+          flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -806,7 +1104,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of12 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -814,7 +1115,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of12 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -822,7 +1126,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of12 {
-  flex: 0 0 41.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 41.66666667%;
+      -ms-flex: 0 0 41.66666667%;
+          flex: 0 0 41.66666667%;
   max-width: 41.66666667%;
   width: 41.66666667%;
 }
@@ -830,7 +1137,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of12 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -838,7 +1148,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of12 {
-  flex: 0 0 58.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 58.33333333%;
+      -ms-flex: 0 0 58.33333333%;
+          flex: 0 0 58.33333333%;
   max-width: 58.33333333%;
   width: 58.33333333%;
 }
@@ -846,7 +1159,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of12 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -854,7 +1170,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of12 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -862,7 +1181,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of12 {
-  flex: 0 0 83.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 83.33333333%;
+      -ms-flex: 0 0 83.33333333%;
+          flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -870,7 +1192,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of12 {
-  flex: 0 0 91.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 91.66666667%;
+      -ms-flex: 0 0 91.66666667%;
+          flex: 0 0 91.66666667%;
   max-width: 91.66666667%;
   width: 91.66666667%;
 }
@@ -878,7 +1203,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of12 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -886,7 +1214,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of11 {
-  flex: 0 0 9.09090909%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 9.09090909%;
+      -ms-flex: 0 0 9.09090909%;
+          flex: 0 0 9.09090909%;
   max-width: 9.09090909%;
   width: 9.09090909%;
 }
@@ -894,7 +1225,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of11 {
-  flex: 0 0 18.18181818%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 18.18181818%;
+      -ms-flex: 0 0 18.18181818%;
+          flex: 0 0 18.18181818%;
   max-width: 18.18181818%;
   width: 18.18181818%;
 }
@@ -902,7 +1236,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of11 {
-  flex: 0 0 27.27272727%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 27.27272727%;
+      -ms-flex: 0 0 27.27272727%;
+          flex: 0 0 27.27272727%;
   max-width: 27.27272727%;
   width: 27.27272727%;
 }
@@ -910,7 +1247,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of11 {
-  flex: 0 0 36.36363636%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 36.36363636%;
+      -ms-flex: 0 0 36.36363636%;
+          flex: 0 0 36.36363636%;
   max-width: 36.36363636%;
   width: 36.36363636%;
 }
@@ -918,7 +1258,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of11 {
-  flex: 0 0 45.45454545%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 45.45454545%;
+      -ms-flex: 0 0 45.45454545%;
+          flex: 0 0 45.45454545%;
   max-width: 45.45454545%;
   width: 45.45454545%;
 }
@@ -926,7 +1269,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of11 {
-  flex: 0 0 54.54545455%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 54.54545455%;
+      -ms-flex: 0 0 54.54545455%;
+          flex: 0 0 54.54545455%;
   max-width: 54.54545455%;
   width: 54.54545455%;
 }
@@ -934,7 +1280,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of11 {
-  flex: 0 0 63.63636364%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 63.63636364%;
+      -ms-flex: 0 0 63.63636364%;
+          flex: 0 0 63.63636364%;
   max-width: 63.63636364%;
   width: 63.63636364%;
 }
@@ -942,7 +1291,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of11 {
-  flex: 0 0 72.72727273%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 72.72727273%;
+      -ms-flex: 0 0 72.72727273%;
+          flex: 0 0 72.72727273%;
   max-width: 72.72727273%;
   width: 72.72727273%;
 }
@@ -950,7 +1302,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of11 {
-  flex: 0 0 81.81818182%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 81.81818182%;
+      -ms-flex: 0 0 81.81818182%;
+          flex: 0 0 81.81818182%;
   max-width: 81.81818182%;
   width: 81.81818182%;
 }
@@ -958,7 +1313,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of11 {
-  flex: 0 0 90.90909091%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 90.90909091%;
+      -ms-flex: 0 0 90.90909091%;
+          flex: 0 0 90.90909091%;
   max-width: 90.90909091%;
   width: 90.90909091%;
 }
@@ -966,7 +1324,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of11 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -974,7 +1335,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of10 {
-  flex: 0 0 10%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 10%;
+      -ms-flex: 0 0 10%;
+          flex: 0 0 10%;
   max-width: 10%;
   width: 10%;
 }
@@ -982,7 +1346,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of10 {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -990,7 +1357,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of10 {
-  flex: 0 0 30%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 30%;
+      -ms-flex: 0 0 30%;
+          flex: 0 0 30%;
   max-width: 30%;
   width: 30%;
 }
@@ -998,7 +1368,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of10 {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1006,7 +1379,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of10 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1014,7 +1390,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of10 {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1022,7 +1401,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of10 {
-  flex: 0 0 70%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 70%;
+      -ms-flex: 0 0 70%;
+          flex: 0 0 70%;
   max-width: 70%;
   width: 70%;
 }
@@ -1030,7 +1412,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of10 {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1038,7 +1423,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of10 {
-  flex: 0 0 90%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 90%;
+      -ms-flex: 0 0 90%;
+          flex: 0 0 90%;
   max-width: 90%;
   width: 90%;
 }
@@ -1046,7 +1434,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of10 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1054,7 +1445,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of9 {
-  flex: 0 0 11.11111111%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 11.11111111%;
+      -ms-flex: 0 0 11.11111111%;
+          flex: 0 0 11.11111111%;
   max-width: 11.11111111%;
   width: 11.11111111%;
 }
@@ -1062,7 +1456,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of9 {
-  flex: 0 0 22.22222222%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 22.22222222%;
+      -ms-flex: 0 0 22.22222222%;
+          flex: 0 0 22.22222222%;
   max-width: 22.22222222%;
   width: 22.22222222%;
 }
@@ -1070,7 +1467,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of9 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1078,7 +1478,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of9 {
-  flex: 0 0 44.44444444%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 44.44444444%;
+      -ms-flex: 0 0 44.44444444%;
+          flex: 0 0 44.44444444%;
   max-width: 44.44444444%;
   width: 44.44444444%;
 }
@@ -1086,7 +1489,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of9 {
-  flex: 0 0 55.55555556%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 55.55555556%;
+      -ms-flex: 0 0 55.55555556%;
+          flex: 0 0 55.55555556%;
   max-width: 55.55555556%;
   width: 55.55555556%;
 }
@@ -1094,7 +1500,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of9 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1102,7 +1511,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of9 {
-  flex: 0 0 77.77777778%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 77.77777778%;
+      -ms-flex: 0 0 77.77777778%;
+          flex: 0 0 77.77777778%;
   max-width: 77.77777778%;
   width: 77.77777778%;
 }
@@ -1110,7 +1522,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of9 {
-  flex: 0 0 88.88888889%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 88.88888889%;
+      -ms-flex: 0 0 88.88888889%;
+          flex: 0 0 88.88888889%;
   max-width: 88.88888889%;
   width: 88.88888889%;
 }
@@ -1118,7 +1533,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of9 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1126,7 +1544,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of8 {
-  flex: 0 0 12.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 12.5%;
+      -ms-flex: 0 0 12.5%;
+          flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
@@ -1134,7 +1555,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of8 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1142,7 +1566,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of8 {
-  flex: 0 0 37.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 37.5%;
+      -ms-flex: 0 0 37.5%;
+          flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
@@ -1150,7 +1577,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of8 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1158,7 +1588,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of8 {
-  flex: 0 0 62.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 62.5%;
+      -ms-flex: 0 0 62.5%;
+          flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
@@ -1166,7 +1599,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of8 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1174,7 +1610,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of8 {
-  flex: 0 0 87.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 87.5%;
+      -ms-flex: 0 0 87.5%;
+          flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
@@ -1182,7 +1621,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of8 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1190,7 +1632,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of7 {
-  flex: 0 0 14.28571429%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 14.28571429%;
+      -ms-flex: 0 0 14.28571429%;
+          flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -1198,7 +1643,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of7 {
-  flex: 0 0 28.57142857%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 28.57142857%;
+      -ms-flex: 0 0 28.57142857%;
+          flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -1206,7 +1654,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of7 {
-  flex: 0 0 42.85714286%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 42.85714286%;
+      -ms-flex: 0 0 42.85714286%;
+          flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -1214,7 +1665,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of7 {
-  flex: 0 0 57.14285714%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 57.14285714%;
+      -ms-flex: 0 0 57.14285714%;
+          flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -1222,7 +1676,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of7 {
-  flex: 0 0 71.42857143%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 71.42857143%;
+      -ms-flex: 0 0 71.42857143%;
+          flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -1230,7 +1687,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of7 {
-  flex: 0 0 85.71428571%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 85.71428571%;
+      -ms-flex: 0 0 85.71428571%;
+          flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -1238,7 +1698,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of7 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1246,7 +1709,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of6 {
-  flex: 0 0 16.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 16.66666667%;
+      -ms-flex: 0 0 16.66666667%;
+          flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -1254,7 +1720,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of6 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1262,7 +1731,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of6 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1270,7 +1742,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of6 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1278,7 +1753,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of6 {
-  flex: 0 0 83.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 83.33333333%;
+      -ms-flex: 0 0 83.33333333%;
+          flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -1286,7 +1764,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of6 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1294,7 +1775,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of5 {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -1302,7 +1786,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of5 {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1310,7 +1797,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of5 {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1318,7 +1808,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of5 {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1326,7 +1819,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of5 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1334,7 +1830,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of4 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1342,7 +1841,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of4 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1350,7 +1852,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of4 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1358,7 +1863,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of4 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1366,7 +1874,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of3 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1374,7 +1885,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of3 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1382,7 +1896,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of3 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1390,7 +1907,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of2 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1398,7 +1918,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of2 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1406,7 +1929,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of1 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1415,7 +1941,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of15-lg {
-    flex: 0 0 6.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 6.66666667%;
+        -ms-flex: 0 0 6.66666667%;
+            flex: 0 0 6.66666667%;
     max-width: 6.66666667%;
     width: 6.66666667%;
   }
@@ -1423,7 +1952,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of15-lg {
-    flex: 0 0 13.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 13.33333333%;
+        -ms-flex: 0 0 13.33333333%;
+            flex: 0 0 13.33333333%;
     max-width: 13.33333333%;
     width: 13.33333333%;
   }
@@ -1431,7 +1963,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of15-lg {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -1439,7 +1974,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of15-lg {
-    flex: 0 0 26.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 26.66666667%;
+        -ms-flex: 0 0 26.66666667%;
+            flex: 0 0 26.66666667%;
     max-width: 26.66666667%;
     width: 26.66666667%;
   }
@@ -1447,7 +1985,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of15-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -1455,7 +1996,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of15-lg {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -1463,7 +2007,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of15-lg {
-    flex: 0 0 46.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 46.66666667%;
+        -ms-flex: 0 0 46.66666667%;
+            flex: 0 0 46.66666667%;
     max-width: 46.66666667%;
     width: 46.66666667%;
   }
@@ -1471,7 +2018,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of15-lg {
-    flex: 0 0 53.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 53.33333333%;
+        -ms-flex: 0 0 53.33333333%;
+            flex: 0 0 53.33333333%;
     max-width: 53.33333333%;
     width: 53.33333333%;
   }
@@ -1479,7 +2029,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of15-lg {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -1487,7 +2040,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of15-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -1495,7 +2051,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of15-lg {
-    flex: 0 0 73.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 73.33333333%;
+        -ms-flex: 0 0 73.33333333%;
+            flex: 0 0 73.33333333%;
     max-width: 73.33333333%;
     width: 73.33333333%;
   }
@@ -1503,7 +2062,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of15-lg {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -1511,7 +2073,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of15-lg {
-    flex: 0 0 86.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 86.66666667%;
+        -ms-flex: 0 0 86.66666667%;
+            flex: 0 0 86.66666667%;
     max-width: 86.66666667%;
     width: 86.66666667%;
   }
@@ -1519,7 +2084,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of15-lg {
-    flex: 0 0 93.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 93.33333333%;
+        -ms-flex: 0 0 93.33333333%;
+            flex: 0 0 93.33333333%;
     max-width: 93.33333333%;
     width: 93.33333333%;
   }
@@ -1527,7 +2095,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--15of15-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1535,7 +2106,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of14-lg {
-    flex: 0 0 7.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 7.14285714%;
+        -ms-flex: 0 0 7.14285714%;
+            flex: 0 0 7.14285714%;
     max-width: 7.14285714%;
     width: 7.14285714%;
   }
@@ -1543,7 +2117,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of14-lg {
-    flex: 0 0 14.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 14.28571429%;
+        -ms-flex: 0 0 14.28571429%;
+            flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -1551,7 +2128,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of14-lg {
-    flex: 0 0 21.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 21.42857143%;
+        -ms-flex: 0 0 21.42857143%;
+            flex: 0 0 21.42857143%;
     max-width: 21.42857143%;
     width: 21.42857143%;
   }
@@ -1559,7 +2139,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of14-lg {
-    flex: 0 0 28.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 28.57142857%;
+        -ms-flex: 0 0 28.57142857%;
+            flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -1567,7 +2150,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of14-lg {
-    flex: 0 0 35.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 35.71428571%;
+        -ms-flex: 0 0 35.71428571%;
+            flex: 0 0 35.71428571%;
     max-width: 35.71428571%;
     width: 35.71428571%;
   }
@@ -1575,7 +2161,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of14-lg {
-    flex: 0 0 42.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 42.85714286%;
+        -ms-flex: 0 0 42.85714286%;
+            flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -1583,7 +2172,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of14-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1591,7 +2183,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of14-lg {
-    flex: 0 0 57.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 57.14285714%;
+        -ms-flex: 0 0 57.14285714%;
+            flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -1599,7 +2194,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of14-lg {
-    flex: 0 0 64.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 64.28571429%;
+        -ms-flex: 0 0 64.28571429%;
+            flex: 0 0 64.28571429%;
     max-width: 64.28571429%;
     width: 64.28571429%;
   }
@@ -1607,7 +2205,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of14-lg {
-    flex: 0 0 71.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 71.42857143%;
+        -ms-flex: 0 0 71.42857143%;
+            flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -1615,7 +2216,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of14-lg {
-    flex: 0 0 78.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 78.57142857%;
+        -ms-flex: 0 0 78.57142857%;
+            flex: 0 0 78.57142857%;
     max-width: 78.57142857%;
     width: 78.57142857%;
   }
@@ -1623,7 +2227,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of14-lg {
-    flex: 0 0 85.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 85.71428571%;
+        -ms-flex: 0 0 85.71428571%;
+            flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -1631,7 +2238,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of14-lg {
-    flex: 0 0 92.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 92.85714286%;
+        -ms-flex: 0 0 92.85714286%;
+            flex: 0 0 92.85714286%;
     max-width: 92.85714286%;
     width: 92.85714286%;
   }
@@ -1639,7 +2249,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of14-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1647,7 +2260,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of13-lg {
-    flex: 0 0 7.69230769%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 7.69230769%;
+        -ms-flex: 0 0 7.69230769%;
+            flex: 0 0 7.69230769%;
     max-width: 7.69230769%;
     width: 7.69230769%;
   }
@@ -1655,7 +2271,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of13-lg {
-    flex: 0 0 15.38461538%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 15.38461538%;
+        -ms-flex: 0 0 15.38461538%;
+            flex: 0 0 15.38461538%;
     max-width: 15.38461538%;
     width: 15.38461538%;
   }
@@ -1663,7 +2282,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of13-lg {
-    flex: 0 0 23.07692308%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 23.07692308%;
+        -ms-flex: 0 0 23.07692308%;
+            flex: 0 0 23.07692308%;
     max-width: 23.07692308%;
     width: 23.07692308%;
   }
@@ -1671,7 +2293,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of13-lg {
-    flex: 0 0 30.76923077%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 30.76923077%;
+        -ms-flex: 0 0 30.76923077%;
+            flex: 0 0 30.76923077%;
     max-width: 30.76923077%;
     width: 30.76923077%;
   }
@@ -1679,7 +2304,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of13-lg {
-    flex: 0 0 38.46153846%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 38.46153846%;
+        -ms-flex: 0 0 38.46153846%;
+            flex: 0 0 38.46153846%;
     max-width: 38.46153846%;
     width: 38.46153846%;
   }
@@ -1687,7 +2315,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of13-lg {
-    flex: 0 0 46.15384615%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 46.15384615%;
+        -ms-flex: 0 0 46.15384615%;
+            flex: 0 0 46.15384615%;
     max-width: 46.15384615%;
     width: 46.15384615%;
   }
@@ -1695,7 +2326,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of13-lg {
-    flex: 0 0 53.84615385%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 53.84615385%;
+        -ms-flex: 0 0 53.84615385%;
+            flex: 0 0 53.84615385%;
     max-width: 53.84615385%;
     width: 53.84615385%;
   }
@@ -1703,7 +2337,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of13-lg {
-    flex: 0 0 61.53846154%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 61.53846154%;
+        -ms-flex: 0 0 61.53846154%;
+            flex: 0 0 61.53846154%;
     max-width: 61.53846154%;
     width: 61.53846154%;
   }
@@ -1711,7 +2348,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of13-lg {
-    flex: 0 0 69.23076923%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 69.23076923%;
+        -ms-flex: 0 0 69.23076923%;
+            flex: 0 0 69.23076923%;
     max-width: 69.23076923%;
     width: 69.23076923%;
   }
@@ -1719,7 +2359,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of13-lg {
-    flex: 0 0 76.92307692%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 76.92307692%;
+        -ms-flex: 0 0 76.92307692%;
+            flex: 0 0 76.92307692%;
     max-width: 76.92307692%;
     width: 76.92307692%;
   }
@@ -1727,7 +2370,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of13-lg {
-    flex: 0 0 84.61538462%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 84.61538462%;
+        -ms-flex: 0 0 84.61538462%;
+            flex: 0 0 84.61538462%;
     max-width: 84.61538462%;
     width: 84.61538462%;
   }
@@ -1735,7 +2381,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of13-lg {
-    flex: 0 0 92.30769231%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 92.30769231%;
+        -ms-flex: 0 0 92.30769231%;
+            flex: 0 0 92.30769231%;
     max-width: 92.30769231%;
     width: 92.30769231%;
   }
@@ -1743,7 +2392,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of13-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1751,7 +2403,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of12-lg {
-    flex: 0 0 8.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 8.33333333%;
+        -ms-flex: 0 0 8.33333333%;
+            flex: 0 0 8.33333333%;
     max-width: 8.33333333%;
     width: 8.33333333%;
   }
@@ -1759,7 +2414,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of12-lg {
-    flex: 0 0 16.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 16.66666667%;
+        -ms-flex: 0 0 16.66666667%;
+            flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -1767,7 +2425,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of12-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -1775,7 +2436,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of12-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -1783,7 +2447,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of12-lg {
-    flex: 0 0 41.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 41.66666667%;
+        -ms-flex: 0 0 41.66666667%;
+            flex: 0 0 41.66666667%;
     max-width: 41.66666667%;
     width: 41.66666667%;
   }
@@ -1791,7 +2458,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of12-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1799,7 +2469,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of12-lg {
-    flex: 0 0 58.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 58.33333333%;
+        -ms-flex: 0 0 58.33333333%;
+            flex: 0 0 58.33333333%;
     max-width: 58.33333333%;
     width: 58.33333333%;
   }
@@ -1807,7 +2480,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of12-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -1815,7 +2491,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of12-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -1823,7 +2502,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of12-lg {
-    flex: 0 0 83.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 83.33333333%;
+        -ms-flex: 0 0 83.33333333%;
+            flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -1831,7 +2513,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of12-lg {
-    flex: 0 0 91.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 91.66666667%;
+        -ms-flex: 0 0 91.66666667%;
+            flex: 0 0 91.66666667%;
     max-width: 91.66666667%;
     width: 91.66666667%;
   }
@@ -1839,7 +2524,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of12-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1847,7 +2535,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of11-lg {
-    flex: 0 0 9.09090909%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 9.09090909%;
+        -ms-flex: 0 0 9.09090909%;
+            flex: 0 0 9.09090909%;
     max-width: 9.09090909%;
     width: 9.09090909%;
   }
@@ -1855,7 +2546,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of11-lg {
-    flex: 0 0 18.18181818%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 18.18181818%;
+        -ms-flex: 0 0 18.18181818%;
+            flex: 0 0 18.18181818%;
     max-width: 18.18181818%;
     width: 18.18181818%;
   }
@@ -1863,7 +2557,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of11-lg {
-    flex: 0 0 27.27272727%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 27.27272727%;
+        -ms-flex: 0 0 27.27272727%;
+            flex: 0 0 27.27272727%;
     max-width: 27.27272727%;
     width: 27.27272727%;
   }
@@ -1871,7 +2568,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of11-lg {
-    flex: 0 0 36.36363636%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 36.36363636%;
+        -ms-flex: 0 0 36.36363636%;
+            flex: 0 0 36.36363636%;
     max-width: 36.36363636%;
     width: 36.36363636%;
   }
@@ -1879,7 +2579,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of11-lg {
-    flex: 0 0 45.45454545%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 45.45454545%;
+        -ms-flex: 0 0 45.45454545%;
+            flex: 0 0 45.45454545%;
     max-width: 45.45454545%;
     width: 45.45454545%;
   }
@@ -1887,7 +2590,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of11-lg {
-    flex: 0 0 54.54545455%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 54.54545455%;
+        -ms-flex: 0 0 54.54545455%;
+            flex: 0 0 54.54545455%;
     max-width: 54.54545455%;
     width: 54.54545455%;
   }
@@ -1895,7 +2601,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of11-lg {
-    flex: 0 0 63.63636364%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 63.63636364%;
+        -ms-flex: 0 0 63.63636364%;
+            flex: 0 0 63.63636364%;
     max-width: 63.63636364%;
     width: 63.63636364%;
   }
@@ -1903,7 +2612,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of11-lg {
-    flex: 0 0 72.72727273%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 72.72727273%;
+        -ms-flex: 0 0 72.72727273%;
+            flex: 0 0 72.72727273%;
     max-width: 72.72727273%;
     width: 72.72727273%;
   }
@@ -1911,7 +2623,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of11-lg {
-    flex: 0 0 81.81818182%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 81.81818182%;
+        -ms-flex: 0 0 81.81818182%;
+            flex: 0 0 81.81818182%;
     max-width: 81.81818182%;
     width: 81.81818182%;
   }
@@ -1919,7 +2634,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of11-lg {
-    flex: 0 0 90.90909091%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 90.90909091%;
+        -ms-flex: 0 0 90.90909091%;
+            flex: 0 0 90.90909091%;
     max-width: 90.90909091%;
     width: 90.90909091%;
   }
@@ -1927,7 +2645,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of11-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1935,7 +2656,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of10-lg {
-    flex: 0 0 10%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 10%;
+        -ms-flex: 0 0 10%;
+            flex: 0 0 10%;
     max-width: 10%;
     width: 10%;
   }
@@ -1943,7 +2667,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of10-lg {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -1951,7 +2678,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of10-lg {
-    flex: 0 0 30%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 30%;
+        -ms-flex: 0 0 30%;
+            flex: 0 0 30%;
     max-width: 30%;
     width: 30%;
   }
@@ -1959,7 +2689,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of10-lg {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -1967,7 +2700,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of10-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1975,7 +2711,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of10-lg {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -1983,7 +2722,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of10-lg {
-    flex: 0 0 70%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 70%;
+        -ms-flex: 0 0 70%;
+            flex: 0 0 70%;
     max-width: 70%;
     width: 70%;
   }
@@ -1991,7 +2733,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of10-lg {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -1999,7 +2744,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of10-lg {
-    flex: 0 0 90%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 90%;
+        -ms-flex: 0 0 90%;
+            flex: 0 0 90%;
     max-width: 90%;
     width: 90%;
   }
@@ -2007,7 +2755,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of10-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2015,7 +2766,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of9-lg {
-    flex: 0 0 11.11111111%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 11.11111111%;
+        -ms-flex: 0 0 11.11111111%;
+            flex: 0 0 11.11111111%;
     max-width: 11.11111111%;
     width: 11.11111111%;
   }
@@ -2023,7 +2777,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of9-lg {
-    flex: 0 0 22.22222222%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 22.22222222%;
+        -ms-flex: 0 0 22.22222222%;
+            flex: 0 0 22.22222222%;
     max-width: 22.22222222%;
     width: 22.22222222%;
   }
@@ -2031,7 +2788,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of9-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2039,7 +2799,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of9-lg {
-    flex: 0 0 44.44444444%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 44.44444444%;
+        -ms-flex: 0 0 44.44444444%;
+            flex: 0 0 44.44444444%;
     max-width: 44.44444444%;
     width: 44.44444444%;
   }
@@ -2047,7 +2810,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of9-lg {
-    flex: 0 0 55.55555556%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 55.55555556%;
+        -ms-flex: 0 0 55.55555556%;
+            flex: 0 0 55.55555556%;
     max-width: 55.55555556%;
     width: 55.55555556%;
   }
@@ -2055,7 +2821,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of9-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2063,7 +2832,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of9-lg {
-    flex: 0 0 77.77777778%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 77.77777778%;
+        -ms-flex: 0 0 77.77777778%;
+            flex: 0 0 77.77777778%;
     max-width: 77.77777778%;
     width: 77.77777778%;
   }
@@ -2071,7 +2843,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of9-lg {
-    flex: 0 0 88.88888889%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 88.88888889%;
+        -ms-flex: 0 0 88.88888889%;
+            flex: 0 0 88.88888889%;
     max-width: 88.88888889%;
     width: 88.88888889%;
   }
@@ -2079,7 +2854,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of9-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2087,7 +2865,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of8-lg {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -2095,7 +2876,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of8-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2103,7 +2887,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of8-lg {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
@@ -2111,7 +2898,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of8-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2119,7 +2909,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of8-lg {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
@@ -2127,7 +2920,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of8-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2135,7 +2931,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of8-lg {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
@@ -2143,7 +2942,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of8-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2151,7 +2953,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-lg {
-    flex: 0 0 14.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 14.28571429%;
+        -ms-flex: 0 0 14.28571429%;
+            flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2159,7 +2964,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-lg {
-    flex: 0 0 28.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 28.57142857%;
+        -ms-flex: 0 0 28.57142857%;
+            flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2167,7 +2975,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-lg {
-    flex: 0 0 42.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 42.85714286%;
+        -ms-flex: 0 0 42.85714286%;
+            flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2175,7 +2986,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-lg {
-    flex: 0 0 57.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 57.14285714%;
+        -ms-flex: 0 0 57.14285714%;
+            flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -2183,7 +2997,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-lg {
-    flex: 0 0 71.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 71.42857143%;
+        -ms-flex: 0 0 71.42857143%;
+            flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2191,7 +3008,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-lg {
-    flex: 0 0 85.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 85.71428571%;
+        -ms-flex: 0 0 85.71428571%;
+            flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2199,7 +3019,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2207,7 +3030,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-lg {
-    flex: 0 0 16.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 16.66666667%;
+        -ms-flex: 0 0 16.66666667%;
+            flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2215,7 +3041,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2223,7 +3052,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2231,7 +3063,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2239,7 +3074,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-lg {
-    flex: 0 0 83.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 83.33333333%;
+        -ms-flex: 0 0 83.33333333%;
+            flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2247,7 +3085,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2255,7 +3096,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-lg {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2263,7 +3107,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-lg {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2271,7 +3118,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-lg {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2279,7 +3129,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-lg {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2287,7 +3140,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2295,7 +3151,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2303,7 +3162,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2311,7 +3173,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2319,7 +3184,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2327,7 +3195,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2335,7 +3206,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2343,7 +3217,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2351,7 +3228,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2359,7 +3239,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2367,7 +3250,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2377,7 +3263,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-sm {
-    flex: 0 0 14.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 14.28571429%;
+        -ms-flex: 0 0 14.28571429%;
+            flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2385,7 +3274,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-sm {
-    flex: 0 0 28.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 28.57142857%;
+        -ms-flex: 0 0 28.57142857%;
+            flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2393,7 +3285,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-sm {
-    flex: 0 0 42.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 42.85714286%;
+        -ms-flex: 0 0 42.85714286%;
+            flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2401,7 +3296,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-sm {
-    flex: 0 0 57.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 57.14285714%;
+        -ms-flex: 0 0 57.14285714%;
+            flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -2409,7 +3307,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-sm {
-    flex: 0 0 71.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 71.42857143%;
+        -ms-flex: 0 0 71.42857143%;
+            flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2417,7 +3318,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-sm {
-    flex: 0 0 85.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 85.71428571%;
+        -ms-flex: 0 0 85.71428571%;
+            flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2425,7 +3329,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2433,7 +3340,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-sm {
-    flex: 0 0 16.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 16.66666667%;
+        -ms-flex: 0 0 16.66666667%;
+            flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2441,7 +3351,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-sm {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2449,7 +3362,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2457,7 +3373,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-sm {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2465,7 +3384,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-sm {
-    flex: 0 0 83.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 83.33333333%;
+        -ms-flex: 0 0 83.33333333%;
+            flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2473,7 +3395,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2481,7 +3406,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-sm {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2489,7 +3417,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-sm {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2497,7 +3428,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-sm {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2505,7 +3439,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-sm {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2513,7 +3450,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2521,7 +3461,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-sm {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2529,7 +3472,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2537,7 +3483,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-sm {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2545,7 +3494,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2553,7 +3505,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-sm {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2561,7 +3516,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-sm {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2569,7 +3527,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2577,7 +3538,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2585,7 +3549,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2593,7 +3560,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }

--- a/dist/grid/ds4/grid-full.css
+++ b/dist/grid/ds4/grid-full.css
@@ -61,14 +61,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 .grid__group {
   -webkit-box-align: start;
-  -webkit-align-items: flex-start;
-      -ms-flex-align: start;
           align-items: flex-start;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -98,8 +94,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 }
 .grid__cell--grow {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
           flex: 1 1 auto;
 }
 /**
@@ -108,9 +102,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * screen gets smaller
  */
 .grid__group--wrap {
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -139,72 +131,54 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
      */
 .grid__cell--one-half {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -228,128 +202,96 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 .grid__cell--16of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 93.75%;
-      -ms-flex: 0 0 93.75%;
           flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 87.5%;
-      -ms-flex: 0 0 87.5%;
           flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 81.25%;
-      -ms-flex: 0 0 81.25%;
           flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 68.75%;
-      -ms-flex: 0 0 68.75%;
           flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 62.5%;
-      -ms-flex: 0 0 62.5%;
           flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 56.25%;
-      -ms-flex: 0 0 56.25%;
           flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 43.75%;
-      -ms-flex: 0 0 43.75%;
           flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 37.5%;
-      -ms-flex: 0 0 37.5%;
           flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 31.25%;
-      -ms-flex: 0 0 31.25%;
           flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 18.75%;
-      -ms-flex: 0 0 18.75%;
           flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 12.5%;
-      -ms-flex: 0 0 12.5%;
           flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 6.25%;
-      -ms-flex: 0 0 6.25%;
           flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
@@ -365,128 +307,96 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 93.75%;
-        -ms-flex: 0 0 93.75%;
             flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 81.25%;
-        -ms-flex: 0 0 81.25%;
             flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 68.75%;
-        -ms-flex: 0 0 68.75%;
             flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 56.25%;
-        -ms-flex: 0 0 56.25%;
             flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 43.75%;
-        -ms-flex: 0 0 43.75%;
             flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 31.25%;
-        -ms-flex: 0 0 31.25%;
             flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 18.75%;
-        -ms-flex: 0 0 18.75%;
             flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 6.25%;
-        -ms-flex: 0 0 6.25%;
             flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
@@ -501,64 +411,48 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
@@ -596,7 +490,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   margin: 8px auto;
   position: relative;
   right: 8px;
-  width: -webkit-calc(100% - 48px);
   width: calc(100% - 48px);
 }
 /**
@@ -605,8 +498,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 .grid__group--top-to-bottom {
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
           flex-direction: column;
   width: auto;
 }
@@ -621,8 +512,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 6.66666667%;
-      -ms-flex: 0 0 6.66666667%;
           flex: 0 0 6.66666667%;
   max-width: 6.66666667%;
   width: 6.66666667%;
@@ -632,8 +521,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 13.33333333%;
-      -ms-flex: 0 0 13.33333333%;
           flex: 0 0 13.33333333%;
   max-width: 13.33333333%;
   width: 13.33333333%;
@@ -643,8 +530,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
@@ -654,8 +539,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 26.66666667%;
-      -ms-flex: 0 0 26.66666667%;
           flex: 0 0 26.66666667%;
   max-width: 26.66666667%;
   width: 26.66666667%;
@@ -665,8 +548,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -676,8 +557,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
@@ -687,8 +566,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 46.66666667%;
-      -ms-flex: 0 0 46.66666667%;
           flex: 0 0 46.66666667%;
   max-width: 46.66666667%;
   width: 46.66666667%;
@@ -698,8 +575,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 53.33333333%;
-      -ms-flex: 0 0 53.33333333%;
           flex: 0 0 53.33333333%;
   max-width: 53.33333333%;
   width: 53.33333333%;
@@ -709,8 +584,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
@@ -720,8 +593,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -731,8 +602,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 73.33333333%;
-      -ms-flex: 0 0 73.33333333%;
           flex: 0 0 73.33333333%;
   max-width: 73.33333333%;
   width: 73.33333333%;
@@ -742,8 +611,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -753,8 +620,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--13of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 86.66666667%;
-      -ms-flex: 0 0 86.66666667%;
           flex: 0 0 86.66666667%;
   max-width: 86.66666667%;
   width: 86.66666667%;
@@ -764,8 +629,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--14of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 93.33333333%;
-      -ms-flex: 0 0 93.33333333%;
           flex: 0 0 93.33333333%;
   max-width: 93.33333333%;
   width: 93.33333333%;
@@ -775,8 +638,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--15of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -786,8 +647,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 7.14285714%;
-      -ms-flex: 0 0 7.14285714%;
           flex: 0 0 7.14285714%;
   max-width: 7.14285714%;
   width: 7.14285714%;
@@ -797,8 +656,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 14.28571429%;
-      -ms-flex: 0 0 14.28571429%;
           flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
@@ -808,8 +665,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 21.42857143%;
-      -ms-flex: 0 0 21.42857143%;
           flex: 0 0 21.42857143%;
   max-width: 21.42857143%;
   width: 21.42857143%;
@@ -819,8 +674,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 28.57142857%;
-      -ms-flex: 0 0 28.57142857%;
           flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
@@ -830,8 +683,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 35.71428571%;
-      -ms-flex: 0 0 35.71428571%;
           flex: 0 0 35.71428571%;
   max-width: 35.71428571%;
   width: 35.71428571%;
@@ -841,8 +692,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 42.85714286%;
-      -ms-flex: 0 0 42.85714286%;
           flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
@@ -852,8 +701,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -863,8 +710,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 57.14285714%;
-      -ms-flex: 0 0 57.14285714%;
           flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
@@ -874,8 +719,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 64.28571429%;
-      -ms-flex: 0 0 64.28571429%;
           flex: 0 0 64.28571429%;
   max-width: 64.28571429%;
   width: 64.28571429%;
@@ -885,8 +728,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 71.42857143%;
-      -ms-flex: 0 0 71.42857143%;
           flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
@@ -896,8 +737,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 78.57142857%;
-      -ms-flex: 0 0 78.57142857%;
           flex: 0 0 78.57142857%;
   max-width: 78.57142857%;
   width: 78.57142857%;
@@ -907,8 +746,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 85.71428571%;
-      -ms-flex: 0 0 85.71428571%;
           flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
@@ -918,8 +755,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--13of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 92.85714286%;
-      -ms-flex: 0 0 92.85714286%;
           flex: 0 0 92.85714286%;
   max-width: 92.85714286%;
   width: 92.85714286%;
@@ -929,8 +764,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--14of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -940,8 +773,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 7.69230769%;
-      -ms-flex: 0 0 7.69230769%;
           flex: 0 0 7.69230769%;
   max-width: 7.69230769%;
   width: 7.69230769%;
@@ -951,8 +782,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 15.38461538%;
-      -ms-flex: 0 0 15.38461538%;
           flex: 0 0 15.38461538%;
   max-width: 15.38461538%;
   width: 15.38461538%;
@@ -962,8 +791,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 23.07692308%;
-      -ms-flex: 0 0 23.07692308%;
           flex: 0 0 23.07692308%;
   max-width: 23.07692308%;
   width: 23.07692308%;
@@ -973,8 +800,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 30.76923077%;
-      -ms-flex: 0 0 30.76923077%;
           flex: 0 0 30.76923077%;
   max-width: 30.76923077%;
   width: 30.76923077%;
@@ -984,8 +809,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 38.46153846%;
-      -ms-flex: 0 0 38.46153846%;
           flex: 0 0 38.46153846%;
   max-width: 38.46153846%;
   width: 38.46153846%;
@@ -995,8 +818,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 46.15384615%;
-      -ms-flex: 0 0 46.15384615%;
           flex: 0 0 46.15384615%;
   max-width: 46.15384615%;
   width: 46.15384615%;
@@ -1006,8 +827,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 53.84615385%;
-      -ms-flex: 0 0 53.84615385%;
           flex: 0 0 53.84615385%;
   max-width: 53.84615385%;
   width: 53.84615385%;
@@ -1017,8 +836,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 61.53846154%;
-      -ms-flex: 0 0 61.53846154%;
           flex: 0 0 61.53846154%;
   max-width: 61.53846154%;
   width: 61.53846154%;
@@ -1028,8 +845,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 69.23076923%;
-      -ms-flex: 0 0 69.23076923%;
           flex: 0 0 69.23076923%;
   max-width: 69.23076923%;
   width: 69.23076923%;
@@ -1039,8 +854,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 76.92307692%;
-      -ms-flex: 0 0 76.92307692%;
           flex: 0 0 76.92307692%;
   max-width: 76.92307692%;
   width: 76.92307692%;
@@ -1050,8 +863,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 84.61538462%;
-      -ms-flex: 0 0 84.61538462%;
           flex: 0 0 84.61538462%;
   max-width: 84.61538462%;
   width: 84.61538462%;
@@ -1061,8 +872,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 92.30769231%;
-      -ms-flex: 0 0 92.30769231%;
           flex: 0 0 92.30769231%;
   max-width: 92.30769231%;
   width: 92.30769231%;
@@ -1072,8 +881,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--13of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1083,8 +890,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 8.33333333%;
-      -ms-flex: 0 0 8.33333333%;
           flex: 0 0 8.33333333%;
   max-width: 8.33333333%;
   width: 8.33333333%;
@@ -1094,8 +899,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 16.66666667%;
-      -ms-flex: 0 0 16.66666667%;
           flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
@@ -1105,8 +908,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
@@ -1116,8 +917,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1127,8 +926,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 41.66666667%;
-      -ms-flex: 0 0 41.66666667%;
           flex: 0 0 41.66666667%;
   max-width: 41.66666667%;
   width: 41.66666667%;
@@ -1138,8 +935,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1149,8 +944,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 58.33333333%;
-      -ms-flex: 0 0 58.33333333%;
           flex: 0 0 58.33333333%;
   max-width: 58.33333333%;
   width: 58.33333333%;
@@ -1160,8 +953,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1171,8 +962,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
@@ -1182,8 +971,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 83.33333333%;
-      -ms-flex: 0 0 83.33333333%;
           flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
@@ -1193,8 +980,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 91.66666667%;
-      -ms-flex: 0 0 91.66666667%;
           flex: 0 0 91.66666667%;
   max-width: 91.66666667%;
   width: 91.66666667%;
@@ -1204,8 +989,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1215,8 +998,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 9.09090909%;
-      -ms-flex: 0 0 9.09090909%;
           flex: 0 0 9.09090909%;
   max-width: 9.09090909%;
   width: 9.09090909%;
@@ -1226,8 +1007,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 18.18181818%;
-      -ms-flex: 0 0 18.18181818%;
           flex: 0 0 18.18181818%;
   max-width: 18.18181818%;
   width: 18.18181818%;
@@ -1237,8 +1016,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 27.27272727%;
-      -ms-flex: 0 0 27.27272727%;
           flex: 0 0 27.27272727%;
   max-width: 27.27272727%;
   width: 27.27272727%;
@@ -1248,8 +1025,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 36.36363636%;
-      -ms-flex: 0 0 36.36363636%;
           flex: 0 0 36.36363636%;
   max-width: 36.36363636%;
   width: 36.36363636%;
@@ -1259,8 +1034,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 45.45454545%;
-      -ms-flex: 0 0 45.45454545%;
           flex: 0 0 45.45454545%;
   max-width: 45.45454545%;
   width: 45.45454545%;
@@ -1270,8 +1043,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 54.54545455%;
-      -ms-flex: 0 0 54.54545455%;
           flex: 0 0 54.54545455%;
   max-width: 54.54545455%;
   width: 54.54545455%;
@@ -1281,8 +1052,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 63.63636364%;
-      -ms-flex: 0 0 63.63636364%;
           flex: 0 0 63.63636364%;
   max-width: 63.63636364%;
   width: 63.63636364%;
@@ -1292,8 +1061,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 72.72727273%;
-      -ms-flex: 0 0 72.72727273%;
           flex: 0 0 72.72727273%;
   max-width: 72.72727273%;
   width: 72.72727273%;
@@ -1303,8 +1070,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 81.81818182%;
-      -ms-flex: 0 0 81.81818182%;
           flex: 0 0 81.81818182%;
   max-width: 81.81818182%;
   width: 81.81818182%;
@@ -1314,8 +1079,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 90.90909091%;
-      -ms-flex: 0 0 90.90909091%;
           flex: 0 0 90.90909091%;
   max-width: 90.90909091%;
   width: 90.90909091%;
@@ -1325,8 +1088,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1336,8 +1097,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 10%;
-      -ms-flex: 0 0 10%;
           flex: 0 0 10%;
   max-width: 10%;
   width: 10%;
@@ -1347,8 +1106,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
@@ -1358,8 +1115,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 30%;
-      -ms-flex: 0 0 30%;
           flex: 0 0 30%;
   max-width: 30%;
   width: 30%;
@@ -1369,8 +1124,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
@@ -1380,8 +1133,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1391,8 +1142,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
@@ -1402,8 +1151,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 70%;
-      -ms-flex: 0 0 70%;
           flex: 0 0 70%;
   max-width: 70%;
   width: 70%;
@@ -1413,8 +1160,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -1424,8 +1169,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 90%;
-      -ms-flex: 0 0 90%;
           flex: 0 0 90%;
   max-width: 90%;
   width: 90%;
@@ -1435,8 +1178,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1446,8 +1187,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 11.11111111%;
-      -ms-flex: 0 0 11.11111111%;
           flex: 0 0 11.11111111%;
   max-width: 11.11111111%;
   width: 11.11111111%;
@@ -1457,8 +1196,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 22.22222222%;
-      -ms-flex: 0 0 22.22222222%;
           flex: 0 0 22.22222222%;
   max-width: 22.22222222%;
   width: 22.22222222%;
@@ -1468,8 +1205,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1479,8 +1214,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 44.44444444%;
-      -ms-flex: 0 0 44.44444444%;
           flex: 0 0 44.44444444%;
   max-width: 44.44444444%;
   width: 44.44444444%;
@@ -1490,8 +1223,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 55.55555556%;
-      -ms-flex: 0 0 55.55555556%;
           flex: 0 0 55.55555556%;
   max-width: 55.55555556%;
   width: 55.55555556%;
@@ -1501,8 +1232,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1512,8 +1241,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 77.77777778%;
-      -ms-flex: 0 0 77.77777778%;
           flex: 0 0 77.77777778%;
   max-width: 77.77777778%;
   width: 77.77777778%;
@@ -1523,8 +1250,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 88.88888889%;
-      -ms-flex: 0 0 88.88888889%;
           flex: 0 0 88.88888889%;
   max-width: 88.88888889%;
   width: 88.88888889%;
@@ -1534,8 +1259,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1545,8 +1268,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 12.5%;
-      -ms-flex: 0 0 12.5%;
           flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
@@ -1556,8 +1277,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
@@ -1567,8 +1286,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 37.5%;
-      -ms-flex: 0 0 37.5%;
           flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
@@ -1578,8 +1295,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1589,8 +1304,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 62.5%;
-      -ms-flex: 0 0 62.5%;
           flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
@@ -1600,8 +1313,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
@@ -1611,8 +1322,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 87.5%;
-      -ms-flex: 0 0 87.5%;
           flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
@@ -1622,8 +1331,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1633,8 +1340,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 14.28571429%;
-      -ms-flex: 0 0 14.28571429%;
           flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
@@ -1644,8 +1349,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 28.57142857%;
-      -ms-flex: 0 0 28.57142857%;
           flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
@@ -1655,8 +1358,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 42.85714286%;
-      -ms-flex: 0 0 42.85714286%;
           flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
@@ -1666,8 +1367,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 57.14285714%;
-      -ms-flex: 0 0 57.14285714%;
           flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
@@ -1677,8 +1376,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 71.42857143%;
-      -ms-flex: 0 0 71.42857143%;
           flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
@@ -1688,8 +1385,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 85.71428571%;
-      -ms-flex: 0 0 85.71428571%;
           flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
@@ -1699,8 +1394,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1710,8 +1403,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 16.66666667%;
-      -ms-flex: 0 0 16.66666667%;
           flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
@@ -1721,8 +1412,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1732,8 +1421,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1743,8 +1430,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1754,8 +1439,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 83.33333333%;
-      -ms-flex: 0 0 83.33333333%;
           flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
@@ -1765,8 +1448,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1776,8 +1457,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
@@ -1787,8 +1466,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
@@ -1798,8 +1475,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
@@ -1809,8 +1484,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -1820,8 +1493,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1831,8 +1502,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
@@ -1842,8 +1511,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1853,8 +1520,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
@@ -1864,8 +1529,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1875,8 +1538,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of3 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1886,8 +1547,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of3 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1897,8 +1556,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of3 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1908,8 +1565,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of2 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1919,8 +1574,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of2 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1930,8 +1583,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of1 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1942,8 +1593,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 6.66666667%;
-        -ms-flex: 0 0 6.66666667%;
             flex: 0 0 6.66666667%;
     max-width: 6.66666667%;
     width: 6.66666667%;
@@ -1953,8 +1602,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 13.33333333%;
-        -ms-flex: 0 0 13.33333333%;
             flex: 0 0 13.33333333%;
     max-width: 13.33333333%;
     width: 13.33333333%;
@@ -1964,8 +1611,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -1975,8 +1620,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 26.66666667%;
-        -ms-flex: 0 0 26.66666667%;
             flex: 0 0 26.66666667%;
     max-width: 26.66666667%;
     width: 26.66666667%;
@@ -1986,8 +1629,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -1997,8 +1638,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -2008,8 +1647,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 46.66666667%;
-        -ms-flex: 0 0 46.66666667%;
             flex: 0 0 46.66666667%;
     max-width: 46.66666667%;
     width: 46.66666667%;
@@ -2019,8 +1656,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 53.33333333%;
-        -ms-flex: 0 0 53.33333333%;
             flex: 0 0 53.33333333%;
     max-width: 53.33333333%;
     width: 53.33333333%;
@@ -2030,8 +1665,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -2041,8 +1674,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -2052,8 +1683,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 73.33333333%;
-        -ms-flex: 0 0 73.33333333%;
             flex: 0 0 73.33333333%;
     max-width: 73.33333333%;
     width: 73.33333333%;
@@ -2063,8 +1692,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -2074,8 +1701,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--13of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 86.66666667%;
-        -ms-flex: 0 0 86.66666667%;
             flex: 0 0 86.66666667%;
     max-width: 86.66666667%;
     width: 86.66666667%;
@@ -2085,8 +1710,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--14of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 93.33333333%;
-        -ms-flex: 0 0 93.33333333%;
             flex: 0 0 93.33333333%;
     max-width: 93.33333333%;
     width: 93.33333333%;
@@ -2096,8 +1719,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--15of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2107,8 +1728,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 7.14285714%;
-        -ms-flex: 0 0 7.14285714%;
             flex: 0 0 7.14285714%;
     max-width: 7.14285714%;
     width: 7.14285714%;
@@ -2118,8 +1737,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 14.28571429%;
-        -ms-flex: 0 0 14.28571429%;
             flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
@@ -2129,8 +1746,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 21.42857143%;
-        -ms-flex: 0 0 21.42857143%;
             flex: 0 0 21.42857143%;
     max-width: 21.42857143%;
     width: 21.42857143%;
@@ -2140,8 +1755,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 28.57142857%;
-        -ms-flex: 0 0 28.57142857%;
             flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
@@ -2151,8 +1764,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 35.71428571%;
-        -ms-flex: 0 0 35.71428571%;
             flex: 0 0 35.71428571%;
     max-width: 35.71428571%;
     width: 35.71428571%;
@@ -2162,8 +1773,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 42.85714286%;
-        -ms-flex: 0 0 42.85714286%;
             flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
@@ -2173,8 +1782,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2184,8 +1791,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 57.14285714%;
-        -ms-flex: 0 0 57.14285714%;
             flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
@@ -2195,8 +1800,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 64.28571429%;
-        -ms-flex: 0 0 64.28571429%;
             flex: 0 0 64.28571429%;
     max-width: 64.28571429%;
     width: 64.28571429%;
@@ -2206,8 +1809,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 71.42857143%;
-        -ms-flex: 0 0 71.42857143%;
             flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
@@ -2217,8 +1818,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 78.57142857%;
-        -ms-flex: 0 0 78.57142857%;
             flex: 0 0 78.57142857%;
     max-width: 78.57142857%;
     width: 78.57142857%;
@@ -2228,8 +1827,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 85.71428571%;
-        -ms-flex: 0 0 85.71428571%;
             flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
@@ -2239,8 +1836,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--13of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 92.85714286%;
-        -ms-flex: 0 0 92.85714286%;
             flex: 0 0 92.85714286%;
     max-width: 92.85714286%;
     width: 92.85714286%;
@@ -2250,8 +1845,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--14of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2261,8 +1854,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 7.69230769%;
-        -ms-flex: 0 0 7.69230769%;
             flex: 0 0 7.69230769%;
     max-width: 7.69230769%;
     width: 7.69230769%;
@@ -2272,8 +1863,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 15.38461538%;
-        -ms-flex: 0 0 15.38461538%;
             flex: 0 0 15.38461538%;
     max-width: 15.38461538%;
     width: 15.38461538%;
@@ -2283,8 +1872,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 23.07692308%;
-        -ms-flex: 0 0 23.07692308%;
             flex: 0 0 23.07692308%;
     max-width: 23.07692308%;
     width: 23.07692308%;
@@ -2294,8 +1881,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 30.76923077%;
-        -ms-flex: 0 0 30.76923077%;
             flex: 0 0 30.76923077%;
     max-width: 30.76923077%;
     width: 30.76923077%;
@@ -2305,8 +1890,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 38.46153846%;
-        -ms-flex: 0 0 38.46153846%;
             flex: 0 0 38.46153846%;
     max-width: 38.46153846%;
     width: 38.46153846%;
@@ -2316,8 +1899,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 46.15384615%;
-        -ms-flex: 0 0 46.15384615%;
             flex: 0 0 46.15384615%;
     max-width: 46.15384615%;
     width: 46.15384615%;
@@ -2327,8 +1908,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 53.84615385%;
-        -ms-flex: 0 0 53.84615385%;
             flex: 0 0 53.84615385%;
     max-width: 53.84615385%;
     width: 53.84615385%;
@@ -2338,8 +1917,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 61.53846154%;
-        -ms-flex: 0 0 61.53846154%;
             flex: 0 0 61.53846154%;
     max-width: 61.53846154%;
     width: 61.53846154%;
@@ -2349,8 +1926,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 69.23076923%;
-        -ms-flex: 0 0 69.23076923%;
             flex: 0 0 69.23076923%;
     max-width: 69.23076923%;
     width: 69.23076923%;
@@ -2360,8 +1935,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 76.92307692%;
-        -ms-flex: 0 0 76.92307692%;
             flex: 0 0 76.92307692%;
     max-width: 76.92307692%;
     width: 76.92307692%;
@@ -2371,8 +1944,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 84.61538462%;
-        -ms-flex: 0 0 84.61538462%;
             flex: 0 0 84.61538462%;
     max-width: 84.61538462%;
     width: 84.61538462%;
@@ -2382,8 +1953,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 92.30769231%;
-        -ms-flex: 0 0 92.30769231%;
             flex: 0 0 92.30769231%;
     max-width: 92.30769231%;
     width: 92.30769231%;
@@ -2393,8 +1962,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--13of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2404,8 +1971,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 8.33333333%;
-        -ms-flex: 0 0 8.33333333%;
             flex: 0 0 8.33333333%;
     max-width: 8.33333333%;
     width: 8.33333333%;
@@ -2415,8 +1980,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 16.66666667%;
-        -ms-flex: 0 0 16.66666667%;
             flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
@@ -2426,8 +1989,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -2437,8 +1998,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -2448,8 +2007,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 41.66666667%;
-        -ms-flex: 0 0 41.66666667%;
             flex: 0 0 41.66666667%;
     max-width: 41.66666667%;
     width: 41.66666667%;
@@ -2459,8 +2016,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2470,8 +2025,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 58.33333333%;
-        -ms-flex: 0 0 58.33333333%;
             flex: 0 0 58.33333333%;
     max-width: 58.33333333%;
     width: 58.33333333%;
@@ -2481,8 +2034,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -2492,8 +2043,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -2503,8 +2052,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 83.33333333%;
-        -ms-flex: 0 0 83.33333333%;
             flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
@@ -2514,8 +2061,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 91.66666667%;
-        -ms-flex: 0 0 91.66666667%;
             flex: 0 0 91.66666667%;
     max-width: 91.66666667%;
     width: 91.66666667%;
@@ -2525,8 +2070,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2536,8 +2079,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 9.09090909%;
-        -ms-flex: 0 0 9.09090909%;
             flex: 0 0 9.09090909%;
     max-width: 9.09090909%;
     width: 9.09090909%;
@@ -2547,8 +2088,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 18.18181818%;
-        -ms-flex: 0 0 18.18181818%;
             flex: 0 0 18.18181818%;
     max-width: 18.18181818%;
     width: 18.18181818%;
@@ -2558,8 +2097,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 27.27272727%;
-        -ms-flex: 0 0 27.27272727%;
             flex: 0 0 27.27272727%;
     max-width: 27.27272727%;
     width: 27.27272727%;
@@ -2569,8 +2106,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 36.36363636%;
-        -ms-flex: 0 0 36.36363636%;
             flex: 0 0 36.36363636%;
     max-width: 36.36363636%;
     width: 36.36363636%;
@@ -2580,8 +2115,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 45.45454545%;
-        -ms-flex: 0 0 45.45454545%;
             flex: 0 0 45.45454545%;
     max-width: 45.45454545%;
     width: 45.45454545%;
@@ -2591,8 +2124,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 54.54545455%;
-        -ms-flex: 0 0 54.54545455%;
             flex: 0 0 54.54545455%;
     max-width: 54.54545455%;
     width: 54.54545455%;
@@ -2602,8 +2133,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 63.63636364%;
-        -ms-flex: 0 0 63.63636364%;
             flex: 0 0 63.63636364%;
     max-width: 63.63636364%;
     width: 63.63636364%;
@@ -2613,8 +2142,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 72.72727273%;
-        -ms-flex: 0 0 72.72727273%;
             flex: 0 0 72.72727273%;
     max-width: 72.72727273%;
     width: 72.72727273%;
@@ -2624,8 +2151,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 81.81818182%;
-        -ms-flex: 0 0 81.81818182%;
             flex: 0 0 81.81818182%;
     max-width: 81.81818182%;
     width: 81.81818182%;
@@ -2635,8 +2160,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 90.90909091%;
-        -ms-flex: 0 0 90.90909091%;
             flex: 0 0 90.90909091%;
     max-width: 90.90909091%;
     width: 90.90909091%;
@@ -2646,8 +2169,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2657,8 +2178,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 10%;
-        -ms-flex: 0 0 10%;
             flex: 0 0 10%;
     max-width: 10%;
     width: 10%;
@@ -2668,8 +2187,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -2679,8 +2196,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 30%;
-        -ms-flex: 0 0 30%;
             flex: 0 0 30%;
     max-width: 30%;
     width: 30%;
@@ -2690,8 +2205,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -2701,8 +2214,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2712,8 +2223,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -2723,8 +2232,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 70%;
-        -ms-flex: 0 0 70%;
             flex: 0 0 70%;
     max-width: 70%;
     width: 70%;
@@ -2734,8 +2241,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -2745,8 +2250,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 90%;
-        -ms-flex: 0 0 90%;
             flex: 0 0 90%;
     max-width: 90%;
     width: 90%;
@@ -2756,8 +2259,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2767,8 +2268,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 11.11111111%;
-        -ms-flex: 0 0 11.11111111%;
             flex: 0 0 11.11111111%;
     max-width: 11.11111111%;
     width: 11.11111111%;
@@ -2778,8 +2277,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 22.22222222%;
-        -ms-flex: 0 0 22.22222222%;
             flex: 0 0 22.22222222%;
     max-width: 22.22222222%;
     width: 22.22222222%;
@@ -2789,8 +2286,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -2800,8 +2295,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 44.44444444%;
-        -ms-flex: 0 0 44.44444444%;
             flex: 0 0 44.44444444%;
     max-width: 44.44444444%;
     width: 44.44444444%;
@@ -2811,8 +2304,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 55.55555556%;
-        -ms-flex: 0 0 55.55555556%;
             flex: 0 0 55.55555556%;
     max-width: 55.55555556%;
     width: 55.55555556%;
@@ -2822,8 +2313,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -2833,8 +2322,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 77.77777778%;
-        -ms-flex: 0 0 77.77777778%;
             flex: 0 0 77.77777778%;
     max-width: 77.77777778%;
     width: 77.77777778%;
@@ -2844,8 +2331,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 88.88888889%;
-        -ms-flex: 0 0 88.88888889%;
             flex: 0 0 88.88888889%;
     max-width: 88.88888889%;
     width: 88.88888889%;
@@ -2855,8 +2340,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2866,8 +2349,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
@@ -2877,8 +2358,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -2888,8 +2367,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
@@ -2899,8 +2376,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2910,8 +2385,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
@@ -2921,8 +2394,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -2932,8 +2403,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
@@ -2943,8 +2412,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2954,8 +2421,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 14.28571429%;
-        -ms-flex: 0 0 14.28571429%;
             flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
@@ -2965,8 +2430,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 28.57142857%;
-        -ms-flex: 0 0 28.57142857%;
             flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
@@ -2976,8 +2439,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 42.85714286%;
-        -ms-flex: 0 0 42.85714286%;
             flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
@@ -2987,8 +2448,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 57.14285714%;
-        -ms-flex: 0 0 57.14285714%;
             flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
@@ -2998,8 +2457,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 71.42857143%;
-        -ms-flex: 0 0 71.42857143%;
             flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
@@ -3009,8 +2466,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 85.71428571%;
-        -ms-flex: 0 0 85.71428571%;
             flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
@@ -3020,8 +2475,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3031,8 +2484,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 16.66666667%;
-        -ms-flex: 0 0 16.66666667%;
             flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
@@ -3042,8 +2493,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3053,8 +2502,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3064,8 +2511,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3075,8 +2520,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 83.33333333%;
-        -ms-flex: 0 0 83.33333333%;
             flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
@@ -3086,8 +2529,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3097,8 +2538,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -3108,8 +2547,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -3119,8 +2556,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -3130,8 +2565,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -3141,8 +2574,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3152,8 +2583,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -3163,8 +2592,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3174,8 +2601,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -3185,8 +2610,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3196,8 +2619,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of3-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3207,8 +2628,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of3-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3218,8 +2637,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of3-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3229,8 +2646,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of2-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3240,8 +2655,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of2-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3251,8 +2664,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of1-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3264,8 +2675,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 14.28571429%;
-        -ms-flex: 0 0 14.28571429%;
             flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
@@ -3275,8 +2684,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 28.57142857%;
-        -ms-flex: 0 0 28.57142857%;
             flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
@@ -3286,8 +2693,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 42.85714286%;
-        -ms-flex: 0 0 42.85714286%;
             flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
@@ -3297,8 +2702,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 57.14285714%;
-        -ms-flex: 0 0 57.14285714%;
             flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
@@ -3308,8 +2711,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 71.42857143%;
-        -ms-flex: 0 0 71.42857143%;
             flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
@@ -3319,8 +2720,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 85.71428571%;
-        -ms-flex: 0 0 85.71428571%;
             flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
@@ -3330,8 +2729,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3341,8 +2738,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 16.66666667%;
-        -ms-flex: 0 0 16.66666667%;
             flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
@@ -3352,8 +2747,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3363,8 +2756,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3374,8 +2765,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3385,8 +2774,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 83.33333333%;
-        -ms-flex: 0 0 83.33333333%;
             flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
@@ -3396,8 +2783,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3407,8 +2792,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -3418,8 +2801,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -3429,8 +2810,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -3440,8 +2819,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -3451,8 +2828,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3462,8 +2837,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -3473,8 +2846,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3484,8 +2855,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -3495,8 +2864,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3506,8 +2873,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of3-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3517,8 +2882,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of3-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3528,8 +2891,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of3-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3539,8 +2900,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of2-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3550,8 +2909,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of2-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3561,8 +2918,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of1-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;

--- a/dist/grid/ds4/grid-large.css
+++ b/dist/grid/ds4/grid-large.css
@@ -13,7 +13,8 @@
  * a separate class
  */
 .grid {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-width: 1280px;
   padding-left: 0;
   padding-right: 0;
@@ -53,8 +54,15 @@
  * This class extends .grid--gutters
  */
 .grid__group {
-  align-items: flex-start;
-  box-sizing: border-box;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+      -ms-flex-align: start;
+          align-items: flex-start;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -77,12 +85,16 @@
   }
 }
 .grid__cell {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   min-height: 1px;
   padding-right: 16px;
 }
 .grid__cell--grow {
-  flex: 1 1 auto;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 1 auto;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -90,7 +102,9 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -118,47 +132,74 @@
      * commonly used fractions
      */
 .grid__cell--one-half {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -180,82 +221,130 @@
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  flex: 0 0 93.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 93.75%;
+      -ms-flex: 0 0 93.75%;
+          flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  flex: 0 0 87.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 87.5%;
+      -ms-flex: 0 0 87.5%;
+          flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  flex: 0 0 81.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 81.25%;
+      -ms-flex: 0 0 81.25%;
+          flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  flex: 0 0 68.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 68.75%;
+      -ms-flex: 0 0 68.75%;
+          flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  flex: 0 0 62.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 62.5%;
+      -ms-flex: 0 0 62.5%;
+          flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  flex: 0 0 56.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 56.25%;
+      -ms-flex: 0 0 56.25%;
+          flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  flex: 0 0 43.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 43.75%;
+      -ms-flex: 0 0 43.75%;
+          flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  flex: 0 0 37.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 37.5%;
+      -ms-flex: 0 0 37.5%;
+          flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  flex: 0 0 31.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 31.25%;
+      -ms-flex: 0 0 31.25%;
+          flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  flex: 0 0 18.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 18.75%;
+      -ms-flex: 0 0 18.75%;
+          flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  flex: 0 0 12.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 12.5%;
+      -ms-flex: 0 0 12.5%;
+          flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  flex: 0 0 6.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 6.25%;
+      -ms-flex: 0 0 6.25%;
+          flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -269,82 +358,130 @@
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    flex: 0 0 93.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 93.75%;
+        -ms-flex: 0 0 93.75%;
+            flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    flex: 0 0 81.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 81.25%;
+        -ms-flex: 0 0 81.25%;
+            flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    flex: 0 0 68.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 68.75%;
+        -ms-flex: 0 0 68.75%;
+            flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    flex: 0 0 56.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 56.25%;
+        -ms-flex: 0 0 56.25%;
+            flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    flex: 0 0 43.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 43.75%;
+        -ms-flex: 0 0 43.75%;
+            flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    flex: 0 0 31.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 31.25%;
+        -ms-flex: 0 0 31.25%;
+            flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    flex: 0 0 18.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 18.75%;
+        -ms-flex: 0 0 18.75%;
+            flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    flex: 0 0 6.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 6.25%;
+        -ms-flex: 0 0 6.25%;
+            flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }

--- a/dist/grid/ds4/grid-large.css
+++ b/dist/grid/ds4/grid-large.css
@@ -53,12 +53,8 @@
  * This class extends .grid--gutters
  */
 .grid__group {
-  -webkit-box-align: start;
-      -ms-flex-align: start;
-          align-items: flex-start;
+  align-items: flex-start;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -86,9 +82,7 @@
   padding-right: 16px;
 }
 .grid__cell--grow {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -96,8 +90,7 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -125,65 +118,47 @@
      * commonly used fractions
      */
 .grid__cell--one-half {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -205,114 +180,82 @@
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 93.75%;
-          flex: 0 0 93.75%;
+  flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 87.5%;
-          flex: 0 0 87.5%;
+  flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 81.25%;
-          flex: 0 0 81.25%;
+  flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 68.75%;
-          flex: 0 0 68.75%;
+  flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 62.5%;
-          flex: 0 0 62.5%;
+  flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 56.25%;
-          flex: 0 0 56.25%;
+  flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 43.75%;
-          flex: 0 0 43.75%;
+  flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 37.5%;
-          flex: 0 0 37.5%;
+  flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 31.25%;
-          flex: 0 0 31.25%;
+  flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 18.75%;
-          flex: 0 0 18.75%;
+  flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 12.5%;
-          flex: 0 0 12.5%;
+  flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 6.25%;
-          flex: 0 0 6.25%;
+  flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -326,114 +269,82 @@
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 93.75%;
-            flex: 0 0 93.75%;
+    flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 81.25%;
-            flex: 0 0 81.25%;
+    flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 68.75%;
-            flex: 0 0 68.75%;
+    flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 56.25%;
-            flex: 0 0 56.25%;
+    flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 43.75%;
-            flex: 0 0 43.75%;
+    flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 31.25%;
-            flex: 0 0 31.25%;
+    flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 18.75%;
-            flex: 0 0 18.75%;
+    flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 6.25%;
-            flex: 0 0 6.25%;
+    flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }

--- a/dist/grid/ds4/grid-large.css
+++ b/dist/grid/ds4/grid-large.css
@@ -55,14 +55,10 @@
  */
 .grid__group {
   -webkit-box-align: start;
-  -webkit-align-items: flex-start;
-      -ms-flex-align: start;
           align-items: flex-start;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -92,8 +88,6 @@
 }
 .grid__cell--grow {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
           flex: 1 1 auto;
 }
 /**
@@ -102,9 +96,7 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -133,72 +125,54 @@
      */
 .grid__cell--one-half {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -222,128 +196,96 @@
  */
 .grid__cell--16of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 93.75%;
-      -ms-flex: 0 0 93.75%;
           flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 87.5%;
-      -ms-flex: 0 0 87.5%;
           flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 81.25%;
-      -ms-flex: 0 0 81.25%;
           flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 68.75%;
-      -ms-flex: 0 0 68.75%;
           flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 62.5%;
-      -ms-flex: 0 0 62.5%;
           flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 56.25%;
-      -ms-flex: 0 0 56.25%;
           flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 43.75%;
-      -ms-flex: 0 0 43.75%;
           flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 37.5%;
-      -ms-flex: 0 0 37.5%;
           flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 31.25%;
-      -ms-flex: 0 0 31.25%;
           flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 18.75%;
-      -ms-flex: 0 0 18.75%;
           flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 12.5%;
-      -ms-flex: 0 0 12.5%;
           flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 6.25%;
-      -ms-flex: 0 0 6.25%;
           flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
@@ -359,128 +301,96 @@
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 93.75%;
-        -ms-flex: 0 0 93.75%;
             flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 81.25%;
-        -ms-flex: 0 0 81.25%;
             flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 68.75%;
-        -ms-flex: 0 0 68.75%;
             flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 56.25%;
-        -ms-flex: 0 0 56.25%;
             flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 43.75%;
-        -ms-flex: 0 0 43.75%;
             flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 31.25%;
-        -ms-flex: 0 0 31.25%;
             flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 18.75%;
-        -ms-flex: 0 0 18.75%;
             flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 6.25%;
-        -ms-flex: 0 0 6.25%;
             flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;

--- a/dist/grid/ds4/grid-small.css
+++ b/dist/grid/ds4/grid-small.css
@@ -55,14 +55,10 @@
  */
 .grid__group {
   -webkit-box-align: start;
-  -webkit-align-items: flex-start;
-      -ms-flex-align: start;
           align-items: flex-start;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -92,8 +88,6 @@
 }
 .grid__cell--grow {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
           flex: 1 1 auto;
 }
 /**
@@ -102,9 +96,7 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -133,72 +125,54 @@
      */
 .grid__cell--one-half {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -222,64 +196,48 @@
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;

--- a/dist/grid/ds4/grid-small.css
+++ b/dist/grid/ds4/grid-small.css
@@ -13,7 +13,8 @@
  * a separate class
  */
 .grid {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-width: 1280px;
   padding-left: 0;
   padding-right: 0;
@@ -53,8 +54,15 @@
  * This class extends .grid--gutters
  */
 .grid__group {
-  align-items: flex-start;
-  box-sizing: border-box;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+      -ms-flex-align: start;
+          align-items: flex-start;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -77,12 +85,16 @@
   }
 }
 .grid__cell {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   min-height: 1px;
   padding-right: 16px;
 }
 .grid__cell--grow {
-  flex: 1 1 auto;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 1 auto;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -90,7 +102,9 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -118,47 +132,74 @@
      * commonly used fractions
      */
 .grid__cell--one-half {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -180,42 +221,66 @@
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }

--- a/dist/grid/ds4/grid-small.css
+++ b/dist/grid/ds4/grid-small.css
@@ -53,12 +53,8 @@
  * This class extends .grid--gutters
  */
 .grid__group {
-  -webkit-box-align: start;
-      -ms-flex-align: start;
-          align-items: flex-start;
+  align-items: flex-start;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -86,9 +82,7 @@
   padding-right: 16px;
 }
 .grid__cell--grow {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -96,8 +90,7 @@
  * screen gets smaller
  */
 .grid__group--wrap {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -125,65 +118,47 @@
      * commonly used fractions
      */
 .grid__cell--one-half {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -205,58 +180,42 @@
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }

--- a/dist/label/ds6/label.css
+++ b/dist/label/ds6/label.css
@@ -30,6 +30,7 @@ label.floating-label__label--disabled {
   color: #ebebeb;
 }
 label.floating-label__label--animate {
+  -webkit-transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
   transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
   transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
   transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);

--- a/dist/listbox/ds4/listbox.css
+++ b/dist/listbox/ds4/listbox.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/listbox/ds4/listbox.css
+++ b/dist/listbox/ds4/listbox.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/listbox/ds4/listbox.css
+++ b/dist/listbox/ds4/listbox.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/listbox/ds6/listbox.css
+++ b/dist/listbox/ds6/listbox.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -194,12 +186,8 @@ button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,

--- a/dist/listbox/ds6/listbox.css
+++ b/dist/listbox/ds6/listbox.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -187,12 +180,8 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,

--- a/dist/listbox/ds6/listbox.css
+++ b/dist/listbox/ds6/listbox.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -180,8 +193,14 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -90,8 +90,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -115,8 +113,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -144,9 +140,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -162,9 +156,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -194,12 +186,8 @@ button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -86,8 +86,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -110,9 +108,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -139,9 +135,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -157,8 +151,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -187,12 +180,8 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -55,8 +55,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -85,7 +87,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -108,7 +114,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -135,7 +144,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -151,7 +162,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -180,8 +193,14 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,

--- a/dist/notice/ds4/notice.css
+++ b/dist/notice/ds4/notice.css
@@ -1,7 +1,5 @@
 .page-notice {
   -webkit-box-align: stretch;
-  -webkit-align-items: stretch;
-      -ms-flex-align: stretch;
           align-items: stretch;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
@@ -9,21 +7,15 @@
 div[role="region"].page-notice,
 section.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -34,8 +26,6 @@ span[role="region"].page-notice {
 }
 .page-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   width: 100%;
   /* stylelint-disable */
@@ -78,8 +68,6 @@ button.page-notice__close span {
 a.page-notice,
 button.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -88,15 +76,11 @@ a.page-notice {
 }
 div.inline-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -116,15 +100,11 @@ span.inline-notice {
 }
 .flyout-notice__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .flyout-notice__content p {
@@ -134,9 +114,7 @@ span.inline-notice {
   margin-top: 4px;
 }
 button.flyout-notice__close {
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -185,7 +163,6 @@ button.flyout-notice__close span {
   z-index: 0;
   top: -7px;
   background-color: #ccc;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -195,7 +172,6 @@ button.flyout-notice__close span {
 }
 .flyout-notice__pointer--top {
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
   background-color: #ccc;
 }
@@ -219,7 +195,6 @@ button.flyout-notice__close span {
   top: auto;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
@@ -233,7 +208,6 @@ button.flyout-notice__close span {
 }
 .flyout-notice__pointer--left {
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
@@ -241,7 +215,6 @@ button.flyout-notice__close span {
 }
 .flyout-notice__pointer--right {
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -288,9 +261,7 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {

--- a/dist/notice/ds4/notice.css
+++ b/dist/notice/ds4/notice.css
@@ -1,16 +1,29 @@
 .page-notice {
-  align-items: stretch;
-  box-sizing: border-box;
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -20,7 +33,10 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -61,6 +77,9 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -68,10 +87,16 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -79,7 +104,8 @@ span.inline-notice {
   max-width: 344px;
   min-width: 320px;
   z-index: 1;
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
   position: absolute;
 }
 .flyout-notice__mask {
@@ -89,11 +115,17 @@ span.inline-notice {
   border-top: 2px solid #ccc;
 }
 .flyout-notice__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -102,7 +134,9 @@ span.inline-notice {
   margin-top: 4px;
 }
 button.flyout-notice__close {
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -151,6 +185,7 @@ button.flyout-notice__close span {
   z-index: 0;
   top: -7px;
   background-color: #ccc;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -160,6 +195,7 @@ button.flyout-notice__close span {
 }
 .flyout-notice__pointer--top {
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
   background-color: #ccc;
 }
@@ -173,36 +209,44 @@ button.flyout-notice__close span {
   background-color: white;
   bottom: -7px;
   top: auto;
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   left: 12px;
 }
 .flyout-notice__pointer--bottom {
   background-color: white;
   bottom: -7px;
   top: auto;
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
   background-color: white;
   bottom: -7px;
   top: auto;
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   left: auto;
   right: 12px;
 }
 .flyout-notice__pointer--left {
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
 }
 .flyout-notice__pointer--right {
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
 }
 @media (min-width: 601px) {
   .flyout-notice {
@@ -244,7 +288,9 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {

--- a/dist/notice/ds4/notice.css
+++ b/dist/notice/ds4/notice.css
@@ -1,24 +1,16 @@
 .page-notice {
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+  align-items: stretch;
   box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -28,9 +20,7 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -71,8 +61,6 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -80,14 +68,10 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -105,15 +89,11 @@ span.inline-notice {
   border-top: 2px solid #ccc;
 }
 .flyout-notice__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -122,8 +102,7 @@ span.inline-notice {
   margin-top: 4px;
 }
 button.flyout-notice__close {
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -265,9 +244,7 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {

--- a/dist/notice/ds6/notice.css
+++ b/dist/notice/ds6/notice.css
@@ -1,7 +1,5 @@
 .page-notice {
   -webkit-box-align: stretch;
-  -webkit-align-items: stretch;
-      -ms-flex-align: stretch;
           align-items: stretch;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
@@ -9,21 +7,15 @@
 div[role="region"].page-notice,
 section.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -34,8 +26,6 @@ span[role="region"].page-notice {
 }
 .page-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   width: 100%;
   /* stylelint-disable */
@@ -78,8 +68,6 @@ button.page-notice__close span {
 a.page-notice,
 button.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -88,15 +76,11 @@ a.page-notice {
 }
 div.inline-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -115,15 +99,11 @@ span.inline-notice {
 }
 .flyout-notice__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .flyout-notice__content p {
@@ -133,9 +113,7 @@ span.inline-notice {
   margin-top: 4px;
 }
 button.flyout-notice__close {
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -170,7 +148,6 @@ button.flyout-notice__close:hover {
   background-color: white;
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -185,7 +162,6 @@ button.flyout-notice__close:hover {
   background-color: white;
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
@@ -210,7 +186,6 @@ button.flyout-notice__close:hover {
   top: auto;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
@@ -224,7 +199,6 @@ button.flyout-notice__close:hover {
 }
 .flyout-notice__pointer--left {
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
@@ -232,7 +206,6 @@ button.flyout-notice__close:hover {
 }
 .flyout-notice__pointer--right {
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -277,8 +250,6 @@ button.flyout-notice__close:hover {
 }
 .page-notice__status {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   color: #fff;
   padding: 12px 16px 12px 12px;
@@ -303,9 +274,7 @@ span.page-notice__cta {
 }
 span.page-notice__cta,
 svg.page-notice__cta {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   margin: 0 16px;
 }
 .page-notice__status span {

--- a/dist/notice/ds6/notice.css
+++ b/dist/notice/ds6/notice.css
@@ -1,16 +1,29 @@
 .page-notice {
-  align-items: stretch;
-  box-sizing: border-box;
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -20,7 +33,10 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -61,6 +77,9 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -68,10 +87,16 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -79,7 +104,8 @@ span.inline-notice {
   max-width: 344px;
   min-width: 320px;
   z-index: 1;
-  box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
   position: absolute;
 }
 .flyout-notice__mask {
@@ -88,11 +114,17 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -101,7 +133,9 @@ span.inline-notice {
   margin-top: 4px;
 }
 button.flyout-notice__close {
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -134,25 +168,31 @@ button.flyout-notice__close:hover {
   z-index: 0;
   top: -7px;
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
   top: -7px;
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   left: 12px;
 }
 .flyout-notice__pointer--top {
   top: -7px;
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
   top: -7px;
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   left: auto;
   right: 12px;
 }
@@ -160,36 +200,44 @@ button.flyout-notice__close:hover {
   background-color: white;
   bottom: -7px;
   top: auto;
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   left: 12px;
 }
 .flyout-notice__pointer--bottom {
   background-color: white;
   bottom: -7px;
   top: auto;
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
   background-color: white;
   bottom: -7px;
   top: auto;
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   left: auto;
   right: 12px;
 }
 .flyout-notice__pointer--left {
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
 }
 .flyout-notice__pointer--right {
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
 }
 @media (min-width: 601px) {
   .flyout-notice {
@@ -228,7 +276,10 @@ button.flyout-notice__close:hover {
   background-color: #3665f3;
 }
 .page-notice__status {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #fff;
   padding: 12px 16px 12px 12px;
 }
@@ -252,7 +303,9 @@ span.page-notice__cta {
 }
 span.page-notice__cta,
 svg.page-notice__cta {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   margin: 0 16px;
 }
 .page-notice__status span {

--- a/dist/notice/ds6/notice.css
+++ b/dist/notice/ds6/notice.css
@@ -1,24 +1,16 @@
 .page-notice {
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+  align-items: stretch;
   box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -28,9 +20,7 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -71,8 +61,6 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -80,14 +68,10 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -104,15 +88,11 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -121,8 +101,7 @@ span.inline-notice {
   margin-top: 4px;
 }
 button.flyout-notice__close {
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -249,9 +228,7 @@ button.flyout-notice__close:hover {
   background-color: #3665f3;
 }
 .page-notice__status {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   color: #fff;
   padding: 12px 16px 12px 12px;
 }
@@ -275,9 +252,7 @@ span.page-notice__cta {
 }
 span.page-notice__cta,
 svg.page-notice__cta {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   margin: 0 16px;
 }
 .page-notice__status span {

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -1,11 +1,16 @@
 .pagination {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -50,15 +55,27 @@
   vertical-align: middle;
 }
 .pagination--fluid {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  flex: 1 0 48px;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 0 48px;
+      -ms-flex: 1 0 48px;
+          flex: 1 0 48px;
 }
 .pagination {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -1,14 +1,11 @@
 .pagination {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -53,23 +50,15 @@
   vertical-align: middle;
 }
 .pagination--fluid {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
 }
 .pagination--fluid .pagination__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 48px;
-          flex: 1 0 48px;
+  flex: 1 0 48px;
 }
 .pagination {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -1,16 +1,12 @@
 .pagination {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -56,25 +52,17 @@
 }
 .pagination--fluid {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 0 48px;
-      -ms-flex: 1 0 48px;
           flex: 1 0 48px;
 }
 .pagination {

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -1,16 +1,12 @@
 .pagination {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -56,31 +52,21 @@
 }
 .pagination--fluid {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 0 48px;
-      -ms-flex: 1 0 48px;
           flex: 1 0 48px;
 }
 .pagination {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   min-width: 376px;
 }
@@ -122,12 +108,8 @@
 .pagination__next,
 .pagination__previous {
   -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-      -ms-flex-positive: 0;
           flex-grow: 0;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   line-height: 56px;
   width: 48px;
 }
@@ -168,20 +150,14 @@
 }
 .pagination--fluid .pagination__items {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
   max-width: none;
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
   -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-      -ms-flex-positive: 0;
           flex-grow: 0;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -1,14 +1,11 @@
 .pagination {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -53,28 +50,18 @@
   vertical-align: middle;
 }
 .pagination--fluid {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
 }
 .pagination--fluid .pagination__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 48px;
-          flex: 1 0 48px;
+  flex: 1 0 48px;
 }
 .pagination {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   min-width: 376px;
 }
 .pagination a,
@@ -113,11 +100,8 @@
 }
 .pagination__next,
 .pagination__previous {
-  -webkit-box-flex: 0;
-      -ms-flex-positive: 0;
-          flex-grow: 0;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-grow: 0;
+  flex-shrink: 0;
   line-height: 56px;
   width: 48px;
 }
@@ -157,18 +141,13 @@
   width: 100%;
 }
 .pagination--fluid .pagination__items {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
   max-width: none;
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
-  -webkit-box-flex: 0;
-      -ms-flex-positive: 0;
-          flex-grow: 0;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-grow: 0;
+  flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -1,11 +1,16 @@
 .pagination {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -50,18 +55,33 @@
   vertical-align: middle;
 }
 .pagination--fluid {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  flex: 1 0 48px;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 0 48px;
+      -ms-flex: 1 0 48px;
+          flex: 1 0 48px;
 }
 .pagination {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   min-width: 376px;
 }
 .pagination a,
@@ -78,7 +98,8 @@
   width: 56px;
 }
 .pagination__item {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-size: 0.875rem;
   font-weight: 700;
   line-height: 48px;
@@ -100,8 +121,13 @@
 }
 .pagination__next,
 .pagination__previous {
-  flex-grow: 0;
-  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   line-height: 56px;
   width: 48px;
 }
@@ -141,13 +167,21 @@
   width: 100%;
 }
 .pagination--fluid .pagination__items {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
   max-width: none;
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
-  flex-grow: 0;
-  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {

--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -1,23 +1,17 @@
 .radio {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {

--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -1,14 +1,23 @@
 .radio {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {

--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -1,20 +1,14 @@
 .radio {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -1,23 +1,17 @@
 .radio {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -1,14 +1,23 @@
 .radio {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -1,20 +1,14 @@
 .radio {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -80,7 +80,6 @@ span.select__icon {
   height: 5.2px;
   width: 9px;
   background-size: 9px 5.2px;
-  top: -webkit-calc(50% - 2.6px);
   top: calc(50% - 2.6px);
 }
 @media screen and (-ms-high-contrast: white-on-black) {

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -80,6 +80,7 @@ span.select__icon {
   height: 5.2px;
   width: 9px;
   background-size: 9px 5.2px;
+  top: -webkit-calc(50% - 2.6px);
   top: calc(50% - 2.6px);
 }
 @media screen and (-ms-high-contrast: white-on-black) {

--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -7,20 +7,14 @@
 }
 div.switch {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;

--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -1,17 +1,26 @@
 .switch {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   height: 40px;
   position: relative;
   vertical-align: middle;
 }
 div.switch {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -19,6 +28,7 @@ span.switch__button {
   height: 24px;
   position: relative;
   text-indent: 100%;
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 40px;
 }
@@ -33,6 +43,7 @@ span.switch__button::after {
   top: 4px;
   -webkit-transform: translate3d(0, 0, 0);
           transform: translate3d(0, 0, 0);
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 16px;
 }

--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -5,19 +5,13 @@
   vertical-align: middle;
 }
 div.switch {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -7,20 +7,14 @@
 }
 div.switch {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -1,17 +1,26 @@
 .switch {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   height: 40px;
   position: relative;
   vertical-align: middle;
 }
 div.switch {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -19,6 +28,7 @@ span.switch__button {
   height: 24px;
   position: relative;
   text-indent: 100%;
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 40px;
 }
@@ -33,6 +43,7 @@ span.switch__button::after {
   top: 4px;
   -webkit-transform: translate3d(0, 0, 0);
           transform: translate3d(0, 0, 0);
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 16px;
 }

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -5,19 +5,13 @@
   vertical-align: middle;
 }
 div.switch {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;

--- a/dist/tab/ds4/tab.css
+++ b/dist/tab/ds4/tab.css
@@ -4,13 +4,8 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -20,32 +15,20 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   font-size: 14px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;

--- a/dist/tab/ds4/tab.css
+++ b/dist/tab/ds4/tab.css
@@ -4,8 +4,15 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+          flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -15,20 +22,39 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;

--- a/dist/tab/ds4/tab.css
+++ b/dist/tab/ds4/tab.css
@@ -5,13 +5,9 @@ span.fake-tabs {
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
           flex-direction: row;
   list-style: none;
   margin: 0;
@@ -23,19 +19,13 @@ div.tabs__item[role="tab"] {
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-bottom: 2px solid transparent;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   margin: 0 2px;
   min-height: 40px;
@@ -43,17 +33,11 @@ li.fake-tabs__item {
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   font-size: 14px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 8px 16px;
   text-align: center;

--- a/dist/tab/ds6/tab.css
+++ b/dist/tab/ds6/tab.css
@@ -4,13 +4,8 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -20,32 +15,20 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   font-size: 14px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;

--- a/dist/tab/ds6/tab.css
+++ b/dist/tab/ds6/tab.css
@@ -4,8 +4,15 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+          flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -15,20 +22,39 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;

--- a/dist/tab/ds6/tab.css
+++ b/dist/tab/ds6/tab.css
@@ -5,13 +5,9 @@ span.fake-tabs {
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
           flex-direction: row;
   list-style: none;
   margin: 0;
@@ -23,19 +19,13 @@ div.tabs__item[role="tab"] {
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-bottom: 2px solid transparent;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   margin: 0 2px;
   min-height: 40px;
@@ -43,17 +33,11 @@ li.fake-tabs__item {
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   font-size: 14px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 8px 16px;
   text-align: center;

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -10,7 +10,8 @@ textarea.textbox__control {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 0;
   padding: 0 16px 0 16px;
 }
@@ -55,6 +56,9 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -63,7 +67,9 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -57,8 +57,6 @@ textarea.textbox__control {
 span.textbox__icon,
 .textbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -67,9 +65,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -55,8 +55,6 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -65,9 +63,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -10,7 +10,8 @@ textarea.textbox__control {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 0;
   padding: 0 16px 0 16px;
 }
@@ -55,6 +56,9 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -63,7 +67,9 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,
@@ -101,7 +107,8 @@ textarea.textbox__control {
   background: #fff;
   border-color: #6e6e6e;
   border-radius: 0;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   color: #111820;
   font-family: inherit;
   font-size: 0.875rem;
@@ -133,6 +140,9 @@ input.textbox__control--underline {
 input.textbox__control--underline::-webkit-input-placeholder {
   color: transparent;
 }
+input.textbox__control--underline::-moz-placeholder {
+  color: transparent;
+}
 input.textbox__control--underline:-ms-input-placeholder {
   color: transparent;
 }
@@ -145,6 +155,9 @@ input.textbox__control--underline::placeholder {
 input.textbox__control--underline:focus::-webkit-input-placeholder {
   color: #6e6e6e;
 }
+input.textbox__control--underline:focus::-moz-placeholder {
+  color: #6e6e6e;
+}
 input.textbox__control--underline:focus:-ms-input-placeholder {
   color: #6e6e6e;
 }
@@ -155,6 +168,9 @@ input.textbox__control--underline:focus::placeholder {
   color: #6e6e6e;
 }
 input.textbox__control--underline[disabled]::-webkit-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-moz-placeholder {
   color: transparent;
 }
 input.textbox__control--underline[disabled]:-ms-input-placeholder {

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -55,8 +55,6 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -65,9 +63,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,
@@ -140,6 +136,9 @@ input.textbox__control--underline::-webkit-input-placeholder {
 input.textbox__control--underline:-ms-input-placeholder {
   color: transparent;
 }
+input.textbox__control--underline::-ms-input-placeholder {
+  color: transparent;
+}
 input.textbox__control--underline::placeholder {
   color: transparent;
 }
@@ -149,6 +148,9 @@ input.textbox__control--underline:focus::-webkit-input-placeholder {
 input.textbox__control--underline:focus:-ms-input-placeholder {
   color: #6e6e6e;
 }
+input.textbox__control--underline:focus::-ms-input-placeholder {
+  color: #6e6e6e;
+}
 input.textbox__control--underline:focus::placeholder {
   color: #6e6e6e;
 }
@@ -156,6 +158,9 @@ input.textbox__control--underline[disabled]::-webkit-input-placeholder {
   color: transparent;
 }
 input.textbox__control--underline[disabled]:-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-ms-input-placeholder {
   color: transparent;
 }
 input.textbox__control--underline[disabled]::placeholder {

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -57,8 +57,6 @@ textarea.textbox__control {
 span.textbox__icon,
 .textbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -67,9 +65,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/dist/tooltip/ds4/tooltip.css
+++ b/dist/tooltip/ds4/tooltip.css
@@ -1,7 +1,8 @@
 .tooltip__overlay,
 .infotip__overlay,
 .tourtip__overlay {
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -20,13 +21,19 @@
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -43,7 +50,9 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -106,6 +115,7 @@ button.tourtip__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -120,6 +130,7 @@ button.tourtip__close span {
 .tourtip__pointer--top {
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -133,7 +144,8 @@ button.tourtip__close span {
 .tooltip__pointer--bottom-left,
 .infotip__pointer--bottom-left,
 .tourtip__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -142,16 +154,19 @@ button.tourtip__close span {
 .tooltip__pointer--bottom,
 .infotip__pointer--bottom,
 .tourtip__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
 .infotip__pointer--bottom-right,
 .tourtip__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -161,15 +176,18 @@ button.tourtip__close span {
 .tooltip__pointer--left,
 .infotip__pointer--left,
 .tourtip__pointer--left {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .tooltip__pointer--left-bottom,
 .infotip__pointer--left-bottom,
 .tourtip__pointer--left-bottom {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
   bottom: 12px;
   left: -7px;
@@ -178,7 +196,8 @@ button.tourtip__close span {
 .tooltip__pointer--left-top,
 .infotip__pointer--left-top,
 .tourtip__pointer--left-top {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
   left: -7px;
   top: 12px;
@@ -186,8 +205,10 @@ button.tourtip__close span {
 .tooltip__pointer--right,
 .infotip__pointer--right,
 .tourtip__pointer--right {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -195,7 +216,8 @@ button.tourtip__close span {
 .tooltip__pointer--right-bottom,
 .infotip__pointer--right-bottom,
 .tourtip__pointer--right-bottom {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
   bottom: 12px;
   left: auto;
@@ -205,7 +227,8 @@ button.tourtip__close span {
 .tooltip__pointer--right-top,
 .infotip__pointer--right-top,
 .tourtip__pointer--right-top {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
   left: auto;
   right: -7px;

--- a/dist/tooltip/ds4/tooltip.css
+++ b/dist/tooltip/ds4/tooltip.css
@@ -20,17 +20,13 @@
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -47,8 +43,7 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;

--- a/dist/tooltip/ds4/tooltip.css
+++ b/dist/tooltip/ds4/tooltip.css
@@ -22,8 +22,6 @@
 .infotip__cell,
 .tourtip__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
@@ -31,8 +29,6 @@
 .infotip__content,
 .tourtip__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .tooltip__content p,
@@ -50,9 +46,7 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -115,7 +109,6 @@ button.tourtip__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -130,7 +123,6 @@ button.tourtip__close span {
 .tourtip__pointer--top {
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -159,7 +151,6 @@ button.tourtip__close span {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
@@ -179,7 +170,6 @@ button.tourtip__close span {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -208,7 +198,6 @@ button.tourtip__close span {
   -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
           box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -1,7 +1,8 @@
 .tooltip__overlay,
 .infotip__overlay,
 .tourtip__overlay {
-  box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -19,13 +20,19 @@
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -44,7 +51,9 @@ button.tourtip__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -80,15 +89,18 @@ button.tourtip__close:hover {
   width: 16px;
   z-index: 0;
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
 .infotip__pointer--top-left,
 .tourtip__pointer--top-left {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
   left: 12px;
 }
@@ -96,15 +108,18 @@ button.tourtip__close:hover {
 .infotip__pointer--top,
 .tourtip__pointer--top {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
 .infotip__pointer--top-right,
 .tourtip__pointer--top-right {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
   left: auto;
   right: 12px;
@@ -112,7 +127,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--bottom-left,
 .infotip__pointer--bottom-left,
 .tourtip__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -121,16 +137,19 @@ button.tourtip__close:hover {
 .tooltip__pointer--bottom,
 .infotip__pointer--bottom,
 .tourtip__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
 .infotip__pointer--bottom-right,
 .tourtip__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -140,15 +159,18 @@ button.tourtip__close:hover {
 .tooltip__pointer--left,
 .infotip__pointer--left,
 .tourtip__pointer--left {
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .tooltip__pointer--left-bottom,
 .infotip__pointer--left-bottom,
 .tourtip__pointer--left-bottom {
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: 12px;
   left: -7px;
@@ -157,7 +179,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--left-top,
 .infotip__pointer--left-top,
 .tourtip__pointer--left-top {
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   left: -7px;
   top: 12px;
@@ -165,8 +188,10 @@ button.tourtip__close:hover {
 .tooltip__pointer--right,
 .infotip__pointer--right,
 .tourtip__pointer--right {
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -174,7 +199,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--right-bottom,
 .infotip__pointer--right-bottom,
 .tourtip__pointer--right-bottom {
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: 12px;
   left: auto;
@@ -184,7 +210,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--right-top,
 .infotip__pointer--right-top,
 .tourtip__pointer--right-top {
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   left: auto;
   right: -7px;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -19,17 +19,13 @@
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -48,8 +44,7 @@ button.tourtip__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -21,8 +21,6 @@
 .infotip__cell,
 .tourtip__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
@@ -30,8 +28,6 @@
 .infotip__content,
 .tourtip__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .tooltip__content p,
@@ -51,9 +47,7 @@ button.tourtip__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -92,7 +86,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -111,7 +104,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -142,7 +134,6 @@ button.tourtip__close:hover {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
@@ -162,7 +153,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -191,7 +181,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;

--- a/docs/static/ds4/grid-full.css
+++ b/docs/static/ds4/grid-full.css
@@ -59,12 +59,8 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * This class extends .grid--gutters
  */
 .grid__group {
-  -webkit-box-align: start;
-      -ms-flex-align: start;
-          align-items: flex-start;
+  align-items: flex-start;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -92,9 +88,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   padding-right: 16px;
 }
 .grid__cell--grow {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 1 auto;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -102,8 +96,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * screen gets smaller
  */
 .grid__group--wrap {
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -131,65 +124,47 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
      * commonly used fractions
      */
 .grid__cell--one-half {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -211,114 +186,82 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 93.75%;
-          flex: 0 0 93.75%;
+  flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 87.5%;
-          flex: 0 0 87.5%;
+  flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 81.25%;
-          flex: 0 0 81.25%;
+  flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 68.75%;
-          flex: 0 0 68.75%;
+  flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 62.5%;
-          flex: 0 0 62.5%;
+  flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 56.25%;
-          flex: 0 0 56.25%;
+  flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 43.75%;
-          flex: 0 0 43.75%;
+  flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 37.5%;
-          flex: 0 0 37.5%;
+  flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 31.25%;
-          flex: 0 0 31.25%;
+  flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 18.75%;
-          flex: 0 0 18.75%;
+  flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 12.5%;
-          flex: 0 0 12.5%;
+  flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 6.25%;
-          flex: 0 0 6.25%;
+  flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -332,114 +275,82 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 93.75%;
-            flex: 0 0 93.75%;
+    flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 81.25%;
-            flex: 0 0 81.25%;
+    flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 68.75%;
-            flex: 0 0 68.75%;
+    flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 56.25%;
-            flex: 0 0 56.25%;
+    flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 43.75%;
-            flex: 0 0 43.75%;
+    flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 31.25%;
-            flex: 0 0 31.25%;
+    flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 18.75%;
-            flex: 0 0 18.75%;
+    flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 6.25%;
-            flex: 0 0 6.25%;
+    flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }
@@ -452,58 +363,42 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -546,10 +441,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * HIGHLY EXPERIMENTAL
  */
 .grid__group--top-to-bottom {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   width: auto;
 }
 .grid__group--top-to-bottom .grid__cell {
@@ -562,9 +454,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 6.66666667%;
-          flex: 0 0 6.66666667%;
+  flex: 0 0 6.66666667%;
   max-width: 6.66666667%;
   width: 6.66666667%;
 }
@@ -572,9 +462,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 13.33333333%;
-          flex: 0 0 13.33333333%;
+  flex: 0 0 13.33333333%;
   max-width: 13.33333333%;
   width: 13.33333333%;
 }
@@ -582,9 +470,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -592,9 +478,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 26.66666667%;
-          flex: 0 0 26.66666667%;
+  flex: 0 0 26.66666667%;
   max-width: 26.66666667%;
   width: 26.66666667%;
 }
@@ -602,9 +486,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -612,9 +494,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -622,9 +502,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 46.66666667%;
-          flex: 0 0 46.66666667%;
+  flex: 0 0 46.66666667%;
   max-width: 46.66666667%;
   width: 46.66666667%;
 }
@@ -632,9 +510,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 53.33333333%;
-          flex: 0 0 53.33333333%;
+  flex: 0 0 53.33333333%;
   max-width: 53.33333333%;
   width: 53.33333333%;
 }
@@ -642,9 +518,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -652,9 +526,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -662,9 +534,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 73.33333333%;
-          flex: 0 0 73.33333333%;
+  flex: 0 0 73.33333333%;
   max-width: 73.33333333%;
   width: 73.33333333%;
 }
@@ -672,9 +542,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -682,9 +550,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 86.66666667%;
-          flex: 0 0 86.66666667%;
+  flex: 0 0 86.66666667%;
   max-width: 86.66666667%;
   width: 86.66666667%;
 }
@@ -692,9 +558,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 93.33333333%;
-          flex: 0 0 93.33333333%;
+  flex: 0 0 93.33333333%;
   max-width: 93.33333333%;
   width: 93.33333333%;
 }
@@ -702,9 +566,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--15of15 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -712,9 +574,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 7.14285714%;
-          flex: 0 0 7.14285714%;
+  flex: 0 0 7.14285714%;
   max-width: 7.14285714%;
   width: 7.14285714%;
 }
@@ -722,9 +582,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 14.28571429%;
-          flex: 0 0 14.28571429%;
+  flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -732,9 +590,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 21.42857143%;
-          flex: 0 0 21.42857143%;
+  flex: 0 0 21.42857143%;
   max-width: 21.42857143%;
   width: 21.42857143%;
 }
@@ -742,9 +598,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 28.57142857%;
-          flex: 0 0 28.57142857%;
+  flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -752,9 +606,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 35.71428571%;
-          flex: 0 0 35.71428571%;
+  flex: 0 0 35.71428571%;
   max-width: 35.71428571%;
   width: 35.71428571%;
 }
@@ -762,9 +614,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 42.85714286%;
-          flex: 0 0 42.85714286%;
+  flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -772,9 +622,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -782,9 +630,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 57.14285714%;
-          flex: 0 0 57.14285714%;
+  flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -792,9 +638,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 64.28571429%;
-          flex: 0 0 64.28571429%;
+  flex: 0 0 64.28571429%;
   max-width: 64.28571429%;
   width: 64.28571429%;
 }
@@ -802,9 +646,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 71.42857143%;
-          flex: 0 0 71.42857143%;
+  flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -812,9 +654,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 78.57142857%;
-          flex: 0 0 78.57142857%;
+  flex: 0 0 78.57142857%;
   max-width: 78.57142857%;
   width: 78.57142857%;
 }
@@ -822,9 +662,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 85.71428571%;
-          flex: 0 0 85.71428571%;
+  flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -832,9 +670,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 92.85714286%;
-          flex: 0 0 92.85714286%;
+  flex: 0 0 92.85714286%;
   max-width: 92.85714286%;
   width: 92.85714286%;
 }
@@ -842,9 +678,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of14 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -852,9 +686,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 7.69230769%;
-          flex: 0 0 7.69230769%;
+  flex: 0 0 7.69230769%;
   max-width: 7.69230769%;
   width: 7.69230769%;
 }
@@ -862,9 +694,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 15.38461538%;
-          flex: 0 0 15.38461538%;
+  flex: 0 0 15.38461538%;
   max-width: 15.38461538%;
   width: 15.38461538%;
 }
@@ -872,9 +702,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 23.07692308%;
-          flex: 0 0 23.07692308%;
+  flex: 0 0 23.07692308%;
   max-width: 23.07692308%;
   width: 23.07692308%;
 }
@@ -882,9 +710,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 30.76923077%;
-          flex: 0 0 30.76923077%;
+  flex: 0 0 30.76923077%;
   max-width: 30.76923077%;
   width: 30.76923077%;
 }
@@ -892,9 +718,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 38.46153846%;
-          flex: 0 0 38.46153846%;
+  flex: 0 0 38.46153846%;
   max-width: 38.46153846%;
   width: 38.46153846%;
 }
@@ -902,9 +726,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 46.15384615%;
-          flex: 0 0 46.15384615%;
+  flex: 0 0 46.15384615%;
   max-width: 46.15384615%;
   width: 46.15384615%;
 }
@@ -912,9 +734,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 53.84615385%;
-          flex: 0 0 53.84615385%;
+  flex: 0 0 53.84615385%;
   max-width: 53.84615385%;
   width: 53.84615385%;
 }
@@ -922,9 +742,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 61.53846154%;
-          flex: 0 0 61.53846154%;
+  flex: 0 0 61.53846154%;
   max-width: 61.53846154%;
   width: 61.53846154%;
 }
@@ -932,9 +750,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 69.23076923%;
-          flex: 0 0 69.23076923%;
+  flex: 0 0 69.23076923%;
   max-width: 69.23076923%;
   width: 69.23076923%;
 }
@@ -942,9 +758,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 76.92307692%;
-          flex: 0 0 76.92307692%;
+  flex: 0 0 76.92307692%;
   max-width: 76.92307692%;
   width: 76.92307692%;
 }
@@ -952,9 +766,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 84.61538462%;
-          flex: 0 0 84.61538462%;
+  flex: 0 0 84.61538462%;
   max-width: 84.61538462%;
   width: 84.61538462%;
 }
@@ -962,9 +774,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 92.30769231%;
-          flex: 0 0 92.30769231%;
+  flex: 0 0 92.30769231%;
   max-width: 92.30769231%;
   width: 92.30769231%;
 }
@@ -972,9 +782,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of13 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -982,9 +790,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 8.33333333%;
-          flex: 0 0 8.33333333%;
+  flex: 0 0 8.33333333%;
   max-width: 8.33333333%;
   width: 8.33333333%;
 }
@@ -992,9 +798,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 16.66666667%;
-          flex: 0 0 16.66666667%;
+  flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -1002,9 +806,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1012,9 +814,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1022,9 +822,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 41.66666667%;
-          flex: 0 0 41.66666667%;
+  flex: 0 0 41.66666667%;
   max-width: 41.66666667%;
   width: 41.66666667%;
 }
@@ -1032,9 +830,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1042,9 +838,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 58.33333333%;
-          flex: 0 0 58.33333333%;
+  flex: 0 0 58.33333333%;
   max-width: 58.33333333%;
   width: 58.33333333%;
 }
@@ -1052,9 +846,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1062,9 +854,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1072,9 +862,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 83.33333333%;
-          flex: 0 0 83.33333333%;
+  flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -1082,9 +870,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 91.66666667%;
-          flex: 0 0 91.66666667%;
+  flex: 0 0 91.66666667%;
   max-width: 91.66666667%;
   width: 91.66666667%;
 }
@@ -1092,9 +878,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of12 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1102,9 +886,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 9.09090909%;
-          flex: 0 0 9.09090909%;
+  flex: 0 0 9.09090909%;
   max-width: 9.09090909%;
   width: 9.09090909%;
 }
@@ -1112,9 +894,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 18.18181818%;
-          flex: 0 0 18.18181818%;
+  flex: 0 0 18.18181818%;
   max-width: 18.18181818%;
   width: 18.18181818%;
 }
@@ -1122,9 +902,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 27.27272727%;
-          flex: 0 0 27.27272727%;
+  flex: 0 0 27.27272727%;
   max-width: 27.27272727%;
   width: 27.27272727%;
 }
@@ -1132,9 +910,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 36.36363636%;
-          flex: 0 0 36.36363636%;
+  flex: 0 0 36.36363636%;
   max-width: 36.36363636%;
   width: 36.36363636%;
 }
@@ -1142,9 +918,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 45.45454545%;
-          flex: 0 0 45.45454545%;
+  flex: 0 0 45.45454545%;
   max-width: 45.45454545%;
   width: 45.45454545%;
 }
@@ -1152,9 +926,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 54.54545455%;
-          flex: 0 0 54.54545455%;
+  flex: 0 0 54.54545455%;
   max-width: 54.54545455%;
   width: 54.54545455%;
 }
@@ -1162,9 +934,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 63.63636364%;
-          flex: 0 0 63.63636364%;
+  flex: 0 0 63.63636364%;
   max-width: 63.63636364%;
   width: 63.63636364%;
 }
@@ -1172,9 +942,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 72.72727273%;
-          flex: 0 0 72.72727273%;
+  flex: 0 0 72.72727273%;
   max-width: 72.72727273%;
   width: 72.72727273%;
 }
@@ -1182,9 +950,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 81.81818182%;
-          flex: 0 0 81.81818182%;
+  flex: 0 0 81.81818182%;
   max-width: 81.81818182%;
   width: 81.81818182%;
 }
@@ -1192,9 +958,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 90.90909091%;
-          flex: 0 0 90.90909091%;
+  flex: 0 0 90.90909091%;
   max-width: 90.90909091%;
   width: 90.90909091%;
 }
@@ -1202,9 +966,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of11 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1212,9 +974,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 10%;
-          flex: 0 0 10%;
+  flex: 0 0 10%;
   max-width: 10%;
   width: 10%;
 }
@@ -1222,9 +982,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -1232,9 +990,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 30%;
-          flex: 0 0 30%;
+  flex: 0 0 30%;
   max-width: 30%;
   width: 30%;
 }
@@ -1242,9 +998,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1252,9 +1006,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1262,9 +1014,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1272,9 +1022,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 70%;
-          flex: 0 0 70%;
+  flex: 0 0 70%;
   max-width: 70%;
   width: 70%;
 }
@@ -1282,9 +1030,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1292,9 +1038,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 90%;
-          flex: 0 0 90%;
+  flex: 0 0 90%;
   max-width: 90%;
   width: 90%;
 }
@@ -1302,9 +1046,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of10 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1312,9 +1054,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 11.11111111%;
-          flex: 0 0 11.11111111%;
+  flex: 0 0 11.11111111%;
   max-width: 11.11111111%;
   width: 11.11111111%;
 }
@@ -1322,9 +1062,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 22.22222222%;
-          flex: 0 0 22.22222222%;
+  flex: 0 0 22.22222222%;
   max-width: 22.22222222%;
   width: 22.22222222%;
 }
@@ -1332,9 +1070,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1342,9 +1078,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 44.44444444%;
-          flex: 0 0 44.44444444%;
+  flex: 0 0 44.44444444%;
   max-width: 44.44444444%;
   width: 44.44444444%;
 }
@@ -1352,9 +1086,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 55.55555556%;
-          flex: 0 0 55.55555556%;
+  flex: 0 0 55.55555556%;
   max-width: 55.55555556%;
   width: 55.55555556%;
 }
@@ -1362,9 +1094,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1372,9 +1102,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 77.77777778%;
-          flex: 0 0 77.77777778%;
+  flex: 0 0 77.77777778%;
   max-width: 77.77777778%;
   width: 77.77777778%;
 }
@@ -1382,9 +1110,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 88.88888889%;
-          flex: 0 0 88.88888889%;
+  flex: 0 0 88.88888889%;
   max-width: 88.88888889%;
   width: 88.88888889%;
 }
@@ -1392,9 +1118,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of9 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1402,9 +1126,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 12.5%;
-          flex: 0 0 12.5%;
+  flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
@@ -1412,9 +1134,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1422,9 +1142,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 37.5%;
-          flex: 0 0 37.5%;
+  flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
@@ -1432,9 +1150,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1442,9 +1158,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 62.5%;
-          flex: 0 0 62.5%;
+  flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
@@ -1452,9 +1166,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1462,9 +1174,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 87.5%;
-          flex: 0 0 87.5%;
+  flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
@@ -1472,9 +1182,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of8 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1482,9 +1190,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 14.28571429%;
-          flex: 0 0 14.28571429%;
+  flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -1492,9 +1198,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 28.57142857%;
-          flex: 0 0 28.57142857%;
+  flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -1502,9 +1206,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 42.85714286%;
-          flex: 0 0 42.85714286%;
+  flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -1512,9 +1214,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 57.14285714%;
-          flex: 0 0 57.14285714%;
+  flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -1522,9 +1222,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 71.42857143%;
-          flex: 0 0 71.42857143%;
+  flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -1532,9 +1230,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 85.71428571%;
-          flex: 0 0 85.71428571%;
+  flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -1542,9 +1238,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of7 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1552,9 +1246,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 16.66666667%;
-          flex: 0 0 16.66666667%;
+  flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -1562,9 +1254,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1572,9 +1262,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1582,9 +1270,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1592,9 +1278,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 83.33333333%;
-          flex: 0 0 83.33333333%;
+  flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -1602,9 +1286,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of6 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1612,9 +1294,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 20%;
-          flex: 0 0 20%;
+  flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -1622,9 +1302,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 40%;
-          flex: 0 0 40%;
+  flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1632,9 +1310,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 60%;
-          flex: 0 0 60%;
+  flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1642,9 +1318,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 80%;
-          flex: 0 0 80%;
+  flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1652,9 +1326,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of5 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1662,9 +1334,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 25%;
-          flex: 0 0 25%;
+  flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1672,9 +1342,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1682,9 +1350,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 75%;
-          flex: 0 0 75%;
+  flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1692,9 +1358,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of4 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1702,9 +1366,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of3 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 33.33333333%;
-          flex: 0 0 33.33333333%;
+  flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1712,9 +1374,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of3 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 66.66666667%;
-          flex: 0 0 66.66666667%;
+  flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1722,9 +1382,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of3 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1732,9 +1390,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of2 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 50%;
-          flex: 0 0 50%;
+  flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1742,9 +1398,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of2 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1752,9 +1406,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of1 {
-  -webkit-box-flex: 0;
-      -ms-flex: 0 0 100%;
-          flex: 0 0 100%;
+  flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1763,9 +1415,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 6.66666667%;
-            flex: 0 0 6.66666667%;
+    flex: 0 0 6.66666667%;
     max-width: 6.66666667%;
     width: 6.66666667%;
   }
@@ -1773,9 +1423,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 13.33333333%;
-            flex: 0 0 13.33333333%;
+    flex: 0 0 13.33333333%;
     max-width: 13.33333333%;
     width: 13.33333333%;
   }
@@ -1783,9 +1431,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -1793,9 +1439,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 26.66666667%;
-            flex: 0 0 26.66666667%;
+    flex: 0 0 26.66666667%;
     max-width: 26.66666667%;
     width: 26.66666667%;
   }
@@ -1803,9 +1447,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -1813,9 +1455,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -1823,9 +1463,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 46.66666667%;
-            flex: 0 0 46.66666667%;
+    flex: 0 0 46.66666667%;
     max-width: 46.66666667%;
     width: 46.66666667%;
   }
@@ -1833,9 +1471,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 53.33333333%;
-            flex: 0 0 53.33333333%;
+    flex: 0 0 53.33333333%;
     max-width: 53.33333333%;
     width: 53.33333333%;
   }
@@ -1843,9 +1479,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -1853,9 +1487,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -1863,9 +1495,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 73.33333333%;
-            flex: 0 0 73.33333333%;
+    flex: 0 0 73.33333333%;
     max-width: 73.33333333%;
     width: 73.33333333%;
   }
@@ -1873,9 +1503,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -1883,9 +1511,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 86.66666667%;
-            flex: 0 0 86.66666667%;
+    flex: 0 0 86.66666667%;
     max-width: 86.66666667%;
     width: 86.66666667%;
   }
@@ -1893,9 +1519,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 93.33333333%;
-            flex: 0 0 93.33333333%;
+    flex: 0 0 93.33333333%;
     max-width: 93.33333333%;
     width: 93.33333333%;
   }
@@ -1903,9 +1527,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--15of15-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1913,9 +1535,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 7.14285714%;
-            flex: 0 0 7.14285714%;
+    flex: 0 0 7.14285714%;
     max-width: 7.14285714%;
     width: 7.14285714%;
   }
@@ -1923,9 +1543,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 14.28571429%;
-            flex: 0 0 14.28571429%;
+    flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -1933,9 +1551,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 21.42857143%;
-            flex: 0 0 21.42857143%;
+    flex: 0 0 21.42857143%;
     max-width: 21.42857143%;
     width: 21.42857143%;
   }
@@ -1943,9 +1559,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 28.57142857%;
-            flex: 0 0 28.57142857%;
+    flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -1953,9 +1567,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 35.71428571%;
-            flex: 0 0 35.71428571%;
+    flex: 0 0 35.71428571%;
     max-width: 35.71428571%;
     width: 35.71428571%;
   }
@@ -1963,9 +1575,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 42.85714286%;
-            flex: 0 0 42.85714286%;
+    flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -1973,9 +1583,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1983,9 +1591,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 57.14285714%;
-            flex: 0 0 57.14285714%;
+    flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -1993,9 +1599,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 64.28571429%;
-            flex: 0 0 64.28571429%;
+    flex: 0 0 64.28571429%;
     max-width: 64.28571429%;
     width: 64.28571429%;
   }
@@ -2003,9 +1607,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 71.42857143%;
-            flex: 0 0 71.42857143%;
+    flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2013,9 +1615,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 78.57142857%;
-            flex: 0 0 78.57142857%;
+    flex: 0 0 78.57142857%;
     max-width: 78.57142857%;
     width: 78.57142857%;
   }
@@ -2023,9 +1623,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 85.71428571%;
-            flex: 0 0 85.71428571%;
+    flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2033,9 +1631,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 92.85714286%;
-            flex: 0 0 92.85714286%;
+    flex: 0 0 92.85714286%;
     max-width: 92.85714286%;
     width: 92.85714286%;
   }
@@ -2043,9 +1639,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of14-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2053,9 +1647,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 7.69230769%;
-            flex: 0 0 7.69230769%;
+    flex: 0 0 7.69230769%;
     max-width: 7.69230769%;
     width: 7.69230769%;
   }
@@ -2063,9 +1655,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 15.38461538%;
-            flex: 0 0 15.38461538%;
+    flex: 0 0 15.38461538%;
     max-width: 15.38461538%;
     width: 15.38461538%;
   }
@@ -2073,9 +1663,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 23.07692308%;
-            flex: 0 0 23.07692308%;
+    flex: 0 0 23.07692308%;
     max-width: 23.07692308%;
     width: 23.07692308%;
   }
@@ -2083,9 +1671,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 30.76923077%;
-            flex: 0 0 30.76923077%;
+    flex: 0 0 30.76923077%;
     max-width: 30.76923077%;
     width: 30.76923077%;
   }
@@ -2093,9 +1679,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 38.46153846%;
-            flex: 0 0 38.46153846%;
+    flex: 0 0 38.46153846%;
     max-width: 38.46153846%;
     width: 38.46153846%;
   }
@@ -2103,9 +1687,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 46.15384615%;
-            flex: 0 0 46.15384615%;
+    flex: 0 0 46.15384615%;
     max-width: 46.15384615%;
     width: 46.15384615%;
   }
@@ -2113,9 +1695,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 53.84615385%;
-            flex: 0 0 53.84615385%;
+    flex: 0 0 53.84615385%;
     max-width: 53.84615385%;
     width: 53.84615385%;
   }
@@ -2123,9 +1703,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 61.53846154%;
-            flex: 0 0 61.53846154%;
+    flex: 0 0 61.53846154%;
     max-width: 61.53846154%;
     width: 61.53846154%;
   }
@@ -2133,9 +1711,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 69.23076923%;
-            flex: 0 0 69.23076923%;
+    flex: 0 0 69.23076923%;
     max-width: 69.23076923%;
     width: 69.23076923%;
   }
@@ -2143,9 +1719,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 76.92307692%;
-            flex: 0 0 76.92307692%;
+    flex: 0 0 76.92307692%;
     max-width: 76.92307692%;
     width: 76.92307692%;
   }
@@ -2153,9 +1727,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 84.61538462%;
-            flex: 0 0 84.61538462%;
+    flex: 0 0 84.61538462%;
     max-width: 84.61538462%;
     width: 84.61538462%;
   }
@@ -2163,9 +1735,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 92.30769231%;
-            flex: 0 0 92.30769231%;
+    flex: 0 0 92.30769231%;
     max-width: 92.30769231%;
     width: 92.30769231%;
   }
@@ -2173,9 +1743,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of13-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2183,9 +1751,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 8.33333333%;
-            flex: 0 0 8.33333333%;
+    flex: 0 0 8.33333333%;
     max-width: 8.33333333%;
     width: 8.33333333%;
   }
@@ -2193,9 +1759,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 16.66666667%;
-            flex: 0 0 16.66666667%;
+    flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2203,9 +1767,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2213,9 +1775,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2223,9 +1783,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 41.66666667%;
-            flex: 0 0 41.66666667%;
+    flex: 0 0 41.66666667%;
     max-width: 41.66666667%;
     width: 41.66666667%;
   }
@@ -2233,9 +1791,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2243,9 +1799,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 58.33333333%;
-            flex: 0 0 58.33333333%;
+    flex: 0 0 58.33333333%;
     max-width: 58.33333333%;
     width: 58.33333333%;
   }
@@ -2253,9 +1807,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2263,9 +1815,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2273,9 +1823,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 83.33333333%;
-            flex: 0 0 83.33333333%;
+    flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2283,9 +1831,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 91.66666667%;
-            flex: 0 0 91.66666667%;
+    flex: 0 0 91.66666667%;
     max-width: 91.66666667%;
     width: 91.66666667%;
   }
@@ -2293,9 +1839,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of12-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2303,9 +1847,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 9.09090909%;
-            flex: 0 0 9.09090909%;
+    flex: 0 0 9.09090909%;
     max-width: 9.09090909%;
     width: 9.09090909%;
   }
@@ -2313,9 +1855,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 18.18181818%;
-            flex: 0 0 18.18181818%;
+    flex: 0 0 18.18181818%;
     max-width: 18.18181818%;
     width: 18.18181818%;
   }
@@ -2323,9 +1863,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 27.27272727%;
-            flex: 0 0 27.27272727%;
+    flex: 0 0 27.27272727%;
     max-width: 27.27272727%;
     width: 27.27272727%;
   }
@@ -2333,9 +1871,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 36.36363636%;
-            flex: 0 0 36.36363636%;
+    flex: 0 0 36.36363636%;
     max-width: 36.36363636%;
     width: 36.36363636%;
   }
@@ -2343,9 +1879,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 45.45454545%;
-            flex: 0 0 45.45454545%;
+    flex: 0 0 45.45454545%;
     max-width: 45.45454545%;
     width: 45.45454545%;
   }
@@ -2353,9 +1887,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 54.54545455%;
-            flex: 0 0 54.54545455%;
+    flex: 0 0 54.54545455%;
     max-width: 54.54545455%;
     width: 54.54545455%;
   }
@@ -2363,9 +1895,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 63.63636364%;
-            flex: 0 0 63.63636364%;
+    flex: 0 0 63.63636364%;
     max-width: 63.63636364%;
     width: 63.63636364%;
   }
@@ -2373,9 +1903,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 72.72727273%;
-            flex: 0 0 72.72727273%;
+    flex: 0 0 72.72727273%;
     max-width: 72.72727273%;
     width: 72.72727273%;
   }
@@ -2383,9 +1911,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 81.81818182%;
-            flex: 0 0 81.81818182%;
+    flex: 0 0 81.81818182%;
     max-width: 81.81818182%;
     width: 81.81818182%;
   }
@@ -2393,9 +1919,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 90.90909091%;
-            flex: 0 0 90.90909091%;
+    flex: 0 0 90.90909091%;
     max-width: 90.90909091%;
     width: 90.90909091%;
   }
@@ -2403,9 +1927,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of11-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2413,9 +1935,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 10%;
-            flex: 0 0 10%;
+    flex: 0 0 10%;
     max-width: 10%;
     width: 10%;
   }
@@ -2423,9 +1943,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2433,9 +1951,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 30%;
-            flex: 0 0 30%;
+    flex: 0 0 30%;
     max-width: 30%;
     width: 30%;
   }
@@ -2443,9 +1959,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2453,9 +1967,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2463,9 +1975,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2473,9 +1983,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 70%;
-            flex: 0 0 70%;
+    flex: 0 0 70%;
     max-width: 70%;
     width: 70%;
   }
@@ -2483,9 +1991,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2493,9 +1999,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 90%;
-            flex: 0 0 90%;
+    flex: 0 0 90%;
     max-width: 90%;
     width: 90%;
   }
@@ -2503,9 +2007,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of10-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2513,9 +2015,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 11.11111111%;
-            flex: 0 0 11.11111111%;
+    flex: 0 0 11.11111111%;
     max-width: 11.11111111%;
     width: 11.11111111%;
   }
@@ -2523,9 +2023,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 22.22222222%;
-            flex: 0 0 22.22222222%;
+    flex: 0 0 22.22222222%;
     max-width: 22.22222222%;
     width: 22.22222222%;
   }
@@ -2533,9 +2031,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2543,9 +2039,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 44.44444444%;
-            flex: 0 0 44.44444444%;
+    flex: 0 0 44.44444444%;
     max-width: 44.44444444%;
     width: 44.44444444%;
   }
@@ -2553,9 +2047,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 55.55555556%;
-            flex: 0 0 55.55555556%;
+    flex: 0 0 55.55555556%;
     max-width: 55.55555556%;
     width: 55.55555556%;
   }
@@ -2563,9 +2055,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2573,9 +2063,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 77.77777778%;
-            flex: 0 0 77.77777778%;
+    flex: 0 0 77.77777778%;
     max-width: 77.77777778%;
     width: 77.77777778%;
   }
@@ -2583,9 +2071,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 88.88888889%;
-            flex: 0 0 88.88888889%;
+    flex: 0 0 88.88888889%;
     max-width: 88.88888889%;
     width: 88.88888889%;
   }
@@ -2593,9 +2079,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of9-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2603,9 +2087,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 12.5%;
-            flex: 0 0 12.5%;
+    flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -2613,9 +2095,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2623,9 +2103,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 37.5%;
-            flex: 0 0 37.5%;
+    flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
@@ -2633,9 +2111,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2643,9 +2119,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 62.5%;
-            flex: 0 0 62.5%;
+    flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
@@ -2653,9 +2127,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2663,9 +2135,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 87.5%;
-            flex: 0 0 87.5%;
+    flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
@@ -2673,9 +2143,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of8-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2683,9 +2151,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 14.28571429%;
-            flex: 0 0 14.28571429%;
+    flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2693,9 +2159,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 28.57142857%;
-            flex: 0 0 28.57142857%;
+    flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2703,9 +2167,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 42.85714286%;
-            flex: 0 0 42.85714286%;
+    flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2713,9 +2175,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 57.14285714%;
-            flex: 0 0 57.14285714%;
+    flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -2723,9 +2183,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 71.42857143%;
-            flex: 0 0 71.42857143%;
+    flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2733,9 +2191,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 85.71428571%;
-            flex: 0 0 85.71428571%;
+    flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2743,9 +2199,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2753,9 +2207,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 16.66666667%;
-            flex: 0 0 16.66666667%;
+    flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2763,9 +2215,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2773,9 +2223,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2783,9 +2231,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2793,9 +2239,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 83.33333333%;
-            flex: 0 0 83.33333333%;
+    flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2803,9 +2247,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2813,9 +2255,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2823,9 +2263,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2833,9 +2271,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2843,9 +2279,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2853,9 +2287,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2863,9 +2295,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2873,9 +2303,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2883,9 +2311,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2893,9 +2319,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2903,9 +2327,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2913,9 +2335,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2923,9 +2343,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2933,9 +2351,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2943,9 +2359,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2953,9 +2367,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-lg {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2965,9 +2377,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 14.28571429%;
-            flex: 0 0 14.28571429%;
+    flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2975,9 +2385,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 28.57142857%;
-            flex: 0 0 28.57142857%;
+    flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2985,9 +2393,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 42.85714286%;
-            flex: 0 0 42.85714286%;
+    flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2995,9 +2401,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 57.14285714%;
-            flex: 0 0 57.14285714%;
+    flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -3005,9 +2409,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 71.42857143%;
-            flex: 0 0 71.42857143%;
+    flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -3015,9 +2417,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 85.71428571%;
-            flex: 0 0 85.71428571%;
+    flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -3025,9 +2425,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3035,9 +2433,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 16.66666667%;
-            flex: 0 0 16.66666667%;
+    flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -3045,9 +2441,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -3055,9 +2449,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -3065,9 +2457,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -3075,9 +2465,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 83.33333333%;
-            flex: 0 0 83.33333333%;
+    flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -3085,9 +2473,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3095,9 +2481,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 20%;
-            flex: 0 0 20%;
+    flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -3105,9 +2489,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 40%;
-            flex: 0 0 40%;
+    flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -3115,9 +2497,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 60%;
-            flex: 0 0 60%;
+    flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -3125,9 +2505,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 80%;
-            flex: 0 0 80%;
+    flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -3135,9 +2513,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3145,9 +2521,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 25%;
-            flex: 0 0 25%;
+    flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -3155,9 +2529,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -3165,9 +2537,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 75%;
-            flex: 0 0 75%;
+    flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -3175,9 +2545,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3185,9 +2553,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 33.33333333%;
-            flex: 0 0 33.33333333%;
+    flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -3195,9 +2561,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 66.66666667%;
-            flex: 0 0 66.66666667%;
+    flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -3205,9 +2569,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3215,9 +2577,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 50%;
-            flex: 0 0 50%;
+    flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -3225,9 +2585,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -3235,9 +2593,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-sm {
-    -webkit-box-flex: 0;
-        -ms-flex: 0 0 100%;
-            flex: 0 0 100%;
+    flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }

--- a/docs/static/ds4/grid-full.css
+++ b/docs/static/ds4/grid-full.css
@@ -19,7 +19,8 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * a separate class
  */
 .grid {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-width: 1280px;
   padding-left: 0;
   padding-right: 0;
@@ -59,8 +60,15 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * This class extends .grid--gutters
  */
 .grid__group {
-  align-items: flex-start;
-  box-sizing: border-box;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+      -ms-flex-align: start;
+          align-items: flex-start;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -83,12 +91,16 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   }
 }
 .grid__cell {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   min-height: 1px;
   padding-right: 16px;
 }
 .grid__cell--grow {
-  flex: 1 1 auto;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 1 auto;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
 }
 /**
  * Used to allow the content in the
@@ -96,7 +108,9 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * screen gets smaller
  */
 .grid__group--wrap {
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -124,47 +138,74 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
      * commonly used fractions
      */
 .grid__cell--one-half {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -186,82 +227,130 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * Equivalent to large
  */
 .grid__cell--16of16 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
-  flex: 0 0 93.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 93.75%;
+      -ms-flex: 0 0 93.75%;
+          flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
-  flex: 0 0 87.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 87.5%;
+      -ms-flex: 0 0 87.5%;
+          flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
-  flex: 0 0 81.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 81.25%;
+      -ms-flex: 0 0 81.25%;
+          flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
-  flex: 0 0 68.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 68.75%;
+      -ms-flex: 0 0 68.75%;
+          flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
-  flex: 0 0 62.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 62.5%;
+      -ms-flex: 0 0 62.5%;
+          flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
-  flex: 0 0 56.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 56.25%;
+      -ms-flex: 0 0 56.25%;
+          flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
-  flex: 0 0 43.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 43.75%;
+      -ms-flex: 0 0 43.75%;
+          flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
-  flex: 0 0 37.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 37.5%;
+      -ms-flex: 0 0 37.5%;
+          flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
-  flex: 0 0 31.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 31.25%;
+      -ms-flex: 0 0 31.25%;
+          flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
-  flex: 0 0 18.75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 18.75%;
+      -ms-flex: 0 0 18.75%;
+          flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
-  flex: 0 0 12.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 12.5%;
+      -ms-flex: 0 0 12.5%;
+          flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
-  flex: 0 0 6.25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 6.25%;
+      -ms-flex: 0 0 6.25%;
+          flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
 }
@@ -275,82 +364,130 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
-    flex: 0 0 93.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 93.75%;
+        -ms-flex: 0 0 93.75%;
+            flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
-    flex: 0 0 81.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 81.25%;
+        -ms-flex: 0 0 81.25%;
+            flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
-    flex: 0 0 68.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 68.75%;
+        -ms-flex: 0 0 68.75%;
+            flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
-    flex: 0 0 56.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 56.25%;
+        -ms-flex: 0 0 56.25%;
+            flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
-    flex: 0 0 43.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 43.75%;
+        -ms-flex: 0 0 43.75%;
+            flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
-    flex: 0 0 31.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 31.25%;
+        -ms-flex: 0 0 31.25%;
+            flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
-    flex: 0 0 18.75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 18.75%;
+        -ms-flex: 0 0 18.75%;
+            flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
-    flex: 0 0 6.25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 6.25%;
+        -ms-flex: 0 0 6.25%;
+            flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
   }
@@ -363,42 +500,66 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -435,13 +596,18 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   margin: 8px auto;
   position: relative;
   right: 8px;
+  width: -webkit-calc(100% - 48px);
   width: calc(100% - 48px);
 }
 /**
  * HIGHLY EXPERIMENTAL
  */
 .grid__group--top-to-bottom {
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column;
   width: auto;
 }
 .grid__group--top-to-bottom .grid__cell {
@@ -454,7 +620,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of15 {
-  flex: 0 0 6.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 6.66666667%;
+      -ms-flex: 0 0 6.66666667%;
+          flex: 0 0 6.66666667%;
   max-width: 6.66666667%;
   width: 6.66666667%;
 }
@@ -462,7 +631,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of15 {
-  flex: 0 0 13.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 13.33333333%;
+      -ms-flex: 0 0 13.33333333%;
+          flex: 0 0 13.33333333%;
   max-width: 13.33333333%;
   width: 13.33333333%;
 }
@@ -470,7 +642,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of15 {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -478,7 +653,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of15 {
-  flex: 0 0 26.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 26.66666667%;
+      -ms-flex: 0 0 26.66666667%;
+          flex: 0 0 26.66666667%;
   max-width: 26.66666667%;
   width: 26.66666667%;
 }
@@ -486,7 +664,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of15 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -494,7 +675,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of15 {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -502,7 +686,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of15 {
-  flex: 0 0 46.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 46.66666667%;
+      -ms-flex: 0 0 46.66666667%;
+          flex: 0 0 46.66666667%;
   max-width: 46.66666667%;
   width: 46.66666667%;
 }
@@ -510,7 +697,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of15 {
-  flex: 0 0 53.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 53.33333333%;
+      -ms-flex: 0 0 53.33333333%;
+          flex: 0 0 53.33333333%;
   max-width: 53.33333333%;
   width: 53.33333333%;
 }
@@ -518,7 +708,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of15 {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -526,7 +719,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of15 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -534,7 +730,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of15 {
-  flex: 0 0 73.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 73.33333333%;
+      -ms-flex: 0 0 73.33333333%;
+          flex: 0 0 73.33333333%;
   max-width: 73.33333333%;
   width: 73.33333333%;
 }
@@ -542,7 +741,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of15 {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -550,7 +752,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of15 {
-  flex: 0 0 86.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 86.66666667%;
+      -ms-flex: 0 0 86.66666667%;
+          flex: 0 0 86.66666667%;
   max-width: 86.66666667%;
   width: 86.66666667%;
 }
@@ -558,7 +763,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of15 {
-  flex: 0 0 93.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 93.33333333%;
+      -ms-flex: 0 0 93.33333333%;
+          flex: 0 0 93.33333333%;
   max-width: 93.33333333%;
   width: 93.33333333%;
 }
@@ -566,7 +774,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--15of15 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -574,7 +785,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of14 {
-  flex: 0 0 7.14285714%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 7.14285714%;
+      -ms-flex: 0 0 7.14285714%;
+          flex: 0 0 7.14285714%;
   max-width: 7.14285714%;
   width: 7.14285714%;
 }
@@ -582,7 +796,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of14 {
-  flex: 0 0 14.28571429%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 14.28571429%;
+      -ms-flex: 0 0 14.28571429%;
+          flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -590,7 +807,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of14 {
-  flex: 0 0 21.42857143%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 21.42857143%;
+      -ms-flex: 0 0 21.42857143%;
+          flex: 0 0 21.42857143%;
   max-width: 21.42857143%;
   width: 21.42857143%;
 }
@@ -598,7 +818,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of14 {
-  flex: 0 0 28.57142857%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 28.57142857%;
+      -ms-flex: 0 0 28.57142857%;
+          flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -606,7 +829,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of14 {
-  flex: 0 0 35.71428571%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 35.71428571%;
+      -ms-flex: 0 0 35.71428571%;
+          flex: 0 0 35.71428571%;
   max-width: 35.71428571%;
   width: 35.71428571%;
 }
@@ -614,7 +840,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of14 {
-  flex: 0 0 42.85714286%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 42.85714286%;
+      -ms-flex: 0 0 42.85714286%;
+          flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -622,7 +851,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of14 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -630,7 +862,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of14 {
-  flex: 0 0 57.14285714%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 57.14285714%;
+      -ms-flex: 0 0 57.14285714%;
+          flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -638,7 +873,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of14 {
-  flex: 0 0 64.28571429%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 64.28571429%;
+      -ms-flex: 0 0 64.28571429%;
+          flex: 0 0 64.28571429%;
   max-width: 64.28571429%;
   width: 64.28571429%;
 }
@@ -646,7 +884,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of14 {
-  flex: 0 0 71.42857143%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 71.42857143%;
+      -ms-flex: 0 0 71.42857143%;
+          flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -654,7 +895,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of14 {
-  flex: 0 0 78.57142857%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 78.57142857%;
+      -ms-flex: 0 0 78.57142857%;
+          flex: 0 0 78.57142857%;
   max-width: 78.57142857%;
   width: 78.57142857%;
 }
@@ -662,7 +906,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of14 {
-  flex: 0 0 85.71428571%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 85.71428571%;
+      -ms-flex: 0 0 85.71428571%;
+          flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -670,7 +917,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of14 {
-  flex: 0 0 92.85714286%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 92.85714286%;
+      -ms-flex: 0 0 92.85714286%;
+          flex: 0 0 92.85714286%;
   max-width: 92.85714286%;
   width: 92.85714286%;
 }
@@ -678,7 +928,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--14of14 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -686,7 +939,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of13 {
-  flex: 0 0 7.69230769%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 7.69230769%;
+      -ms-flex: 0 0 7.69230769%;
+          flex: 0 0 7.69230769%;
   max-width: 7.69230769%;
   width: 7.69230769%;
 }
@@ -694,7 +950,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of13 {
-  flex: 0 0 15.38461538%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 15.38461538%;
+      -ms-flex: 0 0 15.38461538%;
+          flex: 0 0 15.38461538%;
   max-width: 15.38461538%;
   width: 15.38461538%;
 }
@@ -702,7 +961,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of13 {
-  flex: 0 0 23.07692308%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 23.07692308%;
+      -ms-flex: 0 0 23.07692308%;
+          flex: 0 0 23.07692308%;
   max-width: 23.07692308%;
   width: 23.07692308%;
 }
@@ -710,7 +972,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of13 {
-  flex: 0 0 30.76923077%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 30.76923077%;
+      -ms-flex: 0 0 30.76923077%;
+          flex: 0 0 30.76923077%;
   max-width: 30.76923077%;
   width: 30.76923077%;
 }
@@ -718,7 +983,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of13 {
-  flex: 0 0 38.46153846%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 38.46153846%;
+      -ms-flex: 0 0 38.46153846%;
+          flex: 0 0 38.46153846%;
   max-width: 38.46153846%;
   width: 38.46153846%;
 }
@@ -726,7 +994,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of13 {
-  flex: 0 0 46.15384615%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 46.15384615%;
+      -ms-flex: 0 0 46.15384615%;
+          flex: 0 0 46.15384615%;
   max-width: 46.15384615%;
   width: 46.15384615%;
 }
@@ -734,7 +1005,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of13 {
-  flex: 0 0 53.84615385%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 53.84615385%;
+      -ms-flex: 0 0 53.84615385%;
+          flex: 0 0 53.84615385%;
   max-width: 53.84615385%;
   width: 53.84615385%;
 }
@@ -742,7 +1016,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of13 {
-  flex: 0 0 61.53846154%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 61.53846154%;
+      -ms-flex: 0 0 61.53846154%;
+          flex: 0 0 61.53846154%;
   max-width: 61.53846154%;
   width: 61.53846154%;
 }
@@ -750,7 +1027,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of13 {
-  flex: 0 0 69.23076923%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 69.23076923%;
+      -ms-flex: 0 0 69.23076923%;
+          flex: 0 0 69.23076923%;
   max-width: 69.23076923%;
   width: 69.23076923%;
 }
@@ -758,7 +1038,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of13 {
-  flex: 0 0 76.92307692%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 76.92307692%;
+      -ms-flex: 0 0 76.92307692%;
+          flex: 0 0 76.92307692%;
   max-width: 76.92307692%;
   width: 76.92307692%;
 }
@@ -766,7 +1049,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of13 {
-  flex: 0 0 84.61538462%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 84.61538462%;
+      -ms-flex: 0 0 84.61538462%;
+          flex: 0 0 84.61538462%;
   max-width: 84.61538462%;
   width: 84.61538462%;
 }
@@ -774,7 +1060,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of13 {
-  flex: 0 0 92.30769231%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 92.30769231%;
+      -ms-flex: 0 0 92.30769231%;
+          flex: 0 0 92.30769231%;
   max-width: 92.30769231%;
   width: 92.30769231%;
 }
@@ -782,7 +1071,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--13of13 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -790,7 +1082,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of12 {
-  flex: 0 0 8.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 8.33333333%;
+      -ms-flex: 0 0 8.33333333%;
+          flex: 0 0 8.33333333%;
   max-width: 8.33333333%;
   width: 8.33333333%;
 }
@@ -798,7 +1093,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of12 {
-  flex: 0 0 16.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 16.66666667%;
+      -ms-flex: 0 0 16.66666667%;
+          flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -806,7 +1104,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of12 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -814,7 +1115,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of12 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -822,7 +1126,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of12 {
-  flex: 0 0 41.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 41.66666667%;
+      -ms-flex: 0 0 41.66666667%;
+          flex: 0 0 41.66666667%;
   max-width: 41.66666667%;
   width: 41.66666667%;
 }
@@ -830,7 +1137,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of12 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -838,7 +1148,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of12 {
-  flex: 0 0 58.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 58.33333333%;
+      -ms-flex: 0 0 58.33333333%;
+          flex: 0 0 58.33333333%;
   max-width: 58.33333333%;
   width: 58.33333333%;
 }
@@ -846,7 +1159,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of12 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -854,7 +1170,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of12 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -862,7 +1181,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of12 {
-  flex: 0 0 83.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 83.33333333%;
+      -ms-flex: 0 0 83.33333333%;
+          flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -870,7 +1192,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of12 {
-  flex: 0 0 91.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 91.66666667%;
+      -ms-flex: 0 0 91.66666667%;
+          flex: 0 0 91.66666667%;
   max-width: 91.66666667%;
   width: 91.66666667%;
 }
@@ -878,7 +1203,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--12of12 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -886,7 +1214,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of11 {
-  flex: 0 0 9.09090909%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 9.09090909%;
+      -ms-flex: 0 0 9.09090909%;
+          flex: 0 0 9.09090909%;
   max-width: 9.09090909%;
   width: 9.09090909%;
 }
@@ -894,7 +1225,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of11 {
-  flex: 0 0 18.18181818%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 18.18181818%;
+      -ms-flex: 0 0 18.18181818%;
+          flex: 0 0 18.18181818%;
   max-width: 18.18181818%;
   width: 18.18181818%;
 }
@@ -902,7 +1236,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of11 {
-  flex: 0 0 27.27272727%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 27.27272727%;
+      -ms-flex: 0 0 27.27272727%;
+          flex: 0 0 27.27272727%;
   max-width: 27.27272727%;
   width: 27.27272727%;
 }
@@ -910,7 +1247,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of11 {
-  flex: 0 0 36.36363636%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 36.36363636%;
+      -ms-flex: 0 0 36.36363636%;
+          flex: 0 0 36.36363636%;
   max-width: 36.36363636%;
   width: 36.36363636%;
 }
@@ -918,7 +1258,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of11 {
-  flex: 0 0 45.45454545%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 45.45454545%;
+      -ms-flex: 0 0 45.45454545%;
+          flex: 0 0 45.45454545%;
   max-width: 45.45454545%;
   width: 45.45454545%;
 }
@@ -926,7 +1269,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of11 {
-  flex: 0 0 54.54545455%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 54.54545455%;
+      -ms-flex: 0 0 54.54545455%;
+          flex: 0 0 54.54545455%;
   max-width: 54.54545455%;
   width: 54.54545455%;
 }
@@ -934,7 +1280,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of11 {
-  flex: 0 0 63.63636364%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 63.63636364%;
+      -ms-flex: 0 0 63.63636364%;
+          flex: 0 0 63.63636364%;
   max-width: 63.63636364%;
   width: 63.63636364%;
 }
@@ -942,7 +1291,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of11 {
-  flex: 0 0 72.72727273%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 72.72727273%;
+      -ms-flex: 0 0 72.72727273%;
+          flex: 0 0 72.72727273%;
   max-width: 72.72727273%;
   width: 72.72727273%;
 }
@@ -950,7 +1302,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of11 {
-  flex: 0 0 81.81818182%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 81.81818182%;
+      -ms-flex: 0 0 81.81818182%;
+          flex: 0 0 81.81818182%;
   max-width: 81.81818182%;
   width: 81.81818182%;
 }
@@ -958,7 +1313,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of11 {
-  flex: 0 0 90.90909091%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 90.90909091%;
+      -ms-flex: 0 0 90.90909091%;
+          flex: 0 0 90.90909091%;
   max-width: 90.90909091%;
   width: 90.90909091%;
 }
@@ -966,7 +1324,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--11of11 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -974,7 +1335,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of10 {
-  flex: 0 0 10%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 10%;
+      -ms-flex: 0 0 10%;
+          flex: 0 0 10%;
   max-width: 10%;
   width: 10%;
 }
@@ -982,7 +1346,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of10 {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -990,7 +1357,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of10 {
-  flex: 0 0 30%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 30%;
+      -ms-flex: 0 0 30%;
+          flex: 0 0 30%;
   max-width: 30%;
   width: 30%;
 }
@@ -998,7 +1368,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of10 {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1006,7 +1379,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of10 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1014,7 +1390,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of10 {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1022,7 +1401,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of10 {
-  flex: 0 0 70%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 70%;
+      -ms-flex: 0 0 70%;
+          flex: 0 0 70%;
   max-width: 70%;
   width: 70%;
 }
@@ -1030,7 +1412,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of10 {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1038,7 +1423,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of10 {
-  flex: 0 0 90%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 90%;
+      -ms-flex: 0 0 90%;
+          flex: 0 0 90%;
   max-width: 90%;
   width: 90%;
 }
@@ -1046,7 +1434,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--10of10 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1054,7 +1445,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of9 {
-  flex: 0 0 11.11111111%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 11.11111111%;
+      -ms-flex: 0 0 11.11111111%;
+          flex: 0 0 11.11111111%;
   max-width: 11.11111111%;
   width: 11.11111111%;
 }
@@ -1062,7 +1456,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of9 {
-  flex: 0 0 22.22222222%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 22.22222222%;
+      -ms-flex: 0 0 22.22222222%;
+          flex: 0 0 22.22222222%;
   max-width: 22.22222222%;
   width: 22.22222222%;
 }
@@ -1070,7 +1467,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of9 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1078,7 +1478,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of9 {
-  flex: 0 0 44.44444444%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 44.44444444%;
+      -ms-flex: 0 0 44.44444444%;
+          flex: 0 0 44.44444444%;
   max-width: 44.44444444%;
   width: 44.44444444%;
 }
@@ -1086,7 +1489,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of9 {
-  flex: 0 0 55.55555556%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 55.55555556%;
+      -ms-flex: 0 0 55.55555556%;
+          flex: 0 0 55.55555556%;
   max-width: 55.55555556%;
   width: 55.55555556%;
 }
@@ -1094,7 +1500,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of9 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1102,7 +1511,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of9 {
-  flex: 0 0 77.77777778%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 77.77777778%;
+      -ms-flex: 0 0 77.77777778%;
+          flex: 0 0 77.77777778%;
   max-width: 77.77777778%;
   width: 77.77777778%;
 }
@@ -1110,7 +1522,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of9 {
-  flex: 0 0 88.88888889%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 88.88888889%;
+      -ms-flex: 0 0 88.88888889%;
+          flex: 0 0 88.88888889%;
   max-width: 88.88888889%;
   width: 88.88888889%;
 }
@@ -1118,7 +1533,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--9of9 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1126,7 +1544,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of8 {
-  flex: 0 0 12.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 12.5%;
+      -ms-flex: 0 0 12.5%;
+          flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
@@ -1134,7 +1555,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of8 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1142,7 +1566,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of8 {
-  flex: 0 0 37.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 37.5%;
+      -ms-flex: 0 0 37.5%;
+          flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
@@ -1150,7 +1577,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of8 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1158,7 +1588,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of8 {
-  flex: 0 0 62.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 62.5%;
+      -ms-flex: 0 0 62.5%;
+          flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
@@ -1166,7 +1599,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of8 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1174,7 +1610,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of8 {
-  flex: 0 0 87.5%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 87.5%;
+      -ms-flex: 0 0 87.5%;
+          flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
@@ -1182,7 +1621,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--8of8 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1190,7 +1632,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of7 {
-  flex: 0 0 14.28571429%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 14.28571429%;
+      -ms-flex: 0 0 14.28571429%;
+          flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
 }
@@ -1198,7 +1643,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of7 {
-  flex: 0 0 28.57142857%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 28.57142857%;
+      -ms-flex: 0 0 28.57142857%;
+          flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
 }
@@ -1206,7 +1654,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of7 {
-  flex: 0 0 42.85714286%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 42.85714286%;
+      -ms-flex: 0 0 42.85714286%;
+          flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
 }
@@ -1214,7 +1665,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of7 {
-  flex: 0 0 57.14285714%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 57.14285714%;
+      -ms-flex: 0 0 57.14285714%;
+          flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
 }
@@ -1222,7 +1676,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of7 {
-  flex: 0 0 71.42857143%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 71.42857143%;
+      -ms-flex: 0 0 71.42857143%;
+          flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
 }
@@ -1230,7 +1687,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of7 {
-  flex: 0 0 85.71428571%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 85.71428571%;
+      -ms-flex: 0 0 85.71428571%;
+          flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
 }
@@ -1238,7 +1698,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--7of7 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1246,7 +1709,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of6 {
-  flex: 0 0 16.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 16.66666667%;
+      -ms-flex: 0 0 16.66666667%;
+          flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
 }
@@ -1254,7 +1720,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of6 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1262,7 +1731,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of6 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1270,7 +1742,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of6 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1278,7 +1753,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of6 {
-  flex: 0 0 83.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 83.33333333%;
+      -ms-flex: 0 0 83.33333333%;
+          flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
 }
@@ -1286,7 +1764,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--6of6 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1294,7 +1775,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of5 {
-  flex: 0 0 20%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 20%;
+      -ms-flex: 0 0 20%;
+          flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
@@ -1302,7 +1786,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of5 {
-  flex: 0 0 40%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 40%;
+      -ms-flex: 0 0 40%;
+          flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
@@ -1310,7 +1797,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of5 {
-  flex: 0 0 60%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 60%;
+      -ms-flex: 0 0 60%;
+          flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
@@ -1318,7 +1808,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of5 {
-  flex: 0 0 80%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 80%;
+      -ms-flex: 0 0 80%;
+          flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
 }
@@ -1326,7 +1819,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--5of5 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1334,7 +1830,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of4 {
-  flex: 0 0 25%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 25%;
+      -ms-flex: 0 0 25%;
+          flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
@@ -1342,7 +1841,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of4 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1350,7 +1852,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of4 {
-  flex: 0 0 75%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 75%;
+      -ms-flex: 0 0 75%;
+          flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
@@ -1358,7 +1863,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--4of4 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1366,7 +1874,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of3 {
-  flex: 0 0 33.33333333%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 33.33333333%;
+      -ms-flex: 0 0 33.33333333%;
+          flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
@@ -1374,7 +1885,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of3 {
-  flex: 0 0 66.66666667%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 66.66666667%;
+      -ms-flex: 0 0 66.66666667%;
+          flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
@@ -1382,7 +1896,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--3of3 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1390,7 +1907,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of2 {
-  flex: 0 0 50%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 50%;
+      -ms-flex: 0 0 50%;
+          flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
@@ -1398,7 +1918,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--2of2 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1406,7 +1929,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
 .grid__cell--1of1 {
-  flex: 0 0 100%;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 100%;
+      -ms-flex: 0 0 100%;
+          flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
@@ -1415,7 +1941,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of15-lg {
-    flex: 0 0 6.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 6.66666667%;
+        -ms-flex: 0 0 6.66666667%;
+            flex: 0 0 6.66666667%;
     max-width: 6.66666667%;
     width: 6.66666667%;
   }
@@ -1423,7 +1952,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of15-lg {
-    flex: 0 0 13.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 13.33333333%;
+        -ms-flex: 0 0 13.33333333%;
+            flex: 0 0 13.33333333%;
     max-width: 13.33333333%;
     width: 13.33333333%;
   }
@@ -1431,7 +1963,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of15-lg {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -1439,7 +1974,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of15-lg {
-    flex: 0 0 26.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 26.66666667%;
+        -ms-flex: 0 0 26.66666667%;
+            flex: 0 0 26.66666667%;
     max-width: 26.66666667%;
     width: 26.66666667%;
   }
@@ -1447,7 +1985,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of15-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -1455,7 +1996,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of15-lg {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -1463,7 +2007,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of15-lg {
-    flex: 0 0 46.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 46.66666667%;
+        -ms-flex: 0 0 46.66666667%;
+            flex: 0 0 46.66666667%;
     max-width: 46.66666667%;
     width: 46.66666667%;
   }
@@ -1471,7 +2018,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of15-lg {
-    flex: 0 0 53.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 53.33333333%;
+        -ms-flex: 0 0 53.33333333%;
+            flex: 0 0 53.33333333%;
     max-width: 53.33333333%;
     width: 53.33333333%;
   }
@@ -1479,7 +2029,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of15-lg {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -1487,7 +2040,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of15-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -1495,7 +2051,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of15-lg {
-    flex: 0 0 73.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 73.33333333%;
+        -ms-flex: 0 0 73.33333333%;
+            flex: 0 0 73.33333333%;
     max-width: 73.33333333%;
     width: 73.33333333%;
   }
@@ -1503,7 +2062,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of15-lg {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -1511,7 +2073,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of15-lg {
-    flex: 0 0 86.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 86.66666667%;
+        -ms-flex: 0 0 86.66666667%;
+            flex: 0 0 86.66666667%;
     max-width: 86.66666667%;
     width: 86.66666667%;
   }
@@ -1519,7 +2084,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of15-lg {
-    flex: 0 0 93.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 93.33333333%;
+        -ms-flex: 0 0 93.33333333%;
+            flex: 0 0 93.33333333%;
     max-width: 93.33333333%;
     width: 93.33333333%;
   }
@@ -1527,7 +2095,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--15of15-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1535,7 +2106,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of14-lg {
-    flex: 0 0 7.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 7.14285714%;
+        -ms-flex: 0 0 7.14285714%;
+            flex: 0 0 7.14285714%;
     max-width: 7.14285714%;
     width: 7.14285714%;
   }
@@ -1543,7 +2117,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of14-lg {
-    flex: 0 0 14.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 14.28571429%;
+        -ms-flex: 0 0 14.28571429%;
+            flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -1551,7 +2128,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of14-lg {
-    flex: 0 0 21.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 21.42857143%;
+        -ms-flex: 0 0 21.42857143%;
+            flex: 0 0 21.42857143%;
     max-width: 21.42857143%;
     width: 21.42857143%;
   }
@@ -1559,7 +2139,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of14-lg {
-    flex: 0 0 28.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 28.57142857%;
+        -ms-flex: 0 0 28.57142857%;
+            flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -1567,7 +2150,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of14-lg {
-    flex: 0 0 35.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 35.71428571%;
+        -ms-flex: 0 0 35.71428571%;
+            flex: 0 0 35.71428571%;
     max-width: 35.71428571%;
     width: 35.71428571%;
   }
@@ -1575,7 +2161,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of14-lg {
-    flex: 0 0 42.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 42.85714286%;
+        -ms-flex: 0 0 42.85714286%;
+            flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -1583,7 +2172,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of14-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1591,7 +2183,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of14-lg {
-    flex: 0 0 57.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 57.14285714%;
+        -ms-flex: 0 0 57.14285714%;
+            flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -1599,7 +2194,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of14-lg {
-    flex: 0 0 64.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 64.28571429%;
+        -ms-flex: 0 0 64.28571429%;
+            flex: 0 0 64.28571429%;
     max-width: 64.28571429%;
     width: 64.28571429%;
   }
@@ -1607,7 +2205,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of14-lg {
-    flex: 0 0 71.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 71.42857143%;
+        -ms-flex: 0 0 71.42857143%;
+            flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -1615,7 +2216,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of14-lg {
-    flex: 0 0 78.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 78.57142857%;
+        -ms-flex: 0 0 78.57142857%;
+            flex: 0 0 78.57142857%;
     max-width: 78.57142857%;
     width: 78.57142857%;
   }
@@ -1623,7 +2227,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of14-lg {
-    flex: 0 0 85.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 85.71428571%;
+        -ms-flex: 0 0 85.71428571%;
+            flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -1631,7 +2238,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of14-lg {
-    flex: 0 0 92.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 92.85714286%;
+        -ms-flex: 0 0 92.85714286%;
+            flex: 0 0 92.85714286%;
     max-width: 92.85714286%;
     width: 92.85714286%;
   }
@@ -1639,7 +2249,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--14of14-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1647,7 +2260,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of13-lg {
-    flex: 0 0 7.69230769%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 7.69230769%;
+        -ms-flex: 0 0 7.69230769%;
+            flex: 0 0 7.69230769%;
     max-width: 7.69230769%;
     width: 7.69230769%;
   }
@@ -1655,7 +2271,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of13-lg {
-    flex: 0 0 15.38461538%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 15.38461538%;
+        -ms-flex: 0 0 15.38461538%;
+            flex: 0 0 15.38461538%;
     max-width: 15.38461538%;
     width: 15.38461538%;
   }
@@ -1663,7 +2282,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of13-lg {
-    flex: 0 0 23.07692308%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 23.07692308%;
+        -ms-flex: 0 0 23.07692308%;
+            flex: 0 0 23.07692308%;
     max-width: 23.07692308%;
     width: 23.07692308%;
   }
@@ -1671,7 +2293,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of13-lg {
-    flex: 0 0 30.76923077%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 30.76923077%;
+        -ms-flex: 0 0 30.76923077%;
+            flex: 0 0 30.76923077%;
     max-width: 30.76923077%;
     width: 30.76923077%;
   }
@@ -1679,7 +2304,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of13-lg {
-    flex: 0 0 38.46153846%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 38.46153846%;
+        -ms-flex: 0 0 38.46153846%;
+            flex: 0 0 38.46153846%;
     max-width: 38.46153846%;
     width: 38.46153846%;
   }
@@ -1687,7 +2315,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of13-lg {
-    flex: 0 0 46.15384615%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 46.15384615%;
+        -ms-flex: 0 0 46.15384615%;
+            flex: 0 0 46.15384615%;
     max-width: 46.15384615%;
     width: 46.15384615%;
   }
@@ -1695,7 +2326,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of13-lg {
-    flex: 0 0 53.84615385%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 53.84615385%;
+        -ms-flex: 0 0 53.84615385%;
+            flex: 0 0 53.84615385%;
     max-width: 53.84615385%;
     width: 53.84615385%;
   }
@@ -1703,7 +2337,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of13-lg {
-    flex: 0 0 61.53846154%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 61.53846154%;
+        -ms-flex: 0 0 61.53846154%;
+            flex: 0 0 61.53846154%;
     max-width: 61.53846154%;
     width: 61.53846154%;
   }
@@ -1711,7 +2348,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of13-lg {
-    flex: 0 0 69.23076923%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 69.23076923%;
+        -ms-flex: 0 0 69.23076923%;
+            flex: 0 0 69.23076923%;
     max-width: 69.23076923%;
     width: 69.23076923%;
   }
@@ -1719,7 +2359,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of13-lg {
-    flex: 0 0 76.92307692%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 76.92307692%;
+        -ms-flex: 0 0 76.92307692%;
+            flex: 0 0 76.92307692%;
     max-width: 76.92307692%;
     width: 76.92307692%;
   }
@@ -1727,7 +2370,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of13-lg {
-    flex: 0 0 84.61538462%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 84.61538462%;
+        -ms-flex: 0 0 84.61538462%;
+            flex: 0 0 84.61538462%;
     max-width: 84.61538462%;
     width: 84.61538462%;
   }
@@ -1735,7 +2381,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of13-lg {
-    flex: 0 0 92.30769231%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 92.30769231%;
+        -ms-flex: 0 0 92.30769231%;
+            flex: 0 0 92.30769231%;
     max-width: 92.30769231%;
     width: 92.30769231%;
   }
@@ -1743,7 +2392,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--13of13-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1751,7 +2403,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of12-lg {
-    flex: 0 0 8.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 8.33333333%;
+        -ms-flex: 0 0 8.33333333%;
+            flex: 0 0 8.33333333%;
     max-width: 8.33333333%;
     width: 8.33333333%;
   }
@@ -1759,7 +2414,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of12-lg {
-    flex: 0 0 16.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 16.66666667%;
+        -ms-flex: 0 0 16.66666667%;
+            flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -1767,7 +2425,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of12-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -1775,7 +2436,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of12-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -1783,7 +2447,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of12-lg {
-    flex: 0 0 41.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 41.66666667%;
+        -ms-flex: 0 0 41.66666667%;
+            flex: 0 0 41.66666667%;
     max-width: 41.66666667%;
     width: 41.66666667%;
   }
@@ -1791,7 +2458,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of12-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1799,7 +2469,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of12-lg {
-    flex: 0 0 58.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 58.33333333%;
+        -ms-flex: 0 0 58.33333333%;
+            flex: 0 0 58.33333333%;
     max-width: 58.33333333%;
     width: 58.33333333%;
   }
@@ -1807,7 +2480,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of12-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -1815,7 +2491,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of12-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -1823,7 +2502,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of12-lg {
-    flex: 0 0 83.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 83.33333333%;
+        -ms-flex: 0 0 83.33333333%;
+            flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -1831,7 +2513,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of12-lg {
-    flex: 0 0 91.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 91.66666667%;
+        -ms-flex: 0 0 91.66666667%;
+            flex: 0 0 91.66666667%;
     max-width: 91.66666667%;
     width: 91.66666667%;
   }
@@ -1839,7 +2524,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--12of12-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1847,7 +2535,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of11-lg {
-    flex: 0 0 9.09090909%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 9.09090909%;
+        -ms-flex: 0 0 9.09090909%;
+            flex: 0 0 9.09090909%;
     max-width: 9.09090909%;
     width: 9.09090909%;
   }
@@ -1855,7 +2546,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of11-lg {
-    flex: 0 0 18.18181818%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 18.18181818%;
+        -ms-flex: 0 0 18.18181818%;
+            flex: 0 0 18.18181818%;
     max-width: 18.18181818%;
     width: 18.18181818%;
   }
@@ -1863,7 +2557,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of11-lg {
-    flex: 0 0 27.27272727%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 27.27272727%;
+        -ms-flex: 0 0 27.27272727%;
+            flex: 0 0 27.27272727%;
     max-width: 27.27272727%;
     width: 27.27272727%;
   }
@@ -1871,7 +2568,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of11-lg {
-    flex: 0 0 36.36363636%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 36.36363636%;
+        -ms-flex: 0 0 36.36363636%;
+            flex: 0 0 36.36363636%;
     max-width: 36.36363636%;
     width: 36.36363636%;
   }
@@ -1879,7 +2579,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of11-lg {
-    flex: 0 0 45.45454545%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 45.45454545%;
+        -ms-flex: 0 0 45.45454545%;
+            flex: 0 0 45.45454545%;
     max-width: 45.45454545%;
     width: 45.45454545%;
   }
@@ -1887,7 +2590,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of11-lg {
-    flex: 0 0 54.54545455%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 54.54545455%;
+        -ms-flex: 0 0 54.54545455%;
+            flex: 0 0 54.54545455%;
     max-width: 54.54545455%;
     width: 54.54545455%;
   }
@@ -1895,7 +2601,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of11-lg {
-    flex: 0 0 63.63636364%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 63.63636364%;
+        -ms-flex: 0 0 63.63636364%;
+            flex: 0 0 63.63636364%;
     max-width: 63.63636364%;
     width: 63.63636364%;
   }
@@ -1903,7 +2612,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of11-lg {
-    flex: 0 0 72.72727273%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 72.72727273%;
+        -ms-flex: 0 0 72.72727273%;
+            flex: 0 0 72.72727273%;
     max-width: 72.72727273%;
     width: 72.72727273%;
   }
@@ -1911,7 +2623,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of11-lg {
-    flex: 0 0 81.81818182%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 81.81818182%;
+        -ms-flex: 0 0 81.81818182%;
+            flex: 0 0 81.81818182%;
     max-width: 81.81818182%;
     width: 81.81818182%;
   }
@@ -1919,7 +2634,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of11-lg {
-    flex: 0 0 90.90909091%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 90.90909091%;
+        -ms-flex: 0 0 90.90909091%;
+            flex: 0 0 90.90909091%;
     max-width: 90.90909091%;
     width: 90.90909091%;
   }
@@ -1927,7 +2645,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--11of11-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -1935,7 +2656,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of10-lg {
-    flex: 0 0 10%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 10%;
+        -ms-flex: 0 0 10%;
+            flex: 0 0 10%;
     max-width: 10%;
     width: 10%;
   }
@@ -1943,7 +2667,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of10-lg {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -1951,7 +2678,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of10-lg {
-    flex: 0 0 30%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 30%;
+        -ms-flex: 0 0 30%;
+            flex: 0 0 30%;
     max-width: 30%;
     width: 30%;
   }
@@ -1959,7 +2689,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of10-lg {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -1967,7 +2700,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of10-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -1975,7 +2711,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of10-lg {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -1983,7 +2722,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of10-lg {
-    flex: 0 0 70%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 70%;
+        -ms-flex: 0 0 70%;
+            flex: 0 0 70%;
     max-width: 70%;
     width: 70%;
   }
@@ -1991,7 +2733,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of10-lg {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -1999,7 +2744,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of10-lg {
-    flex: 0 0 90%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 90%;
+        -ms-flex: 0 0 90%;
+            flex: 0 0 90%;
     max-width: 90%;
     width: 90%;
   }
@@ -2007,7 +2755,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--10of10-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2015,7 +2766,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of9-lg {
-    flex: 0 0 11.11111111%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 11.11111111%;
+        -ms-flex: 0 0 11.11111111%;
+            flex: 0 0 11.11111111%;
     max-width: 11.11111111%;
     width: 11.11111111%;
   }
@@ -2023,7 +2777,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of9-lg {
-    flex: 0 0 22.22222222%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 22.22222222%;
+        -ms-flex: 0 0 22.22222222%;
+            flex: 0 0 22.22222222%;
     max-width: 22.22222222%;
     width: 22.22222222%;
   }
@@ -2031,7 +2788,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of9-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2039,7 +2799,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of9-lg {
-    flex: 0 0 44.44444444%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 44.44444444%;
+        -ms-flex: 0 0 44.44444444%;
+            flex: 0 0 44.44444444%;
     max-width: 44.44444444%;
     width: 44.44444444%;
   }
@@ -2047,7 +2810,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of9-lg {
-    flex: 0 0 55.55555556%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 55.55555556%;
+        -ms-flex: 0 0 55.55555556%;
+            flex: 0 0 55.55555556%;
     max-width: 55.55555556%;
     width: 55.55555556%;
   }
@@ -2055,7 +2821,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of9-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2063,7 +2832,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of9-lg {
-    flex: 0 0 77.77777778%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 77.77777778%;
+        -ms-flex: 0 0 77.77777778%;
+            flex: 0 0 77.77777778%;
     max-width: 77.77777778%;
     width: 77.77777778%;
   }
@@ -2071,7 +2843,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of9-lg {
-    flex: 0 0 88.88888889%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 88.88888889%;
+        -ms-flex: 0 0 88.88888889%;
+            flex: 0 0 88.88888889%;
     max-width: 88.88888889%;
     width: 88.88888889%;
   }
@@ -2079,7 +2854,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--9of9-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2087,7 +2865,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of8-lg {
-    flex: 0 0 12.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 12.5%;
+        -ms-flex: 0 0 12.5%;
+            flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
@@ -2095,7 +2876,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of8-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2103,7 +2887,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of8-lg {
-    flex: 0 0 37.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 37.5%;
+        -ms-flex: 0 0 37.5%;
+            flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
@@ -2111,7 +2898,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of8-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2119,7 +2909,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of8-lg {
-    flex: 0 0 62.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 62.5%;
+        -ms-flex: 0 0 62.5%;
+            flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
@@ -2127,7 +2920,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of8-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2135,7 +2931,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of8-lg {
-    flex: 0 0 87.5%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 87.5%;
+        -ms-flex: 0 0 87.5%;
+            flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
@@ -2143,7 +2942,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--8of8-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2151,7 +2953,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-lg {
-    flex: 0 0 14.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 14.28571429%;
+        -ms-flex: 0 0 14.28571429%;
+            flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2159,7 +2964,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-lg {
-    flex: 0 0 28.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 28.57142857%;
+        -ms-flex: 0 0 28.57142857%;
+            flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2167,7 +2975,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-lg {
-    flex: 0 0 42.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 42.85714286%;
+        -ms-flex: 0 0 42.85714286%;
+            flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2175,7 +2986,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-lg {
-    flex: 0 0 57.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 57.14285714%;
+        -ms-flex: 0 0 57.14285714%;
+            flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -2183,7 +2997,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-lg {
-    flex: 0 0 71.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 71.42857143%;
+        -ms-flex: 0 0 71.42857143%;
+            flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2191,7 +3008,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-lg {
-    flex: 0 0 85.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 85.71428571%;
+        -ms-flex: 0 0 85.71428571%;
+            flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2199,7 +3019,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2207,7 +3030,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-lg {
-    flex: 0 0 16.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 16.66666667%;
+        -ms-flex: 0 0 16.66666667%;
+            flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2215,7 +3041,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2223,7 +3052,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2231,7 +3063,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2239,7 +3074,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-lg {
-    flex: 0 0 83.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 83.33333333%;
+        -ms-flex: 0 0 83.33333333%;
+            flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2247,7 +3085,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2255,7 +3096,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-lg {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2263,7 +3107,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-lg {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2271,7 +3118,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-lg {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2279,7 +3129,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-lg {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2287,7 +3140,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2295,7 +3151,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-lg {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2303,7 +3162,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2311,7 +3173,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-lg {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2319,7 +3184,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2327,7 +3195,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-lg {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2335,7 +3206,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-lg {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2343,7 +3217,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2351,7 +3228,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-lg {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2359,7 +3239,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2367,7 +3250,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-lg {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2377,7 +3263,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of7-sm {
-    flex: 0 0 14.28571429%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 14.28571429%;
+        -ms-flex: 0 0 14.28571429%;
+            flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
   }
@@ -2385,7 +3274,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of7-sm {
-    flex: 0 0 28.57142857%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 28.57142857%;
+        -ms-flex: 0 0 28.57142857%;
+            flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
   }
@@ -2393,7 +3285,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of7-sm {
-    flex: 0 0 42.85714286%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 42.85714286%;
+        -ms-flex: 0 0 42.85714286%;
+            flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
   }
@@ -2401,7 +3296,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of7-sm {
-    flex: 0 0 57.14285714%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 57.14285714%;
+        -ms-flex: 0 0 57.14285714%;
+            flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
   }
@@ -2409,7 +3307,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of7-sm {
-    flex: 0 0 71.42857143%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 71.42857143%;
+        -ms-flex: 0 0 71.42857143%;
+            flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
   }
@@ -2417,7 +3318,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of7-sm {
-    flex: 0 0 85.71428571%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 85.71428571%;
+        -ms-flex: 0 0 85.71428571%;
+            flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
   }
@@ -2425,7 +3329,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--7of7-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2433,7 +3340,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of6-sm {
-    flex: 0 0 16.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 16.66666667%;
+        -ms-flex: 0 0 16.66666667%;
+            flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
   }
@@ -2441,7 +3351,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of6-sm {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2449,7 +3362,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of6-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2457,7 +3373,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of6-sm {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2465,7 +3384,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of6-sm {
-    flex: 0 0 83.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 83.33333333%;
+        -ms-flex: 0 0 83.33333333%;
+            flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
   }
@@ -2473,7 +3395,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--6of6-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2481,7 +3406,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of5-sm {
-    flex: 0 0 20%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 20%;
+        -ms-flex: 0 0 20%;
+            flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
   }
@@ -2489,7 +3417,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of5-sm {
-    flex: 0 0 40%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 40%;
+        -ms-flex: 0 0 40%;
+            flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
   }
@@ -2497,7 +3428,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of5-sm {
-    flex: 0 0 60%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 60%;
+        -ms-flex: 0 0 60%;
+            flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
   }
@@ -2505,7 +3439,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of5-sm {
-    flex: 0 0 80%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 80%;
+        -ms-flex: 0 0 80%;
+            flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
   }
@@ -2513,7 +3450,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--5of5-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2521,7 +3461,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of4-sm {
-    flex: 0 0 25%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 25%;
+        -ms-flex: 0 0 25%;
+            flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
@@ -2529,7 +3472,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of4-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2537,7 +3483,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of4-sm {
-    flex: 0 0 75%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 75%;
+        -ms-flex: 0 0 75%;
+            flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
@@ -2545,7 +3494,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--4of4-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2553,7 +3505,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of3-sm {
-    flex: 0 0 33.33333333%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 33.33333333%;
+        -ms-flex: 0 0 33.33333333%;
+            flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
   }
@@ -2561,7 +3516,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of3-sm {
-    flex: 0 0 66.66666667%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 66.66666667%;
+        -ms-flex: 0 0 66.66666667%;
+            flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
   }
@@ -2569,7 +3527,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--3of3-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2577,7 +3538,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of2-sm {
-    flex: 0 0 50%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 50%;
+        -ms-flex: 0 0 50%;
+            flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
@@ -2585,7 +3549,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--2of2-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
@@ -2593,7 +3560,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          *   All the subgrid
          */
   .grid__cell--1of1-sm {
-    flex: 0 0 100%;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 100%;
+        -ms-flex: 0 0 100%;
+            flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }

--- a/docs/static/ds4/grid-full.css
+++ b/docs/static/ds4/grid-full.css
@@ -61,14 +61,10 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 .grid__group {
   -webkit-box-align: start;
-  -webkit-align-items: flex-start;
-      -ms-flex-align: start;
           align-items: flex-start;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin-right: -16px;
@@ -98,8 +94,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 }
 .grid__cell--grow {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 auto;
-      -ms-flex: 1 1 auto;
           flex: 1 1 auto;
 }
 /**
@@ -108,9 +102,7 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  * screen gets smaller
  */
 .grid__group--wrap {
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 /**
  * Removes the gutters of a row
@@ -139,72 +131,54 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
      */
 .grid__cell--one-half {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--one-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
 }
 .grid__cell--two-third {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
 }
 .grid__cell--one-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--three-fourth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--one-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
 }
 .grid__cell--two-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
 }
 .grid__cell--three-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
 }
 .grid__cell--four-fifth {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -228,128 +202,96 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
  */
 .grid__cell--16of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
 }
 .grid__cell--15of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 93.75%;
-      -ms-flex: 0 0 93.75%;
           flex: 0 0 93.75%;
   max-width: 93.75%;
   width: 93.75%;
 }
 .grid__cell--14of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 87.5%;
-      -ms-flex: 0 0 87.5%;
           flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
 }
 .grid__cell--13of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 81.25%;
-      -ms-flex: 0 0 81.25%;
           flex: 0 0 81.25%;
   max-width: 81.25%;
   width: 81.25%;
 }
 .grid__cell--12of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
 }
 .grid__cell--11of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 68.75%;
-      -ms-flex: 0 0 68.75%;
           flex: 0 0 68.75%;
   max-width: 68.75%;
   width: 68.75%;
 }
 .grid__cell--10of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 62.5%;
-      -ms-flex: 0 0 62.5%;
           flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
 }
 .grid__cell--9of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 56.25%;
-      -ms-flex: 0 0 56.25%;
           flex: 0 0 56.25%;
   max-width: 56.25%;
   width: 56.25%;
 }
 .grid__cell--8of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
 }
 .grid__cell--7of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 43.75%;
-      -ms-flex: 0 0 43.75%;
           flex: 0 0 43.75%;
   max-width: 43.75%;
   width: 43.75%;
 }
 .grid__cell--6of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 37.5%;
-      -ms-flex: 0 0 37.5%;
           flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
 }
 .grid__cell--5of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 31.25%;
-      -ms-flex: 0 0 31.25%;
           flex: 0 0 31.25%;
   max-width: 31.25%;
   width: 31.25%;
 }
 .grid__cell--4of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
 }
 .grid__cell--3of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 18.75%;
-      -ms-flex: 0 0 18.75%;
           flex: 0 0 18.75%;
   max-width: 18.75%;
   width: 18.75%;
 }
 .grid__cell--2of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 12.5%;
-      -ms-flex: 0 0 12.5%;
           flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
 }
 .grid__cell--1of16 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 6.25%;
-      -ms-flex: 0 0 6.25%;
           flex: 0 0 6.25%;
   max-width: 6.25%;
   width: 6.25%;
@@ -365,128 +307,96 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 @media (min-width: 961px) {
   .grid__cell--16of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--15of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 93.75%;
-        -ms-flex: 0 0 93.75%;
             flex: 0 0 93.75%;
     max-width: 93.75%;
     width: 93.75%;
   }
   .grid__cell--14of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--13of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 81.25%;
-        -ms-flex: 0 0 81.25%;
             flex: 0 0 81.25%;
     max-width: 81.25%;
     width: 81.25%;
   }
   .grid__cell--12of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--11of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 68.75%;
-        -ms-flex: 0 0 68.75%;
             flex: 0 0 68.75%;
     max-width: 68.75%;
     width: 68.75%;
   }
   .grid__cell--10of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--9of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 56.25%;
-        -ms-flex: 0 0 56.25%;
             flex: 0 0 56.25%;
     max-width: 56.25%;
     width: 56.25%;
   }
   .grid__cell--8of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--7of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 43.75%;
-        -ms-flex: 0 0 43.75%;
             flex: 0 0 43.75%;
     max-width: 43.75%;
     width: 43.75%;
   }
   .grid__cell--6of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--5of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 31.25%;
-        -ms-flex: 0 0 31.25%;
             flex: 0 0 31.25%;
     max-width: 31.25%;
     width: 31.25%;
   }
   .grid__cell--4of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--3of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 18.75%;
-        -ms-flex: 0 0 18.75%;
             flex: 0 0 18.75%;
     max-width: 18.75%;
     width: 18.75%;
   }
   .grid__cell--2of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
   }
   .grid__cell--1of16-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 6.25%;
-        -ms-flex: 0 0 6.25%;
             flex: 0 0 6.25%;
     max-width: 6.25%;
     width: 6.25%;
@@ -501,64 +411,48 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 @media (max-width: 600px) {
   .grid__cell--8of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
   }
   .grid__cell--7of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
   }
   .grid__cell--6of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
   }
   .grid__cell--5of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
   }
   .grid__cell--4of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
   }
   .grid__cell--3of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
   }
   .grid__cell--2of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
   }
   .grid__cell--1of8-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
@@ -596,7 +490,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
   margin: 8px auto;
   position: relative;
   right: 8px;
-  width: -webkit-calc(100% - 48px);
   width: calc(100% - 48px);
 }
 /**
@@ -605,8 +498,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
 .grid__group--top-to-bottom {
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
           flex-direction: column;
   width: auto;
 }
@@ -621,8 +512,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 6.66666667%;
-      -ms-flex: 0 0 6.66666667%;
           flex: 0 0 6.66666667%;
   max-width: 6.66666667%;
   width: 6.66666667%;
@@ -632,8 +521,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 13.33333333%;
-      -ms-flex: 0 0 13.33333333%;
           flex: 0 0 13.33333333%;
   max-width: 13.33333333%;
   width: 13.33333333%;
@@ -643,8 +530,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
@@ -654,8 +539,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 26.66666667%;
-      -ms-flex: 0 0 26.66666667%;
           flex: 0 0 26.66666667%;
   max-width: 26.66666667%;
   width: 26.66666667%;
@@ -665,8 +548,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -676,8 +557,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
@@ -687,8 +566,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 46.66666667%;
-      -ms-flex: 0 0 46.66666667%;
           flex: 0 0 46.66666667%;
   max-width: 46.66666667%;
   width: 46.66666667%;
@@ -698,8 +575,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 53.33333333%;
-      -ms-flex: 0 0 53.33333333%;
           flex: 0 0 53.33333333%;
   max-width: 53.33333333%;
   width: 53.33333333%;
@@ -709,8 +584,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
@@ -720,8 +593,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -731,8 +602,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 73.33333333%;
-      -ms-flex: 0 0 73.33333333%;
           flex: 0 0 73.33333333%;
   max-width: 73.33333333%;
   width: 73.33333333%;
@@ -742,8 +611,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -753,8 +620,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--13of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 86.66666667%;
-      -ms-flex: 0 0 86.66666667%;
           flex: 0 0 86.66666667%;
   max-width: 86.66666667%;
   width: 86.66666667%;
@@ -764,8 +629,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--14of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 93.33333333%;
-      -ms-flex: 0 0 93.33333333%;
           flex: 0 0 93.33333333%;
   max-width: 93.33333333%;
   width: 93.33333333%;
@@ -775,8 +638,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--15of15 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -786,8 +647,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 7.14285714%;
-      -ms-flex: 0 0 7.14285714%;
           flex: 0 0 7.14285714%;
   max-width: 7.14285714%;
   width: 7.14285714%;
@@ -797,8 +656,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 14.28571429%;
-      -ms-flex: 0 0 14.28571429%;
           flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
@@ -808,8 +665,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 21.42857143%;
-      -ms-flex: 0 0 21.42857143%;
           flex: 0 0 21.42857143%;
   max-width: 21.42857143%;
   width: 21.42857143%;
@@ -819,8 +674,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 28.57142857%;
-      -ms-flex: 0 0 28.57142857%;
           flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
@@ -830,8 +683,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 35.71428571%;
-      -ms-flex: 0 0 35.71428571%;
           flex: 0 0 35.71428571%;
   max-width: 35.71428571%;
   width: 35.71428571%;
@@ -841,8 +692,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 42.85714286%;
-      -ms-flex: 0 0 42.85714286%;
           flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
@@ -852,8 +701,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -863,8 +710,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 57.14285714%;
-      -ms-flex: 0 0 57.14285714%;
           flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
@@ -874,8 +719,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 64.28571429%;
-      -ms-flex: 0 0 64.28571429%;
           flex: 0 0 64.28571429%;
   max-width: 64.28571429%;
   width: 64.28571429%;
@@ -885,8 +728,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 71.42857143%;
-      -ms-flex: 0 0 71.42857143%;
           flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
@@ -896,8 +737,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 78.57142857%;
-      -ms-flex: 0 0 78.57142857%;
           flex: 0 0 78.57142857%;
   max-width: 78.57142857%;
   width: 78.57142857%;
@@ -907,8 +746,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 85.71428571%;
-      -ms-flex: 0 0 85.71428571%;
           flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
@@ -918,8 +755,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--13of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 92.85714286%;
-      -ms-flex: 0 0 92.85714286%;
           flex: 0 0 92.85714286%;
   max-width: 92.85714286%;
   width: 92.85714286%;
@@ -929,8 +764,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--14of14 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -940,8 +773,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 7.69230769%;
-      -ms-flex: 0 0 7.69230769%;
           flex: 0 0 7.69230769%;
   max-width: 7.69230769%;
   width: 7.69230769%;
@@ -951,8 +782,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 15.38461538%;
-      -ms-flex: 0 0 15.38461538%;
           flex: 0 0 15.38461538%;
   max-width: 15.38461538%;
   width: 15.38461538%;
@@ -962,8 +791,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 23.07692308%;
-      -ms-flex: 0 0 23.07692308%;
           flex: 0 0 23.07692308%;
   max-width: 23.07692308%;
   width: 23.07692308%;
@@ -973,8 +800,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 30.76923077%;
-      -ms-flex: 0 0 30.76923077%;
           flex: 0 0 30.76923077%;
   max-width: 30.76923077%;
   width: 30.76923077%;
@@ -984,8 +809,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 38.46153846%;
-      -ms-flex: 0 0 38.46153846%;
           flex: 0 0 38.46153846%;
   max-width: 38.46153846%;
   width: 38.46153846%;
@@ -995,8 +818,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 46.15384615%;
-      -ms-flex: 0 0 46.15384615%;
           flex: 0 0 46.15384615%;
   max-width: 46.15384615%;
   width: 46.15384615%;
@@ -1006,8 +827,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 53.84615385%;
-      -ms-flex: 0 0 53.84615385%;
           flex: 0 0 53.84615385%;
   max-width: 53.84615385%;
   width: 53.84615385%;
@@ -1017,8 +836,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 61.53846154%;
-      -ms-flex: 0 0 61.53846154%;
           flex: 0 0 61.53846154%;
   max-width: 61.53846154%;
   width: 61.53846154%;
@@ -1028,8 +845,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 69.23076923%;
-      -ms-flex: 0 0 69.23076923%;
           flex: 0 0 69.23076923%;
   max-width: 69.23076923%;
   width: 69.23076923%;
@@ -1039,8 +854,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 76.92307692%;
-      -ms-flex: 0 0 76.92307692%;
           flex: 0 0 76.92307692%;
   max-width: 76.92307692%;
   width: 76.92307692%;
@@ -1050,8 +863,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 84.61538462%;
-      -ms-flex: 0 0 84.61538462%;
           flex: 0 0 84.61538462%;
   max-width: 84.61538462%;
   width: 84.61538462%;
@@ -1061,8 +872,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 92.30769231%;
-      -ms-flex: 0 0 92.30769231%;
           flex: 0 0 92.30769231%;
   max-width: 92.30769231%;
   width: 92.30769231%;
@@ -1072,8 +881,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--13of13 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1083,8 +890,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 8.33333333%;
-      -ms-flex: 0 0 8.33333333%;
           flex: 0 0 8.33333333%;
   max-width: 8.33333333%;
   width: 8.33333333%;
@@ -1094,8 +899,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 16.66666667%;
-      -ms-flex: 0 0 16.66666667%;
           flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
@@ -1105,8 +908,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
@@ -1116,8 +917,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1127,8 +926,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 41.66666667%;
-      -ms-flex: 0 0 41.66666667%;
           flex: 0 0 41.66666667%;
   max-width: 41.66666667%;
   width: 41.66666667%;
@@ -1138,8 +935,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1149,8 +944,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 58.33333333%;
-      -ms-flex: 0 0 58.33333333%;
           flex: 0 0 58.33333333%;
   max-width: 58.33333333%;
   width: 58.33333333%;
@@ -1160,8 +953,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1171,8 +962,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
@@ -1182,8 +971,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 83.33333333%;
-      -ms-flex: 0 0 83.33333333%;
           flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
@@ -1193,8 +980,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 91.66666667%;
-      -ms-flex: 0 0 91.66666667%;
           flex: 0 0 91.66666667%;
   max-width: 91.66666667%;
   width: 91.66666667%;
@@ -1204,8 +989,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--12of12 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1215,8 +998,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 9.09090909%;
-      -ms-flex: 0 0 9.09090909%;
           flex: 0 0 9.09090909%;
   max-width: 9.09090909%;
   width: 9.09090909%;
@@ -1226,8 +1007,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 18.18181818%;
-      -ms-flex: 0 0 18.18181818%;
           flex: 0 0 18.18181818%;
   max-width: 18.18181818%;
   width: 18.18181818%;
@@ -1237,8 +1016,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 27.27272727%;
-      -ms-flex: 0 0 27.27272727%;
           flex: 0 0 27.27272727%;
   max-width: 27.27272727%;
   width: 27.27272727%;
@@ -1248,8 +1025,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 36.36363636%;
-      -ms-flex: 0 0 36.36363636%;
           flex: 0 0 36.36363636%;
   max-width: 36.36363636%;
   width: 36.36363636%;
@@ -1259,8 +1034,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 45.45454545%;
-      -ms-flex: 0 0 45.45454545%;
           flex: 0 0 45.45454545%;
   max-width: 45.45454545%;
   width: 45.45454545%;
@@ -1270,8 +1043,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 54.54545455%;
-      -ms-flex: 0 0 54.54545455%;
           flex: 0 0 54.54545455%;
   max-width: 54.54545455%;
   width: 54.54545455%;
@@ -1281,8 +1052,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 63.63636364%;
-      -ms-flex: 0 0 63.63636364%;
           flex: 0 0 63.63636364%;
   max-width: 63.63636364%;
   width: 63.63636364%;
@@ -1292,8 +1061,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 72.72727273%;
-      -ms-flex: 0 0 72.72727273%;
           flex: 0 0 72.72727273%;
   max-width: 72.72727273%;
   width: 72.72727273%;
@@ -1303,8 +1070,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 81.81818182%;
-      -ms-flex: 0 0 81.81818182%;
           flex: 0 0 81.81818182%;
   max-width: 81.81818182%;
   width: 81.81818182%;
@@ -1314,8 +1079,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 90.90909091%;
-      -ms-flex: 0 0 90.90909091%;
           flex: 0 0 90.90909091%;
   max-width: 90.90909091%;
   width: 90.90909091%;
@@ -1325,8 +1088,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--11of11 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1336,8 +1097,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 10%;
-      -ms-flex: 0 0 10%;
           flex: 0 0 10%;
   max-width: 10%;
   width: 10%;
@@ -1347,8 +1106,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
@@ -1358,8 +1115,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 30%;
-      -ms-flex: 0 0 30%;
           flex: 0 0 30%;
   max-width: 30%;
   width: 30%;
@@ -1369,8 +1124,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
@@ -1380,8 +1133,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1391,8 +1142,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
@@ -1402,8 +1151,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 70%;
-      -ms-flex: 0 0 70%;
           flex: 0 0 70%;
   max-width: 70%;
   width: 70%;
@@ -1413,8 +1160,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -1424,8 +1169,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 90%;
-      -ms-flex: 0 0 90%;
           flex: 0 0 90%;
   max-width: 90%;
   width: 90%;
@@ -1435,8 +1178,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--10of10 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1446,8 +1187,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 11.11111111%;
-      -ms-flex: 0 0 11.11111111%;
           flex: 0 0 11.11111111%;
   max-width: 11.11111111%;
   width: 11.11111111%;
@@ -1457,8 +1196,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 22.22222222%;
-      -ms-flex: 0 0 22.22222222%;
           flex: 0 0 22.22222222%;
   max-width: 22.22222222%;
   width: 22.22222222%;
@@ -1468,8 +1205,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1479,8 +1214,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 44.44444444%;
-      -ms-flex: 0 0 44.44444444%;
           flex: 0 0 44.44444444%;
   max-width: 44.44444444%;
   width: 44.44444444%;
@@ -1490,8 +1223,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 55.55555556%;
-      -ms-flex: 0 0 55.55555556%;
           flex: 0 0 55.55555556%;
   max-width: 55.55555556%;
   width: 55.55555556%;
@@ -1501,8 +1232,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1512,8 +1241,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 77.77777778%;
-      -ms-flex: 0 0 77.77777778%;
           flex: 0 0 77.77777778%;
   max-width: 77.77777778%;
   width: 77.77777778%;
@@ -1523,8 +1250,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 88.88888889%;
-      -ms-flex: 0 0 88.88888889%;
           flex: 0 0 88.88888889%;
   max-width: 88.88888889%;
   width: 88.88888889%;
@@ -1534,8 +1259,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--9of9 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1545,8 +1268,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 12.5%;
-      -ms-flex: 0 0 12.5%;
           flex: 0 0 12.5%;
   max-width: 12.5%;
   width: 12.5%;
@@ -1556,8 +1277,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
@@ -1567,8 +1286,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 37.5%;
-      -ms-flex: 0 0 37.5%;
           flex: 0 0 37.5%;
   max-width: 37.5%;
   width: 37.5%;
@@ -1578,8 +1295,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1589,8 +1304,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 62.5%;
-      -ms-flex: 0 0 62.5%;
           flex: 0 0 62.5%;
   max-width: 62.5%;
   width: 62.5%;
@@ -1600,8 +1313,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
@@ -1611,8 +1322,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 87.5%;
-      -ms-flex: 0 0 87.5%;
           flex: 0 0 87.5%;
   max-width: 87.5%;
   width: 87.5%;
@@ -1622,8 +1331,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--8of8 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1633,8 +1340,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 14.28571429%;
-      -ms-flex: 0 0 14.28571429%;
           flex: 0 0 14.28571429%;
   max-width: 14.28571429%;
   width: 14.28571429%;
@@ -1644,8 +1349,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 28.57142857%;
-      -ms-flex: 0 0 28.57142857%;
           flex: 0 0 28.57142857%;
   max-width: 28.57142857%;
   width: 28.57142857%;
@@ -1655,8 +1358,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 42.85714286%;
-      -ms-flex: 0 0 42.85714286%;
           flex: 0 0 42.85714286%;
   max-width: 42.85714286%;
   width: 42.85714286%;
@@ -1666,8 +1367,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 57.14285714%;
-      -ms-flex: 0 0 57.14285714%;
           flex: 0 0 57.14285714%;
   max-width: 57.14285714%;
   width: 57.14285714%;
@@ -1677,8 +1376,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 71.42857143%;
-      -ms-flex: 0 0 71.42857143%;
           flex: 0 0 71.42857143%;
   max-width: 71.42857143%;
   width: 71.42857143%;
@@ -1688,8 +1385,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 85.71428571%;
-      -ms-flex: 0 0 85.71428571%;
           flex: 0 0 85.71428571%;
   max-width: 85.71428571%;
   width: 85.71428571%;
@@ -1699,8 +1394,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--7of7 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1710,8 +1403,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 16.66666667%;
-      -ms-flex: 0 0 16.66666667%;
           flex: 0 0 16.66666667%;
   max-width: 16.66666667%;
   width: 16.66666667%;
@@ -1721,8 +1412,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1732,8 +1421,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1743,8 +1430,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1754,8 +1439,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 83.33333333%;
-      -ms-flex: 0 0 83.33333333%;
           flex: 0 0 83.33333333%;
   max-width: 83.33333333%;
   width: 83.33333333%;
@@ -1765,8 +1448,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--6of6 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1776,8 +1457,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 20%;
-      -ms-flex: 0 0 20%;
           flex: 0 0 20%;
   max-width: 20%;
   width: 20%;
@@ -1787,8 +1466,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 40%;
-      -ms-flex: 0 0 40%;
           flex: 0 0 40%;
   max-width: 40%;
   width: 40%;
@@ -1798,8 +1475,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 60%;
-      -ms-flex: 0 0 60%;
           flex: 0 0 60%;
   max-width: 60%;
   width: 60%;
@@ -1809,8 +1484,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 80%;
-      -ms-flex: 0 0 80%;
           flex: 0 0 80%;
   max-width: 80%;
   width: 80%;
@@ -1820,8 +1493,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--5of5 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1831,8 +1502,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 25%;
-      -ms-flex: 0 0 25%;
           flex: 0 0 25%;
   max-width: 25%;
   width: 25%;
@@ -1842,8 +1511,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1853,8 +1520,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 75%;
-      -ms-flex: 0 0 75%;
           flex: 0 0 75%;
   max-width: 75%;
   width: 75%;
@@ -1864,8 +1529,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--4of4 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1875,8 +1538,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of3 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 33.33333333%;
-      -ms-flex: 0 0 33.33333333%;
           flex: 0 0 33.33333333%;
   max-width: 33.33333333%;
   width: 33.33333333%;
@@ -1886,8 +1547,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of3 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 66.66666667%;
-      -ms-flex: 0 0 66.66666667%;
           flex: 0 0 66.66666667%;
   max-width: 66.66666667%;
   width: 66.66666667%;
@@ -1897,8 +1556,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--3of3 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1908,8 +1565,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of2 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 50%;
-      -ms-flex: 0 0 50%;
           flex: 0 0 50%;
   max-width: 50%;
   width: 50%;
@@ -1919,8 +1574,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--2of2 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1930,8 +1583,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
 .grid__cell--1of1 {
   -webkit-box-flex: 0;
-  -webkit-flex: 0 0 100%;
-      -ms-flex: 0 0 100%;
           flex: 0 0 100%;
   max-width: 100%;
   width: 100%;
@@ -1942,8 +1593,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 6.66666667%;
-        -ms-flex: 0 0 6.66666667%;
             flex: 0 0 6.66666667%;
     max-width: 6.66666667%;
     width: 6.66666667%;
@@ -1953,8 +1602,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 13.33333333%;
-        -ms-flex: 0 0 13.33333333%;
             flex: 0 0 13.33333333%;
     max-width: 13.33333333%;
     width: 13.33333333%;
@@ -1964,8 +1611,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -1975,8 +1620,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 26.66666667%;
-        -ms-flex: 0 0 26.66666667%;
             flex: 0 0 26.66666667%;
     max-width: 26.66666667%;
     width: 26.66666667%;
@@ -1986,8 +1629,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -1997,8 +1638,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -2008,8 +1647,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 46.66666667%;
-        -ms-flex: 0 0 46.66666667%;
             flex: 0 0 46.66666667%;
     max-width: 46.66666667%;
     width: 46.66666667%;
@@ -2019,8 +1656,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 53.33333333%;
-        -ms-flex: 0 0 53.33333333%;
             flex: 0 0 53.33333333%;
     max-width: 53.33333333%;
     width: 53.33333333%;
@@ -2030,8 +1665,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -2041,8 +1674,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -2052,8 +1683,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 73.33333333%;
-        -ms-flex: 0 0 73.33333333%;
             flex: 0 0 73.33333333%;
     max-width: 73.33333333%;
     width: 73.33333333%;
@@ -2063,8 +1692,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -2074,8 +1701,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--13of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 86.66666667%;
-        -ms-flex: 0 0 86.66666667%;
             flex: 0 0 86.66666667%;
     max-width: 86.66666667%;
     width: 86.66666667%;
@@ -2085,8 +1710,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--14of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 93.33333333%;
-        -ms-flex: 0 0 93.33333333%;
             flex: 0 0 93.33333333%;
     max-width: 93.33333333%;
     width: 93.33333333%;
@@ -2096,8 +1719,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--15of15-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2107,8 +1728,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 7.14285714%;
-        -ms-flex: 0 0 7.14285714%;
             flex: 0 0 7.14285714%;
     max-width: 7.14285714%;
     width: 7.14285714%;
@@ -2118,8 +1737,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 14.28571429%;
-        -ms-flex: 0 0 14.28571429%;
             flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
@@ -2129,8 +1746,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 21.42857143%;
-        -ms-flex: 0 0 21.42857143%;
             flex: 0 0 21.42857143%;
     max-width: 21.42857143%;
     width: 21.42857143%;
@@ -2140,8 +1755,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 28.57142857%;
-        -ms-flex: 0 0 28.57142857%;
             flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
@@ -2151,8 +1764,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 35.71428571%;
-        -ms-flex: 0 0 35.71428571%;
             flex: 0 0 35.71428571%;
     max-width: 35.71428571%;
     width: 35.71428571%;
@@ -2162,8 +1773,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 42.85714286%;
-        -ms-flex: 0 0 42.85714286%;
             flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
@@ -2173,8 +1782,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2184,8 +1791,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 57.14285714%;
-        -ms-flex: 0 0 57.14285714%;
             flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
@@ -2195,8 +1800,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 64.28571429%;
-        -ms-flex: 0 0 64.28571429%;
             flex: 0 0 64.28571429%;
     max-width: 64.28571429%;
     width: 64.28571429%;
@@ -2206,8 +1809,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 71.42857143%;
-        -ms-flex: 0 0 71.42857143%;
             flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
@@ -2217,8 +1818,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 78.57142857%;
-        -ms-flex: 0 0 78.57142857%;
             flex: 0 0 78.57142857%;
     max-width: 78.57142857%;
     width: 78.57142857%;
@@ -2228,8 +1827,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 85.71428571%;
-        -ms-flex: 0 0 85.71428571%;
             flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
@@ -2239,8 +1836,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--13of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 92.85714286%;
-        -ms-flex: 0 0 92.85714286%;
             flex: 0 0 92.85714286%;
     max-width: 92.85714286%;
     width: 92.85714286%;
@@ -2250,8 +1845,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--14of14-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2261,8 +1854,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 7.69230769%;
-        -ms-flex: 0 0 7.69230769%;
             flex: 0 0 7.69230769%;
     max-width: 7.69230769%;
     width: 7.69230769%;
@@ -2272,8 +1863,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 15.38461538%;
-        -ms-flex: 0 0 15.38461538%;
             flex: 0 0 15.38461538%;
     max-width: 15.38461538%;
     width: 15.38461538%;
@@ -2283,8 +1872,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 23.07692308%;
-        -ms-flex: 0 0 23.07692308%;
             flex: 0 0 23.07692308%;
     max-width: 23.07692308%;
     width: 23.07692308%;
@@ -2294,8 +1881,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 30.76923077%;
-        -ms-flex: 0 0 30.76923077%;
             flex: 0 0 30.76923077%;
     max-width: 30.76923077%;
     width: 30.76923077%;
@@ -2305,8 +1890,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 38.46153846%;
-        -ms-flex: 0 0 38.46153846%;
             flex: 0 0 38.46153846%;
     max-width: 38.46153846%;
     width: 38.46153846%;
@@ -2316,8 +1899,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 46.15384615%;
-        -ms-flex: 0 0 46.15384615%;
             flex: 0 0 46.15384615%;
     max-width: 46.15384615%;
     width: 46.15384615%;
@@ -2327,8 +1908,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 53.84615385%;
-        -ms-flex: 0 0 53.84615385%;
             flex: 0 0 53.84615385%;
     max-width: 53.84615385%;
     width: 53.84615385%;
@@ -2338,8 +1917,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 61.53846154%;
-        -ms-flex: 0 0 61.53846154%;
             flex: 0 0 61.53846154%;
     max-width: 61.53846154%;
     width: 61.53846154%;
@@ -2349,8 +1926,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 69.23076923%;
-        -ms-flex: 0 0 69.23076923%;
             flex: 0 0 69.23076923%;
     max-width: 69.23076923%;
     width: 69.23076923%;
@@ -2360,8 +1935,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 76.92307692%;
-        -ms-flex: 0 0 76.92307692%;
             flex: 0 0 76.92307692%;
     max-width: 76.92307692%;
     width: 76.92307692%;
@@ -2371,8 +1944,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 84.61538462%;
-        -ms-flex: 0 0 84.61538462%;
             flex: 0 0 84.61538462%;
     max-width: 84.61538462%;
     width: 84.61538462%;
@@ -2382,8 +1953,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 92.30769231%;
-        -ms-flex: 0 0 92.30769231%;
             flex: 0 0 92.30769231%;
     max-width: 92.30769231%;
     width: 92.30769231%;
@@ -2393,8 +1962,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--13of13-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2404,8 +1971,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 8.33333333%;
-        -ms-flex: 0 0 8.33333333%;
             flex: 0 0 8.33333333%;
     max-width: 8.33333333%;
     width: 8.33333333%;
@@ -2415,8 +1980,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 16.66666667%;
-        -ms-flex: 0 0 16.66666667%;
             flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
@@ -2426,8 +1989,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -2437,8 +1998,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -2448,8 +2007,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 41.66666667%;
-        -ms-flex: 0 0 41.66666667%;
             flex: 0 0 41.66666667%;
     max-width: 41.66666667%;
     width: 41.66666667%;
@@ -2459,8 +2016,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2470,8 +2025,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 58.33333333%;
-        -ms-flex: 0 0 58.33333333%;
             flex: 0 0 58.33333333%;
     max-width: 58.33333333%;
     width: 58.33333333%;
@@ -2481,8 +2034,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -2492,8 +2043,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -2503,8 +2052,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 83.33333333%;
-        -ms-flex: 0 0 83.33333333%;
             flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
@@ -2514,8 +2061,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 91.66666667%;
-        -ms-flex: 0 0 91.66666667%;
             flex: 0 0 91.66666667%;
     max-width: 91.66666667%;
     width: 91.66666667%;
@@ -2525,8 +2070,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--12of12-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2536,8 +2079,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 9.09090909%;
-        -ms-flex: 0 0 9.09090909%;
             flex: 0 0 9.09090909%;
     max-width: 9.09090909%;
     width: 9.09090909%;
@@ -2547,8 +2088,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 18.18181818%;
-        -ms-flex: 0 0 18.18181818%;
             flex: 0 0 18.18181818%;
     max-width: 18.18181818%;
     width: 18.18181818%;
@@ -2558,8 +2097,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 27.27272727%;
-        -ms-flex: 0 0 27.27272727%;
             flex: 0 0 27.27272727%;
     max-width: 27.27272727%;
     width: 27.27272727%;
@@ -2569,8 +2106,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 36.36363636%;
-        -ms-flex: 0 0 36.36363636%;
             flex: 0 0 36.36363636%;
     max-width: 36.36363636%;
     width: 36.36363636%;
@@ -2580,8 +2115,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 45.45454545%;
-        -ms-flex: 0 0 45.45454545%;
             flex: 0 0 45.45454545%;
     max-width: 45.45454545%;
     width: 45.45454545%;
@@ -2591,8 +2124,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 54.54545455%;
-        -ms-flex: 0 0 54.54545455%;
             flex: 0 0 54.54545455%;
     max-width: 54.54545455%;
     width: 54.54545455%;
@@ -2602,8 +2133,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 63.63636364%;
-        -ms-flex: 0 0 63.63636364%;
             flex: 0 0 63.63636364%;
     max-width: 63.63636364%;
     width: 63.63636364%;
@@ -2613,8 +2142,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 72.72727273%;
-        -ms-flex: 0 0 72.72727273%;
             flex: 0 0 72.72727273%;
     max-width: 72.72727273%;
     width: 72.72727273%;
@@ -2624,8 +2151,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 81.81818182%;
-        -ms-flex: 0 0 81.81818182%;
             flex: 0 0 81.81818182%;
     max-width: 81.81818182%;
     width: 81.81818182%;
@@ -2635,8 +2160,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 90.90909091%;
-        -ms-flex: 0 0 90.90909091%;
             flex: 0 0 90.90909091%;
     max-width: 90.90909091%;
     width: 90.90909091%;
@@ -2646,8 +2169,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--11of11-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2657,8 +2178,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 10%;
-        -ms-flex: 0 0 10%;
             flex: 0 0 10%;
     max-width: 10%;
     width: 10%;
@@ -2668,8 +2187,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -2679,8 +2196,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 30%;
-        -ms-flex: 0 0 30%;
             flex: 0 0 30%;
     max-width: 30%;
     width: 30%;
@@ -2690,8 +2205,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -2701,8 +2214,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2712,8 +2223,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -2723,8 +2232,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 70%;
-        -ms-flex: 0 0 70%;
             flex: 0 0 70%;
     max-width: 70%;
     width: 70%;
@@ -2734,8 +2241,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -2745,8 +2250,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 90%;
-        -ms-flex: 0 0 90%;
             flex: 0 0 90%;
     max-width: 90%;
     width: 90%;
@@ -2756,8 +2259,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--10of10-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2767,8 +2268,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 11.11111111%;
-        -ms-flex: 0 0 11.11111111%;
             flex: 0 0 11.11111111%;
     max-width: 11.11111111%;
     width: 11.11111111%;
@@ -2778,8 +2277,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 22.22222222%;
-        -ms-flex: 0 0 22.22222222%;
             flex: 0 0 22.22222222%;
     max-width: 22.22222222%;
     width: 22.22222222%;
@@ -2789,8 +2286,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -2800,8 +2295,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 44.44444444%;
-        -ms-flex: 0 0 44.44444444%;
             flex: 0 0 44.44444444%;
     max-width: 44.44444444%;
     width: 44.44444444%;
@@ -2811,8 +2304,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 55.55555556%;
-        -ms-flex: 0 0 55.55555556%;
             flex: 0 0 55.55555556%;
     max-width: 55.55555556%;
     width: 55.55555556%;
@@ -2822,8 +2313,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -2833,8 +2322,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 77.77777778%;
-        -ms-flex: 0 0 77.77777778%;
             flex: 0 0 77.77777778%;
     max-width: 77.77777778%;
     width: 77.77777778%;
@@ -2844,8 +2331,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 88.88888889%;
-        -ms-flex: 0 0 88.88888889%;
             flex: 0 0 88.88888889%;
     max-width: 88.88888889%;
     width: 88.88888889%;
@@ -2855,8 +2340,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--9of9-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2866,8 +2349,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 12.5%;
-        -ms-flex: 0 0 12.5%;
             flex: 0 0 12.5%;
     max-width: 12.5%;
     width: 12.5%;
@@ -2877,8 +2358,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -2888,8 +2367,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 37.5%;
-        -ms-flex: 0 0 37.5%;
             flex: 0 0 37.5%;
     max-width: 37.5%;
     width: 37.5%;
@@ -2899,8 +2376,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -2910,8 +2385,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 62.5%;
-        -ms-flex: 0 0 62.5%;
             flex: 0 0 62.5%;
     max-width: 62.5%;
     width: 62.5%;
@@ -2921,8 +2394,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -2932,8 +2403,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 87.5%;
-        -ms-flex: 0 0 87.5%;
             flex: 0 0 87.5%;
     max-width: 87.5%;
     width: 87.5%;
@@ -2943,8 +2412,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--8of8-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -2954,8 +2421,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 14.28571429%;
-        -ms-flex: 0 0 14.28571429%;
             flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
@@ -2965,8 +2430,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 28.57142857%;
-        -ms-flex: 0 0 28.57142857%;
             flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
@@ -2976,8 +2439,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 42.85714286%;
-        -ms-flex: 0 0 42.85714286%;
             flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
@@ -2987,8 +2448,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 57.14285714%;
-        -ms-flex: 0 0 57.14285714%;
             flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
@@ -2998,8 +2457,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 71.42857143%;
-        -ms-flex: 0 0 71.42857143%;
             flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
@@ -3009,8 +2466,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 85.71428571%;
-        -ms-flex: 0 0 85.71428571%;
             flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
@@ -3020,8 +2475,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of7-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3031,8 +2484,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 16.66666667%;
-        -ms-flex: 0 0 16.66666667%;
             flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
@@ -3042,8 +2493,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3053,8 +2502,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3064,8 +2511,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3075,8 +2520,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 83.33333333%;
-        -ms-flex: 0 0 83.33333333%;
             flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
@@ -3086,8 +2529,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of6-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3097,8 +2538,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -3108,8 +2547,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -3119,8 +2556,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -3130,8 +2565,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -3141,8 +2574,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of5-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3152,8 +2583,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -3163,8 +2592,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3174,8 +2601,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -3185,8 +2610,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of4-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3196,8 +2619,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of3-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3207,8 +2628,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of3-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3218,8 +2637,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of3-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3229,8 +2646,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of2-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3240,8 +2655,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of2-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3251,8 +2664,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of1-lg {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3264,8 +2675,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 14.28571429%;
-        -ms-flex: 0 0 14.28571429%;
             flex: 0 0 14.28571429%;
     max-width: 14.28571429%;
     width: 14.28571429%;
@@ -3275,8 +2684,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 28.57142857%;
-        -ms-flex: 0 0 28.57142857%;
             flex: 0 0 28.57142857%;
     max-width: 28.57142857%;
     width: 28.57142857%;
@@ -3286,8 +2693,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 42.85714286%;
-        -ms-flex: 0 0 42.85714286%;
             flex: 0 0 42.85714286%;
     max-width: 42.85714286%;
     width: 42.85714286%;
@@ -3297,8 +2702,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 57.14285714%;
-        -ms-flex: 0 0 57.14285714%;
             flex: 0 0 57.14285714%;
     max-width: 57.14285714%;
     width: 57.14285714%;
@@ -3308,8 +2711,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 71.42857143%;
-        -ms-flex: 0 0 71.42857143%;
             flex: 0 0 71.42857143%;
     max-width: 71.42857143%;
     width: 71.42857143%;
@@ -3319,8 +2720,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 85.71428571%;
-        -ms-flex: 0 0 85.71428571%;
             flex: 0 0 85.71428571%;
     max-width: 85.71428571%;
     width: 85.71428571%;
@@ -3330,8 +2729,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--7of7-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3341,8 +2738,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 16.66666667%;
-        -ms-flex: 0 0 16.66666667%;
             flex: 0 0 16.66666667%;
     max-width: 16.66666667%;
     width: 16.66666667%;
@@ -3352,8 +2747,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3363,8 +2756,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3374,8 +2765,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3385,8 +2774,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 83.33333333%;
-        -ms-flex: 0 0 83.33333333%;
             flex: 0 0 83.33333333%;
     max-width: 83.33333333%;
     width: 83.33333333%;
@@ -3396,8 +2783,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--6of6-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3407,8 +2792,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 20%;
-        -ms-flex: 0 0 20%;
             flex: 0 0 20%;
     max-width: 20%;
     width: 20%;
@@ -3418,8 +2801,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 40%;
-        -ms-flex: 0 0 40%;
             flex: 0 0 40%;
     max-width: 40%;
     width: 40%;
@@ -3429,8 +2810,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 60%;
-        -ms-flex: 0 0 60%;
             flex: 0 0 60%;
     max-width: 60%;
     width: 60%;
@@ -3440,8 +2819,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 80%;
-        -ms-flex: 0 0 80%;
             flex: 0 0 80%;
     max-width: 80%;
     width: 80%;
@@ -3451,8 +2828,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--5of5-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3462,8 +2837,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 25%;
-        -ms-flex: 0 0 25%;
             flex: 0 0 25%;
     max-width: 25%;
     width: 25%;
@@ -3473,8 +2846,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3484,8 +2855,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 75%;
-        -ms-flex: 0 0 75%;
             flex: 0 0 75%;
     max-width: 75%;
     width: 75%;
@@ -3495,8 +2864,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--4of4-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3506,8 +2873,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of3-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 33.33333333%;
-        -ms-flex: 0 0 33.33333333%;
             flex: 0 0 33.33333333%;
     max-width: 33.33333333%;
     width: 33.33333333%;
@@ -3517,8 +2882,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of3-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 66.66666667%;
-        -ms-flex: 0 0 66.66666667%;
             flex: 0 0 66.66666667%;
     max-width: 66.66666667%;
     width: 66.66666667%;
@@ -3528,8 +2891,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--3of3-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3539,8 +2900,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of2-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 50%;
-        -ms-flex: 0 0 50%;
             flex: 0 0 50%;
     max-width: 50%;
     width: 50%;
@@ -3550,8 +2909,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--2of2-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;
@@ -3561,8 +2918,6 @@ https://github.com/eBay/skin/blob/master/LICENSE.txt"
          */
   .grid__cell--1of1-sm {
     -webkit-box-flex: 0;
-    -webkit-flex: 0 0 100%;
-        -ms-flex: 0 0 100%;
             flex: 0 0 100%;
     max-width: 100%;
     width: 100%;

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -207,11 +207,21 @@ button.img-btn:not([disabled]):active {
   z-index: 1;
 }
 .badge {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 20px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -219,6 +229,7 @@ button.img-btn:not([disabled]):active {
   height: 20px;
   min-width: 20px;
   position: relative;
+  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {
@@ -295,7 +306,8 @@ a.cta-btn {
   background-color: transparent;
   border: 1px solid;
   border-color: inherit;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   color: inherit;
   display: inline-block;
   font-family: inherit;
@@ -337,7 +349,9 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -365,7 +379,13 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -374,6 +394,9 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -384,13 +407,19 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -401,16 +430,25 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
 }
 .expand-btn__cell {
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -426,11 +464,16 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -442,7 +485,9 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -455,13 +500,27 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 24px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column;
   height: 48px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -712,7 +771,9 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   overflow: visible;
 }
 button.btn--small,
@@ -963,16 +1024,25 @@ body .grid .card {
   background-color: #fff;
 }
 .checkbox {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1099,8 +1169,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -1129,7 +1201,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1152,7 +1228,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -1179,7 +1258,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1195,7 +1276,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1278,7 +1361,8 @@ span.fake-menu__status {
   }
 }
 .combobox {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   display: inline-block;
 }
 .combobox__control > input {
@@ -1286,7 +1370,8 @@ span.fake-menu__status {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-family: inherit;
   text-align: left;
 }
@@ -1425,6 +1510,7 @@ span.combobox__icon {
   position: absolute;
   right: 0;
   top: 15%;
+  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -1472,8 +1558,11 @@ span.combobox__icon {
 }
 .dialog__window--left,
 .dialog__window--right {
+  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
+  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -1485,7 +1574,8 @@ span.combobox__icon {
   left: auto;
 }
 .dialog__body {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 16px;
   min-height: 100%;
   position: relative;
@@ -1514,18 +1604,22 @@ span.combobox__icon {
 }
 .dialog--show.dialog--mask-fade,
 .dialog--hide.dialog--mask-fade {
+  -webkit-transition: background-color 0.16s ease-out;
   transition: background-color 0.16s ease-out;
 }
 .dialog--show.dialog--mask-fade-slow,
 .dialog--hide.dialog--mask-fade-slow {
+  -webkit-transition: background-color 0.32s ease-out;
   transition: background-color 0.32s ease-out;
 }
 .dialog--show .dialog__window--fade,
 .dialog--hide .dialog__window--fade {
+  -webkit-transition: opacity 0.16s ease-out;
   transition: opacity 0.16s ease-out;
 }
 .dialog--show .dialog__window--slide,
 .dialog--hide .dialog__window--slide {
+  -webkit-transition: -webkit-transform 0.32s ease-out;
   transition: -webkit-transform 0.32s ease-out;
   transition: transform 0.32s ease-out;
   transition: transform 0.32s ease-out, -webkit-transform 0.32s ease-out;
@@ -1567,20 +1661,27 @@ span.combobox__icon {
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
+    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
+    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
+    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
+    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -1632,12 +1733,14 @@ span.combobox__icon {
 }
 .dialog__body {
   font-size: 0.875rem;
+  padding-top: -webkit-calc(1.125rem + 12px);
   padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
   background-color: #fff;
   border-bottom: 1px solid #eee;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-size: 1.125rem;
   font-weight: 400;
   left: 0;
@@ -1649,6 +1752,7 @@ span.combobox__icon {
   text-overflow: ellipsis;
   top: 0;
   white-space: nowrap;
+  width: -webkit-calc(100% + 32px);
   width: calc(100% + 32px);
 }
 .dialog--hide.dialog--mask-fade,
@@ -1678,6 +1782,7 @@ span.combobox__icon {
   .dialog__window:not(.dialog__window--full) {
     max-width: 980px;
     min-width: auto;
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
   }
   .dialog__body h2:first-of-type {
@@ -1700,6 +1805,9 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -1714,12 +1822,20 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.field__group {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .field__label {
@@ -2681,18 +2797,31 @@ span.fake-menu__status {
   margin-left: 8px;
 }
 .page-notice {
-  align-items: stretch;
-  box-sizing: border-box;
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2702,7 +2831,10 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -2743,6 +2875,9 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2750,14 +2885,21 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -2771,11 +2913,17 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -2786,7 +2934,9 @@ span.inline-notice {
 button.flyout-notice__close {
   color: #555;
   margin: 0 0 0 16px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -2833,6 +2983,7 @@ button.flyout-notice__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -2843,6 +2994,7 @@ button.flyout-notice__close span {
 .flyout-notice__pointer--top {
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
@@ -2852,21 +3004,25 @@ button.flyout-notice__close span {
   right: 12px;
 }
 .flyout-notice__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
   left: 12px;
 }
 .flyout-notice__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -2874,14 +3030,18 @@ button.flyout-notice__close span {
   right: 12px;
 }
 .flyout-notice__pointer--left {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .flyout-notice__pointer--right {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -2926,7 +3086,9 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {
@@ -3142,13 +3304,18 @@ button.page-notice__close span {
   background-color: #dd1e31;
 }
 .pagination {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -3193,15 +3360,27 @@ button.page-notice__close span {
   vertical-align: middle;
 }
 .pagination--fluid {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  flex: 1 0 48px;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 0 48px;
+      -ms-flex: 1 0 48px;
+          flex: 1 0 48px;
 }
 .pagination {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
@@ -3293,16 +3472,25 @@ button.page-notice__close span {
   }
 }
 .radio {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3548,19 +3736,28 @@ span.select__icon {
   width: 60px;
 }
 .switch {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   height: 40px;
   position: relative;
   vertical-align: middle;
 }
 div.switch {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3568,6 +3765,7 @@ span.switch__button {
   height: 24px;
   position: relative;
   text-indent: 100%;
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 40px;
 }
@@ -3582,6 +3780,7 @@ span.switch__button::after {
   top: 4px;
   -webkit-transform: translate3d(0, 0, 0);
           transform: translate3d(0, 0, 0);
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 16px;
 }
@@ -3625,8 +3824,15 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+          flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -3636,20 +3842,39 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;
@@ -3685,7 +3910,8 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .tooltip__overlay,
 .infotip__overlay,
 .tourtip__overlay {
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -3704,13 +3930,19 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -3727,7 +3959,9 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -3790,6 +4024,7 @@ button.tourtip__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -3804,6 +4039,7 @@ button.tourtip__close span {
 .tourtip__pointer--top {
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -3817,7 +4053,8 @@ button.tourtip__close span {
 .tooltip__pointer--bottom-left,
 .infotip__pointer--bottom-left,
 .tourtip__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -3826,16 +4063,19 @@ button.tourtip__close span {
 .tooltip__pointer--bottom,
 .infotip__pointer--bottom,
 .tourtip__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
 .infotip__pointer--bottom-right,
 .tourtip__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -3845,15 +4085,18 @@ button.tourtip__close span {
 .tooltip__pointer--left,
 .infotip__pointer--left,
 .tourtip__pointer--left {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .tooltip__pointer--left-bottom,
 .infotip__pointer--left-bottom,
 .tourtip__pointer--left-bottom {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
   bottom: 12px;
   left: -7px;
@@ -3862,7 +4105,8 @@ button.tourtip__close span {
 .tooltip__pointer--left-top,
 .infotip__pointer--left-top,
 .tourtip__pointer--left-top {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
   left: -7px;
   top: 12px;
@@ -3870,8 +4114,10 @@ button.tourtip__close span {
 .tooltip__pointer--right,
 .infotip__pointer--right,
 .tourtip__pointer--right {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -3879,7 +4125,8 @@ button.tourtip__close span {
 .tooltip__pointer--right-bottom,
 .infotip__pointer--right-bottom,
 .tourtip__pointer--right-bottom {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
   bottom: 12px;
   left: auto;
@@ -3889,7 +4136,8 @@ button.tourtip__close span {
 .tooltip__pointer--right-top,
 .infotip__pointer--right-top,
 .tourtip__pointer--right-top {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
   left: auto;
   right: -7px;
@@ -3971,7 +4219,8 @@ textarea.textbox__control {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 0;
   padding: 0 16px 0 16px;
 }
@@ -4016,6 +4265,9 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -4024,7 +4276,9 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -208,19 +208,13 @@ button.img-btn:not([disabled]):active {
 }
 .badge {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
@@ -229,7 +223,6 @@ button.img-btn:not([disabled]):active {
   height: 20px;
   min-width: 20px;
   position: relative;
-  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {
@@ -349,9 +342,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -380,12 +371,8 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -395,8 +382,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -407,10 +392,7 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
@@ -418,8 +400,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -430,24 +410,17 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
 }
 .expand-btn__cell {
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 svg.btn__icon,
@@ -464,16 +437,12 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -485,9 +454,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -501,25 +468,17 @@ button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 24px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
           flex-direction: column;
   height: 48px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   max-width: 180px;
   min-width: 80px;
@@ -771,9 +730,7 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   overflow: visible;
 }
 button.btn--small,
@@ -1025,24 +982,18 @@ body .grid .card {
 }
 .checkbox {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1204,8 +1155,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1229,8 +1178,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -1258,9 +1205,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1276,9 +1221,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1510,7 +1453,6 @@ span.combobox__icon {
   position: absolute;
   right: 0;
   top: 15%;
-  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -1558,11 +1500,8 @@ span.combobox__icon {
 }
 .dialog__window--left,
 .dialog__window--right {
-  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
-  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
-  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -1661,27 +1600,20 @@ span.combobox__icon {
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
-    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
-    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
-    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
-    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -1733,7 +1665,6 @@ span.combobox__icon {
 }
 .dialog__body {
   font-size: 0.875rem;
-  padding-top: -webkit-calc(1.125rem + 12px);
   padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
@@ -1752,7 +1683,6 @@ span.combobox__icon {
   text-overflow: ellipsis;
   top: 0;
   white-space: nowrap;
-  width: -webkit-calc(100% + 32px);
   width: calc(100% + 32px);
 }
 .dialog--hide.dialog--mask-fade,
@@ -1782,7 +1712,6 @@ span.combobox__icon {
   .dialog__window:not(.dialog__window--full) {
     max-width: 980px;
     min-width: auto;
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
   }
   .dialog__body h2:first-of-type {
@@ -1806,8 +1735,6 @@ div.field {
 }
 .field-group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -1822,20 +1749,14 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.field__group {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {
@@ -2798,8 +2719,6 @@ span.fake-menu__status {
 }
 .page-notice {
   -webkit-box-align: stretch;
-  -webkit-align-items: stretch;
-      -ms-flex-align: stretch;
           align-items: stretch;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
@@ -2807,21 +2726,15 @@ span.fake-menu__status {
 div[role="region"].page-notice,
 section.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2832,8 +2745,6 @@ span[role="region"].page-notice {
 }
 .page-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   width: 100%;
   /* stylelint-disable */
@@ -2876,8 +2787,6 @@ button.page-notice__close span {
 a.page-notice,
 button.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2886,15 +2795,11 @@ a.page-notice {
 }
 div.inline-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -2914,15 +2819,11 @@ span.inline-notice {
 }
 .flyout-notice__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .flyout-notice__content p {
@@ -2934,9 +2835,7 @@ span.inline-notice {
 button.flyout-notice__close {
   color: #555;
   margin: 0 0 0 16px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -2983,7 +2882,6 @@ button.flyout-notice__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -2994,7 +2892,6 @@ button.flyout-notice__close span {
 .flyout-notice__pointer--top {
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
@@ -3017,7 +2914,6 @@ button.flyout-notice__close span {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
@@ -3033,7 +2929,6 @@ button.flyout-notice__close span {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -3041,7 +2936,6 @@ button.flyout-notice__close span {
   -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
           box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -3086,9 +2980,7 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {
@@ -3305,17 +3197,13 @@ button.page-notice__close span {
 }
 .pagination {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -3361,25 +3249,17 @@ button.page-notice__close span {
 }
 .pagination--fluid {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 0 48px;
-      -ms-flex: 1 0 48px;
           flex: 1 0 48px;
 }
 .pagination {
@@ -3473,24 +3353,18 @@ button.page-notice__close span {
 }
 .radio {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3744,20 +3618,14 @@ span.select__icon {
 }
 div.switch {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3825,13 +3693,9 @@ span.fake-tabs {
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
           flex-direction: row;
   list-style: none;
   margin: 0;
@@ -3843,19 +3707,13 @@ div.tabs__item[role="tab"] {
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-bottom: 2px solid transparent;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   margin: 0 2px;
   min-height: 40px;
@@ -3863,17 +3721,11 @@ li.fake-tabs__item {
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   font-size: 14px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 8px 16px;
   text-align: center;
@@ -3931,8 +3783,6 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .infotip__cell,
 .tourtip__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
@@ -3940,8 +3790,6 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .infotip__content,
 .tourtip__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .tooltip__content p,
@@ -3959,9 +3807,7 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -4024,7 +3870,6 @@ button.tourtip__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -4039,7 +3884,6 @@ button.tourtip__close span {
 .tourtip__pointer--top {
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -4068,7 +3912,6 @@ button.tourtip__close span {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
@@ -4088,7 +3931,6 @@ button.tourtip__close span {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -4117,7 +3959,6 @@ button.tourtip__close span {
   -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
           box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -4266,8 +4107,6 @@ textarea.textbox__control {
 span.textbox__icon,
 .textbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -4276,9 +4115,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/docs/static/ds4/skin-full.css
+++ b/docs/static/ds4/skin-full.css
@@ -207,17 +207,11 @@ button.img-btn:not([disabled]):active {
   z-index: 1;
 }
 .badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 20px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -343,9 +337,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -373,11 +365,7 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
   height: 100%;
   width: 100%;
@@ -386,8 +374,6 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -398,16 +384,13 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -418,21 +401,16 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 .expand-btn__cell {
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -448,14 +426,11 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -467,9 +442,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -482,22 +455,13 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 24px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   height: 48px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -748,9 +712,7 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   overflow: visible;
 }
 button.btn--small,
@@ -1001,22 +963,16 @@ body .grid .card {
   background-color: #fff;
 }
 .checkbox {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1174,8 +1130,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1198,9 +1152,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -1227,9 +1179,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1245,8 +1195,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1751,8 +1700,6 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -1767,18 +1714,12 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.field__group {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {
@@ -2740,26 +2681,18 @@ span.fake-menu__status {
   margin-left: 8px;
 }
 .page-notice {
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+  align-items: stretch;
   box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2769,9 +2702,7 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -2812,8 +2743,6 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2821,14 +2750,10 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -2846,15 +2771,11 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -2865,8 +2786,7 @@ span.inline-notice {
 button.flyout-notice__close {
   color: #555;
   margin: 0 0 0 16px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -3006,9 +2926,7 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {
@@ -3224,16 +3142,13 @@ button.page-notice__close span {
   background-color: #dd1e31;
 }
 .pagination {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -3278,23 +3193,15 @@ button.page-notice__close span {
   vertical-align: middle;
 }
 .pagination--fluid {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
 }
 .pagination--fluid .pagination__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 48px;
-          flex: 1 0 48px;
+  flex: 1 0 48px;
 }
 .pagination {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
@@ -3386,22 +3293,16 @@ button.page-notice__close span {
   }
 }
 .radio {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3653,19 +3554,13 @@ span.select__icon {
   vertical-align: middle;
 }
 div.switch {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3730,13 +3625,8 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -3746,32 +3636,20 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   font-size: 14px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;
@@ -3826,17 +3704,13 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -3853,8 +3727,7 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -4143,8 +4016,6 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -4153,9 +4024,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -207,11 +207,21 @@ button.img-btn:not([disabled]):active {
   z-index: 1;
 }
 .badge {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 20px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -219,6 +229,7 @@ button.img-btn:not([disabled]):active {
   height: 20px;
   min-width: 20px;
   position: relative;
+  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {
@@ -295,7 +306,8 @@ a.cta-btn {
   background-color: transparent;
   border: 1px solid;
   border-color: inherit;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   color: inherit;
   display: inline-block;
   font-family: inherit;
@@ -337,7 +349,9 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -365,7 +379,13 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -374,6 +394,9 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -384,13 +407,19 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -401,16 +430,25 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
 }
 .expand-btn__cell {
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -426,11 +464,16 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -442,7 +485,9 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -455,13 +500,27 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 24px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column;
   height: 48px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -712,7 +771,9 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   overflow: visible;
 }
 button.btn--small,
@@ -963,16 +1024,25 @@ body .grid .card {
   background-color: #fff;
 }
 .checkbox {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1099,8 +1169,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -1129,7 +1201,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1152,7 +1228,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -1179,7 +1258,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1195,7 +1276,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1278,7 +1361,8 @@ span.fake-menu__status {
   }
 }
 .combobox {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   display: inline-block;
 }
 .combobox__control > input {
@@ -1286,7 +1370,8 @@ span.fake-menu__status {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-family: inherit;
   text-align: left;
 }
@@ -1425,6 +1510,7 @@ span.combobox__icon {
   position: absolute;
   right: 0;
   top: 15%;
+  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -1472,8 +1558,11 @@ span.combobox__icon {
 }
 .dialog__window--left,
 .dialog__window--right {
+  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
+  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -1485,7 +1574,8 @@ span.combobox__icon {
   left: auto;
 }
 .dialog__body {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 16px;
   min-height: 100%;
   position: relative;
@@ -1514,18 +1604,22 @@ span.combobox__icon {
 }
 .dialog--show.dialog--mask-fade,
 .dialog--hide.dialog--mask-fade {
+  -webkit-transition: background-color 0.16s ease-out;
   transition: background-color 0.16s ease-out;
 }
 .dialog--show.dialog--mask-fade-slow,
 .dialog--hide.dialog--mask-fade-slow {
+  -webkit-transition: background-color 0.32s ease-out;
   transition: background-color 0.32s ease-out;
 }
 .dialog--show .dialog__window--fade,
 .dialog--hide .dialog__window--fade {
+  -webkit-transition: opacity 0.16s ease-out;
   transition: opacity 0.16s ease-out;
 }
 .dialog--show .dialog__window--slide,
 .dialog--hide .dialog__window--slide {
+  -webkit-transition: -webkit-transform 0.32s ease-out;
   transition: -webkit-transform 0.32s ease-out;
   transition: transform 0.32s ease-out;
   transition: transform 0.32s ease-out, -webkit-transform 0.32s ease-out;
@@ -1567,20 +1661,27 @@ span.combobox__icon {
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
+    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
+    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
+    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
+    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -1632,12 +1733,14 @@ span.combobox__icon {
 }
 .dialog__body {
   font-size: 0.875rem;
+  padding-top: -webkit-calc(1.125rem + 12px);
   padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
   background-color: #fff;
   border-bottom: 1px solid #eee;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-size: 1.125rem;
   font-weight: 400;
   left: 0;
@@ -1649,6 +1752,7 @@ span.combobox__icon {
   text-overflow: ellipsis;
   top: 0;
   white-space: nowrap;
+  width: -webkit-calc(100% + 32px);
   width: calc(100% + 32px);
 }
 .dialog--hide.dialog--mask-fade,
@@ -1678,6 +1782,7 @@ span.combobox__icon {
   .dialog__window:not(.dialog__window--full) {
     max-width: 980px;
     min-width: auto;
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
   }
   .dialog__body h2:first-of-type {
@@ -1700,6 +1805,9 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -1714,12 +1822,20 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.field__group {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .field__label {
@@ -2681,18 +2797,31 @@ span.fake-menu__status {
   margin-left: 8px;
 }
 .page-notice {
-  align-items: stretch;
-  box-sizing: border-box;
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2702,7 +2831,10 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -2743,6 +2875,9 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2750,14 +2885,21 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -2771,11 +2913,17 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -2786,7 +2934,9 @@ span.inline-notice {
 button.flyout-notice__close {
   color: #555;
   margin: 0 0 0 16px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -2833,6 +2983,7 @@ button.flyout-notice__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -2843,6 +2994,7 @@ button.flyout-notice__close span {
 .flyout-notice__pointer--top {
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
@@ -2852,21 +3004,25 @@ button.flyout-notice__close span {
   right: 12px;
 }
 .flyout-notice__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
   left: 12px;
 }
 .flyout-notice__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -2874,14 +3030,18 @@ button.flyout-notice__close span {
   right: 12px;
 }
 .flyout-notice__pointer--left {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .flyout-notice__pointer--right {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -2926,7 +3086,9 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {
@@ -3142,13 +3304,18 @@ button.page-notice__close span {
   background-color: #dd1e31;
 }
 .pagination {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -3193,15 +3360,27 @@ button.page-notice__close span {
   vertical-align: middle;
 }
 .pagination--fluid {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  flex: 1 0 48px;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 0 48px;
+      -ms-flex: 1 0 48px;
+          flex: 1 0 48px;
 }
 .pagination {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
@@ -3293,16 +3472,25 @@ button.page-notice__close span {
   }
 }
 .radio {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3548,19 +3736,28 @@ span.select__icon {
   width: 60px;
 }
 .switch {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   height: 40px;
   position: relative;
   vertical-align: middle;
 }
 div.switch {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3568,6 +3765,7 @@ span.switch__button {
   height: 24px;
   position: relative;
   text-indent: 100%;
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 40px;
 }
@@ -3582,6 +3780,7 @@ span.switch__button::after {
   top: 4px;
   -webkit-transform: translate3d(0, 0, 0);
           transform: translate3d(0, 0, 0);
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 16px;
 }
@@ -3625,8 +3824,15 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+          flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -3636,20 +3842,39 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;
@@ -3685,7 +3910,8 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .tooltip__overlay,
 .infotip__overlay,
 .tourtip__overlay {
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 3px 7px rgba(0, 0, 0, 0.15);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -3704,13 +3930,19 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -3727,7 +3959,9 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -3790,6 +4024,7 @@ button.tourtip__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -3804,6 +4039,7 @@ button.tourtip__close span {
 .tourtip__pointer--top {
   background-color: #ccc;
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -3817,7 +4053,8 @@ button.tourtip__close span {
 .tooltip__pointer--bottom-left,
 .infotip__pointer--bottom-left,
 .tourtip__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -3826,16 +4063,19 @@ button.tourtip__close span {
 .tooltip__pointer--bottom,
 .infotip__pointer--bottom,
 .tourtip__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
 .infotip__pointer--bottom-right,
 .tourtip__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+          box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -3845,15 +4085,18 @@ button.tourtip__close span {
 .tooltip__pointer--left,
 .infotip__pointer--left,
 .tourtip__pointer--left {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .tooltip__pointer--left-bottom,
 .infotip__pointer--left-bottom,
 .tourtip__pointer--left-bottom {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
   bottom: 12px;
   left: -7px;
@@ -3862,7 +4105,8 @@ button.tourtip__close span {
 .tooltip__pointer--left-top,
 .infotip__pointer--left-top,
 .tourtip__pointer--left-top {
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+          box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
   left: -7px;
   top: 12px;
@@ -3870,8 +4114,10 @@ button.tourtip__close span {
 .tooltip__pointer--right,
 .infotip__pointer--right,
 .tourtip__pointer--right {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -3879,7 +4125,8 @@ button.tourtip__close span {
 .tooltip__pointer--right-bottom,
 .infotip__pointer--right-bottom,
 .tourtip__pointer--right-bottom {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
   bottom: 12px;
   left: auto;
@@ -3889,7 +4136,8 @@ button.tourtip__close span {
 .tooltip__pointer--right-top,
 .infotip__pointer--right-top,
 .tourtip__pointer--right-top {
-  box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
   left: auto;
   right: -7px;
@@ -3971,7 +4219,8 @@ textarea.textbox__control {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 0;
   padding: 0 16px 0 16px;
 }
@@ -4016,6 +4265,9 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -4024,7 +4276,9 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -208,19 +208,13 @@ button.img-btn:not([disabled]):active {
 }
 .badge {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
@@ -229,7 +223,6 @@ button.img-btn:not([disabled]):active {
   height: 20px;
   min-width: 20px;
   position: relative;
-  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {
@@ -349,9 +342,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -380,12 +371,8 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -395,8 +382,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -407,10 +392,7 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
@@ -418,8 +400,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -430,24 +410,17 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
 }
 .expand-btn__cell {
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 svg.btn__icon,
@@ -464,16 +437,12 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -485,9 +454,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -501,25 +468,17 @@ button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 24px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
           flex-direction: column;
   height: 48px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   max-width: 180px;
   min-width: 80px;
@@ -771,9 +730,7 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   overflow: visible;
 }
 button.btn--small,
@@ -1025,24 +982,18 @@ body .grid .card {
 }
 .checkbox {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1204,8 +1155,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1229,8 +1178,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -1258,9 +1205,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1276,9 +1221,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1510,7 +1453,6 @@ span.combobox__icon {
   position: absolute;
   right: 0;
   top: 15%;
-  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -1558,11 +1500,8 @@ span.combobox__icon {
 }
 .dialog__window--left,
 .dialog__window--right {
-  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
-  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
-  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -1661,27 +1600,20 @@ span.combobox__icon {
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
-    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
-    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
-    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
-    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -1733,7 +1665,6 @@ span.combobox__icon {
 }
 .dialog__body {
   font-size: 0.875rem;
-  padding-top: -webkit-calc(1.125rem + 12px);
   padding-top: calc(1.125rem + 12px);
 }
 .dialog__body h2:first-of-type {
@@ -1752,7 +1683,6 @@ span.combobox__icon {
   text-overflow: ellipsis;
   top: 0;
   white-space: nowrap;
-  width: -webkit-calc(100% + 32px);
   width: calc(100% + 32px);
 }
 .dialog--hide.dialog--mask-fade,
@@ -1782,7 +1712,6 @@ span.combobox__icon {
   .dialog__window:not(.dialog__window--full) {
     max-width: 980px;
     min-width: auto;
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
   }
   .dialog__body h2:first-of-type {
@@ -1806,8 +1735,6 @@ div.field {
 }
 .field-group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -1822,20 +1749,14 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.field__group {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {
@@ -2798,8 +2719,6 @@ span.fake-menu__status {
 }
 .page-notice {
   -webkit-box-align: stretch;
-  -webkit-align-items: stretch;
-      -ms-flex-align: stretch;
           align-items: stretch;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
@@ -2807,21 +2726,15 @@ span.fake-menu__status {
 div[role="region"].page-notice,
 section.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2832,8 +2745,6 @@ span[role="region"].page-notice {
 }
 .page-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   width: 100%;
   /* stylelint-disable */
@@ -2876,8 +2787,6 @@ button.page-notice__close span {
 a.page-notice,
 button.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2886,15 +2795,11 @@ a.page-notice {
 }
 div.inline-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -2914,15 +2819,11 @@ span.inline-notice {
 }
 .flyout-notice__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .flyout-notice__content p {
@@ -2934,9 +2835,7 @@ span.inline-notice {
 button.flyout-notice__close {
   color: #555;
   margin: 0 0 0 16px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -2983,7 +2882,6 @@ button.flyout-notice__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -2994,7 +2892,6 @@ button.flyout-notice__close span {
 .flyout-notice__pointer--top {
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
@@ -3017,7 +2914,6 @@ button.flyout-notice__close span {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
@@ -3033,7 +2929,6 @@ button.flyout-notice__close span {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -3041,7 +2936,6 @@ button.flyout-notice__close span {
   -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
           box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -3086,9 +2980,7 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {
@@ -3305,17 +3197,13 @@ button.page-notice__close span {
 }
 .pagination {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -3361,25 +3249,17 @@ button.page-notice__close span {
 }
 .pagination--fluid {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 0 48px;
-      -ms-flex: 1 0 48px;
           flex: 1 0 48px;
 }
 .pagination {
@@ -3473,24 +3353,18 @@ button.page-notice__close span {
 }
 .radio {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3744,20 +3618,14 @@ span.select__icon {
 }
 div.switch {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3825,13 +3693,9 @@ span.fake-tabs {
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
           flex-direction: row;
   list-style: none;
   margin: 0;
@@ -3843,19 +3707,13 @@ div.tabs__item[role="tab"] {
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-bottom: 2px solid transparent;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   margin: 0 2px;
   min-height: 40px;
@@ -3863,17 +3721,11 @@ li.fake-tabs__item {
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   font-size: 14px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 8px 16px;
   text-align: center;
@@ -3931,8 +3783,6 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .infotip__cell,
 .tourtip__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
@@ -3940,8 +3790,6 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .infotip__content,
 .tourtip__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .tooltip__content p,
@@ -3959,9 +3807,7 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -4024,7 +3870,6 @@ button.tourtip__close span {
   z-index: 0;
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -4039,7 +3884,6 @@ button.tourtip__close span {
 .tourtip__pointer--top {
   background-color: #ccc;
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -4068,7 +3912,6 @@ button.tourtip__close span {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
@@ -4088,7 +3931,6 @@ button.tourtip__close span {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -4117,7 +3959,6 @@ button.tourtip__close span {
   -webkit-box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
           box-shadow: 3px -3px 3px rgba(0, 0, 0, 0.1);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -4266,8 +4107,6 @@ textarea.textbox__control {
 span.textbox__icon,
 .textbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -4276,9 +4115,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/docs/static/ds4/skin.css
+++ b/docs/static/ds4/skin.css
@@ -207,17 +207,11 @@ button.img-btn:not([disabled]):active {
   z-index: 1;
 }
 .badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 20px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -343,9 +337,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -373,11 +365,7 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
   height: 100%;
   width: 100%;
@@ -386,8 +374,6 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -398,16 +384,13 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -418,21 +401,16 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 .expand-btn__cell {
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -448,14 +426,11 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -467,9 +442,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -482,22 +455,13 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 24px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   height: 48px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -748,9 +712,7 @@ a.cta-btn__cell--fixed-height button.btn__icon,
 a.cta-btn__cell--fixed-height button.expand-btn__icon,
 a.cta-btn__cell--fixed-height a.fake-btn__icon,
 a.cta-btn__cell--fixed-height a.cta-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   overflow: visible;
 }
 button.btn--small,
@@ -1001,22 +963,16 @@ body .grid .card {
   background-color: #fff;
 }
 .checkbox {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1174,8 +1130,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1198,9 +1152,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -1227,9 +1179,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1245,8 +1195,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1751,8 +1700,6 @@ div.field {
   margin: 16px 0;
 }
 .field-group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 16px 0;
 }
@@ -1767,18 +1714,12 @@ div.field--table {
 }
 .field__group > .field__description,
 .field__group > .field__label {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.field__group {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 div.field__group {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 .field__label {
@@ -2740,26 +2681,18 @@ span.fake-menu__status {
   margin-left: 8px;
 }
 .page-notice {
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+  align-items: stretch;
   box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2769,9 +2702,7 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -2812,8 +2743,6 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2821,14 +2750,10 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -2846,15 +2771,11 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -2865,8 +2786,7 @@ span.inline-notice {
 button.flyout-notice__close {
   color: #555;
   margin: 0 0 0 16px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -3006,9 +2926,7 @@ a.page-notice--priority {
   margin-top: 8px;
 }
 .page-notice__content--align-middle + .page-notice__cta {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   margin-top: 0;
 }
 .page-notice__content--align-middle p {
@@ -3224,16 +3142,13 @@ button.page-notice__close span {
   background-color: #dd1e31;
 }
 .pagination {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -3278,23 +3193,15 @@ button.page-notice__close span {
   vertical-align: middle;
 }
 .pagination--fluid {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
 }
 .pagination--fluid .pagination__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 48px;
-          flex: 1 0 48px;
+  flex: 1 0 48px;
 }
 .pagination {
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
@@ -3386,22 +3293,16 @@ button.page-notice__close span {
   }
 }
 .radio {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3653,19 +3554,13 @@ span.select__icon {
   vertical-align: middle;
 }
 div.switch {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3730,13 +3625,8 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -3746,32 +3636,20 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   font-size: 14px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;
@@ -3826,17 +3704,13 @@ li.fake-tabs__item--current > a[aria-current="page"] {
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -3853,8 +3727,7 @@ button.infotip__close,
 button.tourtip__close {
   color: #555;
   margin: 0 0 0 16px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -4143,8 +4016,6 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -4153,9 +4024,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -89,11 +89,21 @@ body {
   z-index: 1;
 }
 .badge {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 20px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -101,6 +111,7 @@ body {
   height: 20px;
   min-width: 20px;
   position: relative;
+  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {
@@ -169,7 +180,8 @@ a.cta-btn {
   background-color: transparent;
   border: 1px solid;
   border-color: inherit;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   color: inherit;
   display: inline-block;
   font-family: inherit;
@@ -211,7 +223,9 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -239,7 +253,13 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -248,6 +268,9 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -258,13 +281,19 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -275,16 +304,25 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  align-self: baseline;
+  -webkit-align-self: baseline;
+      -ms-flex-item-align: baseline;
+          align-self: baseline;
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
 }
 .expand-btn__cell {
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -300,11 +338,16 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -316,7 +359,9 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -329,13 +374,27 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-radius: 24px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+          flex-direction: column;
   height: 48px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -574,7 +633,9 @@ button.btn__cell--fixed-height svg.cta-btn__icon,
 button.expand-btn__cell--fixed-height svg.cta-btn__icon,
 a.fake-btn__cell--fixed-height svg.cta-btn__icon,
 a.cta-btn__cell--fixed-height svg.cta-btn__icon {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   height: 1rem;
   width: 1rem;
 }
@@ -759,7 +820,9 @@ svg.fake-btn__icon {
 }
 svg.cta-btn__icon,
 svg.expand-btn__icon {
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
 }
 svg.cta-btn__icon {
   height: 10px;
@@ -781,16 +844,25 @@ span.expand-btn__icon {
   }
 }
 .checkbox {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -947,8 +1019,10 @@ span.combobox {
 .listbox__options[role="listbox"],
 .fake-menu__items {
   border: 1px solid;
-  box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-sizing: border-box;
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;
@@ -977,7 +1051,11 @@ div.combobox__option[role^="option"],
 a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1000,7 +1078,10 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -1027,7 +1108,9 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1043,7 +1126,9 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1072,8 +1157,14 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,
@@ -1150,7 +1241,8 @@ span.fake-menu__status {
   }
 }
 .combobox {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   display: inline-block;
 }
 .combobox__control > input {
@@ -1158,7 +1250,8 @@ span.fake-menu__status {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-family: inherit;
   text-align: left;
 }
@@ -1292,6 +1385,7 @@ span.combobox__icon {
   position: absolute;
   right: 0;
   top: 15%;
+  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -1339,8 +1433,11 @@ span.combobox__icon {
 }
 .dialog__window--left,
 .dialog__window--right {
+  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
+  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
+  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -1352,7 +1449,8 @@ span.combobox__icon {
   left: auto;
 }
 .dialog__body {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 16px;
   min-height: 100%;
   position: relative;
@@ -1381,18 +1479,22 @@ span.combobox__icon {
 }
 .dialog--show.dialog--mask-fade,
 .dialog--hide.dialog--mask-fade {
+  -webkit-transition: background-color 0.16s ease-out;
   transition: background-color 0.16s ease-out;
 }
 .dialog--show.dialog--mask-fade-slow,
 .dialog--hide.dialog--mask-fade-slow {
+  -webkit-transition: background-color 0.32s ease-out;
   transition: background-color 0.32s ease-out;
 }
 .dialog--show .dialog__window--fade,
 .dialog--hide .dialog__window--fade {
+  -webkit-transition: opacity 0.16s ease-out;
   transition: opacity 0.16s ease-out;
 }
 .dialog--show .dialog__window--slide,
 .dialog--hide .dialog__window--slide {
+  -webkit-transition: -webkit-transform 0.32s ease-out;
   transition: -webkit-transform 0.32s ease-out;
   transition: transform 0.32s ease-out;
   transition: transform 0.32s ease-out, -webkit-transform 0.32s ease-out;
@@ -1434,20 +1536,27 @@ span.combobox__icon {
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
+    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
+    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
+    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
+    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
+    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -1537,6 +1646,7 @@ label.floating-label__label--disabled {
   color: #ebebeb;
 }
 label.floating-label__label--animate {
+  -webkit-transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
   transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
   transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
   transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
@@ -2205,18 +2315,31 @@ span.fake-menu__status {
   margin-left: 8px;
 }
 .page-notice {
-  align-items: stretch;
-  box-sizing: border-box;
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+      -ms-flex-align: stretch;
+          align-items: stretch;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2226,7 +2349,10 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -2267,6 +2393,9 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2274,14 +2403,21 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
-  box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -2294,11 +2430,17 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -2311,7 +2453,9 @@ button.flyout-notice__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -2339,45 +2483,55 @@ button.flyout-notice__close:hover {
   width: 16px;
   z-index: 0;
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
   left: 12px;
 }
 .flyout-notice__pointer--top {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
   left: auto;
   right: 12px;
 }
 .flyout-notice__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
   left: 12px;
 }
 .flyout-notice__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -2385,14 +2539,18 @@ button.flyout-notice__close:hover {
   right: 12px;
 }
 .flyout-notice__pointer--left {
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .flyout-notice__pointer--right {
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -2434,7 +2592,10 @@ button.flyout-notice__close:hover {
   background-color: #3665f3;
 }
 .page-notice__status {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   color: #fff;
   padding: 12px 16px 12px 12px;
 }
@@ -2458,7 +2619,9 @@ span.page-notice__cta {
 }
 span.page-notice__cta,
 svg.page-notice__cta {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   margin: 0 16px;
 }
 .page-notice__status span {
@@ -2564,13 +2727,18 @@ svg.page-notice__cta {
   outline-offset: 4px;
 }
 .pagination {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -2615,18 +2783,33 @@ svg.page-notice__cta {
   vertical-align: middle;
 }
 .pagination--fluid {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  flex: 1 0 48px;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 0 48px;
+      -ms-flex: 1 0 48px;
+          flex: 1 0 48px;
 }
 .pagination {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   min-width: 376px;
 }
 .pagination a,
@@ -2643,7 +2826,8 @@ svg.page-notice__cta {
   width: 56px;
 }
 .pagination__item {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   font-size: 0.875rem;
   font-weight: 700;
   line-height: 48px;
@@ -2665,8 +2849,13 @@ svg.page-notice__cta {
 }
 .pagination__next,
 .pagination__previous {
-  flex-grow: 0;
-  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
   line-height: 56px;
   width: 48px;
 }
@@ -2706,13 +2895,21 @@ svg.page-notice__cta {
   width: 100%;
 }
 .pagination--fluid .pagination__items {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
   max-width: none;
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
-  flex-grow: 0;
-  flex-shrink: 0;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+  -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+          flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {
@@ -2737,16 +2934,25 @@ svg.page-notice__cta {
   }
 }
 .radio {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -2898,6 +3104,7 @@ span.select__icon {
   height: 5.2px;
   width: 9px;
   background-size: 9px 5.2px;
+  top: -webkit-calc(50% - 2.6px);
   top: calc(50% - 2.6px);
 }
 @media screen and (-ms-high-contrast: white-on-black) {
@@ -2940,19 +3147,28 @@ span.select__icon {
   height: 48px;
 }
 .switch {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   height: 40px;
   position: relative;
   vertical-align: middle;
 }
 div.switch {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -2960,6 +3176,7 @@ span.switch__button {
   height: 24px;
   position: relative;
   text-indent: 100%;
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 40px;
 }
@@ -2974,6 +3191,7 @@ span.switch__button::after {
   top: 4px;
   -webkit-transform: translate3d(0, 0, 0);
           transform: translate3d(0, 0, 0);
+  -webkit-transition: left 0.15s ease-out 0s;
   transition: left 0.15s ease-out 0s;
   width: 16px;
 }
@@ -3017,8 +3235,15 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+          flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -3028,20 +3253,39 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  align-items: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+      -ms-flex-align: center;
+          align-items: center;
   border-bottom: 2px solid transparent;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
-  flex: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   font-size: 14px;
-  justify-content: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;
@@ -3095,7 +3339,8 @@ textarea.textbox__control {
      -moz-appearance: none;
           appearance: none;
   border: 1px solid;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   margin: 0;
   padding: 0 16px 0 16px;
 }
@@ -3167,6 +3412,9 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -3175,7 +3423,9 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  align-self: center;
+  -webkit-align-self: center;
+      -ms-flex-item-align: center;
+          align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,
@@ -3213,7 +3463,8 @@ textarea.textbox__control {
   background: #fff;
   border-color: #6e6e6e;
   border-radius: 0;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   color: #111820;
   font-family: inherit;
   font-size: 0.875rem;
@@ -3245,6 +3496,9 @@ input.textbox__control--underline {
 input.textbox__control--underline::-webkit-input-placeholder {
   color: transparent;
 }
+input.textbox__control--underline::-moz-placeholder {
+  color: transparent;
+}
 input.textbox__control--underline:-ms-input-placeholder {
   color: transparent;
 }
@@ -3257,6 +3511,9 @@ input.textbox__control--underline::placeholder {
 input.textbox__control--underline:focus::-webkit-input-placeholder {
   color: #6e6e6e;
 }
+input.textbox__control--underline:focus::-moz-placeholder {
+  color: #6e6e6e;
+}
 input.textbox__control--underline:focus:-ms-input-placeholder {
   color: #6e6e6e;
 }
@@ -3267,6 +3524,9 @@ input.textbox__control--underline:focus::placeholder {
   color: #6e6e6e;
 }
 input.textbox__control--underline[disabled]::-webkit-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-moz-placeholder {
   color: transparent;
 }
 input.textbox__control--underline[disabled]:-ms-input-placeholder {
@@ -3319,7 +3579,8 @@ span.textbox__icon:first-child,
 .tooltip__overlay,
 .infotip__overlay,
 .tourtip__overlay {
-  box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -3337,13 +3598,19 @@ span.textbox__icon:first-child,
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  flex-grow: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -3362,7 +3629,9 @@ button.tourtip__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  align-self: flex-start;
+  -webkit-align-self: flex-start;
+      -ms-flex-item-align: start;
+          align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -3398,15 +3667,18 @@ button.tourtip__close:hover {
   width: 16px;
   z-index: 0;
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
 .infotip__pointer--top-left,
 .tourtip__pointer--top-left {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
   left: 12px;
 }
@@ -3414,15 +3686,18 @@ button.tourtip__close:hover {
 .infotip__pointer--top,
 .tourtip__pointer--top {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
 .infotip__pointer--top-right,
 .tourtip__pointer--top-right {
   background-color: white;
-  box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
   left: auto;
   right: 12px;
@@ -3430,7 +3705,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--bottom-left,
 .infotip__pointer--bottom-left,
 .tourtip__pointer--bottom-left {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -3439,16 +3715,19 @@ button.tourtip__close:hover {
 .tooltip__pointer--bottom,
 .infotip__pointer--bottom,
 .tourtip__pointer--bottom {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
+  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
 .infotip__pointer--bottom-right,
 .tourtip__pointer--bottom-right {
-  box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: -7px;
   top: auto;
@@ -3458,15 +3737,18 @@ button.tourtip__close:hover {
 .tooltip__pointer--left,
 .infotip__pointer--left,
 .tourtip__pointer--left {
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
 .tooltip__pointer--left-bottom,
 .infotip__pointer--left-bottom,
 .tourtip__pointer--left-bottom {
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: 12px;
   left: -7px;
@@ -3475,7 +3757,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--left-top,
 .infotip__pointer--left-top,
 .tourtip__pointer--left-top {
-  box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   left: -7px;
   top: 12px;
@@ -3483,8 +3766,10 @@ button.tourtip__close:hover {
 .tooltip__pointer--right,
 .infotip__pointer--right,
 .tourtip__pointer--right {
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
+  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -3492,7 +3777,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--right-bottom,
 .infotip__pointer--right-bottom,
 .tourtip__pointer--right-bottom {
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   bottom: 12px;
   left: auto;
@@ -3502,7 +3788,8 @@ button.tourtip__close:hover {
 .tooltip__pointer--right-top,
 .infotip__pointer--right-top,
 .tourtip__pointer--right-top {
-  box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+          box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
   left: auto;
   right: -7px;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -89,17 +89,11 @@ body {
   z-index: 1;
 }
 .badge {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 20px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
   white-space: nowrap;
@@ -217,9 +211,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -247,11 +239,7 @@ a.cta-btn--fluid {
 .expand-btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
   height: 100%;
   width: 100%;
@@ -260,8 +248,6 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height,
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -272,16 +258,13 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
 .expand-btn__cell--truncated,
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -292,21 +275,16 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -ms-flex-item-align: baseline;
-      align-self: baseline;
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
 }
 .expand-btn__cell {
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 svg.btn__icon,
 svg.expand-btn__icon,
@@ -322,14 +300,11 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -341,9 +316,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -356,22 +329,13 @@ button.btn.btn--pill,
 button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-radius: 24px;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex-direction: column;
   height: 48px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   max-width: 180px;
   min-width: 80px;
   padding: 4px 24px;
@@ -610,9 +574,7 @@ button.btn__cell--fixed-height svg.cta-btn__icon,
 button.expand-btn__cell--fixed-height svg.cta-btn__icon,
 a.fake-btn__cell--fixed-height svg.cta-btn__icon,
 a.cta-btn__cell--fixed-height svg.cta-btn__icon {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   height: 1rem;
   width: 1rem;
 }
@@ -797,8 +759,7 @@ svg.fake-btn__icon {
 }
 svg.cta-btn__icon,
 svg.expand-btn__icon {
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
 }
 svg.cta-btn__icon {
   height: 10px;
@@ -820,22 +781,16 @@ span.expand-btn__icon {
   }
 }
 .checkbox {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1023,8 +978,6 @@ a.fake-menu__item,
 button.fake-menu__item {
   border: 1px solid;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1047,9 +1000,7 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
 div.listbox__option--active-descendant[role="option"] .listbox__status,
@@ -1076,9 +1027,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1094,8 +1043,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1124,12 +1072,8 @@ a.fake-menu__item,
 button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-pack: justify;
-      -ms-flex-pack: justify;
-          justify-content: space-between;
+  justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
 div.listbox__option[role="option"]:hover,
@@ -2261,26 +2205,18 @@ span.fake-menu__status {
   margin-left: 8px;
 }
 .page-notice {
-  -webkit-box-align: stretch;
-      -ms-flex-align: stretch;
-          align-items: stretch;
+  align-items: stretch;
   box-sizing: border-box;
 }
 div[role="region"].page-notice,
 section.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2290,9 +2226,7 @@ span[role="region"].page-notice {
   display: inline-block;
 }
 .page-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   width: 100%;
   /* stylelint-disable */
   -ms-word-break: break-all;
@@ -2333,8 +2267,6 @@ button.page-notice__close span {
 }
 a.page-notice,
 button.page-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2342,14 +2274,10 @@ a.page-notice {
   text-decoration: none;
 }
 div.inline-notice {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -2366,15 +2294,11 @@ span.inline-notice {
   z-index: 1;
 }
 .flyout-notice__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .flyout-notice__content p {
   margin: 0;
@@ -2387,8 +2311,7 @@ button.flyout-notice__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -2511,9 +2434,7 @@ button.flyout-notice__close:hover {
   background-color: #3665f3;
 }
 .page-notice__status {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   color: #fff;
   padding: 12px 16px 12px 12px;
 }
@@ -2537,9 +2458,7 @@ span.page-notice__cta {
 }
 span.page-notice__cta,
 svg.page-notice__cta {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   margin: 0 16px;
 }
 .page-notice__status span {
@@ -2645,16 +2564,13 @@ svg.page-notice__cta {
   outline-offset: 4px;
 }
 .pagination {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -2699,28 +2615,18 @@ svg.page-notice__cta {
   vertical-align: middle;
 }
 .pagination--fluid {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: -ms-flexbox;
+  align-items: center;
   display: flex;
 }
 .pagination--fluid .pagination__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
-  -webkit-box-flex: 1;
-      -ms-flex: 1 0 48px;
-          flex: 1 0 48px;
+  flex: 1 0 48px;
 }
 .pagination {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   min-width: 376px;
 }
 .pagination a,
@@ -2759,11 +2665,8 @@ svg.page-notice__cta {
 }
 .pagination__next,
 .pagination__previous {
-  -webkit-box-flex: 0;
-      -ms-flex-positive: 0;
-          flex-grow: 0;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-grow: 0;
+  flex-shrink: 0;
   line-height: 56px;
   width: 48px;
 }
@@ -2803,18 +2706,13 @@ svg.page-notice__cta {
   width: 100%;
 }
 .pagination--fluid .pagination__items {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
   max-width: none;
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
-  -webkit-box-flex: 0;
-      -ms-flex-positive: 0;
-          flex-grow: 0;
-  -ms-flex-negative: 0;
-      flex-shrink: 0;
+  flex-grow: 0;
+  flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {
@@ -2839,22 +2737,16 @@ svg.page-notice__cta {
   }
 }
 .radio {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3054,19 +2946,13 @@ span.select__icon {
   vertical-align: middle;
 }
 div.switch {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3131,13 +3017,8 @@ span.fake-tabs {
 }
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-direction: row;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -3147,32 +3028,20 @@ div.tabs__item[role="tab"] {
 }
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
+  align-items: center;
   border-bottom: 2px solid transparent;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   margin: 0 2px;
   min-height: 40px;
 }
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   font-size: 14px;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  justify-content: center;
   padding: 8px 16px;
   text-align: center;
   text-decoration: none;
@@ -3298,8 +3167,6 @@ textarea.textbox__control {
 }
 span.textbox__icon,
 .textbox__icon {
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -3308,9 +3175,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,
@@ -3383,6 +3248,9 @@ input.textbox__control--underline::-webkit-input-placeholder {
 input.textbox__control--underline:-ms-input-placeholder {
   color: transparent;
 }
+input.textbox__control--underline::-ms-input-placeholder {
+  color: transparent;
+}
 input.textbox__control--underline::placeholder {
   color: transparent;
 }
@@ -3392,6 +3260,9 @@ input.textbox__control--underline:focus::-webkit-input-placeholder {
 input.textbox__control--underline:focus:-ms-input-placeholder {
   color: #6e6e6e;
 }
+input.textbox__control--underline:focus::-ms-input-placeholder {
+  color: #6e6e6e;
+}
 input.textbox__control--underline:focus::placeholder {
   color: #6e6e6e;
 }
@@ -3399,6 +3270,9 @@ input.textbox__control--underline[disabled]::-webkit-input-placeholder {
   color: transparent;
 }
 input.textbox__control--underline[disabled]:-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-ms-input-placeholder {
   color: transparent;
 }
 input.textbox__control--underline[disabled]::placeholder {
@@ -3463,17 +3337,13 @@ span.textbox__icon:first-child,
 .tooltip__cell,
 .infotip__cell,
 .tourtip__cell {
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .tooltip__content,
 .infotip__content,
 .tourtip__content {
-  -webkit-box-flex: 1;
-      -ms-flex-positive: 1;
-          flex-grow: 1;
+  flex-grow: 1;
 }
 .tooltip__content p,
 .infotip__content p,
@@ -3492,8 +3362,7 @@ button.tourtip__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  -ms-flex-item-align: start;
-      align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;

--- a/docs/static/ds6/skin.css
+++ b/docs/static/ds6/skin.css
@@ -90,19 +90,13 @@ body {
 }
 .badge {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 1px 7px 0;
   vertical-align: middle;
@@ -111,7 +105,6 @@ body {
   height: 20px;
   min-width: 20px;
   position: relative;
-  top: -webkit-calc(50% - 20px);
   top: calc(50% - 20px);
 }
 .badge {
@@ -223,9 +216,7 @@ a.fake-btn {
 .fake-btn__icon,
 .cta-btn__icon,
 .expand-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__icon:first-child,
 .fake-btn__icon:first-child,
@@ -254,12 +245,8 @@ a.cta-btn--fluid {
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 100%;
   width: 100%;
@@ -269,8 +256,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--fixed-height,
 .cta-btn__cell--fixed-height {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--fixed-height > span,
@@ -281,10 +266,7 @@ a.cta-btn--fluid {
 .expand-btn__cell--fixed-height > svg,
 .fake-btn__cell--fixed-height > svg,
 .cta-btn__cell--fixed-height > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell--truncated,
@@ -292,8 +274,6 @@ a.cta-btn--fluid {
 .fake-btn__cell--truncated,
 .cta-btn__cell--truncated {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .btn__cell--truncated > span,
@@ -304,24 +284,17 @@ a.cta-btn--fluid {
 .expand-btn__cell--truncated > svg,
 .fake-btn__cell--truncated > svg,
 .cta-btn__cell--truncated > svg {
-  -webkit-align-self: baseline;
-      -ms-flex-item-align: baseline;
-          align-self: baseline;
-  max-width: -webkit-calc(100% - 32px);
+  align-self: baseline;
   max-width: calc(100% - 32px);
 }
 .btn__cell,
 .fake-btn__cell,
 .cta-btn__cell {
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
 }
 .expand-btn__cell {
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 svg.btn__icon,
@@ -338,16 +311,12 @@ span.expand-btn__icon {
   display: inline-block;
   vertical-align: middle;
   background-position-y: center;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   margin-left: 8px;
 }
 span.expand-btn__icon:only-child,
 svg.expand-btn__icon:only-child {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -359,9 +328,7 @@ svg.expand-btn__icon:only-child {
 .expand-btn__cell--fixed-height svg.icon,
 .fake-btn__cell--fixed-height svg.icon,
 .cta-btn__cell--fixed-height svg.icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 .btn__cell--fixed-height svg.icon,
 .expand-btn__cell--fixed-height svg.icon,
@@ -375,25 +342,17 @@ button.expand-btn.expand-btn--pill,
 a.cta-btn.cta-btn--pill,
 a.fake-btn.fake-btn--pill {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-radius: 24px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
           flex-direction: column;
   height: 48px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   max-width: 180px;
   min-width: 80px;
@@ -633,9 +592,7 @@ button.btn__cell--fixed-height svg.cta-btn__icon,
 button.expand-btn__cell--fixed-height svg.cta-btn__icon,
 a.fake-btn__cell--fixed-height svg.cta-btn__icon,
 a.cta-btn__cell--fixed-height svg.cta-btn__icon {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   height: 1rem;
   width: 1rem;
 }
@@ -820,9 +777,7 @@ svg.fake-btn__icon {
 }
 svg.cta-btn__icon,
 svg.expand-btn__icon {
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
 }
 svg.cta-btn__icon {
   height: 10px;
@@ -845,24 +800,18 @@ span.expand-btn__icon {
 }
 .checkbox {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .checkbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .checkbox__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .checkbox__icon:not([hidden]) {
@@ -1054,8 +1003,6 @@ button.fake-menu__item {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
   height: 100%;
@@ -1079,8 +1026,6 @@ button.fake-menu__item span:not([class*="fake-menu__status"]) {
   text-overflow: ellipsis;
   white-space: nowrap;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] .menu__status,
@@ -1108,9 +1053,7 @@ button.fake-menu__item {
 .listbox__status,
 .combobox__status,
 .fake-menu__status {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   fill: currentColor;
   height: 8px;
   stroke: currentColor;
@@ -1126,9 +1069,7 @@ span.fake-menu__status {
   background-size: contain;
   display: inline-block;
   vertical-align: middle;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   pointer-events: none;
 }
 .menu__items--fix-width[role="menu"],
@@ -1158,12 +1099,8 @@ button.fake-menu__item {
   background-color: #fff;
   border-color: #fff;
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-      -ms-flex-pack: justify;
           justify-content: space-between;
 }
 div.menu__item[role^="menuitem"]:hover,
@@ -1385,7 +1322,6 @@ span.combobox__icon {
   position: absolute;
   right: 0;
   top: 15%;
-  width: -webkit-calc(100% - 32px);
   width: calc(100% - 32px);
   will-change: opacity, transform;
 }
@@ -1433,11 +1369,8 @@ span.combobox__icon {
 }
 .dialog__window--left,
 .dialog__window--right {
-  width: -webkit-calc(88% - 32px);
   width: calc(88% - 32px);
-  min-width: -webkit-calc(88% - 32px);
   min-width: calc(88% - 32px);
-  max-width: -webkit-calc(100% - 32px);
   max-width: calc(100% - 32px);
 }
 .dialog__window--left {
@@ -1536,27 +1469,20 @@ span.combobox__icon {
 }
 @media (max-width: 600px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(100% - 32px);
     width: calc(100% - 32px);
-    min-width: -webkit-calc(100% - 32px);
     min-width: calc(100% - 32px);
-    max-width: -webkit-calc(100% - 32px);
     max-width: calc(100% - 32px);
   }
 }
 @media (min-width: 601px) and (max-width: 768px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(88% - 32px);
     width: calc(88% - 32px);
-    min-width: -webkit-calc(88% - 32px);
     min-width: calc(88% - 32px);
-    max-width: -webkit-calc(88% - 32px);
     max-width: calc(88% - 32px);
   }
 }
 @media (min-width: 769px) and (max-width: 1024px) {
   .dialog__window:not(.dialog__window--full) {
-    width: -webkit-calc(75% - 32px);
     width: calc(75% - 32px);
     max-width: 616px;
   }
@@ -2316,8 +2242,6 @@ span.fake-menu__status {
 }
 .page-notice {
   -webkit-box-align: stretch;
-  -webkit-align-items: stretch;
-      -ms-flex-align: stretch;
           align-items: stretch;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
@@ -2325,21 +2249,15 @@ span.fake-menu__status {
 div[role="region"].page-notice,
 section.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span[role="region"].page-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .page-notice__status {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 0;
 }
@@ -2350,8 +2268,6 @@ span[role="region"].page-notice {
 }
 .page-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   width: 100%;
   /* stylelint-disable */
@@ -2394,8 +2310,6 @@ button.page-notice__close span {
 a.page-notice,
 button.page-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 a.page-notice {
@@ -2404,15 +2318,11 @@ a.page-notice {
 }
 div.inline-notice {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   margin: 8px 0;
 }
 span.inline-notice {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .flyout-notice {
@@ -2431,15 +2341,11 @@ span.inline-notice {
 }
 .flyout-notice__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
 .flyout-notice__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .flyout-notice__content p {
@@ -2453,9 +2359,7 @@ button.flyout-notice__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -2486,7 +2390,6 @@ button.flyout-notice__close:hover {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-left {
@@ -2501,7 +2404,6 @@ button.flyout-notice__close:hover {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--top-right {
@@ -2526,7 +2428,6 @@ button.flyout-notice__close:hover {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .flyout-notice__pointer--bottom-right {
@@ -2542,7 +2443,6 @@ button.flyout-notice__close:hover {
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -2550,7 +2450,6 @@ button.flyout-notice__close:hover {
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;
@@ -2593,8 +2492,6 @@ button.flyout-notice__close:hover {
 }
 .page-notice__status {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   color: #fff;
   padding: 12px 16px 12px 12px;
@@ -2619,9 +2516,7 @@ span.page-notice__cta {
 }
 span.page-notice__cta,
 svg.page-notice__cta {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   margin: 0 16px;
 }
 .page-notice__status span {
@@ -2728,17 +2623,13 @@ svg.page-notice__cta {
 }
 .pagination {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0;
   max-width: 100%;
 }
 .pagination__items {
   display: inline;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  flex-wrap: wrap;
   list-style-type: none;
   overflow: hidden;
   padding: 0;
@@ -2784,31 +2675,21 @@ svg.page-notice__cta {
 }
 .pagination--fluid {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 .pagination--fluid .pagination__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   min-width: 288px;
 }
 .pagination--fluid .pagination__items > li {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 0 48px;
-      -ms-flex: 1 0 48px;
           flex: 1 0 48px;
 }
 .pagination {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   min-width: 376px;
 }
@@ -2850,12 +2731,8 @@ svg.page-notice__cta {
 .pagination__next,
 .pagination__previous {
   -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-      -ms-flex-positive: 0;
           flex-grow: 0;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
   line-height: 56px;
   width: 48px;
 }
@@ -2896,20 +2773,14 @@ svg.page-notice__cta {
 }
 .pagination--fluid .pagination__items {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
   max-width: none;
 }
 .pagination--fluid .pagination__next,
 .pagination--fluid .pagination__previous {
   -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-      -ms-flex-positive: 0;
           flex-grow: 0;
-  -webkit-flex-shrink: 0;
-      -ms-flex-negative: 0;
-          flex-shrink: 0;
+  flex-shrink: 0;
 }
 @media screen and (-ms-high-contrast: white-on-black) {
   .pagination__next span {
@@ -2935,24 +2806,18 @@ svg.page-notice__cta {
 }
 .radio {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1rem;
   vertical-align: text-bottom;
 }
 .radio__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 1em;
   outline-offset: 1px;
 }
 .radio__icon[hidden] {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 .radio__icon:not([hidden]) {
@@ -3104,7 +2969,6 @@ span.select__icon {
   height: 5.2px;
   width: 9px;
   background-size: 9px 5.2px;
-  top: -webkit-calc(50% - 2.6px);
   top: calc(50% - 2.6px);
 }
 @media screen and (-ms-high-contrast: white-on-black) {
@@ -3155,20 +3019,14 @@ span.select__icon {
 }
 div.switch {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
 }
 span.switch {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 span.switch__button {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
   background: gray none repeat scroll 0 0;
   border-radius: 400px;
   color: transparent;
@@ -3236,13 +3094,9 @@ span.fake-tabs {
 div.tabs__items[role="tablist"],
 ul.fake-tabs__items {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
           flex-direction: row;
   list-style: none;
   margin: 0;
@@ -3254,19 +3108,13 @@ div.tabs__item[role="tab"] {
 div.tabs__item[role="tab"],
 li.fake-tabs__item {
   -webkit-box-align: center;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
           align-items: center;
   border-bottom: 2px solid transparent;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   margin: 0 2px;
   min-height: 40px;
@@ -3274,17 +3122,11 @@ li.fake-tabs__item {
 div.tabs__item[role="tab"] > span,
 li.fake-tabs__item > a {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   -webkit-box-flex: 1;
-  -webkit-flex: 1;
-      -ms-flex: 1;
           flex: 1;
   font-size: 14px;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
-      -ms-flex-pack: center;
           justify-content: center;
   padding: 8px 16px;
   text-align: center;
@@ -3413,8 +3255,6 @@ textarea.textbox__control {
 span.textbox__icon,
 .textbox__icon {
   display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
   display: inline-flex;
   height: 100%;
   pointer-events: none;
@@ -3423,9 +3263,7 @@ span.textbox__icon,
 }
 span.textbox__icon::before,
 .textbox__icon::before {
-  -webkit-align-self: center;
-      -ms-flex-item-align: center;
-          align-self: center;
+  align-self: center;
 }
 span.textbox__icon:first-child + input.textbox__control,
 .textbox__icon:first-child + input.textbox__control,
@@ -3599,8 +3437,6 @@ span.textbox__icon:first-child,
 .infotip__cell,
 .tourtip__cell {
   display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   padding: 16px;
 }
@@ -3608,8 +3444,6 @@ span.textbox__icon:first-child,
 .infotip__content,
 .tourtip__content {
   -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-      -ms-flex-positive: 1;
           flex-grow: 1;
 }
 .tooltip__content p,
@@ -3629,9 +3463,7 @@ button.tourtip__close {
   height: 32px;
   margin: -8px -6px 0 16px;
   width: 32px;
-  -webkit-align-self: flex-start;
-      -ms-flex-item-align: start;
-          align-self: flex-start;
+  align-self: flex-start;
   background: none;
   border: 0;
   padding: 0;
@@ -3670,7 +3502,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-left,
@@ -3689,7 +3520,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
   top: -7px;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right,
@@ -3720,7 +3550,6 @@ button.tourtip__close:hover {
   background-color: white;
   bottom: -7px;
   top: auto;
-  left: -webkit-calc(50% - 8px);
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right,
@@ -3740,7 +3569,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: -7px;
 }
@@ -3769,7 +3597,6 @@ button.tourtip__close:hover {
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
   background-color: white;
-  top: -webkit-calc(50% - 8px);
   top: calc(50% - 8px);
   left: auto;
   right: -7px;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "version": "npm run build && git add -A dist docs"
   },
   "devDependencies": {
+    "@ebay/browserslist-config": "^1",
     "browser-sync": "^2",
     "gulp": "^3",
     "gulp-banner": "~0.1.3",
@@ -70,5 +71,8 @@
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
-  }
+  },
+  "browserslist": [
+    "extends @ebay/browserslist-config"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lasso-autoprefixer": "^3",
     "lasso-cli": "^2",
     "lasso-less": "^3",
-    "less-plugin-autoprefix": "^1",
+    "less-plugin-autoprefix": "^2",
     "less-plugin-clean-css": "^1",
     "makeup-expander": "~0.5.0",
     "makeup-floating-label": "~0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,9 +120,9 @@
     to-fast-properties "^2.0.0"
 
 "@ebay/browserslist-config@^1":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ebay/browserslist-config/-/browserslist-config-1.0.0.tgz#06328378600156458dacb0278767ff8490f2074c"
-  integrity sha512-Q1+zh29IOQQTLNGVqQFKBhYuL9kRQbTV8B51LprQAn/vpgvnHXdtzfdJYUILZMKeoy63R3wMkAdCagC5dmLrhg==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ebay/browserslist-config/-/browserslist-config-1.0.1.tgz#deccafb04101fa52507b8f2204161c8ed5e70375"
+  integrity sha512-5i4XOsKwoCYomZ9cF7H5OBroeHoYUriylg55mJwTARMbQVv21RnYKF/Bwi86ZlHz4S6YepxlaQorsxR6T2xv6w==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,11 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@ebay/browserslist-config@^1":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ebay/browserslist-config/-/browserslist-config-1.0.0.tgz#06328378600156458dacb0278767ff8490f2074c"
+  integrity sha512-Q1+zh29IOQQTLNGVqQFKBhYuL9kRQbTV8B51LprQAn/vpgvnHXdtzfdJYUILZMKeoy63R3wMkAdCagC5dmLrhg==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,18 +491,6 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@^6.0.0:
-  version "6.7.7"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
-  integrity sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=
-  dependencies:
-    browserslist "^1.7.6"
-    caniuse-db "^1.0.30000634"
-    normalize-range "^0.1.2"
-    num2fraction "^1.2.2"
-    postcss "^5.2.16"
-    postcss-value-parser "^3.2.3"
-
 autoprefixer@^7.2.5:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.6.tgz#256672f86f7c735da849c4f07d008abb056067dc"
@@ -513,6 +501,18 @@ autoprefixer@^7.2.5:
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^6.0.17"
+    postcss-value-parser "^3.2.3"
+
+autoprefixer@^8.6.3:
+  version "8.6.5"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.6.5.tgz#343f3d193ed568b3208e00117a1b96eb691d4ee9"
+  integrity sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==
+  dependencies:
+    browserslist "^3.2.8"
+    caniuse-lite "^1.0.30000864"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^6.0.23"
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^9.0.0:
@@ -1262,14 +1262,6 @@ browser-sync@^2:
     ua-parser-js "0.7.17"
     yargs "6.4.0"
 
-browserslist@^1.7.6:
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
-  integrity sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=
-  dependencies:
-    caniuse-db "^1.0.30000639"
-    electron-to-chromium "^1.2.7"
-
 browserslist@^2.1.2:
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.2.tgz#0838eec4b3db2d860cee13bf6c0691e7e8133822"
@@ -1285,6 +1277,14 @@ browserslist@^2.11.3:
   dependencies:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
+
+browserslist@^3.2.8:
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
 
 browserslist@^4.1.0:
   version "4.1.1"
@@ -1381,11 +1381,6 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000784"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000784.tgz#1be95012d9489c7719074f81aee57dbdffe6361b"
-  integrity sha1-G+lQEtlInHcZB0+BruV9vf/mNhs=
-
 caniuse-lite@^1.0.30000784:
   version "1.0.30000784"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz#129ced74e9a1280a441880b6cd2bce30ef59e6c0"
@@ -1395,6 +1390,11 @@ caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805:
   version "1.0.30000808"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz#7d759b5518529ea08b6705a19e70dbf401628ffc"
   integrity sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw==
+
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000864:
+  version "1.0.30000918"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz#6288f79da3c5c8b45e502f47ad8f3eb91f1379a9"
+  integrity sha512-CAZ9QXGViBvhHnmIHhsTPSWFBujDaelKnUj7wwImbyQRxmXynYqKGi3UaZTSz9MoVh+1EVxOS/DFIkrJYgR3aw==
 
 caniuse-lite@^1.0.30000884:
   version "1.0.30000887"
@@ -2040,12 +2040,17 @@ electron-releases@^2.1.0:
   resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
   integrity sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
+electron-to-chromium@^1.3.30:
   version "1.3.30"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
   integrity sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==
   dependencies:
     electron-releases "^2.1.0"
+
+electron-to-chromium@^1.3.47:
+  version "1.3.90"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.90.tgz#b4c51b8303beff18f2b74817402bf4898e09558a"
+  integrity sha512-IjJZKRhFbWSOX1w0sdIXgp4CMRguu6UYcTckyFF/Gjtemsu/25eZ+RXwFlV+UWcIueHyQA1UnRJxocTpH5NdGA==
 
 electron-to-chromium@^1.3.62:
   version "1.3.70"
@@ -3991,13 +3996,13 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-less-plugin-autoprefix@^1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/less-plugin-autoprefix/-/less-plugin-autoprefix-1.5.1.tgz#bca4e5b2e48cac6965a1783142e3b32c3c00ce07"
-  integrity sha1-vKTlsuSMrGlloXgxQuOzLDwAzgc=
+less-plugin-autoprefix@^2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/less-plugin-autoprefix/-/less-plugin-autoprefix-2.0.0.tgz#778e6f2fe56884381c4fc3c747b0879e944f8481"
+  integrity sha512-UktaMtHAhCVTIQxjlceo1MiiQiUZws7gi3hfcpxkCLn1CJdVdlRGCb4n1/M64hniw2DLd7YzOl7ojshs1tWYcQ==
   dependencies:
-    autoprefixer "^6.0.0"
-    postcss "^5.0.0"
+    autoprefixer "^8.6.3"
+    postcss "^6.0.22"
 
 less-plugin-clean-css@^1:
   version "1.5.1"
@@ -5377,7 +5382,7 @@ postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
   integrity sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=
 
-postcss@^5.0.0, postcss@^5.2.16:
+postcss@^5.2.16:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
   integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
@@ -5396,7 +5401,7 @@ postcss@^6.0.17:
     source-map "^0.6.1"
     supports-color "^5.2.0"
 
-postcss@^6.0.8:
+postcss@^6.0.22, postcss@^6.0.23, postcss@^6.0.8:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==


### PR DESCRIPTION
# Issue #484 

I upgraded `less-plugin-autoprefixer` to v2, which updates `autoprefixer` to v8.6.3 (from v6.7.7). This allows us to use a browsers list config:

https://github.com/postcss/autoprefixer/releases/tag/8.0.0