### PR TITLE
Fix gh.browser.json and icon-mixin #482

### DIFF
--- a/gh.browser.json
+++ b/gh.browser.json
@@ -12,7 +12,7 @@
         "less-import: ./src/less/combobox/ds6/combobox-mixin.less",
         "less-import: ./src/less/dialog/ds6/dialog-mixin.less",
         "less-import: ./src/less/global/ds6/global-mixin.less",
-        "less-import: ./src/less/icon/ds6/icon-mixin.less",
+        "less-import: ./src/less/icon/icon-mixin.less",
         "less-import: ./src/less/label/ds6/label-mixin.less",
         "less-import: ./src/less/notice/ds6/notice-mixin.less",
         "less-import: ./src/less/pagination/ds6/pagination-mixin.less",

--- a/src/less/icon/common/ds6/icon-mixin.less
+++ b/src/less/icon/common/ds6/icon-mixin.less
@@ -1,3 +1,0 @@
-.icon-mixin() {
-    @import "../../../../../dist/icon/ds6/icon.css";
-}

--- a/src/less/icon/icon-mixin.less
+++ b/src/less/icon/icon-mixin.less
@@ -1,0 +1,5 @@
+.icon-mixin() {
+    @import "../../../dist/icon/common/ds6/common.css";
+    @import "../../../dist/icon/background/ds6/background.css";
+    @import "../../../dist/icon/foreground/ds6/foreground.css";
+}


### PR DESCRIPTION
# Issue #482

## Goals

1. Fix error thrown when importing `gh.browser.json` due to invalid path.

## Changes

1. Updated `gh.browser.json` with correct path to `icon-mixin.less`
1. Updated `icon-mixin.less` with the 3 paths to common, background and foreground css
