### PR TITLE
Combo: removed @ebay/skin/icon from this bundle (#457)

### DIFF
--- a/combo.browser.json
+++ b/combo.browser.json
@@ -3,12 +3,6 @@
         "@ebay/skin/core",
         "@ebay/skin/dialog",
         "@ebay/skin/form",
-        "@ebay/skin/spinner",
-        {
-            "if-not-flag": "skin-icon-opt-out",
-            "dependencies": [
-                "@ebay/skin/icon"
-            ]
-        }
+        "@ebay/skin/spinner"
     ]
 }

--- a/docs/_includes/common/bundles.html
+++ b/docs/_includes/common/bundles.html
@@ -15,7 +15,6 @@
         <li>@ebay/skin/core</li>
         <li>@ebay/skin/dialog</li>
         <li>@ebay/skin/form</li>
-        <li>@ebay/skin/icon</li>
         <li>@ebay/skin/spinner</li>
     </ul>
     <p><strong>Note:</strong> The combo bundle itself contains two other bundles. Lasso will take care of de-duping modules where necessary.</p>


### PR DESCRIPTION
As previously discussed, this small PR simply removes the `@ebay/skin/icon` module from the combo bundle (used by inception), thus giving the app the choice of whether to use background or foreground icons (or both).

Fixes #457 
