### PR TITLE
Icon: changed module dependency order to fix css cascade

### DIFF
--- a/icon/background.browser.json
+++ b/icon/background.browser.json
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "@ebay/skin/icon/common",
         {
             "path": "../dist/icon/background/ds4/background.css",
             "if-not-flag": "skin-ds6"
@@ -8,6 +7,7 @@
         {
             "path": "../dist/icon/background/ds6/background.css",
             "if-flag": "skin-ds6"
-        }
+        },
+        "@ebay/skin/icon/common"
     ]
 }

--- a/icon/foreground.browser.json
+++ b/icon/foreground.browser.json
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "@ebay/skin/icon/common",
         {
             "path": "../dist/icon/foreground/ds4/foreground.css",
             "if-not-flag": "skin-ds6"
@@ -8,6 +7,7 @@
         {
             "path": "../dist/icon/foreground/ds6/foreground.css",
             "if-flag": "skin-ds6"
-        }
+        },
+        "@ebay/skin/icon/common"
     ]
 }


### PR DESCRIPTION
This addresses the issue we noticed on coreui with small foreground icons due to incorrect css cascade order.