### PR TITLE
Website: remove redundant classes from checkbox (#592)

### DIFF
--- a/docs/_includes/common/checkbox.html
+++ b/docs/_includes/common/checkbox.html
@@ -37,10 +37,10 @@
             <span class="checkbox">
                 <input aria-label="SVG checkbox example" class="checkbox__control" type="checkbox" name="checkbox-svg"/>
                 <span class="checkbox__icon" hidden>
-                    <svg class="icon icon--checkbox--unchecked checkbox__unchecked" focusable="false" height="19" width="21">
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-checkbox-unchecked"></use>
                     </svg>
-                    <svg class="icon icon--checkbox--checked checkbox__checked" focusable="false" height="19" width="21">
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-checkbox-checked"></use>
                     </svg>
                 </span>
@@ -51,10 +51,10 @@
 <span class="checkbox">
     <input aria-label="SVG checkbox example" class="checkbox__control" type="checkbox" />
     <span class="checkbox__icon" hidden>
-        <svg class="icon icon--checkbox--unchecked checkbox__unchecked" focusable="false" height="19" width="21">
+        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-checkbox-unchecked"></use>
         </svg>
-        <svg class="icon icon--checkbox--checked checkbox__checked" focusable="false" height="19" width="21">
+        <svg class="checkbox__checked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-checkbox-checked"></use>
         </svg>
     </span>

--- a/docs/_includes/common/radio.html
+++ b/docs/_includes/common/radio.html
@@ -36,10 +36,10 @@
             <span class="radio">
                 <input aria-label="SVG radio example" class="radio__control" type="radio" name="radio-svg"/>
                 <span class="radio__icon" hidden>
-                    <svg class="icon icon--radio--unchecked radio__unchecked" focusable="false" height="19" width="21">
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-radio-unchecked"></use>
                     </svg>
-                    <svg class="icon icon--radio--checked radio__checked" focusable="false" height="19" width="21">
+                    <svg class="radio__checked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-radio-checked"></use>
                     </svg>
                 </span>
@@ -50,10 +50,10 @@
 <span class="radio">
     <input aria-label="SVG radio example" class="radio__control" type="radio" />
     <span class="radio__icon" hidden>
-        <svg class="icon icon--radio--unchecked radio__unchecked" focusable="false" height="19" width="21">
+        <svg class="radio__unchecked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-radio-unchecked"></use>
         </svg>
-        <svg class="icon icon--radio--checked radio__checked" focusable="false" height="19" width="21">
+        <svg class="radio__checked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-radio-checked"></use>
         </svg>
     </span>


### PR DESCRIPTION
Issue #592

This PR is intended for master branch. Documentation change only.

It appears that there are some redundant icon classes on the checkbox and radio examples that can cause specificity issues in the cascade. See #592 for details.

I also changed the HTML width and height attributes to 18x18 (these are the non-CSS fallback dimensions).
