### PR TITLE
Added browser.json into icons directory

### DIFF
--- a/icon/browser.json
+++ b/icon/browser.json
@@ -1,0 +1,14 @@
+{
+ "requireRemap": [
+    {
+      "from": "../dist/icon/background/ds4/background.css",
+      "to": "../dist/icon/background/ds6/background.css",
+      "if-flag": "skin-ds6"
+    },
+    {
+      "from": "../dist/icon/foreground/ds4/foreground.css",
+      "to": "../dist/icon/foreground/ds6/foreground.css",
+      "if-flag": "skin-ds6"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #676 Remaps DS6 files when DS6 flag is passed

<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
Added a browser.json remap to the icon directory in order to remap ds6 files.

## Context
<!--- Why did you make these changes, and why in this particular way? -->
If the user would reference files from icon directory they will not be remapped properly since it looks for the nearest browser.json in the directory it's currently in.

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
#676 
