### PR TITLE
Website: removed flyout-notice (#675)

### DIFF
--- a/docs/_includes/common/notice.html
+++ b/docs/_includes/common/notice.html
@@ -223,6 +223,7 @@
 </div>
     {% endhighlight %}
 
+    <!--
     <h3 id="notice-flyout">Flyout Notice <sup>DEPRECATED</sup></h3>
     <p>A flyout-level notice is a flyout that <em>points</em> to a specific section or element of the page.</p>
     <p>The DOM order of the element in the page is very important! To avoid keyboard and screen reader accessibility issues, the flyout notice should immediately follow the element that it points to.</p>
@@ -321,6 +322,7 @@
     </div>
 </div>
 {% endhighlight %}
+    -->
 
     {% if page.ds == 6 %}
     <div class="section-footer">


### PR DESCRIPTION
Closes #675 

Simple change to remove flyout-notice section from website. I'm pretty sure we wont see a return of this pattern in DS6.5 review, but I've left it commented out for now (rather than deleted) just in case.