### PR TITLE
Changed browser.json to load icons correctly

### DIFF
--- a/icon.browser.json
+++ b/icon.browser.json
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "./icon/background",
-        "./icon/foreground"
+        "./icon/browser.json"
     ]
 }

--- a/icon/browser.json
+++ b/icon/browser.json
@@ -1,5 +1,9 @@
 {
- "requireRemap": [
+  "dependencies": [
+    "./background",
+    "./foreground"
+  ],
+  "requireRemap": [
     {
       "from": "../dist/icon/background/ds4/background.css",
       "to": "../dist/icon/background/ds6/background.css",


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
Changed browser.json in icon directory to load dependencies. Since a reference of `@ebay/skin/icon` would actually load this browser.json with no depdendencies. 
We also tested that the remaps would work properly but not load the given dependencies (so loading just foreground icons would still work as before).

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Changed the base icon.browser.json to load the ./icon/browser.json in order to not prevent any breaking changes. 

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
ebay/ebayui-core#779

## Screenshots
<!-- Upload screenshots if appropriate-->
