### PR TITLE
Process to version cdn.html file;

### DIFF
--- a/docs/_includes/common/cdn.html
+++ b/docs/_includes/common/cdn.html
@@ -1,7 +1,7 @@
 <div id="cdn">
     <h2>CDN</h2>
     <p>A CSS file containing the full collection of modules (except background icon data-urls) is available via the following url:</p>
-    <p><a href="http://ir.ebaystatic.com/cr/v/c1/skin/v7.4.6/ds{{ page.ds}}/skin.min.css">https://ir.ebaystatic.com/cr/v/c1/skin/v7.4.6/ds{{ page.ds}}/skin.min.css</a></p>
+    <p><a href="http://ir.ebaystatic.com/cr/v/c1/skin/v{{page.version}}/ds{{page.ds}}/skin.min.css">https://ir.ebaystatic.com/cr/v/c1/skin/v{{page.version}}/ds{{page.ds}}/skin.min.css</a></p>
     <p>Due to their large size, background icon data-urls are considered optional, and are available separately via the following url:</p>
-    <p><a href="http://ir.ebaystatic.com/cr/v/c1/skin/v7.4.6/ds{{ page.ds}}/skin-base64.min.css">https://ir.ebaystatic.com/cr/v/c1/skin/v7.4.6/ds{{ page.ds}}/skin-base64.min.css</a></p>
+    <p><a href="http://ir.ebaystatic.com/cr/v/c1/skin/v{{page.version}}/ds{{page.ds}}/skin-base64.min.css">https://ir.ebaystatic.com/cr/v/c1/skin/v{{page.version}}/ds{{page.ds}}/skin-base64.min.css</a></p>
 </div>

--- a/docs/ds6/index.html
+++ b/docs/ds6/index.html
@@ -1,4 +1,5 @@
 ---
+version: 8.0.0-0
 layout: ds6/default
 title: Skin DS6
 ds: 6

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,5 @@
 ---
+version: 8.0.0-0
 layout: ds4/default
 title: Skin
 ds: 4

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "copy:variablesToDist": "mkdirp dist/variables && ncp src/less/variables dist/variables",
     "copy:mixinsToDist": "mkdirp dist/mixins && ncp src/less/mixins dist/mixins",
     "copy:svgToDist": "mkdirp dist/svg && ncp src/svg dist/svg",
-    "version": "npm run build && git add -A dist docs",
+    "version": "node scripts/cdn-version && npm run build && git add -A dist docs",
     "transpile": "babel docs/src/js --out-dir docs/_babel"
   },
   "devDependencies": {

--- a/scripts/cdn-version.js
+++ b/scripts/cdn-version.js
@@ -1,0 +1,15 @@
+/*
+ * Updates the CDN paths with the current version of NPM
+ */
+const fs = require('fs');
+const files = ['./docs/index.html', './docs/ds6/index.html'];
+
+files.forEach(file => {    
+    const newContents = fs.readFileSync(file, 'utf8').replace(/version\:.*\n/gi, `version: ${process.env.npm_package_version}\n`);
+
+    fs.writeFile(file, newContents, 'utf8', (err) => {
+        if (err) {
+            return console.log(err);
+        }
+    });
+});


### PR DESCRIPTION
## Description
- add a script to version the `cdn.html` file
- adds a new `version` variable for Jekyll

## Context
This is an automation so we don't have to update the CDN file manually after versioning.