### PR TITLE
Updated gulpfile to generate CDN folder for different bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "extends @ebay/browserslist-config"
   ],
   "dependencies": {
+    "gulp-if": "^3.0.0",
     "merge-stream": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gulp": "^4",
     "gulp-banner": "~0.1.3",
     "gulp-flatten": "~0.4.0",
+    "gulp-if": "^3.0.0",
     "gulp-less": "^4",
     "gulp-rename": "^1",
     "jekyll": "^3.0.0-beta1",
@@ -62,6 +63,7 @@
     "makeup-navigation-emitter": "~0.3.0",
     "makeup-prevent-scroll-keys": "~0.0.3",
     "makeup-roving-tabindex": "~0.3.0",
+    "merge-stream": "^2.0.0",
     "mkdirp": "~0.5",
     "ncp": "^2",
     "nodelist-foreach-polyfill": "^1",
@@ -84,9 +86,5 @@
   },
   "browserslist": [
     "extends @ebay/browserslist-config"
-  ],
-  "dependencies": {
-    "gulp-if": "^3.0.0",
-    "merge-stream": "^2.0.0"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
   },
   "browserslist": [
     "extends @ebay/browserslist-config"
-  ]
+  ],
+  "dependencies": {
+    "merge-stream": "^2.0.0"
+  }
 }

--- a/src/less/bundles/myebay/ds4/skin.less
+++ b/src/less/bundles/myebay/ds4/skin.less
@@ -1,0 +1,36 @@
+// Source file for generated skin.min.css (used by website and CDN)
+
+@import "../../../global/ds4/global-static.less";
+@import "../../../utility/ds4/utility.less";
+@import "../../../actionable/ds4/actionable.less";
+@import "../../../badge/ds4/badge.less";
+@import "../../../breadcrumb/ds4/breadcrumb.less";
+@import "../../../button/ds4/button.less";
+@import "../../../card/ds4/card.less";
+@import "../../../carousel/ds4/carousel.less";
+@import "../../../checkbox/ds4/checkbox.less";
+@import "../../../combobox/ds4/combobox.less";
+@import "../../../cta-button/ds4/cta-button.less";
+@import "../../../details/ds4/details.less";
+@import "../../../dialog/ds4/dialog.less";
+@import "../../../expand-button/ds4/expand-button.less";
+@import "../../../field/ds4/field.less";
+@import "../../../icon/foreground/ds4/foreground.less";
+@import "../../../label/ds4/label.less";
+@import "../../../link/ds4/link.less";
+@import "../../../listbox/ds4/listbox.less";
+@import "../../../listbox-button/ds4/listbox-button.less";
+@import "../../../marketsans/marketsans.less";
+@import "../../../menu/ds4/menu.less";
+@import "../../../menu-button/ds4/menu-button.less";
+@import "../../../notice/ds4/notice.less";
+@import "../../../pagination/ds4/pagination.less";
+@import "../../../pill/ds4/pill.less";
+@import "../../../radio/ds4/radio.less";
+@import "../../../select/ds4/select.less";
+@import "../../../spinner/ds4/spinner.less";
+@import "../../../switch/ds4/switch.less";
+@import "../../../tab/ds4/tab.less";
+@import "../../../tooltip/ds4/tooltip.less";
+@import "../../../textbox/ds4/textbox.less";
+@import "../../../typography/ds4/typography.less";

--- a/src/less/bundles/myebay/ds6/skin.less
+++ b/src/less/bundles/myebay/ds6/skin.less
@@ -1,0 +1,36 @@
+// Source file for generated skin.min.css (used by website and CDN)
+
+@import "../../../marketsans/marketsans.less";
+@import "../../../global/ds6/global-static.less";
+@import "../../../actionable/ds6/actionable.less";
+@import "../../../badge/ds6/badge.less";
+@import "../../../breadcrumb/ds6/breadcrumb.less";
+@import "../../../button/ds6/button.less";
+@import "../../../carousel/ds6/carousel.less";
+@import "../../../checkbox/ds6/checkbox.less";
+@import "../../../color/ds6/color.less";
+@import "../../../combobox/ds6/combobox.less";
+@import "../../../cta-button/ds6/cta-button.less";
+@import "../../../details/ds6/details.less";
+@import "../../../dialog/ds6/dialog.less";
+@import "../../../expand-button/ds6/expand-button.less";
+@import "../../../field/ds6/field.less";
+@import "../../../label/ds6/label.less";
+@import "../../../icon/foreground/ds6/foreground.less";
+@import "../../../link/ds6/link.less";
+@import "../../../listbox/ds6/listbox.less";
+@import "../../../listbox-button/ds6/listbox-button.less";
+@import "../../../menu/ds6/menu.less";
+@import "../../../menu-button/ds6/menu-button.less";
+@import "../../../notice/ds6/notice.less";
+@import "../../../pagination/ds6/pagination.less";
+@import "../../../pill/ds6/pill.less";
+@import "../../../radio/ds6/radio.less";
+@import "../../../select/ds6/select.less";
+@import "../../../spinner/ds6/spinner.less";
+@import "../../../switch/ds6/switch.less";
+@import "../../../tab/ds6/tab.less";
+@import "../../../textbox/ds6/textbox.less";
+@import "../../../tooltip/ds6/tooltip.less";
+@import "../../../typography/ds6/typography.less";
+@import "../../../utility/ds6/utility.less";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5238,6 +5238,11 @@ meow@^5.0.0:
     trim-newlines "^2.0.0"
     yargs-parser "^10.0.0"
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2709,6 +2709,16 @@ duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+duplexify@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.1.tgz#7027dc374f157b122a8ae08c2d3ea4d2d953aa61"
+  integrity sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==
+  dependencies:
+    end-of-stream "^1.4.1"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+    stream-shift "^1.0.0"
+
 each-props@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/each-props/-/each-props-1.3.2.tgz#ea45a414d16dd5cfa419b1a81720d5ca06892333"
@@ -2774,7 +2784,7 @@ encodeurl@~1.0.1, encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
@@ -3267,6 +3277,11 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+fork-stream@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/fork-stream/-/fork-stream-0.0.4.tgz#db849fce77f6708a5f8f386ae533a0907b54ae70"
+  integrity sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -3574,6 +3589,15 @@ gulp-flatten@~0.4.0:
     plugin-error "^0.1.2"
     through2 "^2.0.0"
 
+gulp-if@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-if/-/gulp-if-3.0.0.tgz#6c3e7edc8bafadc34f2ebecb314bf43324ba1e40"
+  integrity sha512-fCUEngzNiEZEK2YuPm+sdMpO6ukb8+/qzbGfJBXyNOXz85bCG7yBI+pPSl+N90d7gnLvMsarthsAImx0qy7BAw==
+  dependencies:
+    gulp-match "^1.1.0"
+    ternary-stream "^3.0.0"
+    through2 "^3.0.1"
+
 gulp-less@^4:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/gulp-less/-/gulp-less-4.0.1.tgz#348c33a5dde7a207c5771b1d8261d1ac1021ceed"
@@ -3586,6 +3610,13 @@ gulp-less@^4:
     replace-ext "^1.0.0"
     through2 "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.0"
+
+gulp-match@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gulp-match/-/gulp-match-1.1.0.tgz#552b7080fc006ee752c90563f9fec9d61aafdf4f"
+  integrity sha512-DlyVxa1Gj24DitY2OjEsS+X6tDpretuxD6wTfhXE/Rw2hweqc1f6D/XtsJmoiCwLWfXgR87W9ozEityPCVzGtQ==
+  dependencies:
+    minimatch "^3.0.3"
 
 gulp-rename@^1:
   version "1.4.0"
@@ -5326,7 +5357,7 @@ mime@^2.3.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.2.tgz#ce5229a5e99ffc313abac806b482c10e7ba6ac78"
   integrity sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6396,6 +6427,15 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+"readable-stream@2 || 3", readable-stream@^3.1.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -6408,15 +6448,6 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-readable-stream@^3.1.1:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
-  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readable-stream@~1.1.9:
   version "1.1.14"
@@ -7526,6 +7557,16 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
+ternary-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ternary-stream/-/ternary-stream-3.0.0.tgz#7951930ea9e823924d956f03d516151a2d516253"
+  integrity sha512-oIzdi+UL/JdktkT+7KU5tSIQjj8pbShj3OASuvDEhm0NT5lppsm7aXWAmAq4/QMaBIyfuEcNLbAQA+HpaISobQ==
+  dependencies:
+    duplexify "^4.1.1"
+    fork-stream "^0.0.4"
+    merge-stream "^2.0.0"
+    through2 "^3.0.1"
+
 terser@^3.17.0:
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
@@ -7558,6 +7599,13 @@ through2@^2.0.0, through2@^2.0.3, through2@~2.0.0:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+through2@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
+  integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
+  dependencies:
+    readable-stream "2 || 3"
 
 through@^2.3.4, through@^2.3.8:
   version "2.3.8"


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
Changed gulpfile to have a new task to generate _cdn bundles for all directories in bundle. 
I could have changed this to hardcode myebay, but I wanted to make it more generic in case we get more tasks for teams. It simply reads each directory in bundle and creates a _cdn directory out of it. 

## Context
<!--- Why did you make these changes, and why in this particular way? -->
I simply copied the bundles AS IS from the bundles/skin directory since the initial issue did not specify what modules they want or don't want. I just included everything for now and we can drop as needed. 

What could be better is to have a definition of what bundles need what (ie skin would need docs, static, _cdn, myebay only _cdn and then gulpfile would pick up and do what it needs to do). However, it might not be needed. 

## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
#697 

## Screenshots
<!-- Upload screenshots if appropriate-->
<img width="667" alt="Screen Shot 2019-08-06 at 11 49 04 AM" src="https://user-images.githubusercontent.com/1755269/62567562-3ea61400-b840-11e9-9e75-e3a1cf36e477.png">

