### PR TITLE
Infotip bugfixes

### DIFF
--- a/dist/tooltip/ds4/tooltip.css
+++ b/dist/tooltip/ds4/tooltip.css
@@ -255,6 +255,10 @@ span.tourtip {
 .infotip__host[aria-expanded="true"] ~ .infotip__overlay {
   display: block;
 }
+button.infotip__host.icon-btn {
+  height: 16px;
+  width: 16px;
+}
 @media (min-width: 601px) {
   .tooltip__overlay,
   .infotip__overlay,
@@ -277,10 +281,6 @@ span.tourtip {
 .tourtip__pointer--top,
 .tourtip__pointer--top-right {
   background-color: #0654ba;
-}
-button.infotip__host.icon-btn {
-  height: 16px;
-  width: 16px;
 }
 button.infotip__host.icon-btn svg {
   width: 16px;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -266,6 +266,11 @@ span.tourtip {
   background-color: #fff;
   color: #111820;
 }
+button.infotip__host.icon-btn {
+  height: 16px;
+  width: 16px;
+  margin-bottom: 2px;
+}
 button.tourtip__close {
   color: #fff;
 }

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -268,8 +268,8 @@ span.tourtip {
 }
 button.infotip__host.icon-btn {
   height: 16px;
-  width: 16px;
   margin-bottom: 2px;
+  width: 16px;
 }
 button.tourtip__close {
   color: #fff;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -238,6 +238,10 @@ span.tourtip {
 .infotip__host[aria-expanded="true"] ~ .infotip__overlay {
   display: block;
 }
+button.infotip__host.icon-btn {
+  height: 16px;
+  width: 16px;
+}
 @media (min-width: 601px) {
   .tooltip__overlay,
   .infotip__overlay,
@@ -267,9 +271,7 @@ span.tourtip {
   color: #111820;
 }
 button.infotip__host.icon-btn {
-  height: 16px;
   margin-bottom: 2px;
-  width: 16px;
 }
 button.tourtip__close {
   color: #fff;

--- a/docs/_includes/common/tooltip.html
+++ b/docs/_includes/common/tooltip.html
@@ -28,7 +28,7 @@
                         <use xlink:href="#icon-settings"></use>
                     </svg>
                 </button>
-                <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="top: -60px; left: -4px;">
+                <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="left: -4px; right: auto; top: auto; bottom: calc(100% + 12px)">
                     <span class="tooltip__pointer tooltip__pointer--bottom-left"></span>
                     <div class="tooltip__mask">
                         <div class="tooltip__cell">
@@ -48,7 +48,7 @@
             <use xlink:href="#icon-settings"></use>
         </svg>
     </button>
-    <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="top: -60px; left: -4px;">
+    <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="left: -4px; right: auto; top: auto; bottom: calc(100% + 12px)">
         <span class="tooltip__pointer tooltip__pointer--bottom-left"></span>
         <div class="tooltip__mask">
             <div class="tooltip__cell">
@@ -74,7 +74,7 @@
                         <use xlink:href="#icon-information"></use>
                     </svg>
                 </button>
-                <div class="infotip__overlay" style="top: 32px; left: -12px">
+                <div class="infotip__overlay" style="left: calc(-50% - 4px); right: auto; top: calc(100% + 16px); bottom: auto">
                     <span class="infotip__pointer infotip__pointer--top-left"></span>
                     <div class="infotip__mask">
                         <div class="infotip__cell">
@@ -98,7 +98,7 @@
             <use xlink:href="#icon-information"></use>
         </svg>
     </button>
-    <div class="infotip__overlay" style="top: 32px; left: -12px">
+    <div class="infotip__overlay" style="left: calc(-50% - 4px); right: auto; top: calc(100% + 16px); bottom: auto">
         <span class="infotip__pointer infotip__pointer--top-left"></span>
         <div class="infotip__mask">
             <div class="infotip__cell">
@@ -130,7 +130,7 @@
                             <use xlink:href="#icon-information"></use>
                         </svg>
                     </button>
-                    <span class="infotip__overlay" style="top: 32px; left: -12px">
+                    <span class="infotip__overlay" style="left: calc(-50% - 4px); right: auto; top: calc(100% + 16px); bottom: auto">
                         <span class="infotip__pointer infotip__pointer--top-left"></span>
                         <span class="infotip__mask">
                             <span class="infotip__cell">
@@ -157,7 +157,7 @@
                 <use xlink:href="#icon-information"></use>
             </svg>
         </button>
-        <span class="infotip__overlay" style="top: 32px; left: -12px">
+        <span class="infotip__overlay" style="left: calc(-50% - 4px); right: auto; top: calc(100% + 16px); bottom: auto">
             <span class="infotip__pointer infotip__pointer--top-left"></span>
             <span class="infotip__mask">
                 <span class="infotip__cell">
@@ -182,8 +182,8 @@
         <div class="demo__inner">
             <div class="tourtip tourtip--expanded">
                 <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                <div class="tourtip__overlay" style="right: 0; top: 25%" role="region" aria-labelledby="tourtip-label">
-                    <span class="tourtip__pointer tourtip__pointer--left"></span>
+                <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+                    <span class="tourtip__pointer tourtip__pointer--top"></span>
                     <div class="tourtip__mask">
                         <div class="tourtip__cell">
                             <span class="tourtip__content">
@@ -202,8 +202,8 @@
     {% highlight html %}
 <div class="tourtip tourtip--expanded">
     <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <div class="tourtip__overlay" role="region" aria-labelledby="tourtip-label">
-        <span class="tourtip__pointer tourtip__pointer--left"></span>
+    <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+        <span class="tourtip__pointer tourtip__pointer--top"></span>
         <div class="tourtip__mask">
             <div class="tourtip__cell">
                 <span class="tourtip__content">

--- a/docs/_includes/common/tooltip.html
+++ b/docs/_includes/common/tooltip.html
@@ -74,7 +74,7 @@
                         <use xlink:href="#icon-information"></use>
                     </svg>
                 </button>
-                <div class="infotip__overlay" style="top: 32px; left: -12px">
+                <div class="infotip__overlay">
                     <span class="infotip__pointer infotip__pointer--top-left"></span>
                     <div class="infotip__mask">
                         <div class="infotip__cell">
@@ -98,7 +98,7 @@
             <use xlink:href="#icon-information"></use>
         </svg>
     </button>
-    <div class="infotip__overlay" style="top: 32px; left: -12px">
+    <div class="infotip__overlay">
         <span class="infotip__pointer infotip__pointer--top-left"></span>
         <div class="infotip__mask">
             <div class="infotip__cell">
@@ -130,7 +130,7 @@
                             <use xlink:href="#icon-information"></use>
                         </svg>
                     </button>
-                    <span class="infotip__overlay" style="top: 32px; left: -12px">
+                    <span class="infotip__overlay">
                         <span class="infotip__pointer infotip__pointer--top-left"></span>
                         <span class="infotip__mask">
                             <span class="infotip__cell">
@@ -157,7 +157,7 @@
                 <use xlink:href="#icon-information"></use>
             </svg>
         </button>
-        <span class="infotip__overlay" style="top: 32px; left: -12px">
+        <span class="infotip__overlay">
             <span class="infotip__pointer infotip__pointer--top-left"></span>
             <span class="infotip__mask">
                 <span class="infotip__cell">

--- a/docs/_includes/common/tooltip.html
+++ b/docs/_includes/common/tooltip.html
@@ -74,7 +74,7 @@
                         <use xlink:href="#icon-information"></use>
                     </svg>
                 </button>
-                <div class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
+                <div class="infotip__overlay" style="top: 32px; left: -12px">
                     <span class="infotip__pointer infotip__pointer--top-left"></span>
                     <div class="infotip__mask">
                         <div class="infotip__cell">
@@ -98,7 +98,7 @@
             <use xlink:href="#icon-information"></use>
         </svg>
     </button>
-    <div class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
+    <div class="infotip__overlay" style="top: 32px; left: -12px">
         <span class="infotip__pointer infotip__pointer--top-left"></span>
         <div class="infotip__mask">
             <div class="infotip__cell">
@@ -130,7 +130,7 @@
                             <use xlink:href="#icon-information"></use>
                         </svg>
                     </button>
-                    <span class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
+                    <span class="infotip__overlay" style="top: 32px; left: -12px">
                         <span class="infotip__pointer infotip__pointer--top-left"></span>
                         <span class="infotip__mask">
                             <span class="infotip__cell">
@@ -157,7 +157,7 @@
                 <use xlink:href="#icon-information"></use>
             </svg>
         </button>
-        <span class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
+        <span class="infotip__overlay" style="top: 32px; left: -12px">
             <span class="infotip__pointer infotip__pointer--top-left"></span>
             <span class="infotip__mask">
                 <span class="infotip__cell">

--- a/docs/_includes/common/tooltip.html
+++ b/docs/_includes/common/tooltip.html
@@ -48,7 +48,7 @@
             <use xlink:href="#icon-settings"></use>
         </svg>
     </button>
-    <div class="tooltip__overlay" id="tooltip-0" role="tooltip">
+    <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="top: -60px; left: -4px;">
         <span class="tooltip__pointer tooltip__pointer--bottom-left"></span>
         <div class="tooltip__mask">
             <div class="tooltip__cell">
@@ -74,7 +74,7 @@
                         <use xlink:href="#icon-information"></use>
                     </svg>
                 </button>
-                <div class="infotip__overlay">
+                <div class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
                     <span class="infotip__pointer infotip__pointer--top-left"></span>
                     <div class="infotip__mask">
                         <div class="infotip__cell">
@@ -98,7 +98,7 @@
             <use xlink:href="#icon-information"></use>
         </svg>
     </button>
-    <div class="infotip__overlay">
+    <div class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
         <span class="infotip__pointer infotip__pointer--top-left"></span>
         <div class="infotip__mask">
             <div class="infotip__cell">
@@ -130,12 +130,12 @@
                             <use xlink:href="#icon-information"></use>
                         </svg>
                     </button>
-                    <span class="infotip__overlay" style="top: 45px; left: -4px;">
+                    <span class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
                         <span class="infotip__pointer infotip__pointer--top-left"></span>
                         <span class="infotip__mask">
                             <span class="infotip__cell">
                                 <span class="infotip__content">
-                                    <span class="infotip__heading">Infotip</span>
+                                    <span class="infotip__heading" role="heading" aria-level=5>Infotip</span>
                                     <span>Here's a tip to help you be successful at your task.</span>
                                 </span>
                                 <button aria-label="Dismiss infotip" class="infotip__close" type="button">
@@ -157,12 +157,12 @@
                 <use xlink:href="#icon-information"></use>
             </svg>
         </button>
-        <span class="infotip__overlay">
+        <span class="infotip__overlay" style="{% if page.ds == 4 %}top: 32px; left: -12px{% else %}top: 45px; left: -4px{% endif %}">
             <span class="infotip__pointer infotip__pointer--top-left"></span>
             <span class="infotip__mask">
                 <span class="infotip__cell">
                     <span class="infotip__content">
-                        <span class="infotip__heading">Infotip</span>
+                        <span class="infotip__heading" role="heading" aria-level=5>Infotip</span>
                         <span>Here's a tip to help you be successful at your task.</span>
                     </span>
                     <button aria-label="Dismiss infotip" class="infotip__close" type="button">

--- a/docs/_includes/common/tooltip.html
+++ b/docs/_includes/common/tooltip.html
@@ -74,7 +74,7 @@
                         <use xlink:href="#icon-information"></use>
                     </svg>
                 </button>
-                <div class="infotip__overlay">
+                <div class="infotip__overlay" style="top: 32px; left: -12px">
                     <span class="infotip__pointer infotip__pointer--top-left"></span>
                     <div class="infotip__mask">
                         <div class="infotip__cell">
@@ -98,7 +98,7 @@
             <use xlink:href="#icon-information"></use>
         </svg>
     </button>
-    <div class="infotip__overlay">
+    <div class="infotip__overlay" style="top: 32px; left: -12px">
         <span class="infotip__pointer infotip__pointer--top-left"></span>
         <div class="infotip__mask">
             <div class="infotip__cell">
@@ -130,7 +130,7 @@
                             <use xlink:href="#icon-information"></use>
                         </svg>
                     </button>
-                    <span class="infotip__overlay">
+                    <span class="infotip__overlay" style="top: 32px; left: -12px">
                         <span class="infotip__pointer infotip__pointer--top-left"></span>
                         <span class="infotip__mask">
                             <span class="infotip__cell">
@@ -157,7 +157,7 @@
                 <use xlink:href="#icon-information"></use>
             </svg>
         </button>
-        <span class="infotip__overlay">
+        <span class="infotip__overlay" style="top: 32px; left: -12px">
             <span class="infotip__pointer infotip__pointer--top-left"></span>
             <span class="infotip__mask">
                 <span class="infotip__cell">

--- a/src/less/tooltip/base/tooltip.less
+++ b/src/less/tooltip/base/tooltip.less
@@ -148,6 +148,11 @@ span.tourtip {
     display: block;
 }
 
+button.infotip__host.icon-btn {
+    height: 16px;
+    width: 16px;
+}
+
 @media (min-width: 601px) {
     .tooltip__overlay,
     .infotip__overlay,

--- a/src/less/tooltip/ds4/tooltip.less
+++ b/src/less/tooltip/ds4/tooltip.less
@@ -24,9 +24,6 @@
 }
 
 button.infotip__host.icon-btn {
-    height: 16px;
-    width: 16px;
-
     svg {
         width: 16px;
     }

--- a/src/less/tooltip/ds6/tooltip.less
+++ b/src/less/tooltip/ds6/tooltip.less
@@ -32,6 +32,12 @@
     color: @color-black;
 }
 
+button.infotip__host.icon-btn {
+    height: 16px;
+    width: 16px;
+    margin-bottom: 2px;
+}
+
 button.tourtip__close {
     color: @color-white;
 

--- a/src/less/tooltip/ds6/tooltip.less
+++ b/src/less/tooltip/ds6/tooltip.less
@@ -33,9 +33,7 @@
 }
 
 button.infotip__host.icon-btn {
-    height: 16px;
     margin-bottom: 2px;
-    width: 16px;
 }
 
 button.tourtip__close {

--- a/src/less/tooltip/ds6/tooltip.less
+++ b/src/less/tooltip/ds6/tooltip.less
@@ -34,8 +34,8 @@
 
 button.infotip__host.icon-btn {
     height: 16px;
-    width: 16px;
     margin-bottom: 2px;
+    width: 16px;
 }
 
 button.tourtip__close {


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
* Changed infotip to have proper accessibility fixes (i.e. role=heading on span)
* Added top/left alignment for infotip when shown (and added the same to the examples, were not there before). This should align properly with both ds4/6
* Made infotip icon size to 16px. The svg was 16px but the icon was 32. This was creating a large padding around the 16px icon. I also added a margin 2px to align from bottom


## References
<!-- Include links to JIRA, Github, etc. if appropriate -->
#595 
#695 

## Screenshots
<!-- Upload screenshots if appropriate-->
DS6
![image](https://user-images.githubusercontent.com/1755269/63059302-e5735b80-bea3-11e9-9452-0d0994fdecac.png)

DS4
![image](https://user-images.githubusercontent.com/1755269/63059309-e906e280-bea3-11e9-84a1-e837184d8d89.png)

