### PR TITLE
Docs: cleanup & fixes related to new filtering features

### DIFF
--- a/docs/_includes/common/filter-button.html
+++ b/docs/_includes/common/filter-button.html
@@ -1,9 +1,12 @@
 <div id="filter-button">
     <h2><span class="secondary-text">@ebay/skin/</span>filter-button</h2>
-    <p>Use the <span class="highlight">filter-button</span> or <span class="highlight">filter-link</span> classes, 
-    in conjunction with selected/unselected modifiers, to create a button or link styled as a filter button.</p>
+    <p>Use the <span class="highlight">filter-button</span> or <span class="highlight">filter-link</span> classes,
+    to create a button or link styled as a filter button. Group together multiple filter buttons inside of a
+    <span class="highlight">filter-group</span> container.</p>
 
-    <h4>Default Filter Button</h4>
+    <h3>Unselected Filter Button</h3>
+    <p>By default, a filter button is in a non-selected state.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <div class="filter-group">
@@ -27,7 +30,10 @@
     {% endhighlight %}
     </div>
 
-    <h4>Selected Filter Button</h4>
+    <h3>Selected Filter Button</h3>
+    <p>Apply the <span class="highlight">aria-pressed</span> state to a button, or
+    <span class="highlight">filter-link--selected</span> modifier to a link.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <div class="filter-group">
@@ -51,8 +57,8 @@
     {% endhighlight %}
     </div>
 
-    <h4>Truncated Filter Button</h4>
-    <p>Long text will become truncated when it reaches the maximum width.</p>
+    <h3>Truncated Filter Button</h3>
+    <p>Long text will automatically become truncated when it reaches the maximum width.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -76,9 +82,11 @@
 </div>
     {% endhighlight %}
     </div>
-</div>
 
-    <h4>Disabled Filter Button</h4>
+    <h3>Disabled Filter Button</h3>
+    <p>Apply the <span class="highlight">disabled</span> property or remove the <span class="highlight">href</span>
+        attribute to disable a button or link, respectively.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <div class="filter-group">
@@ -101,3 +109,4 @@
 </div>
     {% endhighlight %}
     </div>
+</div>

--- a/docs/_includes/common/filter-menu-button.html
+++ b/docs/_includes/common/filter-menu-button.html
@@ -1,543 +1,268 @@
 <div id="filter-menu-button">
     <h2><span class="secondary-text">@ebay/skin/</span>filter-menu-button</h2>
-    <p>Use the <span class="highlight">filter-menu-button</span> class, in conjunction with selected/unselected modifiers,
-        as well as the <a href="#filter-menu">filter-menu</a>, to create a button which opens a menu of options by which to filter.</p>
+    <p>A filter menu button opens a menu of options by which to filter.</p>
 
-    <h3 id="filter-menu-button-default">Default Filter Menu Button</h3>
+    <h3 id="filter-menu-button-default">Unselected Filter Menu Button</h3>
+    <p>By default, a filter menu button is in a non-selected state.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="filter-group">
-                <span class="filter-menu-button">
-                    <button type="button" class="filter-menu-button__button">
-                        <span class="filter-menu-button__button-cell">
-                            <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                            <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                                <use xlink:href="#icon-chevron-down"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div class="filter-menu-button__menu">
-                        <div class="filter-menu-button__items" role="menu">
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 2</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 3</span>
-                            </div>
+            <span class="filter-menu-button">
+                <button type="button" class="filter-menu-button__button">
+                    <span class="filter-menu-button__button-cell">
+                        <span class="filter-menu-button__button-text">Filter Menu Button</span>
+                        <span class="icon icon--chevron-down"></span>
+                    </span>
+                </button>
+                <div class="filter-menu-button__menu">
+                    <div class="filter-menu-button__items" role="menu">
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 1</span>
+                        </div>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status--inline">
+                                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                                </svg>
+                                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-checked"></use>
+                                </svg>
+                            </span>
+                            <span class="filter-menu-button__text">Item 2</span>
+                        </div>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 3</span>
                         </div>
                     </div>
-                </span>
-            </div>
+                </div>
+            </span>
         </div>
     {% highlight html %}
-<div class="filter-group">
-    <span class="filter-menu-button">
-        <button type="button" class="filter-menu-button__button">
-            <span class="filter-menu-button__button-cell">
-                <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                    <use xlink:href="#icon-chevron-down"></use>
-                </svg>
-            </span>
-        </button>
-        <div class="filter-menu-button__menu">
-            <div class="filter-menu-button__items" role="menu">
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 2</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 3</span>
-                </div>
+<span class="filter-menu-button">
+    <button type="button" class="filter-menu-button__button">
+        <span class="filter-menu-button__button-cell">
+            <span class="filter-menu-button__button-text">Filter Menu Button</span>
+            <span class="icon icon--chevron-down"></span>
+        </span>
+    </button>
+    <div class="filter-menu-button__menu">
+        <div class="filter-menu-button__items" role="menu">
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 1</span>
+            </div>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 2</span>
+            </div>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 3</span>
             </div>
         </div>
-    </span>
-</div>
-    {% endhighlight %}
     </div>
-
-    <h3 id="filter-menu-button-default">Default Filter Menu Button with a Form</h3>
-    <p>When a native form is required as part of the filter menu you should wrap the menu items with a <span class="highlight">form</span> and use the appropriate 
-        checkbox markup.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <div class="filter-group">
-                <span class="filter-menu-button">
-                    <button type="button" class="filter-menu-button__button">
-                        <span class="filter-menu-button__button-cell">
-                            <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                            <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                                <use xlink:href="#icon-chevron-down"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <span class="filter-menu-button__menu">
-                        <form name="filter-menu-button-form-1">
-                            <div class="filter-menu-button__items">
-                                <label for="filter-menu-button-checkbox-item-1" class="filter-menu-button__item">
-                                    <span class="checkbox">
-                                        <input aria-label="filter menu form checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-1" id="filter-menu-button-checkbox-item-1" />
-                                        <span class="checkbox__icon" hidden>
-                                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                                                <use xlink:href="#icon-checkbox-unchecked"></use>
-                                            </svg>
-                                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                                                <use xlink:href="#icon-checkbox-checked"></use>
-                                            </svg>
-                                        </span>
-                                    </span>
-                                    <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                                </label>
-                                <label for="filter-menu-button-checkbox-item-2" class="filter-menu-button__item">
-                                    <span class="checkbox">
-                                        <input aria-label="filter menu form checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-2" id="filter-menu-button-checkbox-item-2" />
-                                        <span class="checkbox__icon" hidden>
-                                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                                                <use xlink:href="#icon-checkbox-unchecked"></use>
-                                            </svg>
-                                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                                                <use xlink:href="#icon-checkbox-checked"></use>
-                                            </svg>
-                                        </span>
-                                    </span>
-                                    <span class="filter-menu-button__text">Item 2</span>
-                                </label>
-                                <label for="filter-menu-button-checkbox-item-3" class="filter-menu-button__item">
-                                    <span class="checkbox">
-                                        <input aria-label="filter menu form checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-3" id="filter-menu-button-checkbox-item-3" />
-                                        <span class="checkbox__icon" hidden>
-                                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                                                <use xlink:href="#icon-checkbox-unchecked"></use>
-                                            </svg>
-                                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                                                <use xlink:href="#icon-checkbox-checked"></use>
-                                            </svg>
-                                        </span>
-                                    </span>
-                                    <span class="filter-menu-button__text">Item 3</span>
-                                </label>
-                            </div>
-                            <button type="button" class="filter-menu__footer">Apply</button>
-                        </form>
-                    </span>
-                </span>
-            </div>
-        </div>
-    {% highlight html %}
-<div class="filter-group">
-    <span class="filter-menu-button">
-        <button type="button" class="filter-menu-button__button">
-            <span class="filter-menu-button__button-cell">
-                <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                    <use xlink:href="#icon-chevron-down"></use>
-                </svg>
-            </span>
-        </button>
-        <div class="filter-menu-button__menu">
-            <div class="filter-menu-button__items" role="menu">
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 2</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 3</span>
-                </div>
-            </div>
-        </div>
-    </span>
-</div>
+</span>
     {% endhighlight %}
     </div>
 
     <h3 id="filter-menu-button-active">Active Filter Menu Button</h3>
-    <p>To show a filter menu button as <em>pressed</em> add <span class="highlight">aria-pressed="true"</span>.</p>
+    <p>Set the button's <span class="highlight">aria-pressed</span> property to render in a selected state.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="filter-group">
-                <span class="filter-menu-button">
-                    <button type="button" class="filter-menu-button__button" aria-pressed="true">
-                        <span class="filter-menu-button__button-cell">
-                            <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                            <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                                <use xlink:href="#icon-chevron-down"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div class="filter-menu-button__menu">
-                        <div class="filter-menu-button__items" role="menu">
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 2</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 3</span>
-                            </div>
+            <span class="filter-menu-button">
+                <button type="button" class="filter-menu-button__button" aria-pressed="true">
+                    <span class="filter-menu-button__button-cell">
+                        <span class="filter-menu-button__button-text">Filter Menu Button</span>
+                        <span class="icon icon--chevron-down"></span>
+                    </span>
+                </button>
+                <div class="filter-menu-button__menu">
+                    <div class="filter-menu-button__items" role="menu">
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 1</span>
+                        </div>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 2</span>
+                        </div>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 3</span>
                         </div>
                     </div>
-                </span>
-            </div>
+                </div>
+            </span>
         </div>
     {% highlight html %}
-<div class="filter-group">
-    <span class="filter-menu-button">
-        <button type="button" class="filter-menu-button__button">
-            <span class="filter-menu-button__button-cell">
-                <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                    <use xlink:href="#icon-chevron-down"></use>
-                </svg>
-            </span>
-        </button>
-        <div class="filter-menu-button__menu">
-            <div class="filter-menu-button__items" role="menu">
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 2</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 3</span>
-                </div>
+<span class="filter-menu-button">
+    <button type="button" class="filter-menu-button__button" aria-pressed="true">
+        <span class="filter-menu-button__button-cell">
+            <span class="filter-menu-button__button-text">Filter Menu Button</span>
+            <span class="icon icon--chevron-down"></span>
+        </span>
+    </button>
+    <div class="filter-menu-button__menu">
+        <div class="filter-menu-button__items" role="menu">
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 1</span>
+            </div>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 2</span>
+            </div>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 3</span>
             </div>
         </div>
+    </div>
+</span>
+    {% endhighlight %}
+    </div>
+
+    <h3 id="filter-menu-button-default">Filter Menu Button with a Form</h3>
+    <p>When a native form is required as part of the filter menu you should wrap the menu items with a <span class="highlight">form</span> and use the appropriate
+        checkbox markup.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="filter-menu-button">
+                <button type="button" class="filter-menu-button__button">
+                    <span class="filter-menu-button__button-cell">
+                        <span class="filter-menu-button__button-text">Filter Menu Button</span>
+                        <span class="icon icon--chevron-down"></span>
+                    </span>
+                </button>
+                <span class="filter-menu-button__menu">
+                    <form name="filter-menu-button-form-1">
+                        <div class="filter-menu-button__items">
+                            <label for="filter-menu-button-checkbox-item-1" class="filter-menu-button__item">
+                                <span class="checkbox">
+                                    <input aria-label="filter menu form checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-1" id="filter-menu-button-checkbox-item-1" />
+                                    <span class="checkbox__icon"></span>
+                                </span>
+                                <span class="filter-menu-button__text">Item 1</span>
+                            </label>
+                            <label for="filter-menu-button-checkbox-item-2" class="filter-menu-button__item">
+                                <span class="checkbox">
+                                    <input aria-label="filter menu form checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-2" id="filter-menu-button-checkbox-item-2" />
+                                    <span class="checkbox__icon"></span>
+                                </span>
+                                <span class="filter-menu-button__text">Item 2</span>
+                            </label>
+                            <label for="filter-menu-button-checkbox-item-3" class="filter-menu-button__item">
+                                <span class="checkbox">
+                                    <input aria-label="filter menu form checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-3" id="filter-menu-button-checkbox-item-3" />
+                                    <span class="checkbox__icon"></span>
+                                </span>
+                                <span class="filter-menu-button__text">Item 3</span>
+                            </label>
+                        </div>
+                        <button type="submit" class="filter-menu__footer">Apply</button>
+                    </form>
+                </span>
+            </span>
+        </div>
+    {% highlight html %}
+<span class="filter-menu-button">
+    <button type="button" class="filter-menu-button__button">
+        <span class="filter-menu-button__button-cell">
+            <span class="filter-menu-button__button-text">Filter Menu Button</span>
+            <span class="icon icon--chevron-down"></span>
+        </span>
+    </button>
+    <span class="filter-menu-button__menu">
+        <form name="filter-menu-button-form-1">
+            <div class="filter-menu-button__items">
+                <label for="filter-menu-button-checkbox-item-1" class="filter-menu-button__item">
+                    <span class="checkbox">
+                        <input aria-label="Item 1" class="checkbox__control" type="checkbox" />
+                        <span class="checkbox__icon"></span>
+                    </span>
+                    <span class="filter-menu-button__text">Item 1</span>
+                </label>
+                <label for="filter-menu-button-checkbox-item-2" class="filter-menu-button__item">
+                    <span class="checkbox">
+                        <input aria-label="Item 2" class="checkbox__control" type="checkbox" />
+                        <span class="checkbox__icon"></span>
+                    </span>
+                    <span class="filter-menu-button__text">Item 2</span>
+                </label>
+                <label for="filter-menu-button-checkbox-item-3" class="filter-menu-button__item">
+                    <span class="checkbox">
+                        <input aria-label="Item 3" class="checkbox__control" type="checkbox" />
+                        <span class="checkbox__icon"></span>
+                    </span>
+                    <span class="filter-menu-button__text">Item 3</span>
+                </label>
+            </div>
+            <button type="submit" class="filter-menu__footer">Apply</button>
+        </form>
     </span>
-</div>
+</span>
     {% endhighlight %}
     </div>
 
     <h3 id="filter-menu-button-disabled">Disabled Filter Menu Button</h3>
-    <p>Given the button with a <span class="highlight">disabled</span> property present, it will show disabled styles and not be able to be interacted with.</p>
+    <p>The button can be disabled using the <span class="highlight">disabled</span> property.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="filter-group">
-                <span class="filter-menu-button">
-                    <button type="button" class="filter-menu-button__button" disabled>
-                        <span class="filter-menu-button__button-cell">
-                            <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                            <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                                <use xlink:href="#icon-chevron-down"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div class="filter-menu-button__menu">
-                        <div class="filter-menu-button__items" role="menu">
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 2</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 3</span>
-                            </div>
+            <span class="filter-menu-button">
+                <button type="button" class="filter-menu-button__button" disabled>
+                    <span class="filter-menu-button__button-cell">
+                        <span class="filter-menu-button__button-text">Filter Menu Button</span>
+                        <span class="icon icon--chevron-down"></span>
+                    </span>
+                </button>
+                <div class="filter-menu-button__menu">
+                    <div class="filter-menu-button__items" role="menu">
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 1</span>
+                        </div>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 2</span>
+                        </div>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 3</span>
                         </div>
                     </div>
-                </span>
-                <span class="filter-menu-button">
-                    <button type="button" class="filter-menu-button__button" aria-pressed="true" disabled>
-                        <span class="filter-menu-button__button-cell">
-                            <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                            <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                                <use xlink:href="#icon-chevron-down"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div class="filter-menu-button__menu">
-                        <div class="filter-menu-button__items" role="menu">
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 2</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 3</span>
-                            </div>
-                        </div>
-                    </div>
-                </span>
-            </div>
+                </div>
+            </span>
         </div>
     {% highlight html %}
-<div class="filter-group">
-    <span class="filter-menu-button">
-        <button type="button" class="filter-menu-button__button" disabled>
-            <span class="filter-menu-button__button-cell">
-                <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                    <use xlink:href="#icon-chevron-down"></use>
-                </svg>
-            </span>
-        </button>
-        <div class="filter-menu-button__menu">
-            <div class="filter-menu-button__items" role="menu">
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 2</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 3</span>
-                </div>
+<span class="filter-menu-button">
+    <button type="button" class="filter-menu-button__button" disabled>
+        <span class="filter-menu-button__button-cell">
+            <span class="filter-menu-button__button-text">Filter Menu Button</span>
+            <span class="icon icon--chevron-down"></span>
+        </span>
+    </button>
+    <div class="filter-menu-button__menu">
+        <div class="filter-menu-button__items" role="menu">
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 1</span>
+            </div>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 2</span>
+            </div>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 3</span>
             </div>
         </div>
-    </span>
-    <span class="filter-menu-button">
-        <button type="button" class="filter-menu-button__button" aria-pressed="true" disabled>
-            <span class="filter-menu-button__button-cell">
-                <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                    <use xlink:href="#icon-chevron-down"></use>
-                </svg>
-            </span>
-        </button>
-        <div class="filter-menu-button__menu">
-            <div class="filter-menu-button__items" role="menu">
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 2</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 3</span>
-                </div>
-            </div>
-        </div>
-    </span>
-</div>
+    </div>
+</span>
     {% endhighlight %}
     </div>
 
@@ -547,108 +272,58 @@
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="filter-group">
-                <span class="filter-menu-button">
-                    <button type="button" class="filter-menu-button__button">
-                        <span class="filter-menu-button__button-cell">
-                            <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                            <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                                <use xlink:href="#icon-chevron-down"></use>
-                            </svg>
-                        </span>
-                    </button>
-                    <div class="filter-menu-button__menu">
-                        <div class="filter-menu-button__items" role="menu">
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 2</span>
-                            </div>
-                            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                                <span class="filter-menu-button__status--inline">
-                                    <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
-                                <span class="filter-menu-button__text">Item 3</span>
-                            </div>
+            <span class="filter-menu-button">
+                <button type="button" class="filter-menu-button__button">
+                    <span class="filter-menu-button__button-cell">
+                        <span class="filter-menu-button__button-text">Filter Menu Button</span>
+                        <span class="icon icon--chevron-down"></span>
+                    </span>
+                </button>
+                <div class="filter-menu-button__menu">
+                    <div class="filter-menu-button__items" role="menu">
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 1</span>
                         </div>
-                        <button type="button" class="filter-menu__footer">Apply</button>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 2</span>
+                        </div>
+                        <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu-button__status"></span>
+                            <span class="filter-menu-button__text">Item 3</span>
+                        </div>
                     </div>
-                </span>
-            </div>
+                    <button type="button" class="filter-menu__footer">Apply</button>
+                </div>
+            </span>
         </div>
     {% highlight html %}
-<div class="filter-group">
-    <span class="filter-menu-button">
-        <button type="button" class="filter-menu-button__button">
-            <span class="filter-menu-button__button-cell">
-                <span class="filter-menu-button__button-text">Filter Menu Button</span>
-                <svg class="icon icon--chevron-down" focusable="false" height="12" width="12">
-                    <use xlink:href="#icon-chevron-down"></use>
-                </svg>
-            </span>
-        </button>
-        <div class="filter-menu-button__menu">
-            <div class="filter-menu-button__items" role="menu">
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 1 with a long string that will wrap to another line</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 2</span>
-                </div>
-                <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
-                    <span class="filter-menu-button__status--inline">
-                        <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
-                    <span class="filter-menu-button__text">Item 3</span>
-                </div>
+<span class="filter-menu-button">
+    <button type="button" class="filter-menu-button__button">
+        <span class="filter-menu-button__button-cell">
+            <span class="filter-menu-button__button-text">Filter Menu Button</span>
+            <span class="icon icon--chevron-down"></span>
+        </span>
+    </button>
+    <div class="filter-menu-button__menu">
+        <div class="filter-menu-button__items" role="menu">
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 1</span>
             </div>
-            <button type="button" class="filter-menu__footer">Apply</button>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 2</span>
+            </div>
+            <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
+                <span class="filter-menu-button__status"></span>
+                <span class="filter-menu-button__text">Item 3</span>
+            </div>
         </div>
-    </span>
-</div>
+        <button type="button" class="filter-menu__footer">Apply</button>
+    </div>
+</span>
     {% endhighlight %}
     </div>
 </div>

--- a/docs/_includes/common/filter-menu.html
+++ b/docs/_includes/common/filter-menu.html
@@ -1,45 +1,22 @@
 <div id="filter-menu">
     <h2><span class="secondary-text">@ebay/skin/</span>filter-menu</h2>
-
-    <h3 id="filter-menu">Filter Menu – Default</h3>
-    <p>The default version of the filter menu is a <em>stateful</em> menu. It's primary purpose is used in conjunction with <a href="#filter-menu-button">filter-menu-button</a>,
-        but can alternatively be used as a standalone menu when necessary.</p>
+    <p>A filter menu forms the basis of the <a href="#filter-menu-button">filter-menu-button</a> module; we provide it
+        here as a standalone version in the case it might be opened or rendered via other means (in a dialog for example).</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="filter-menu">
                 <div class="filter-menu__items" role="menu">
                     <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-                        <span class="filter-menu__status--inline">
-                            <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                <use xlink:href="#icon-checkbox-unchecked"></use>
-                            </svg>
-                            <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                <use xlink:href="#icon-checkbox-checked"></use>
-                            </svg>
-                        </span>
-                        <span class="filter-menu__text">Item 1 with a long string that will wrap to another line</span>
+                        <span class="filter-menu__status"></span>
+                        <span class="filter-menu__text">Item 1</span>
                     </div>
                     <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-                        <span class="filter-menu__status--inline">
-                            <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                <use xlink:href="#icon-checkbox-unchecked"></use>
-                            </svg>
-                            <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                <use xlink:href="#icon-checkbox-checked"></use>
-                            </svg>
-                        </span>
+                        <span class="filter-menu__status"></span>
                         <span class="filter-menu__text">Item 2</span>
                     </div>
                     <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-                        <span class="filter-menu__status--inline">
-                            <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                <use xlink:href="#icon-checkbox-unchecked"></use>
-                            </svg>
-                            <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                <use xlink:href="#icon-checkbox-checked"></use>
-                            </svg>
-                        </span>
+                        <span class="filter-menu__status"></span>
                         <span class="filter-menu__text">Item 3</span>
                     </div>
                 </div>
@@ -49,36 +26,15 @@
 <span class="filter-menu">
     <div class="filter-menu__items" role="menu">
         <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-            <span class="filter-menu__status--inline">
-                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
-            <span class="filter-menu__text">Item 1 with a long string that will wrap to another line</span>
+            <span class="filter-menu__status"></span>
+            <span class="filter-menu__text">Item 1</span>
         </div>
         <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-            <span class="filter-menu__status--inline">
-                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <span class="filter-menu__status"></span>
             <span class="filter-menu__text">Item 2</span>
         </div>
         <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-            <span class="filter-menu__status--inline">
-                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <span class="filter-menu__status"></span>
             <span class="filter-menu__text">Item 3</span>
         </div>
     </div>
@@ -86,10 +42,9 @@
     {% endhighlight %}
     </div>
 
-    <h3 id="filter-menu-apply">Filter Menu – With Button</h3>
-    <p>If you need an additional action button (to "apply" or to further handle the present state of the menu) 
-        you can add a <span class="highlight">button</span> immediately after the <span class="highlight">menu</span>
-        but before the <span class="highlight">form</span> ends.</p>
+    <h3 id="filter-menu-apply">Filter Menu with Footer</h3>
+    <p>If you need an additional action button (to "apply" or to further handle the present state of the menu)
+        you can add a <span class="highlight">button</span> immediately after the <span class="highlight">menu</span>.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -97,7 +52,7 @@
                 <div class="filter-menu__items" role="menu">
                     <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
                         <span class="filter-menu__status"></span>
-                        <span class="filter-menu__text">Item 1 with a long string that will wrap to another line</span>
+                        <span class="filter-menu__text">Item 1</span>
                     </div>
                     <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
                         <span class="filter-menu__status"></span>
@@ -116,7 +71,7 @@
     <div class="filter-menu__items" role="menu">
         <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
             <span class="filter-menu__status"></span>
-            <span class="filter-menu__text">Item 1 with a long string that will wrap to another line</span>
+            <span class="filter-menu__text">Item 1</span>
         </div>
         <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
             <span class="filter-menu__status"></span>
@@ -132,8 +87,9 @@
     {% endhighlight %}
     </div>
 
-    <h3 id="filter-menu-form">Filter Menu - Form Version</h3>
-    <p>The form version of the filter menu is a <em>stateless</em> menu. Therefore, this menu is a form on it's own, and it must contain a submit button.</p>
+    <h3 id="filter-menu-form">Filter Menu as Form</h3>
+    <p>A form version is also available. It uses the <a href="#checkbox">checkbox</a> module to render checkboxes
+        instead of ARIA menu items. The form version must contain a submit button.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -142,45 +98,24 @@
                     <div class="filter-menu-form__items">
                         <label for="filter-menu-form-checkbox-item-1" class="filter-menu-form__item">
                             <span class="checkbox">
-                                <input aria-label="filter menu checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-1" id="filter-menu-form-checkbox-item-1" />
-                                <span class="checkbox__icon" hidden>
-                                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
+                                <input aria-label="Item 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-1" id="filter-menu-form-checkbox-item-1" />
+                                <span class="checkbox__icon"></span>
                             </span>
-                            <span class="filter-menu-form__text">Item 1 with a long string that will wrap to another line</span>
+                            <span class="filter-menu-form__text">Item 1</span>
                         </label>
                         <label for="filter-menu-form-checkbox-item-2" class="filter-menu-form__item">
                             <span class="checkbox">
-                                <input aria-label="filter menu checkbox example option 2" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-2" id="filter-menu-form-checkbox-item-2" />
-                                <span class="checkbox__icon" hidden>
-                                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
+                                <input aria-label="Item 2" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-2" id="filter-menu-form-checkbox-item-2" />
+                                <span class="checkbox__icon"></span>
                             </span>
-                            <span for="filter-menu-form-checkbox-item-2" class="filter-menu-form__text">Item 2</span>
+                            <span class="filter-menu-form__text">Item 2</span>
                         </label>
                         <label for="filter-menu-form-checkbox-item-3" class="filter-menu-form__item">
                             <span class="checkbox">
-                                <input aria-label="filter menu checkbox example option 3" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-3" id="filter-menu-form-checkbox-item-3" />
-                                <span class="checkbox__icon" hidden>
-                                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-unchecked"></use>
-                                    </svg>
-                                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                                        <use xlink:href="#icon-checkbox-checked"></use>
-                                    </svg>
-                                </span>
+                                <input aria-label="Item 3" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-3" id="filter-menu-form-checkbox-item-3" />
+                                <span class="checkbox__icon"></span>
                             </span>
-                            <span for="filter-menu-form-checkbox-item-3" class="filter-menu-form__text">Item 3</span>
+                            <span class="filter-menu-form__text">Item 3</span>
                         </label>
                     </div>
                     <button type="submit" class="filter-menu-form__footer">Apply</button>
@@ -193,45 +128,24 @@
         <div class="filter-menu-form__items">
             <label for="filter-menu-form-checkbox-item-1" class="filter-menu-form__item">
                 <span class="checkbox">
-                    <input aria-label="filter menu checkbox example option 1" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-1" id="filter-menu-form-checkbox-item-1" />
-                    <span class="checkbox__icon" hidden>
-                        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
+                    <input aria-label="Item 1" class="checkbox__control" type="checkbox" />
+                    <span class="checkbox__icon"></span>
                 </span>
-                <span class="filter-menu-form__text">Item 1 with a long string that will wrap to another line</span>
+                <span class="filter-menu-form__text">Item 1</span>
             </label>
             <label for="filter-menu-form-checkbox-item-2" class="filter-menu-form__item">
                 <span class="checkbox">
-                    <input aria-label="filter menu checkbox example option 2" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-2" id="filter-menu-form-checkbox-item-2" />
-                    <span class="checkbox__icon" hidden>
-                        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
+                    <input aria-label="Item 2" class="checkbox__control" type="checkbox" />
+                    <span class="checkbox__icon"></span>
                 </span>
-                <span for="filter-menu-form-checkbox-item-2" class="filter-menu-form__text">Item 2</span>
+                <span class="filter-menu-form__text">Item 2</span>
             </label>
             <label for="filter-menu-form-checkbox-item-3" class="filter-menu-form__item">
                 <span class="checkbox">
-                    <input aria-label="filter menu checkbox example option 3" class="checkbox__control" type="checkbox" name="filter-menu-form-checkbox-item-3" id="filter-menu-form-checkbox-item-3" />
-                    <span class="checkbox__icon" hidden>
-                        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-unchecked"></use>
-                        </svg>
-                        <svg class="checkbox__checked" focusable="false" height="18" width="18">
-                            <use xlink:href="#icon-checkbox-checked"></use>
-                        </svg>
-                    </span>
+                    <input aria-label="Item 3" class="checkbox__control" type="checkbox" />
+                    <span class="checkbox__icon"></span>
                 </span>
-                <span for="filter-menu-form-checkbox-item-3" class="filter-menu-form__text">Item 3</span>
+                <span class="filter-menu-form__text">Item 3</span>
             </label>
         </div>
         <button type="submit" class="filter-menu-form__footer">Apply</button>

--- a/docs/_includes/common/filter-menu.html
+++ b/docs/_includes/common/filter-menu.html
@@ -42,6 +42,93 @@
     {% endhighlight %}
     </div>
 
+    <details class="details">
+        <summary class="details__summary">
+            <span class="details__summary-text">Foreground SVG Version</span><span class="details__icon"></span>
+        </summary>
+        <div class="demo">
+            <div class="demo__inner">
+                <span class="filter-menu">
+                    <div class="filter-menu__items" role="menu">
+                        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu__status--inline">
+                                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                                </svg>
+                                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-checked"></use>
+                                </svg>
+                            </span>
+                            <span class="filter-menu__text">Item 1</span>
+                        </div>
+                        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu__status--inline">
+                                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                                </svg>
+                                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-checked"></use>
+                                </svg>
+                            </span>
+                            <span class="filter-menu__text">Item 2</span>
+                        </div>
+                        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
+                            <span class="filter-menu__status--inline">
+                                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                                </svg>
+                                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
+                                    <use xlink:href="#icon-checkbox-checked"></use>
+                                </svg>
+                            </span>
+                            <span class="filter-menu__text">Item 3</span>
+                        </div>
+                    </div>
+                    <button type="button" class="filter-menu__footer">Apply</button>
+                </span>
+            </div>
+            {% highlight html %}
+<span class="filter-menu">
+    <div class="filter-menu__items" role="menu">
+        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
+            <span class="filter-menu__status--inline">
+                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+            <span class="filter-menu__text">Item 1</span>
+        </div>
+        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
+            <span class="filter-menu__status--inline">
+                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+            <span class="filter-menu__text">Item 2</span>
+        </div>
+        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
+            <span class="filter-menu__status--inline">
+                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+            <span class="filter-menu__text">Item 3</span>
+        </div>
+    </div>
+    <button type="button" class="filter-menu__footer">Apply</button>
+</span>
+        {% endhighlight %}
+    </details>
+
     <h3 id="filter-menu-apply">Filter Menu with Footer</h3>
     <p>If you need an additional action button (to "apply" or to further handle the present state of the menu)
         you can add a <span class="highlight">button</span> immediately after the <span class="highlight">menu</span>.</p>


### PR DESCRIPTION
I went through the filter, filter-button and filter-menu-button docs and cleaned up a few things. Most of the noise in the diff here comes from switching all examples to use background svg (to be consistent with other modules) instead of foreground svg.

Btw, I noticed the filter menu button supports a background icon, but it is not done in a way consistent with other modules. We have to specify the name of the icon, `icon icon--chevron-down`, instead of just supplying `filter-menu-button__icon`. The benefit of the latter approach is that we can abstract away the differences between ds4 & ds6 if neeeded, plus there is no dependency on the icon module (the base64 for the icon can be bundled in with the module's own css).

## Changes

* Changed all examples to use background svg
* Remove `filter-group` wrapper from most examples
* Added a brief explanation of filter-group
* Fixed formatting of some headers
* Adjusted some of the wording for consistent tone of voice
* Removed long text from all examples (those should be covered by test page)
* Removed some redundant or superfluous attributes in example code

## Screenshots

<img width="825" alt="Screen Shot 2019-08-16 at 1 01 14 PM" src="https://user-images.githubusercontent.com/38065/63167750-21382d80-c02a-11e9-9030-f1df4949d5c2.png">
<img width="648" alt="Screen Shot 2019-08-16 at 1 01 18 PM" src="https://user-images.githubusercontent.com/38065/63167751-21d0c400-c02a-11e9-8494-57ceed904de4.png">
<img width="830" alt="Screen Shot 2019-08-16 at 1 01 23 PM" src="https://user-images.githubusercontent.com/38065/63167752-21d0c400-c02a-11e9-9914-97b2d4f28e77.png">

<img width="829" alt="Screen Shot 2019-08-16 at 1 20 28 PM" src="https://user-images.githubusercontent.com/38065/63167774-32813a00-c02a-11e9-9e90-2c730e75d9b8.png">
<img width="825" alt="Screen Shot 2019-08-16 at 1 20 37 PM" src="https://user-images.githubusercontent.com/38065/63167776-32813a00-c02a-11e9-97e0-8526a07720d1.png">

<img width="845" alt="Screen Shot 2019-08-16 at 1 32 13 PM" src="https://user-images.githubusercontent.com/38065/63167815-4e84db80-c02a-11e9-8291-04fecd068950.png">

<img width="829" alt="Screen Shot 2019-08-16 at 1 07 34 PM" src="https://user-images.githubusercontent.com/38065/63167825-52b0f900-c02a-11e9-97ae-9ba9ed933c71.png">

<img width="823" alt="Screen Shot 2019-08-16 at 1 03 00 PM" src="https://user-images.githubusercontent.com/38065/63167840-580e4380-c02a-11e9-8492-b66bcd79b131.png">

<img width="822" alt="Screen Shot 2019-08-16 at 1 02 11 PM" src="https://user-images.githubusercontent.com/38065/63167872-69575000-c02a-11e9-8632-9fd43ce2d107.png">




