### PR TITLE
Updated documentation for inline icons

### DIFF
--- a/docs/_includes/common/icon.html
+++ b/docs/_includes/common/icon.html
@@ -330,4 +330,25 @@
     {% endif %}
 
     {% include ds{{ page.ds}}/icon-custom.html %}
+
+    <h3>Inline Icons for non Node applications</h3>
+    <p>For pages that do not load skin under node, but only use the CSS from it, inline icons need to be included in the HTML page.</p>
+    <p>In order to include inline icons, enter the following markup inside your page's body <span class="highlight">&lt;body&gt;</span> along with any <span class="highlight">&lt;symbol&gt;</span> that are needed on the page</p>
+    <p>View <a href="https://raw.githubusercontent.com/eBay/skin/master/src/svg/ds{{ page.ds }}/icons.svg">inline icon source</a> and pick the icons you need to load on the page.</p>
+
+    {% highlight html %}
+<svg hidden>
+    <symbol id="icon-add" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M19 9h-8V1a1 1 0 0 0-2 0v8H1a1 1 0 0 0 0 2h8v8a1 1 0 0 0 2 0v-8h8a1 1 0 0 0 0-2z"></path></symbol>
+    <!-- And any other symbols from the inline icon source to include -->
+</svg>
+    {% endhighlight %}
+
+    <p>Then you can display the icon in the page by referring to the symbol ID</p>
+
+    {% highlight html %}
+<svg class="icon icon--add" focusable="false" width="16" height="16" aria-hidden="true">
+    <use xlink:href="#icon-add"></use>
+</svg>
+    {% endhighlight %}
+
 </div>


### PR DESCRIPTION

## Description
Created documentation for inline icons on non node applications

## Context
I included the link to the rawgithub context for the ds4/6 icons, because the normal link does not show a source page, but tries to display the `svg`. 
If there's a way around this, I think the normal github link is better.
https://github.com/eBay/skin/blob/master/src/svg/ds6/icons.svg

## References
#796 

## Screenshots
![image](https://user-images.githubusercontent.com/1755269/63892961-cdb8ce80-c99d-11e9-98e1-566496a5504a.png)
![image](https://user-images.githubusercontent.com/1755269/63893018-efb25100-c99d-11e9-8296-1559a26d6639.png)

