### PR TITLE
Removed _cdn from npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-_cdn
 _site
 docs
 .cache


### PR DESCRIPTION

## Description
Removed `_cdn` from `.npmignore`.

## References
Fixes #650
