### PR TITLE
Website: formatting fixes for broken code example sections

### DIFF
--- a/docs/_includes/common/button.html
+++ b/docs/_includes/common/button.html
@@ -25,11 +25,12 @@
             <button class="btn btn--primary">Button</button>
             <a class="fake-btn fake-btn--primary" href="http://www.ebay.com">Link</a>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="btn btn--primary">Button</button>
 <a class="fake-btn fake-btn--primary" href="http://www.ebay.com">Link</a>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="button-secondary">Secondary Button</h3>
     <p>Use the <span class="highlight">secondary</span> block modifier to create a secondary button style.</p>
@@ -38,11 +39,12 @@
             <button class="btn btn--secondary">Button</button>
             <a class="fake-btn fake-btn--secondary" href="http://www.ebay.com">Link</a>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="btn btn--secondary">Button</button>
 <a class="fake-btn fake-btn--secondary" href="http://www.ebay.com">Link</a>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="button-delete">Delete Button</h3>
     <p>Use the <span class="highlight">delete</span> block modifier to create a delete button style.</p>
@@ -51,11 +53,12 @@
             <button class="btn btn--delete">Button</button>
             <a class="fake-btn fake-btn--delete" href="http://www.ebay.com">Link</a>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="btn btn--delete">Button</button>
 <a class="fake-btn fake-btn--delete" href="http://www.ebay.com">Link</a>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="button-disabled">Disabled Button</h3>
     <p>The <span class="highlight">disabled</span> attribute is <strong>required</strong> to fully disable a button tag.</p>
@@ -119,11 +122,12 @@
             <button class="btn btn--primary btn--large">Large Button</button>
             <a class="fake-btn fake-btn--primary fake-btn--large" href="http://www.ebay.com">Large Link</a>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="btn btn--primary btn--large">Button</button>
 <a class="fake-btn fake-btn--primary fake-btn--large" href="http://www.ebay.com">Large Link</a>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="button-icon">Icon Button</h3>
     <p>Any foreground icon can be placed adjacent to the button text.</p>
@@ -138,7 +142,9 @@
                 </span>
             </button>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="btn btn--primary">
     <span class="btn__cell">
         <svg aria-hidden="true" class="btn__icon" focusable="false" height="16" width="16">
@@ -147,8 +153,7 @@
         <span>Button</span>
     </span>
 </button>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <p>To flip position of text and icon, simply swap the DOM order.</p>
 
@@ -163,7 +168,9 @@
                 </span>
             </button>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="btn btn--primary">
     <span class="btn__cell">
         <span>Button</span>
@@ -172,8 +179,7 @@
         </svg>
     </span>
 </button>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <p>Because the button cell uses flex box layout, it is fairly trivial to achieve alternate layouts, as in the example below.</p>
 
@@ -217,6 +223,8 @@
                 Button with a lot of text that will wrap
             </button>
         </div>
+    </div>
+
     {% highlight html %}
 <div style="max-width 200px;">
     <button class="btn">
@@ -224,7 +232,6 @@
     </button>
 </div>
     {% endhighlight %}
-    </div>
 
     <p>To apply a fixed height to a button use <span class="highlight">btn--fixed-height</span> or <span class="highlight">btn--large-fixed-height</span>.</p>
 
@@ -234,6 +241,8 @@
                 Button with a lot of text that will wrap
             </button>
         </div>
+    </div>
+
     {% highlight html %}
 <div style="max-width 200px;">
     <button class="btn btn--fixed-height">
@@ -241,7 +250,6 @@
     </button>
 </div>
     {% endhighlight %}
-    </div>
 
     <div class="demo">
         <div class="demo__inner">
@@ -249,12 +257,13 @@
                 Button with a lot of text that won't wrap
             </button>
         </div>
+    </div>
+
     {% highlight html %}
 <button class="btn btn--fixed-height">
     Button with a lot of text that won't wrap
 </button>
     {% endhighlight %}
-    </div>
 
     <p>To apply truncation to text use use <span class="highlight">btn--truncated</span> or <span class="highlight">btn--large-truncated</span>.</p>
 
@@ -264,6 +273,8 @@
                 Button with a lot of text that will wrap
             </button>
         </div>
+    </div>
+
     {% highlight html %}
 <div style="max-width 200px;">
     <button class="btn btn--truncated">
@@ -271,7 +282,6 @@
     </button>
 </div>
     {% endhighlight %}
-    </div>
 
     {% if page.ds == 6 %}
     <div class="section-footer">

--- a/docs/_includes/common/combobox.html
+++ b/docs/_includes/common/combobox.html
@@ -30,7 +30,9 @@
                 </span>
             </form>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="combobox">
     <span class="combobox__control">
         <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox1" />
@@ -50,8 +52,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="combobox-overflow">Overflow Combobox</h3>
     <p>The combobox overlay becomes automatically scrollable at a height of 400px.</p>
@@ -105,7 +106,9 @@
                 </span>
             </form>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="combobox">
     <span class="combobox__control">
         <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox2" disabled />
@@ -125,8 +128,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="combobox-readonly">Readonly Combobox</h3>
     <p>A readonly combobox is intended for use as a custom implementation of the native HTML select element. Unlike the default combobox, its options <em>do</em> have state. Notice that an additional span element is required within each option to host the status icon.</p>
@@ -161,7 +163,9 @@
                 </span>
             </form>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="combobox combobox--readonly">
     <span class="combobox__control">
         <input role="combobox" type="text" value="Option 1" aria-haspopup="listbox" aria-owns="listbox4" readonly />
@@ -184,8 +188,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     {% if page.ds == 6 %}
     <div class="section-footer">

--- a/docs/_includes/common/cta-button.html
+++ b/docs/_includes/common/cta-button.html
@@ -15,7 +15,9 @@
                 </span>
             </a>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <a class="cta-btn" href="http://www.ebay.com">
     <span class="cta-btn__cell">
         <span>Link</span>
@@ -24,8 +26,7 @@
         </svg>
     </span>
 </a>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <!-- Deviation! DS6 supports coloured CTA buttons -->
     {% if page.ds == 6 %}
@@ -43,6 +44,7 @@
             </a>
         </div>
     </div>
+
     {% highlight html %}
 <a class="cta-btn cta-btn--b4" href="http://www.ebay.com">
     <span class="fake-btn__cell">
@@ -67,6 +69,7 @@
             </a>
         </div>
     </div>
+    
     {% highlight html %}
 <a class="cta-btn cta-btn--r4" href="http://www.ebay.com">
     <span class="cta-btn__cell">

--- a/docs/_includes/common/details.html
+++ b/docs/_includes/common/details.html
@@ -4,7 +4,9 @@
     <p>It uses the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details">details</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary">summary</a> disclosure elements to show/hide content.</p>
     <p>Everything inside <span class="highlight">details</span> and below <span class="highlight">summary</span> is considered the content.</p>
     <p>Since IE/Edge do not support details and summary elements. The <span class="highlight">details-element-polyfill</span> is used to solve this problem.</p>
+
     <h3>Default Details Summary</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <details class="details">
@@ -14,17 +16,20 @@
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </details>
         </div>
-{% highlight html %}
+    </div>
+
+    {% highlight html %}
 <details class="details">
     <summary class="details__summary">
         <span class="details__summary-text">Details</span><span class="details__icon"></span>
     </summary>
     <p>Sample content</p>
 </details>
-{% endhighlight %}
-    </div>
+    {% endhighlight %}
+
     <h3>Opened Details Summary</h3>
     <p>Apply the <span class="highlight">open</span> attribute to change the state.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <details class="details" open>
@@ -34,17 +39,20 @@
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </details>
         </div>
-{% highlight html %}
+    </div>
+
+    {% highlight html %}
 <details class="details" open>
     <summary class="details__summary">
         <span class="details__summary-text">Details</span><span class="details__icon"></span>
     </summary>
     <p>Sample content</p>
 </details>
-{% endhighlight %}
-    </div>
+    {% endhighlight %}
+
     <h3>Centered Details Summary</h3>
     <p>Apply the <span class="highlight">details_summary--center</span> class to center the summary.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <details class="details">
@@ -54,15 +62,17 @@
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </details>
         </div>
-{% highlight html %}
+    </div>
+
+    {% highlight html %}
 <details class="details">
     <summary class="details__summary details_summary--center">
         <span class="details__summary-text">Details</span><span class="details__icon"></span>
     </summary>
     <p>Sample content</p>
 </details>
-{% endhighlight %}
-    </div>
+    {% endhighlight %}
+
     <h3>Small Details Summary</h3>
     <p>Apply the <span class="highlight">details_summary--small</span> class to use the smaller version of summary.</p>
     <div class="demo">
@@ -74,15 +84,17 @@
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </details>
         </div>
-{% highlight html %}
+    </div>
+
+    {% highlight html %}
 <details class="details">
     <summary class="details__summary details_summary--small">
         <span class="details__summary-text">Details</span><span class="details__icon"></span>
     </summary>
     <p>Sample content</p>
 </details>
-{% endhighlight %}
-    </div>
+    {% endhighlight %}
+
     <h3>RTL Details Summary</h3>
     <p>Works with right-to-left languages.</p>
     <div class="demo">
@@ -94,20 +106,22 @@
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </details>
         </div>
-{% highlight html %}
+    </div>
+    {% highlight html %}
 <details class="details" dir="rtl">
     <summary class="details__summary">
         <span class="details__summary-text">Details</span><span class="details__icon"></span>
     </summary>
     <p>Sample content</p>
 </details>
-{% endhighlight %}
-    </div>
+    {% endhighlight %}
+
     <h3>Details Summary with custom icon</h3>
     <p>The default details shown above uses an SVG background image, and therefore has a fixed colour. Foreground SVG,
         while slightly more verbose, honours the CSS cascade, thus allowing any possible colour for the icon. In the example, a custom <span class="highlight">style</span> is added.</p>
     <p>Required: set the <span class="highlight">hidden</span> attribute on <span class="highlight">details__icon</span>. This is because the class has a background-image icon by detault, and it needs to be hidden so only the foreground SVG is shown.</p>
-        <div class="demo">
+
+    <div class="demo">
         <div class="demo__inner">
             <details class="details">
                 <summary class="details__summary">
@@ -121,7 +135,9 @@
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             </details>
         </div>
-{% highlight html %}
+    </div>
+
+    {% highlight html %}
 <details class="details">
     <summary class="details__summary">
         <span class="details__summary-text">Details</span><!--
@@ -133,8 +149,8 @@
     </summary>
     <p>Sample content</p>
 </details>
-{% endhighlight %}
-    </div>
+    {% endhighlight %}
+
     {% if page.ds == 6 %}
     <div class="section-footer">
         <p>DS6.v1.01</p>

--- a/docs/_includes/common/dialog.html
+++ b/docs/_includes/common/dialog.html
@@ -8,6 +8,7 @@
     <h3>Default Dialog</h3>
     <p>The default dialog is a lightbox.</p>
     <p>The lightbox will have a margin of 15vh and automatically scales vertically.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
@@ -27,7 +28,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
     <div class="dialog__window" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -43,11 +46,11 @@
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3>Fill Dialog</h3>
     <p>Apply the <span class="highlight">dialog__window--fill</span> modifier to have the lightbox fill at least 70% of the screen (centered vertically).</p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
@@ -67,7 +70,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
     <div class="dialog__window dialog__window--fill" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -83,11 +88,11 @@
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3>Left Panel Dialog</h3>
     <p>Apply the <span class="highlight">dialog__window--left</span> modifier to have the dialog act as a left side panel (100vh height and aligned to the left side of the screen).</p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
@@ -107,7 +112,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
     <div class="dialog__window dialog__window--left" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -123,11 +130,11 @@
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3>Right Panel Dialog</h3>
     <p>Apply the <span class="highlight">dialog__window--right</span> modifier to have the dialog act as a right side panel (100vh height and aligned to the right side of the screen).</p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
@@ -147,7 +154,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
     <div class="dialog__window dialog__window--right" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -163,12 +172,12 @@
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3>Fullscreen Panel Dialog</h3>
     <p>Apply the <span class="highlight">dialog__window--full</span> modifier to have the dialog take up the entire viewport.</p>
     <p>Having a mask on a fullscreen dialog doesn't typically make sense and can cause the animations to look a bit strange. You can disable the default background mask of the dialog by applying the <span class="highlight">dialog--no-mask</span> modifier on the <span class="highlight">dialog</span> element.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
@@ -188,7 +197,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
     <div class="dialog__window dialog__window--full" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -204,11 +215,11 @@
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3>Scrolling Panel Dialog</h3>
     <p>When you have a lot of content, the <span class="highlight">dialog</span> will automatically handle scrolling for your.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
@@ -228,7 +239,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
     <div class="dialog__window dialog__window--full" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -248,8 +261,7 @@
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="dialog-transitions">Dialog Transitions</h3>
     <p>Skin currently supports two types of dialog transition: fade and slide.
@@ -315,6 +327,7 @@ closeBtnEl.addEventListener("click", () => {
     <h3>Fade Transition</h3>
     <p>Any dialog window and mask can be faded in and out, using the <span class="highlight">dialog__window--fade</span> modifier on the <span class="highlight">dialog__window</span> and a <span class="highlight">dialog--mask-fade</span> modifier on the <span class="highlight">dialog</span>.</p>
     <p>The default fade duration is 16ms.<p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Lightbox</button>
@@ -353,7 +366,9 @@ closeBtnEl.addEventListener("click", () => {
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade" hidden>
     <div class="dialog__window dialog__window--fade" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -387,12 +402,12 @@ closeBtnEl.addEventListener("click", () => {
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3>Slide Transition</h3>
     <p>Any panel or fullscreen dialog can slide in and out, using the <span class="highlight">dialog__window--slide</span> modifier on the <span class="highlight">dialog__window</span>.</p>
     <p>The slide transition duration is 32ms. An accompanying <span class="highlight">dialog--mask-fade-slow</span> modifier on the <span class="highlight">dialog</span> should also be applied. This slower fade matches the 32ms of the slide transition.<p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Left Panel</button>
@@ -429,7 +444,9 @@ closeBtnEl.addEventListener("click", () => {
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade-slow" hidden>
     <div class="dialog__window dialog__window--left dialog__window--slide" role="document">
         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -445,8 +462,7 @@ closeBtnEl.addEventListener("click", () => {
         </div>
     </div>
 </div>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     {% if page.ds == 6 %}
     <div class="section-footer">

--- a/docs/_includes/common/expand-button.html
+++ b/docs/_includes/common/expand-button.html
@@ -12,15 +12,16 @@
                 </span>
             </button>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="expand-btn expand-btn--primary" type="button" aria-expanded="false">
     <span class="expand-btn__cell">
         <span class="expand-btn__text">Expand</span>
         <span class="expand-btn__icon"></span>
     </span>
 </button>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3>Icon Only Expand Button</h3>
     <p>Use the <span class="highlight">expand-btn--no-text</span> modifier for an expand button with no visible text. The button requires an <span class="highlight">aria-label</span> for assitstive technology too.</p>
@@ -31,12 +32,13 @@
                 <span class="expand-btn__icon"></span>
             </button>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <button class="expand-btn expand-btn--primary expand-btn--no-text" type="button" aria-expanded="false" aria-label="Expand/Collapse">
     <span class="expand-btn__icon"></span>
 </button>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     {% if page.ds == 6 %}
     <div class="section-footer">

--- a/docs/_includes/common/filter-button.html
+++ b/docs/_includes/common/filter-button.html
@@ -18,6 +18,8 @@
                 </a>
             </div>
         </div>
+    </div>
+
     {% highlight html %}
 <div class="filter-group">
     <button type="button" class="filter-button">
@@ -28,7 +30,6 @@
     </a>
 </div>
     {% endhighlight %}
-    </div>
 
     <h3>Selected Filter Button</h3>
     <p>Apply the <span class="highlight">aria-pressed</span> state to a button, or
@@ -45,6 +46,8 @@
                 </a>
             </div>
         </div>
+    </div>
+
     {% highlight html %}
 <div class="filter-group">
     <button type="button" class="filter-button" aria-pressed="true">
@@ -55,7 +58,6 @@
     </a>
 </div>
     {% endhighlight %}
-    </div>
 
     <h3>Truncated Filter Button</h3>
     <p>Long text will automatically become truncated when it reaches the maximum width.</p>
@@ -71,6 +73,8 @@
                 </a>
             </div>
         </div>
+    </div>
+
     {% highlight html %}
 <div class="filter-group">
     <button type="button" class="filter-button">
@@ -81,7 +85,6 @@
     </a>
 </div>
     {% endhighlight %}
-    </div>
 
     <h3>Disabled Filter Button</h3>
     <p>Apply the <span class="highlight">disabled</span> property or remove the <span class="highlight">href</span>
@@ -98,6 +101,8 @@
                 </a>
             </div>
         </div>
+    </div>
+
     {% highlight html %}
 <div class="filter-group">
     <button type="button" class="filter-button" aria-pressed="true" disabled>
@@ -108,5 +113,5 @@
     </a>
 </div>
     {% endhighlight %}
-    </div>
+
 </div>

--- a/docs/_includes/common/filter-menu-button.html
+++ b/docs/_includes/common/filter-menu-button.html
@@ -32,6 +32,8 @@
                 </div>
             </span>
         </div>
+    </div>
+
     {% highlight html %}
 <span class="filter-menu-button">
     <button type="button" class="filter-menu-button__button">
@@ -58,7 +60,6 @@
     </div>
 </span>
     {% endhighlight %}
-    </div>
 
     <h3 id="filter-menu-button-active">Active Filter Menu Button</h3>
     <p>Set the button's <span class="highlight">aria-pressed</span> property to render in a selected state.</p>
@@ -90,6 +91,8 @@
                 </div>
             </span>
         </div>
+    </div>
+
     {% highlight html %}
 <span class="filter-menu-button">
     <button type="button" class="filter-menu-button__button" aria-pressed="true">
@@ -116,7 +119,6 @@
     </div>
 </span>
     {% endhighlight %}
-    </div>
 
     <h3 id="filter-menu-button-default">Filter Menu Button with a Form</h3>
     <p>When a native form is required as part of the filter menu you should wrap the menu items with a <span class="highlight">form</span> and use the appropriate
@@ -161,6 +163,8 @@
                 </span>
             </span>
         </div>
+    </div>
+
     {% highlight html %}
 <span class="filter-menu-button">
     <button type="button" class="filter-menu-button__button">
@@ -199,7 +203,6 @@
     </span>
 </span>
     {% endhighlight %}
-    </div>
 
     <h3 id="filter-menu-button-disabled">Disabled Filter Menu Button</h3>
     <p>The button can be disabled using the <span class="highlight">disabled</span> property.</p>
@@ -231,6 +234,8 @@
                 </div>
             </span>
         </div>
+    </div>
+
     {% highlight html %}
 <span class="filter-menu-button">
     <button type="button" class="filter-menu-button__button" disabled>
@@ -257,7 +262,6 @@
     </div>
 </span>
     {% endhighlight %}
-    </div>
 
     <h3 id="filter-menu-button-footer">Filter Menu Button with Footer</h3>
     <p>Some use cases for the filter menu require an additional <em>apply</em> or <em>select all/select none</em> type of button.
@@ -291,6 +295,8 @@
                 </div>
             </span>
         </div>
+    </div>
+
     {% highlight html %}
 <span class="filter-menu-button">
     <button type="button" class="filter-menu-button__button">
@@ -318,5 +324,5 @@
     </div>
 </span>
     {% endhighlight %}
-    </div>
+
 </div>

--- a/docs/_includes/common/filter-menu.html
+++ b/docs/_includes/common/filter-menu.html
@@ -22,7 +22,9 @@
                 </div>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="filter-menu">
     <div class="filter-menu__items" role="menu">
         <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
@@ -40,94 +42,6 @@
     </div>
 </span>
     {% endhighlight %}
-    </div>
-
-    <details class="details">
-        <summary class="details__summary">
-            <span class="details__summary-text">Foreground SVG Version</span><span class="details__icon"></span>
-        </summary>
-        <div class="demo">
-            <div class="demo__inner">
-                <span class="filter-menu">
-                    <div class="filter-menu__items" role="menu">
-                        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-                            <span class="filter-menu__status">
-                                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                                </svg>
-                                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                    <use xlink:href="#icon-checkbox-checked"></use>
-                                </svg>
-                            </span>
-                            <span class="filter-menu__text">Item 1</span>
-                        </div>
-                        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-                            <span class="filter-menu__status">
-                                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                                </svg>
-                                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                    <use xlink:href="#icon-checkbox-checked"></use>
-                                </svg>
-                            </span>
-                            <span class="filter-menu__text">Item 2</span>
-                        </div>
-                        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-                            <span class="filter-menu__status">
-                                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                                </svg>
-                                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                                    <use xlink:href="#icon-checkbox-checked"></use>
-                                </svg>
-                            </span>
-                            <span class="filter-menu__text">Item 3</span>
-                        </div>
-                    </div>
-                    <button type="button" class="filter-menu__footer">Apply</button>
-                </span>
-            </div>
-            {% highlight html %}
-<span class="filter-menu">
-    <div class="filter-menu__items" role="menu">
-        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-            <span class="filter-menu__status">
-                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
-            <span class="filter-menu__text">Item 1</span>
-        </div>
-        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-            <span class="filter-menu__status">
-                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
-            <span class="filter-menu__text">Item 2</span>
-        </div>
-        <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
-            <span class="filter-menu__status">
-                <svg class="icon icon--checkbox-unchecked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="icon icon--checkbox-checked" focusable="false" height="18" width="18">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
-            <span class="filter-menu__text">Item 3</span>
-        </div>
-    </div>
-    <button type="button" class="filter-menu__footer">Apply</button>
-</span>
-        {% endhighlight %}
-    </details>
 
     <h3 id="filter-menu-apply">Filter Menu with Footer</h3>
     <p>If you need an additional action button (to "apply" or to further handle the present state of the menu)
@@ -153,7 +67,9 @@
                 <button type="button" class="filter-menu__footer">Apply</button>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="filter-menu">
     <div class="filter-menu__items" role="menu">
         <div class="filter-menu__item" role="menuitemcheckbox" aria-checked="false">
@@ -172,7 +88,6 @@
     <button type="button" class="filter-menu__footer">Apply</button>
 </span>
     {% endhighlight %}
-    </div>
 
     <h3 id="filter-menu-form">Filter Menu as Form</h3>
     <p>A form version is also available. It uses the <a href="#checkbox">checkbox</a> module to render checkboxes
@@ -209,7 +124,9 @@
                 </form>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="filter-menu-form">
     <form name="filter-menu-form-1" action="https://www.ebay.com">
         <div class="filter-menu-form__items">
@@ -239,5 +156,5 @@
     </form>
 </span>
     {% endhighlight %}
-    </div>
+
 </div>

--- a/docs/_includes/common/link.html
+++ b/docs/_includes/common/link.html
@@ -7,10 +7,11 @@
         <div class="demo__inner">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod <a href="https://www.ebay.com">tempor incididunt</a> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation <a href="https://www.ebay.com">ullamco laboris</a> nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in <a href="https://www.ebay.com">voluptate velit esse cillum</a> dolore eu fugiat nulla pariatur.</p>
         </div>
-        {% highlight html %}
-<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod <a href="https://www.ebay.com">tempor incididunt</a> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation <a href="https://www.ebay.com">ullamco laboris</a> nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in <a href="https://www.ebay.com">voluptate velit esse cillum</a> dolore eu fugiat nulla pariatur.</p>
-        {% endhighlight %}
     </div>
+
+    {% highlight html %}
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod <a href="https://www.ebay.com">tempor incididunt</a> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation <a href="https://www.ebay.com">ullamco laboris</a> nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in <a href="https://www.ebay.com">voluptate velit esse cillum</a> dolore eu fugiat nulla pariatur.</p>
+    {% endhighlight %}
 
     <h3>Action Link</h3>
     <p>Action links are commonly used within item tiles and provide a means to drill-down into additional aspects such as seller page and reviews.</p>
@@ -20,10 +21,11 @@
         <div class="demo__inner">
             <a class="action-link" href="https://www.ebay.com/urw/ZTE-AXON-7-Mini-32GB-Ion-Gold-Unlocked-Smartphone/product-reviews/230215749?_itm=222972816761">See all 17 Reviews</a>
         </div>
-        {% highlight html %}
-<a class="action-link" href="https://www.ebay.com">See all 17 Reviews</a>
-        {% endhighlight %}
     </div>
+
+    {% highlight html %}
+<a class="action-link" href="https://www.ebay.com">See all 17 Reviews</a>
+    {% endhighlight %}
 
     <h3 id="link-nav">Nav Link</h3>
     <p>Nav links remove the default underline <em>and</em> colour. Again, clickability <strong>must</strong> clearly and easily be perceivable via other visual affordances (e.g. headings, spacing or other such contextual clues).</p>
@@ -43,7 +45,9 @@
                 </ul>
             </nav>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <nav aria-labelledby="nav-link-heading" role="navigation">
     <h2 id="nav-link-heading">Navigation</h2>
     <ul>
@@ -54,8 +58,7 @@
         <li><a class="nav-link" href="#link5">Link 5</a></li>
     </ul>
 </nav>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="link-fake">Fake Link</h3>
     <p>To style a button to look like a link, use the <span class="highlight">fake-link</span> class.</p>
@@ -64,10 +67,11 @@
         <div class="demo__inner">
             <button class="fake-link" type="button">Button</button>
         </div>
-        {% highlight html %}
-<button class="fake-link" type="button">Button</button>
-        {% endhighlight %}
     </div>
+
+    {% highlight html %}
+<button class="fake-link" type="button">Button</button>
+    {% endhighlight %}
 
     <p>To style a button to look like an <em>action</em> link, use the <span class="highlight">fake-link--action</span> modifier.</p>
 
@@ -75,10 +79,11 @@
         <div class="demo__inner">
             <button class="fake-link fake-link--action" type="button">Button</button>
         </div>
-        {% highlight html %}
-<button class="fake-link fake-link--action" type="button">Button</button>
-        {% endhighlight %}
     </div>
+
+    {% highlight html %}
+<button class="fake-link fake-link--action" type="button">Button</button>
+    {% endhighlight %}
 
     {% if page.ds == 6 %}
     <div class="section-footer">

--- a/docs/_includes/common/listbox-button.html
+++ b/docs/_includes/common/listbox-button.html
@@ -34,7 +34,9 @@
                 </div>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="listbox-button">
     <button class="expand-btn expand-btn--regular" aria-expanded="false" aria-haspopup="listbox">
         <span class="expand-btn__cell">
@@ -59,8 +61,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="listbox-button-selected">Selected State</h3>
     <p>An initial selection can be specified by applying the <span class="highlight">aria-selected</span> state to a single option.</p>
@@ -92,7 +93,9 @@
                 </div>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="listbox-button">
     <button class="expand-btn expand-btn--regular" aria-expanded="false" aria-haspopup="listbox">
         <span class="expand-btn__cell">
@@ -117,8 +120,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="listbox-button-borderless">Borderless</h3>
     <p>Apply the <span class="highlight">expand-btn--borderless</span> modifier to create a borderless listbox.</p>
@@ -150,7 +152,9 @@
                 </div>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="listbox-button">
     <button class="expand-btn expand-btn--regular expand-btn--borderless" aria-expanded="false" aria-haspopup="listbox">
         <span class="expand-btn__cell">
@@ -175,8 +179,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     {% if page.ds == 6 %}
     <div class="section-footer">

--- a/docs/_includes/common/listbox.html
+++ b/docs/_includes/common/listbox.html
@@ -27,7 +27,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="listbox" style="width: 300px">
     <div class="listbox__options" role="listbox" tabindex="0">
         <div class="listbox__option" role="option">
@@ -44,8 +46,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="listbox-selected">Selected State</h3>
     <p>An initial selection can be specified by applying the <span class="highlight">aria-selected</span> state to a single option.</p>
@@ -69,7 +70,9 @@
                 </div>
             </div>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="listbox" style="width: 300px">
     <div class="listbox__options" role="listbox" tabindex="0">
         <div class="listbox__option" role="option" aria-selected="true">
@@ -86,8 +89,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     {% if page.ds == 6 %}
     <div class="section-footer">

--- a/docs/_includes/common/menu-button.html
+++ b/docs/_includes/common/menu-button.html
@@ -29,7 +29,9 @@
                 </div>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="menu-button">
     <button class="expand-btn expand-btn--regular" aria-expanded="false" aria-haspopup="true" type="button">
         <span class="expand-btn__cell">
@@ -47,8 +49,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <p>For all menu buttons, the overlay becomes automatically scrollable when it's height reaches 400px.</p>
 
@@ -220,6 +221,7 @@
             </span>
         </div>
     </div>
+
     {% highlight html %}
 <span class="fake-menu-button">
     <button class="expand-btn expand-btn--regular" aria-expanded="false" aria-haspopup="true" type="button">
@@ -278,8 +280,9 @@
                 </div>
             </span>
         </div>
+    </div>
 
-        {% highlight html %}
+    {% highlight html %}
 <span class="menu-button">
     <button class="expand-btn expand-btn--regular" aria-expanded="false" aria-haspopup="true" type="button">
         <span class="expand-btn__cell">
@@ -301,12 +304,10 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="menu-button-borderless">Borderless Menu Button</h3>
-    <p>Use the <span class="highlight">expand-btn--borderless</span> element modifier on the expand button
-        to allow for a borderless version of the expand button.</p>
+    <p>Use the <span class="highlight">expand-btn--borderless</span> element modifier on the expand button to allow for a borderless version of the expand button.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -332,8 +333,9 @@
                 </div>
             </span>
         </div>
+    </div>
 
-        {% highlight html %}
+    {% highlight html %}
 <span class="menu-button">
     <button class="expand-btn expand-btn--regular expand-btn--borderless" aria-expanded="false" aria-haspopup="true" type="button">
         <span class="expand-btn__cell">
@@ -355,11 +357,9 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="menu-button-custom">Custom Menu Button</h3>
-
     <p>Any menu can use any kind of button hierarchy as defined in the <a href="#button">button</a> module (e.g. <span class="highlight">.expand-btn--primary</span>).</p>
 
     <div class="demo">
@@ -441,8 +441,9 @@
                 </div>
             </span>
         </div>
+    </div>
 
-        {% highlight html %}
+    {% highlight html %}
 <span class="menu-button">
     <button class="expand-btn" aria-expanded="false" aria-haspopup="true" style="background-color: #6a29b9; color: white" type="button">
         <span class="expand-btn__cell">
@@ -453,9 +454,7 @@
         </span>
     </button>
 </span>
-        {% endhighlight %}
-
-    </div>
+    {% endhighlight %}
 
     <p>A checkbox menu or radio menu can also leverage inline SVG for the checked state of each item:</p>
 
@@ -494,8 +493,9 @@
                 </div>
             </span>
         </div>
+    </div>
 
-        {% highlight html %}
+    {% highlight html %}
 <span class="menu-button">
     <button class="expand-btn" aria-expanded="false" aria-haspopup="true" style="background-color: #5ba71b; color: white" type="button">
         <span class="expand-btn__cell">
@@ -528,9 +528,7 @@
         </div>
     </div>
 </span>
-        {% endhighlight %}
-
-    </div>
+    {% endhighlight %}
 
     <p><strong>TIP:</strong> The positions of the status icon and label have been reversed in this example, simply by flipping their DOM order.</p>
 

--- a/docs/_includes/common/menu.html
+++ b/docs/_includes/common/menu.html
@@ -19,7 +19,9 @@
                 </div>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="menu" style="width: 300px;">
     <div class="menu__items" role="menu">
         <div class="menu__item" role="menuitem">
@@ -29,8 +31,7 @@
         <div class="menu__item" role="menuitem"><span>Item 3</span></div>
     </div>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="menu-radio">Radio Menu</h3>
     <p>For single-select state, use role <span class="highlight">menuitemradio</span> on each menu item.</p>

--- a/docs/_includes/common/select.html
+++ b/docs/_includes/common/select.html
@@ -6,6 +6,7 @@
     <p><strong>IMPORTANT:</strong> The examples below show the select in isolation, without any label. Please see the <a href="#field">field</a> module for details on labeling controls. Remember: every select requires a label!</p>
 
     <h3 id="select-default">Default select</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select">
@@ -17,7 +18,9 @@
                 <span class="select__icon"></span>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select">
     <select name="options">
         <option value="item1">Option 1</option>
@@ -26,10 +29,10 @@
     </select>
     <span class="select__icon"></span>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-disabled">Disabled select</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select">
@@ -41,7 +44,9 @@
                 <span class="select__icon"></span>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select">
     <select name="options" disabled>
         <option value="item1">Option 1</option>
@@ -50,10 +55,10 @@
     </select>
     <span class="select__icon"></span>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-selected-option">Selected option</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select">
@@ -65,7 +70,9 @@
                 <span class="select__icon"></span>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select">
     <select name="options">
         <option value="item1">Option 1</option>
@@ -74,11 +81,11 @@
         <span class="select__icon"></span>
     </select>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-unselected">Unselected Select</h3>
     <p>If no suitable default value exists, the first option in the list can be used as a prompt and set to <span class="highlight">disabled</span> &amp; <span class="highlight">selected</span>.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select">
@@ -91,8 +98,9 @@
                     <span class="select__icon"></span>
             </span>
         </div>
+    </div>
 
-        {% highlight html %}
+    {% highlight html %}
 <span class="select">
     <select>
         <option value="0" disabled selected>-select-</option>
@@ -102,10 +110,10 @@
     </select>
     <span class="select__icon"></span>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-fluid">Fluid select</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select select--fluid">
@@ -117,7 +125,9 @@
                 <span class="select__icon"></span>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select select--fluid">
     <select name="options" id="options">
         <option value="item1">Option 1</option>
@@ -126,10 +136,10 @@
     </select>
     <span class="select__icon"></span>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-borderless">Borderless select</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select select--borderless">
@@ -141,7 +151,9 @@
                 <span class="select__icon"></span>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select select--borderless">
     <select name="options" id="options">
         <option value="item1">Option 1</option>
@@ -150,10 +162,10 @@
     </select>
     <span class="select__icon"></span>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-borderless-disabled">Borderless, disabled select</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select select--borderless">
@@ -165,7 +177,9 @@
                 <span class="select__icon"></span>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select select--borderless">
     <select name="options" id="options" disabled>
         <option value="item1">Option 1</option>
@@ -174,10 +188,10 @@
     </select>
     <span class="select__icon"></span>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-rtl">Right-to-left select</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select" dir="rtl">
@@ -189,7 +203,9 @@
                 <span class="select__icon"></span>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select" dir="rtl">
     <select name="options" id="options">
         <option value="item1">Option 1</option>
@@ -198,10 +214,10 @@
     </select>
     <span class="select__icon"></span>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     <h3 id="select-foreground-icon">Foreground icon select</h3>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select">
@@ -215,7 +231,9 @@
                 </svg>
             </span>
         </div>
-        {% highlight html %}
+    </div>
+
+    {% highlight html %}
 <span class="select">
     <select name="options" id="options">
         <option value="item1">Option 1</option>
@@ -226,13 +244,13 @@
         <use xlink:href="#icon-settings"></use>
     </svg>
 </span>
-        {% endhighlight %}
-    </div>
+    {% endhighlight %}
 
     {% if page.ds == 4 %}
 
     <h3 id="select-small">Small Select (DS4 Only)</h3>
     <p>For a small select, apply the <span class="highlight">select--small</span> modifier.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select select--small">
@@ -261,6 +279,7 @@
 
     <h3 id="select-large">Large Select (DS4 Only)</h3>
     <p>For a large select, apply the <span class="highlight">select--large</span> modifier.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <span class="select select--large">


### PR DESCRIPTION
Demo `div` elements were sometimes being closed before the code sample, and sometimes closed after the sample. This PR makes all sections consistent and closes the div *before* the code sample. This helps us get a clearer idea of the widget boundaries.

Before changes:

<img width="1131" alt="Screen Shot 2019-09-17 at 7 45 38 PM" src="https://user-images.githubusercontent.com/38065/65104789-967b8300-d987-11e9-8073-13c730e48a53.png">

After changes:

<img width="1129" alt="Screen Shot 2019-09-17 at 8 10 40 PM" src="https://user-images.githubusercontent.com/38065/65104796-9e3b2780-d987-11e9-9747-b09f0d0c249b.png">
