### PR TITLE
Fixed typo in guidance test

### DIFF
--- a/docs/_includes/tests/notice.html
+++ b/docs/_includes/tests/notice.html
@@ -802,7 +802,7 @@
 
 <h2>Guided Notice (foreground SVG)</h2>
 <div class="test">
-   <div class="page-notice page-notice--guided page-notice--attention" role="region">
+   <div class="page-notice page-notice--guidance page-notice--attention" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
                 <use xlink:href="#icon-attention-filled"></use>
@@ -812,7 +812,7 @@
             <p>Something went wrong. Please try again.</p>
         </span>
     </div>
-    <div class="page-notice page-notice--guided page-notice--confirmation" role="region">
+    <div class="page-notice page-notice--guidance page-notice--confirmation" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
                 <use xlink:href="#icon-confirmation-filled"></use>
@@ -822,7 +822,7 @@
             <p>Congrats! You are the highest bidder!</p>
         </span>
     </div>
-    <div class="page-notice page-notice--guided page-notice--information" role="region">
+    <div class="page-notice page-notice--guidance page-notice--information" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--information-filled">
                 <use xlink:href="#icon-information-filled"></use>
@@ -832,7 +832,7 @@
             <p>Try refining your search term for more results.</p>
         </span>
     </div>
-    <div class="page-notice page-notice--guided" role="region">
+    <div class="page-notice page-notice--guidance" role="region">
         <span class="page-notice__content">
             <p>Here you go</p>
         </span>
@@ -842,7 +842,7 @@
 
 <h2>Guided Notice (background SVG)</h2>
 <div class="test">
-    <div class="page-notice page-notice--guided page-notice--attention" role="region">
+    <div class="page-notice page-notice--guidance page-notice--attention" role="region">
         <h3 class="page-notice__status">
             <span aria-label="attention" role="img"></span>
         </h3>
@@ -850,7 +850,7 @@
             <p>Something went wrong. Please try again.</p>
         </span>
     </div>
-    <div class="page-notice page-notice--guided page-notice--confirmation" role="region">
+    <div class="page-notice page-notice--guidance page-notice--confirmation" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -858,7 +858,7 @@
             <p>Congrats! You are the highest bidder!</p>
         </span>
     </div>
-    <div class="page-notice page-notice--guided page-notice--information" role="region">
+    <div class="page-notice page-notice--guidance page-notice--information" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -866,7 +866,7 @@
             <p>Try refining your search term for more results.</p>
         </span>
     </div>
-    <div class="page-notice page-notice--guided" role="region">
+    <div class="page-notice page-notice--guidance" role="region">
         <span class="page-notice__content">
             <p>Here you go</p>
         </span>
@@ -876,7 +876,7 @@
 
 <h2>Guided Notice, with Button CTA (foreground SVG)</h2>
 <div class="test">
-    <div class="page-notice page-notice--guided page-notice--attention" role="region">
+    <div class="page-notice page-notice--guidance page-notice--attention" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
                 <use xlink:href="#icon-attention-filled"></use>
@@ -888,7 +888,7 @@
         </span>
         <button class="page-notice__cta">Action button</button>
     </div>
-    <div class="page-notice page-notice--guided page-notice--information" role="region">
+    <div class="page-notice page-notice--guidance page-notice--information" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--information-filled">
                 <use xlink:href="#icon-information-filled"></use>
@@ -901,7 +901,7 @@
         <button class="page-notice__cta">Action button</button>
     </div>
 
-    <div class="page-notice page-notice--guided page-notice--confirmation" role="region">
+    <div class="page-notice page-notice--guidance page-notice--confirmation" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
                 <title>Comfirmation</title>
@@ -914,7 +914,7 @@
         </span>
         <button class="page-notice__cta">Action button</button>
     </div>
-    <div class="page-notice page-notice--guided" role="region">
+    <div class="page-notice page-notice--guidance" role="region">
        <span class="page-notice__content">
             <p>Something went wrong. Please try again.</p>
             <p>Click button to get More info</p>
@@ -926,7 +926,7 @@
 
 <h2>Guided Notice, with Button CTA (background SVG)</h2>
 <div class="test">
-    <div class="page-notice page-notice--guided page-notice--attention" role="region">
+    <div class="page-notice page-notice--guidance page-notice--attention" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -936,7 +936,7 @@
         </span>
         <button class="page-notice__cta">Action button</button>
     </div>
-    <div class="page-notice page-notice--guided page-notice--information" role="region">
+    <div class="page-notice page-notice--guidance page-notice--information" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -947,7 +947,7 @@
         <button class="page-notice__cta">Action button</button>
     </div>
 
-    <div class="page-notice page-notice--guided page-notice--confirmation" role="region">
+    <div class="page-notice page-notice--guidance page-notice--confirmation" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -957,7 +957,7 @@
         </span>
         <button class="page-notice__cta">Action button</button>
     </div>
-    <div class="page-notice page-notice--guided" role="region">
+    <div class="page-notice page-notice--guidance" role="region">
        <span class="page-notice__content">
             <p>Something went wrong. Please try again.</p>
             <p>Click button to get More info</p>
@@ -969,7 +969,7 @@
 
 <h2>Guided Notice, with Link CTA (foreground SVG)</h2>
 <div class="test">
-    <div class="page-notice page-notice--guided page-notice--attention" role="region">
+    <div class="page-notice page-notice--guidance page-notice--attention" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
                 <use xlink:href="#icon-attention-filled"></use>
@@ -981,7 +981,7 @@
         </span>
         <a href="https://www.ebay.com" class="page-notice__cta">Action button</a>
     </div>
-    <div class="page-notice page-notice--guided page-notice--information" role="region">
+    <div class="page-notice page-notice--guidance page-notice--information" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--information-filled">
                 <use xlink:href="#icon-information-filled"></use>
@@ -994,7 +994,7 @@
         <a href="https://www.ebay.com" class="page-notice__cta">Action button</a>
     </div>
 
-    <div class="page-notice page-notice--guided page-notice--confirmation" role="region">
+    <div class="page-notice page-notice--guidance page-notice--confirmation" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
                 <title>Comfirmation</title>
@@ -1011,7 +1011,7 @@
 
 <h2>Guided Notice, with Link CTA (background SVG)</h2>
 <div class="test">
-    <div class="page-notice page-notice--guided page-notice--attention" role="region">
+    <div class="page-notice page-notice--guidance page-notice--attention" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -1021,7 +1021,7 @@
         </span>
         <a href="https://www.ebay.com" class="page-notice__cta">Action button</a>
     </div>
-    <div class="page-notice page-notice--guided page-notice--information" role="region">
+    <div class="page-notice page-notice--guidance page-notice--information" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -1032,7 +1032,7 @@
         <a href="https://www.ebay.com" class="page-notice__cta">Action button</a>
     </div>
 
-    <div class="page-notice page-notice--guided page-notice--confirmation" role="region">
+    <div class="page-notice page-notice--guidance page-notice--confirmation" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -1042,26 +1042,23 @@
         </span>
         <a href="https://www.ebay.com" class="page-notice__cta">Action button</a>
     </div>
-   <div class="page-notice page-notice--guided" role="region">
+   <div class="page-notice page-notice--guidance" role="region">
        <span class="page-notice__content">
             <p>Something went wrong. Please try again.</p>
             <p>Click button to get More info</p>
         </span>
-        <a href="http://www.ebay.com" class="page-notice__cta">Action link</a>
+        <a href="http://www.ebay.com" class="page-notice__cta">Action button</a>
     </div>
-
-
 </div>
-
 
 <h2>Multiline Guided, (foreground SVG)</h2>
 <div class="test">
-    <div class="page-notice page-notice--guided" role="region">
+    <div class="page-notice page-notice--guidance" role="region">
        <span class="page-notice__content">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </span>
     </div>
-    <div class="page-notice page-notice--attention page-notice--guided" role="region">
+    <div class="page-notice page-notice--attention page-notice--guidance" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
                 <use xlink:href="#icon-attention-filled"></use>
@@ -1071,7 +1068,7 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </span>
     </div>
-    <div class="page-notice page-notice--confirmation page-notice--guided" role="region">
+    <div class="page-notice page-notice--confirmation page-notice--guidance" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
                 <use xlink:href="#icon-confirmation-filled"></use>
@@ -1081,7 +1078,7 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </span>
     </div>
-    <div class="page-notice page-notice--information page-notice--guided" role="region">
+    <div class="page-notice page-notice--information page-notice--guidance" role="region">
         <h3 class="page-notice__status">
             <svg aria-hidden="true" focusable="false" class="icon--information-filled">
                 <use xlink:href="#icon-information-filled"></use>
@@ -1095,12 +1092,12 @@
 
 <h2>Multiline guided, (background SVG)</h2>
 <div class="test">
-    <div class="page-notice page-notice--guided" role="region">
+    <div class="page-notice page-notice--guidance" role="region">
        <span class="page-notice__content">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </span>
    </div>
-    <div class="page-notice page-notice--attention page-notice--guided" role="region">
+    <div class="page-notice page-notice--attention page-notice--guidance" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -1108,7 +1105,7 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </span>
    </div>
-    <div class="page-notice page-notice--confirmation page-notice--guided" role="region">
+    <div class="page-notice page-notice--confirmation page-notice--guidance" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>
@@ -1116,7 +1113,7 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </span>
    </div>
-    <div class="page-notice page-notice--information page-notice--guided" role="region">
+    <div class="page-notice page-notice--information page-notice--guidance" role="region">
         <h3 class="page-notice__status">
             <span></span>
         </h3>


### PR DESCRIPTION
## Description
Had a typo in guidance test page. Named the guidance class incorrectly. 
Renmaed `page-notice--guided` to `page-notice-guidance`.
Also removed some misc whitespace and changed a text from Link to button to match the other ones. 
