### PR TITLE
Remove magic number in outline color (9.5.0)

### DIFF
--- a/dist/variables/ds4/color-variables.less
+++ b/dist/variables/ds4/color-variables.less
@@ -142,6 +142,7 @@
 @color-badge-background: @color-core-red;
 @color-badge-text: @color-core-white;
 @color-star: yellow;
+@color-control-outline: @color-grey5;
 
 // More DS6 Aliases
 //-----------------------------

--- a/dist/variables/ds6/color-variables.less
+++ b/dist/variables/ds6/color-variables.less
@@ -113,6 +113,7 @@
 @color-star: @color-y4;
 @color-badge-text: @color-white;
 @color-badge-background: @color-r4;
+@color-control-outline: @color-grey5;
 
 // deprecated
 @color-badge: @color-badge-background;

--- a/src/less/checkbox/base/checkbox.less
+++ b/src/less/checkbox/base/checkbox.less
@@ -46,7 +46,7 @@
     }
 
     &:focus + .checkbox__icon {
-        outline: 1px dotted #767676;
+        outline: 1px dotted @color-control-outline;
     }
 
     &[disabled] + .checkbox__icon {

--- a/src/less/radio/base/radio.less
+++ b/src/less/radio/base/radio.less
@@ -51,7 +51,7 @@
     }
 
     &:focus + .radio__icon {
-        outline: 1px dotted #767676;
+        outline: 1px dotted @color-control-outline;
     }
 
     &[disabled] + .radio__icon {

--- a/src/less/switch/base/switch.less
+++ b/src/less/switch/base/switch.less
@@ -55,7 +55,7 @@ span.switch__control {
     z-index: 1;
 
     &:focus + span.switch__button {
-        outline: 1px dotted #767676;
+        outline: 1px dotted @color-control-outline;
     }
 }
 

--- a/src/less/variables/ds4/color-variables.less
+++ b/src/less/variables/ds4/color-variables.less
@@ -142,6 +142,7 @@
 @color-badge-background: @color-core-red;
 @color-badge-text: @color-core-white;
 @color-star: yellow;
+@color-control-outline: @color-grey5;
 
 // More DS6 Aliases
 //-----------------------------

--- a/src/less/variables/ds6/color-variables.less
+++ b/src/less/variables/ds6/color-variables.less
@@ -113,6 +113,7 @@
 @color-star: @color-y4;
 @color-badge-text: @color-white;
 @color-badge-background: @color-r4;
+@color-control-outline: @color-grey5;
 
 // deprecated
 @color-badge: @color-badge-background;


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
<!--- What are the changes? -->
Replace color numbers with a variable

## Context
<!--- Why did you make these changes, and why in this particular way? -->
Because magic numbers are hard to maintain

Not sure if I've put the variables in the correct places...