### PR TITLE
GH: fix missing browser.json paths

### DIFF
--- a/gh.browser.json
+++ b/gh.browser.json
@@ -1,7 +1,12 @@
 {
     "dependencies": [
-        "less-import: ./src/less/less/ds6/variables.less",
-        "less-import: ./src/less/less/ds6/mixins.less",
+        "less-import: ./src/less/variables/ds6/base64-variables.less",
+        "less-import: ./src/less/variables/ds6/color-variables.less",
+        "less-import: ./src/less/variables/ds6/icon-variables.less",
+        "less-import: ./src/less/variables/ds6/typography-variables.less",
+        "less-import: ./src/less/mixins/utility/utility-mixins.less",
+        "less-import: ./src/less/mixins/icon/ds6/icon-mixins.less",
+        "less-import: ./src/less/mixins/typography/ds6/typography-mixins.less",
         "less-import: ./src/less/gh/ds6/gh-mixins.less"
     ]
 }


### PR DESCRIPTION
Fixes #961 

Updates paths to variables and mixins (they were split up, into different locations, a few releases back)

