### PR TITLE
Fix examples for radio & checkbox with inline SVG

### DIFF
--- a/docs/_includes/common/checkbox.html
+++ b/docs/_includes/common/checkbox.html
@@ -30,10 +30,10 @@
             <span class="checkbox">
                 <input aria-label="SVG checkbox example" class="checkbox__control" type="checkbox" name="checkbox-svg"/>
                 <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <svg aria-hidden="true" class="checkbox__unchecked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-checkbox-unchecked"></use>
                     </svg>
-                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <svg aria-hidden="true" class="checkbox__checked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-checkbox-checked"></use>
                     </svg>
                 </span>
@@ -44,10 +44,10 @@
 <span class="checkbox">
     <input aria-label="SVG checkbox example" class="checkbox__control" type="checkbox" />
     <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+        <svg aria-hidden="true" class="checkbox__unchecked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-checkbox-unchecked"></use>
         </svg>
-        <svg class="checkbox__checked" focusable="false" height="18" width="18">
+        <svg aria-hidden="true" class="checkbox__checked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-checkbox-checked"></use>
         </svg>
     </span>

--- a/docs/_includes/common/radio.html
+++ b/docs/_includes/common/radio.html
@@ -29,10 +29,10 @@
             <span class="radio">
                 <input aria-label="SVG radio example" class="radio__control" type="radio" name="radio-svg"/>
                 <span class="radio__icon" hidden>
-                    <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <svg aria-hidden="true" class="radio__unchecked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-radio-unchecked"></use>
                     </svg>
-                    <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <svg aria-hidden="true" class="radio__checked" focusable="false" height="18" width="18">
                         <use xlink:href="#icon-radio-checked"></use>
                     </svg>
                 </span>
@@ -43,10 +43,10 @@
 <span class="radio">
     <input aria-label="SVG radio example" class="radio__control" type="radio" />
     <span class="radio__icon" hidden>
-        <svg class="radio__unchecked" focusable="false" height="18" width="18">
+        <svg aria-hidden="true" class="radio__unchecked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-radio-unchecked"></use>
         </svg>
-        <svg class="radio__checked" focusable="false" height="18" width="18">
+        <svg aria-hidden="true" class="radio__checked" focusable="false" height="18" width="18">
             <use xlink:href="#icon-radio-checked"></use>
         </svg>
     </span>


### PR DESCRIPTION
## Description

Fix the example code on documentation for radio & checkbox with inline/foreground SVG by adding `aria-hidden=true` to prevent unnecessary focus.

## Context

Documentation update to always have aria-hidden=true on any inline/foreground SVG to prevent unnecessary focus. I found out this while testing our application with Safari + VO and our checkbox was copy-paste directly from Skin Doc.

## References

Current doc: https://ebay.github.io/skin/ds6/index.html#radio

## Screenshots

<img width="611" alt="radio-no-aria-hidden" src="https://user-images.githubusercontent.com/1072047/71364657-2a6b7500-259d-11ea-8768-134335269c7e.png">

Compare to radio button with custom SVG, which has aria-hidden:

<img width="611" alt="radio-no-aria-hidden" src="https://user-images.githubusercontent.com/1072047/71364720-55ee5f80-259d-11ea-8699-e0937a4ad8f0.png">
