### PR TITLE
Dialog: added aria-modal & removed nested role=document

### DIFF
--- a/docs/_includes/common/dialog.html
+++ b/docs/_includes/common/dialog.html
@@ -13,8 +13,8 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden id="default-0">
-                <div class="dialog__window" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden id="default-0" role="dialog">
+                <div class="dialog__window">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -34,8 +34,8 @@
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
-    <div class="dialog__window" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
+    <div class="dialog__window">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -59,8 +59,8 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden id="fill-0">
-                <div class="dialog__window dialog__window--fill" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden id="fill-0" role="dialog">
+                <div class="dialog__window dialog__window--fill">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -80,8 +80,8 @@
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
-    <div class="dialog__window dialog__window--fill" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
+    <div class="dialog__window dialog__window--fill">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -105,8 +105,8 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden id="left-panel-0">
-                <div class="dialog__window dialog__window--left" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden id="left-panel-0" role="dialog">
+                <div class="dialog__window dialog__window--left">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -126,8 +126,8 @@
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
-    <div class="dialog__window dialog__window--left" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
+    <div class="dialog__window dialog__window--left">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -151,8 +151,8 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden id="right-panel-0">
-                <div class="dialog__window dialog__window--right" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden id="right-panel-0" role="dialog">
+                <div class="dialog__window dialog__window--right">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -172,8 +172,8 @@
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog" hidden>
-    <div class="dialog__window dialog__window--right" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
+    <div class="dialog__window dialog__window--right">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -198,8 +198,8 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden id="fullscreen-0">
-                <div class="dialog__window dialog__window--full" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden id="fullscreen-0" role="dialog">
+                <div class="dialog__window dialog__window--full">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -219,8 +219,8 @@
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
-    <div class="dialog__window dialog__window--full" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
+    <div class="dialog__window dialog__window--full">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -244,8 +244,8 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Preview</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade" hidden id="scrolling-0">
-                <div class="dialog__window" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--mask-fade" hidden id="scrolling-0" role="dialog">
+                <div class="dialog__window">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -265,8 +265,8 @@
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
-    <div class="dialog__window dialog__window--full" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
+    <div class="dialog__window dialog__window--full">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -356,8 +356,8 @@ closeBtnEl.addEventListener("click", () => {
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Lightbox</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade" hidden id="fade-lightbox-0">
-                <div class="dialog__window dialog__window--fade" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--mask-fade" hidden id="fade-lightbox-0" role="dialog">
+                <div class="dialog__window dialog__window--fade">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -377,8 +377,8 @@ closeBtnEl.addEventListener("click", () => {
             </div>
 
             <button class="btn btn--primary dialog-button" type="button">Fullscreen</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden id="fade-fullscreen-0">
-                <div class="dialog__window dialog__window--full dialog__window--fade" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden id="fade-fullscreen-0" role="dialog">
+                <div class="dialog__window dialog__window--full dialog__window--fade">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -398,8 +398,8 @@ closeBtnEl.addEventListener("click", () => {
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade" hidden>
-    <div class="dialog__window dialog__window--fade" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--mask-fade" hidden role="dialog">
+    <div class="dialog__window dialog__window--fade">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -418,8 +418,8 @@ closeBtnEl.addEventListener("click", () => {
     </div>
 </div>
 
-<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--no-mask" hidden>
-    <div class="dialog__window dialog__window--full dialog__window--fade" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
+    <div class="dialog__window dialog__window--full dialog__window--fade">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
@@ -444,8 +444,8 @@ closeBtnEl.addEventListener("click", () => {
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" type="button">Left Panel</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade-slow" hidden id="slide-left-panel-0">
-                <div class="dialog__window dialog__window--left dialog__window--slide" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--mask-fade-slow" hidden id="slide-left-panel-0" role="dialog">
+                <div class="dialog__window dialog__window--left dialog__window--slide">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -463,8 +463,8 @@ closeBtnEl.addEventListener("click", () => {
             </div>
 
             <button class="btn btn--primary dialog-button" type="button">Right Panel</button>
-            <div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade-slow" hidden id="slide-right-panel-0">
-                <div class="dialog__window dialog__window--right dialog__window--slide" role="document">
+            <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--mask-fade-slow" hidden id="slide-right-panel-0" role="dialog">
+                <div class="dialog__window dialog__window--right dialog__window--slide">
                     <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                             <use xlink:href="#icon-close"></use>
@@ -484,8 +484,8 @@ closeBtnEl.addEventListener("click", () => {
     </div>
 
     {% highlight html %}
-<div role="dialog" aria-labelledby="dialog-title" class="dialog dialog--mask-fade-slow" hidden>
-    <div class="dialog__window dialog__window--left dialog__window--slide" role="document">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--mask-fade-slow" hidden role="dialog">
+    <div class="dialog__window dialog__window--left dialog__window--slide">
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>

--- a/docs/_includes/tests/dialog-full.html
+++ b/docs/_includes/tests/dialog-full.html
@@ -1,6 +1,6 @@
 <div class="test">
-    <div role="dialog" class="dialog" id="dialog" aria-labelledby="dialog-title">
-        <div class="dialog__window dialog__window--full" role="document">
+    <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
+        <div class="dialog__window dialog__window--full">
             <button class="dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
                     <use xlink:href="#icon-close"></use>

--- a/docs/_includes/tests/dialog-lightbox.html
+++ b/docs/_includes/tests/dialog-lightbox.html
@@ -1,5 +1,5 @@
 <div class="test">
-    <div role="dialog" class="dialog" id="dialog_window" aria-labelledby="dialog-title">
+    <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog_window" role="dialog">
         <div class="dialog__window" role="document">
             <button class="dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">

--- a/docs/_includes/tests/dialog-multistep.html
+++ b/docs/_includes/tests/dialog-multistep.html
@@ -1,5 +1,5 @@
 <div class="test">
-    <div role="dialog" class="dialog" id="dialog" aria-labelledby="dialog-title">
+    <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
         <div class="dialog__window dialog__window--full" role="document">
             <button class="dialog__back" type="button" aria-label="Back">
                 <svg class="icon icon--back" aria-hidden="true">

--- a/docs/_includes/tests/dialog-panel-left.html
+++ b/docs/_includes/tests/dialog-panel-left.html
@@ -1,5 +1,5 @@
 <div class="test">
-    <div role="dialog" class="dialog" id="panel" aria-labelledby="panel-title">
+    <div aria-labelledby="panel-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
         <div class="dialog__window dialog__window--left" role="document">
             <button class="dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">

--- a/docs/_includes/tests/dialog-panel-right.html
+++ b/docs/_includes/tests/dialog-panel-right.html
@@ -1,5 +1,5 @@
 <div class="test">
-    <div role="dialog" class="dialog" id="panel" aria-labelledby="panel-title">
+    <div aria-labelledby="panel-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
         <div class="dialog__window dialog__window--right" role="document">
             <button class="dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">

--- a/docs/_includes/tests/dialog-subpage.html
+++ b/docs/_includes/tests/dialog-subpage.html
@@ -1,5 +1,5 @@
 <div class="test">
-    <div role="dialog" class="dialog" id="dialog" aria-labelledby="dialog-title">
+    <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
         <div class="dialog__window dialog__window--full" role="document">
             <button class="dialog__back" type="button" aria-label="Back">
                 <svg class="icon icon--back" aria-hidden="true">


### PR DESCRIPTION
Been meaning to do this for a while. Bones, MIND Patterns and now Skin are updated to:

* add `aria-modal`
* remove `role=document`
  * no longer needed in ARIA 1.1. See: https://a11ysupport.io/tests/aria_dialog_document_mode

```html
<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
    <div class="dialog__window">
        <button aria-label="Close dialog" class="dialog__close" type="button">
            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                <use xlink:href="#icon-close"></use>
            </svg>
        </button>
        <div class="dialog__body">
            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
        </div>
    </div>
</div>
```

