### PR TITLE
feat: Add actionable textbox icon

### DIFF
--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -7,6 +7,16 @@
 span.textbox {
   display: inline-block;
 }
+span.textbox button.icon-btn {
+  padding: 0;
+  position: absolute;
+  right: 0;
+}
+span.textbox button.icon-btn .textbox__icon {
+  left: 0;
+  right: 0;
+  width: 1em;
+}
 textarea.textbox__control {
   min-height: 200px;
   overflow: auto;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -7,6 +7,16 @@
 span.textbox {
   display: inline-block;
 }
+span.textbox button.icon-btn {
+  padding: 0;
+  position: absolute;
+  right: 0;
+}
+span.textbox button.icon-btn .textbox__icon {
+  left: 0;
+  right: 0;
+  width: 14px;
+}
 textarea.textbox__control {
   min-height: 200px;
   overflow: auto;

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -135,6 +135,34 @@
     {% endhighlight %}
     <p><strong>NOTE:</strong> The icon is presentational, and therefore hidden from assistive technology using <span class="highlight">aria-hidden</span>. Remember, the purpose of the field must be conveyed using a label.</p>
 
+    <h4 id="textbox-icon">With Actionable Icon</h4>
+    <p>If you want the icon to be actionable, wrap <span class="highlight">textbox__icon</span> inside a <span class="highlight">button</span> with class <span class="highlight">icon-btn</span></p>
+    <p>Try clicking the icon below:</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="textbox textbox--icon-end">
+                <input class="textbox__control" type="text" placeholder="placeholder text" />
+                    <button class="icon-btn" type="button" aria-label="Choose Contact">
+                        <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
+                            <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
+                        </svg>
+                </button>
+            </span>
+        </div>
+    </div>
+
+    {% highlight html %}
+    <span class="textbox textbox--icon-end">
+        <input class="textbox__control" type="text" placeholder="placeholder text" />
+        <button class="icon-btn" type="button" aria-label="Choose Contact">
+            <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
+                <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
+            </svg>
+        </button>
+    </span>
+    {% endhighlight %}
+
     <h3 id="textbox-underline">Underline Textbox</h3>
     <p>Use <span class="highlight">textbox__control--underline</span> modifier to style the textbox with only a bottom border to be used in conjuction with floating labels.</p>
     <p>Please see the <a href="#label">label</a> module for details on labelling controls. Remember: every textbox requires a label!</p>

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -135,18 +135,17 @@
     {% endhighlight %}
     <p><strong>NOTE:</strong> The icon is presentational, and therefore hidden from assistive technology using <span class="highlight">aria-hidden</span>. Remember, the purpose of the field must be conveyed using a label.</p>
 
-    <h4 id="textbox-icon">With Actionable Icon</h4>
-    <p>If you want the icon to be actionable, wrap <span class="highlight">textbox__icon</span> inside a <span class="highlight">button</span> with class <span class="highlight">icon-btn</span></p>
-    <p>Try clicking the icon below:</p>
+    <h4 id="textbox-icon-actionable">With Actionable Icon</h4>
+    <p>If you want the icon to be actionable, wrap <span class="highlight">textbox__icon</span> inside a <span class="highlight">button</span> with class <span class="highlight">icon-btn</span>.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="textbox textbox--icon-end">
                 <input class="textbox__control" type="text" placeholder="placeholder text" />
-                    <button class="icon-btn" type="button" aria-label="Choose Contact">
-                        <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
-                            <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
-                        </svg>
+                <button class="icon-btn" type="button" aria-label="Choose Contact">
+                    <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
+                        <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
+                    </svg>
                 </button>
             </span>
         </div>

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -152,14 +152,14 @@
     </div>
 
     {% highlight html %}
-    <span class="textbox textbox--icon-end">
-        <input class="textbox__control" type="text" placeholder="placeholder text" />
-        <button class="icon-btn" type="button" aria-label="Choose Contact">
-            <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
-                <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
-            </svg>
-        </button>
-    </span>
+<span class="textbox textbox--icon-end">
+    <input class="textbox__control" type="text" placeholder="placeholder text" />
+    <button class="icon-btn" type="button" aria-label="Choose Contact">
+        <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
+            <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
+        </svg>
+    </button>
+</span>
     {% endhighlight %}
 
     <h3 id="textbox-underline">Underline Textbox</h3>

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -10,6 +10,18 @@
 
 span.textbox {
     display: inline-block;
+
+    button.icon-btn {
+        padding: 0;
+        position: absolute;
+        right: 0;
+
+        .textbox__icon {
+            left: 0;
+            right: 0;
+            width: @textbox-icon-width;
+        }
+    }
 }
 
 textarea.textbox__control {


### PR DESCRIPTION
## Description
Textbox icons can now be actionable/clickable in certain use cases

## Context
As an example, a textbox can represent a calendar component where
a user can click on the calendar icon and then a calendar dropdown
shows up.

## References
https://github.com/eBay/skin/issues/977

## Screenshots
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/23395619/72420318-5eb4fa00-3733-11ea-97bc-70af90c63933.gif)
