### PR TITLE
Add textbox actionable icon test

### DIFF
--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -4,18 +4,18 @@
   font-size: inherit;
   position: relative;
 }
-span.textbox {
-  display: inline-block;
-}
-span.textbox button.icon-btn {
+.textbox button.icon-btn {
   padding: 0;
   position: absolute;
   right: 0;
 }
-span.textbox button.icon-btn .textbox__icon {
+.textbox button.icon-btn svg.icon {
   left: 0;
   right: 0;
   width: 1.274em;
+}
+span.textbox {
+  display: inline-block;
 }
 textarea.textbox__control {
   min-height: 200px;

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -13,9 +13,11 @@ span.textbox button.icon-btn {
   right: 0;
 }
 span.textbox button.icon-btn .textbox__icon {
+  height: 40px;
   left: 0;
   right: 0;
-  width: 1em;
+  top: -1px;
+  width: 1.274em;
 }
 textarea.textbox__control {
   min-height: 200px;

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -13,10 +13,8 @@ span.textbox button.icon-btn {
   right: 0;
 }
 span.textbox button.icon-btn .textbox__icon {
-  height: 40px;
   left: 0;
   right: 0;
-  top: -1px;
   width: 1.274em;
 }
 textarea.textbox__control {

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -4,18 +4,18 @@
   font-size: 0.875rem;
   position: relative;
 }
-span.textbox {
-  display: inline-block;
-}
-span.textbox button.icon-btn {
+.textbox button.icon-btn {
   padding: 0;
   position: absolute;
   right: 0;
 }
-span.textbox button.icon-btn .textbox__icon {
+.textbox button.icon-btn svg.icon {
   left: 0;
   right: 0;
   width: 14px;
+}
+span.textbox {
+  display: inline-block;
 }
 textarea.textbox__control {
   min-height: 200px;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -13,8 +13,10 @@ span.textbox button.icon-btn {
   right: 0;
 }
 span.textbox button.icon-btn .textbox__icon {
+  height: 40px;
   left: 0;
   right: 0;
+  top: -1px;
   width: 14px;
 }
 textarea.textbox__control {

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -13,10 +13,8 @@ span.textbox button.icon-btn {
   right: 0;
 }
 span.textbox button.icon-btn .textbox__icon {
-  height: 40px;
   left: 0;
   right: 0;
-  top: -1px;
   width: 14px;
 }
 textarea.textbox__control {

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -143,8 +143,8 @@
             <span class="textbox textbox--icon-end">
                 <input class="textbox__control" type="text" placeholder="placeholder text" />
                 <button class="icon-btn" type="button" aria-label="Choose Contact">
-                    <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
-                        <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
+                    <svg aria-hidden="true" class="icon icon--messages textbox__icon" focusable="false" width="16" height="16">
+                        <use xlink:href="#icon-messages"></use>
                     </svg>
                 </button>
             </span>
@@ -155,8 +155,8 @@
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
     <button class="icon-btn" type="button" aria-label="Choose Contact">
-        <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
-            <use xlink:href="#{% if page.ds == 4 %}icon-mail{% else %}icon-messages{% endif %}"></use>
+        <svg aria-hidden="true" class="icon icon--messages textbox__icon" focusable="false" width="16" height="16">
+            <use xlink:href="#icon-messages"></use>
         </svg>
     </button>
 </span>

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -143,7 +143,7 @@
             <span class="textbox textbox--icon-end">
                 <input class="textbox__control" type="text" placeholder="placeholder text" />
                 <button class="icon-btn" type="button" aria-label="Choose Contact">
-                    <svg aria-hidden="true" class="icon icon--messages textbox__icon" focusable="false" width="16" height="16">
+                    <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
                         <use xlink:href="#icon-messages"></use>
                     </svg>
                 </button>
@@ -155,7 +155,7 @@
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
     <button class="icon-btn" type="button" aria-label="Choose Contact">
-        <svg aria-hidden="true" class="icon icon--messages textbox__icon" focusable="false" width="16" height="16">
+        <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
             <use xlink:href="#icon-messages"></use>
         </svg>
     </button>

--- a/docs/_includes/tests/textbox.html
+++ b/docs/_includes/tests/textbox.html
@@ -117,3 +117,13 @@
         </span>
     </div>
 </div>
+
+<h2>Actionable Icon</h2>
+<span class="textbox textbox--icon-end">
+    <input class="textbox__control" type="text" placeholder="placeholder text" />
+    <button class="icon-btn" type="button" aria-label="Choose Contact">
+        <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
+            <use xlink:href="#icon-messages"></use>
+        </svg>
+    </button>
+</span>

--- a/docs/_includes/tests/textbox.html
+++ b/docs/_includes/tests/textbox.html
@@ -122,7 +122,7 @@
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
     <button class="icon-btn" type="button" aria-label="Choose Contact">
-        <svg aria-hidden="true" class="textbox__icon" focusable="false" width="16" height="16">
+        <svg aria-hidden="true" class="icon icon--messages textbox__icon" focusable="false" width="16" height="16">
             <use xlink:href="#icon-messages"></use>
         </svg>
     </button>

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -17,10 +17,8 @@ span.textbox {
         right: 0;
 
         .textbox__icon {
-            height: @textbox-control-height;
             left: 0;
             right: 0;
-            top: -1px;
             width: @textbox-actionable-icon-width;
         }
     }

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -17,9 +17,11 @@ span.textbox {
         right: 0;
 
         .textbox__icon {
+            height: @textbox-control-height;
             left: 0;
             right: 0;
-            width: @textbox-icon-width;
+            top: -1px;
+            width: @textbox-actionable-icon-width;
         }
     }
 }

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -6,22 +6,22 @@
     color: @textbox-control-color;
     font-size: @textbox-control-font-size;
     position: relative;
-}
-
-span.textbox {
-    display: inline-block;
 
     button.icon-btn {
         padding: 0;
         position: absolute;
         right: 0;
 
-        .textbox__icon {
+        svg.icon {
             left: 0;
             right: 0;
             width: @textbox-actionable-icon-width;
         }
     }
+}
+
+span.textbox {
+    display: inline-block;
 }
 
 textarea.textbox__control {

--- a/src/less/textbox/ds4/textbox.less
+++ b/src/less/textbox/ds4/textbox.less
@@ -87,6 +87,7 @@
 @textbox-icon-color: @color-core-gray-spanish;
 @textbox-icon-fill: @color-core-gray-spanish;
 @textbox-icon-width: 1em;
+@textbox-actionable-icon-width: 1.274em;
 
 // Fixed Height Values for Textbox, Combobox & Button
 // (size are PX intentionally, and should not scale with root font size)

--- a/src/less/textbox/ds6/textbox.less
+++ b/src/less/textbox/ds6/textbox.less
@@ -87,6 +87,7 @@
 @textbox-icon-color: @color-grey3;
 @textbox-icon-fill: @color-grey3;
 @textbox-icon-width: 14px;
+@textbox-actionable-icon-width: @textbox-icon-width;
 
 // Fixed Height Values for Textbox, Combobox & Button
 // (size are PX intentionally, and should not scale with root font size)


### PR DESCRIPTION

<img width="1054" alt="Screen Shot 2020-01-21 at 1 01 36 PM" src="https://user-images.githubusercontent.com/23395619/72842890-4458b000-3c4e-11ea-8561-14b707d6ec50.png">


## Description
- Add a test for actionable icon for a textbox
- Also fix styles to achieve 14w x 40h icon measurements which is in compliance with the existing icons for a text-box 

## References
977


