### PR TITLE
Menu Button: fix font-size and colour of fake-items

### DIFF
--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -99,8 +99,9 @@ a.fake-menu-button__item:visited {
 }
 button.fake-menu-button__item {
   background-color: #fff;
-  color: #767676;
+  color: #333;
   font-family: inherit;
+  font-size: 1em;
   text-align: left;
 }
 button.fake-menu-button__item:active svg.icon,

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -101,6 +101,7 @@ button.fake-menu-button__item {
   background-color: #fff;
   color: #111820;
   font-family: inherit;
+  font-size: 1em;
   text-align: left;
 }
 button.fake-menu-button__item:active svg.icon,

--- a/dist/variables/ds4/dropdown-variables.less
+++ b/dist/variables/ds4/dropdown-variables.less
@@ -12,6 +12,6 @@
 
 @dropdown-fake-anchor-color: @color-core-gray-jet;
 @dropdown-fake-button-background-color: @color-core-white;
-@dropdown-fake-button-color: @color-core-gray-dim;
+@dropdown-fake-button-color: @color-core-gray-jet;
 
 @dropdown-status-color: @color-core-gray-dim;

--- a/docs/_includes/common/menu-button.html
+++ b/docs/_includes/common/menu-button.html
@@ -240,9 +240,9 @@
     {% endhighlight %}
 
     <h3 id="menu-button-fake">Fake Menu Button</h3>
-    <p>A fake menu button <em>looks</em> like a normal menu button component, but it contains a list of hyperlinks (instead of a menu of menuitems) and thus behaves more like a navigational component.</p>
-    <p>A valid HREF attribute is <strong>required</strong> for all anchor tags. A value of "javascript" (or any such variant) is <strong>not</strong> a valid URL!</p>
+    <p>At first glance, a fake menu button <em>appears</em> to be a normal menu button component, but it contains a list of hyperlinks and thus behaves more like a navigational component.</p>
     <p>Use the <span class="highlight">aria-current</span> attribute to denote the link that matches the current page URL (if applicable).</p>
+    <p>A valid <span class="highlight">href</span> attribute is <strong>required</strong> for all anchor tags (a value of "javascript" is <strong>not</strong> valid!) The <span class="highlight">button</span> tag is also supported (as demonstrated in the following example) if JavaScript behaviour is required alongside items with navigation behaviour.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -270,14 +270,14 @@
                         </a>
                     </li>
                     <li>
-                        <a href="http://www.ebay.com" class="fake-menu-button__item">
-                            <span>Link 3<span>
-                        </a>
+                        <button class="fake-menu-button__item" type="button">
+                            <span>Button 3<span>
+                        </button>
                     </li>
                     <li>
-                        <a href="http://www.ebay.com" class="fake-menu-button__item">
-                            <span>Link 4<span>
-                        </a>
+                        <button class="fake-menu-button__item" type="button">
+                            <span>Button 4<span>
+                        </button>
                     </li>
                 </ul>
             </span>
@@ -309,14 +309,14 @@
             </a>
         </li>
         <li>
-            <a href="http://www.ebay.com" class="fake-menu-button__item">
-                <span>Link 3<span>
-            </a>
+            <button class="fake-menu-button__item" type="button">
+                <span>Button 3<span>
+            </button>
         </li>
         <li>
-            <a href="http://www.ebay.com" class="fake-menu-button__item">
-                <span>Link 4<span>
-            </a>
+            <button class="fake-menu-button__item" type="button">
+                <span>Button 4<span>
+            </button>
         </li>
     </ul>
 </span>

--- a/docs/_includes/tests/menu-button.html
+++ b/docs/_includes/tests/menu-button.html
@@ -160,6 +160,82 @@
     </div>
 </div>
 
+<h2>Default Size, Fake</h2>
+<div class="demo" style="margin-bottom: 100px">
+    <div class="demo__inner">
+        <span class="fake-menu-button">
+            <button class="expand-btn" aria-expanded="false" aria-haspopup="true" type="button">
+                <span class="expand-btn__cell">
+                    <span class="expand-btn__text">Button</span>
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </span>
+            </button>
+            <ul class="fake-menu-button__menu">
+                <li>
+                    <a class="fake-menu-button__item" href="http://www.ebay.com" aria-current="page">
+                        <span>Link 1</span>
+                        <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                            <use xlink:href="#icon-tick-small"></use>
+                        </svg>
+                    </a>
+                </li>
+                <li>
+                    <a href="http://www.ebay.com" class="fake-menu-button__item">
+                        <span>Link 2<span>
+                    </a>
+                </li>
+                <li>
+                    <button class="fake-menu-button__item" type="button">
+                        <span>Button 3<span>
+                    </button>
+                </li>
+                <li>
+                    <button class="fake-menu-button__item" type="button">
+                        <span>Button 4<span>
+                    </button>
+                </li>
+            </ul>
+        </span>
+        <span class="fake-menu-button">
+            <button class="expand-btn" aria-expanded="true" aria-haspopup="true" type="button">
+                <span class="expand-btn__cell">
+                    <span class="expand-btn__text">Button</span>
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </span>
+            </button>
+            <ul class="fake-menu-button__menu">
+                <li>
+                    <a class="fake-menu-button__item" href="http://www.ebay.com" aria-current="page">
+                        <span>Link 1</span>
+                        <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                            <use xlink:href="#icon-tick-small"></use>
+                        </svg>
+                    </a>
+                </li>
+                <li>
+                    <a href="http://www.ebay.com" class="fake-menu-button__item">
+                        <span>Link 2<span>
+                    </a>
+                </li>
+                <li>
+                    <button class="fake-menu-button__item" type="button">
+                        <span>Button 3<span>
+                    </button>
+                </li>
+                <li>
+                    <button class="fake-menu-button__item" type="button">
+                        <span>Button 4<span>
+                    </button>
+                </li>
+            </ul>
+        </span>
+    </div>
+</div>
+
 <h2>Default Size, Default Items, Inherit Colour (purple)</h2>
 <div class="demo" style="margin-bottom: 100px">
     <div class="demo__inner">

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -65,6 +65,7 @@ button.fake-menu-button__item {
     background-color: @dropdown-fake-button-background-color;
     color: @dropdown-fake-button-color;
     font-family: inherit;
+    font-size: 1em;
     text-align: left;
 }
 

--- a/src/less/variables/ds4/dropdown-variables.less
+++ b/src/less/variables/ds4/dropdown-variables.less
@@ -12,6 +12,6 @@
 
 @dropdown-fake-anchor-color: @color-core-gray-jet;
 @dropdown-fake-button-background-color: @color-core-white;
-@dropdown-fake-button-color: @color-core-gray-dim;
+@dropdown-fake-button-color: @color-core-gray-jet;
 
 @dropdown-status-color: @color-core-gray-dim;


### PR DESCRIPTION
Fixes issue (ticket coming soon) found in QA of 10.0.0 re-release.

Also adds missing test case.

Before fix:
![Screen Shot 2020-01-28 at 12 47 41 PM](https://user-images.githubusercontent.com/38065/73306545-4af8a180-41d1-11ea-8961-53c1131ad8e7.png)

After fix:
![Screen Shot 2020-01-28 at 12 54 13 PM](https://user-images.githubusercontent.com/38065/73306546-4af8a180-41d1-11ea-92c9-15ed10b70068.png)
