### PR TITLE
Fixed combobox readonly and badge width on menu

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -76,6 +76,16 @@ span.combobox {
 .combobox__option[role^="option"]:hover {
   background-color: #eee;
 }
+.combobox__option[role^="option"] svg.icon {
+  align-self: center;
+  fill: currentColor;
+  height: 8px;
+  margin: 0 auto;
+  opacity: 0;
+  stroke: currentColor;
+  stroke-width: 0;
+  width: 8px;
+}
 .combobox__option--active[role^="option"] {
   background-color: #eee;
 }

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -76,6 +76,16 @@ span.combobox {
 .combobox__option[role^="option"]:hover {
   background-color: #e5e5e5;
 }
+.combobox__option[role^="option"] svg.icon {
+  align-self: center;
+  fill: currentColor;
+  height: 8px;
+  margin: 0 auto;
+  opacity: 0;
+  stroke: currentColor;
+  stroke-width: 0;
+  width: 8px;
+}
 .combobox__option--active[role^="option"] {
   background-color: #e5e5e5;
 }

--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -136,6 +136,12 @@ div.menu-button__item[role^="menuitem"] span {
           flex: 1 0 auto;
   white-space: nowrap;
 }
+a.fake-menu-button__item span.badge,
+button.fake-menu-button__item span.badge,
+div.menu-button__item[role^="menuitem"] span.badge {
+  -webkit-box-flex: initial;
+          flex: initial;
+}
 .menu-button__menu--scroll {
   overflow-y: scroll;
 }

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -136,6 +136,12 @@ div.menu-button__item[role^="menuitem"] span {
           flex: 1 0 auto;
   white-space: nowrap;
 }
+a.fake-menu-button__item span.badge,
+button.fake-menu-button__item span.badge,
+div.menu-button__item[role^="menuitem"] span.badge {
+  -webkit-box-flex: initial;
+          flex: initial;
+}
 .menu-button__menu--scroll {
   overflow-y: scroll;
 }

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -100,6 +100,12 @@ div.menu__item[role^="menuitem"] span {
   text-align: left;
   white-space: nowrap;
 }
+a.fake-menu__item span.badge,
+button.fake-menu__item span.badge,
+div.menu__item[role^="menuitem"] span.badge {
+  -webkit-box-flex: initial;
+          flex: initial;
+}
 .menu__items--scroll[role="menu"] {
   overflow-y: scroll;
 }

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -100,6 +100,12 @@ div.menu__item[role^="menuitem"] span {
   text-align: left;
   white-space: nowrap;
 }
+a.fake-menu__item span.badge,
+button.fake-menu__item span.badge,
+div.menu__item[role^="menuitem"] span.badge {
+  -webkit-box-flex: initial;
+          flex: initial;
+}
 .menu__items--scroll[role="menu"] {
   overflow-y: scroll;
 }

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -47,6 +47,10 @@ span.combobox {
     &:hover {
         background-color: @dropdown-item-hover-background-color;
     }
+
+    svg.icon {
+        .dropdown-status();
+    }
 }
 
 .combobox__option--active[role^="option"] {

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -105,6 +105,12 @@ div.menu-button__item[role^="menuitem"] span {
     white-space: nowrap;
 }
 
+a.fake-menu-button__item span.badge,
+button.fake-menu-button__item span.badge,
+div.menu-button__item[role^="menuitem"] span.badge {
+    flex: initial;
+}
+
 .menu-button__menu--scroll {
     overflow-y: scroll;
 }

--- a/src/less/menu/base/menu.less
+++ b/src/less/menu/base/menu.less
@@ -77,6 +77,12 @@ div.menu__item[role^="menuitem"] span {
     white-space: nowrap;
 }
 
+a.fake-menu__item span.badge,
+button.fake-menu__item span.badge,
+div.menu__item[role^="menuitem"] span.badge {
+    flex: initial;
+}
+
 .menu__items--scroll[role="menu"] {
     overflow-y: scroll;
 }


### PR DESCRIPTION
## Description
* For combobox added a dropdown status mixin to the svg icon, this fixes that issue
* For the menu badge, this was a problem caused by flex. Since badge was nested inside of the span menu option it would not have a flex center align (the center align would have to be put on items inside the menu item). So in order to fix it, in ebayui I had to put the badge in the same level as the tick and text
So makeup is:
```
<div menu__item>
  <span> Text</span>
  <span badge>
  <svg tick>
</div>
```
This way when the badge is there it picks up the parent alignment.  However the flex throws it off since the flex is set to 1 from the `menu__item > span` which forces the badge to fill the rest of the content. So I make it initial so it does not have any flex


## References
#1014
eBay/ebayui-core#1039

## Screenshots
<img width="760" alt="image" src="https://user-images.githubusercontent.com/1755269/73711194-eea6ed80-46ba-11ea-925e-617415ad2b64.png">
