### PR TITLE
Fixed position of tick element and removed dropdown status

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -77,8 +77,21 @@ span.combobox {
 .combobox__option[role^="option"]:hover {
   background-color: #eee;
 }
+.combobox__option[role^="option"] svg.icon {
+  align-self: center;
+  fill: currentColor;
+  height: 8px;
+  margin: 0 auto;
+  opacity: 0;
+  stroke: currentColor;
+  stroke-width: 0;
+  width: 8px;
+}
 .combobox__option--active[role^="option"] {
   background-color: #eee;
+}
+.combobox__option--active[role^="option"] svg.icon {
+  opacity: 1;
 }
 .combobox .expand-btn[aria-expanded="true"] {
   border-bottom-color: transparent;

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -57,6 +57,7 @@ span.combobox {
   padding: 8px 12px;
   width: 100%;
   cursor: default;
+  position: relative;
 }
 .combobox__option[role^="option"]:not(:last-child) {
   margin-bottom: 1px;
@@ -75,16 +76,6 @@ span.combobox {
 }
 .combobox__option[role^="option"]:hover {
   background-color: #eee;
-}
-.combobox__option[role^="option"] svg.icon {
-  align-self: center;
-  fill: currentColor;
-  height: 8px;
-  margin: 0 auto;
-  opacity: 0;
-  stroke: currentColor;
-  stroke-width: 0;
-  width: 8px;
 }
 .combobox__option--active[role^="option"] {
   background-color: #eee;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -57,6 +57,7 @@ span.combobox {
   padding: 8px 15px;
   width: 100%;
   cursor: default;
+  position: relative;
 }
 .combobox__option[role^="option"]:not(:last-child) {
   margin-bottom: 1px;
@@ -75,16 +76,6 @@ span.combobox {
 }
 .combobox__option[role^="option"]:hover {
   background-color: #e5e5e5;
-}
-.combobox__option[role^="option"] svg.icon {
-  align-self: center;
-  fill: currentColor;
-  height: 8px;
-  margin: 0 auto;
-  opacity: 0;
-  stroke: currentColor;
-  stroke-width: 0;
-  width: 8px;
 }
 .combobox__option--active[role^="option"] {
   background-color: #e5e5e5;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -77,8 +77,21 @@ span.combobox {
 .combobox__option[role^="option"]:hover {
   background-color: #e5e5e5;
 }
+.combobox__option[role^="option"] svg.icon {
+  align-self: center;
+  fill: currentColor;
+  height: 8px;
+  margin: 0 auto;
+  opacity: 0;
+  stroke: currentColor;
+  stroke-width: 0;
+  width: 8px;
+}
 .combobox__option--active[role^="option"] {
   background-color: #e5e5e5;
+}
+.combobox__option--active[role^="option"] svg.icon {
+  opacity: 1;
 }
 .combobox .expand-btn[aria-expanded="true"] {
   border-bottom-color: transparent;

--- a/docs/_includes/common/combobox.html
+++ b/docs/_includes/common/combobox.html
@@ -161,15 +161,21 @@
                         <div id="listbox4" class="combobox__options" role="listbox">
                             <div class="combobox__option" role="option">
                                 <span class="combobox__value">Option 1</span>
-                                <span class="combobox__status"></span>
+                                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                                    <use xlink:href="#icon-tick-small"></use>
+                                </svg>
                             </div>
                             <div class="combobox__option" role="option">
                                 <span class="combobox__value">Option 2</span>
-                                <span class="combobox__status"></span>
+                                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                                    <use xlink:href="#icon-tick-small"></use>
+                                </svg>
                             </div>
                             <div class="combobox__option" role="option">
                                 <span class="combobox__value">Option 3</span>
-                                <span class="combobox__status"></span>
+                                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                                    <use xlink:href="#icon-tick-small"></use>
+                                </svg>
                             </div>
                         </div>
                     </div>
@@ -190,15 +196,21 @@
         <div id="listbox4" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span class="combobox__value">Option 1</span>
-                <span class="combobox__status"></span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use xlink:href="#icon-tick-small"></use>
+                </svg>
             </div>
             <div class="combobox__option" role="option">
                 <span class="combobox__value">Option 2</span>
-                <span class="combobox__status"></span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use xlink:href="#icon-tick-small"></use>
+                </svg>
             </div>
             <div class="combobox__option" role="option">
                 <span class="combobox__value">Option 3</span>
-                <span class="combobox__status"></span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use xlink:href="#icon-tick-small"></use>
+                </svg>
             </div>
         </div>
     </div>

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -48,10 +48,18 @@ span.combobox {
     &:hover {
         background-color: @dropdown-item-hover-background-color;
     }
+
+    svg.icon {
+        .dropdown-status();
+    }
 }
 
 .combobox__option--active[role^="option"] {
     background-color: @dropdown-item-hover-background-color;
+
+    svg.icon {
+        opacity: 1;
+    }
 }
 
 .combobox .expand-btn[aria-expanded="true"] {

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -39,6 +39,7 @@ span.combobox {
     .dropdown-option-base();
 
     cursor: default; // needed to override text cursor
+    position: relative; // needed for icon to show properly
 
     &:not(:last-child) {
         margin-bottom: 1px;
@@ -46,10 +47,6 @@ span.combobox {
 
     &:hover {
         background-color: @dropdown-item-hover-background-color;
-    }
-
-    svg.icon {
-        .dropdown-status();
     }
 }
 


### PR DESCRIPTION
For #1014

## Description
~~Seems like my previous fix was not working as intended. I had some problems in my local which I fixed~~
~~The fix for this one is just making the containers position relative. I removed that previous code from the https://github.com/eBay/skin/pull/1016 which was causing some other issues with opacity~~

So combobox readonly did not have the code changed to support background icons. This fix does that. Basically reverted the last fix and added opacity to the checkbox. I also left in position relative to position the tick correctly. 
Updated skin docs. 


## References
#1014 

## Screenshots
![image](https://user-images.githubusercontent.com/1755269/73862905-164da100-47f4-11ea-8833-12ad47544b22.png)

Skin docs side:
![image](https://user-images.githubusercontent.com/1755269/73869513-3767bf00-47ff-11ea-9904-60074ee7646a.png)

