### PR TITLE
Menu: add divider #1006

### DIFF
--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -181,3 +181,6 @@ div.menu-button__item[role^="menuitem"] span.badge {
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu-button__menu {
   top: 41px;
 }
+hr.menu-button__separator {
+  border: 1px solid #ddd;
+}

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -181,6 +181,9 @@ div.menu-button__item[role^="menuitem"] span.badge {
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu-button__menu {
   top: 41px;
 }
+hr.menu-button__separator {
+  border: 1px solid #e5e5e5;
+}
 div.menu-button__option--active[role="option"] {
   font-weight: bold;
 }

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -129,3 +129,6 @@ div.menu__item[role^="menuitem"] span.badge {
   outline: none;
   text-decoration: underline;
 }
+hr.menu__separator {
+  border: 1px solid #ddd;
+}

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -129,3 +129,6 @@ div.menu__item[role^="menuitem"] span.badge {
   outline: none;
   text-decoration: underline;
 }
+hr.menu__separator {
+  border: 1px solid #e5e5e5;
+}

--- a/docs/_includes/common/menu-button.html
+++ b/docs/_includes/common/menu-button.html
@@ -239,6 +239,78 @@
 </span>
     {% endhighlight %}
 
+    <h3 id="menu-button-grouped">Grouped Menu Button</h3>
+    <p>Menu button items can be separated into groups, using the <span class="highlight">hr</span> tag.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="menu-button">
+                <button class="expand-btn" aria-expanded="false" aria-haspopup="true" type="button">
+                    <span class="expand-btn__cell">
+                        <span class="expand-btn__text">Button</span>
+                        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                            <use xlink:href="#icon-dropdown"></use>
+                        </svg>
+                    </span>
+                </button>
+                <div class="menu-button__menu">
+                    <div class="menu-button__items" role="menu">
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Menu Item 1</span>
+                        </div>
+                        <hr class="menu-button__separator" role="separator" />
+                        <div class="menu-button__item" role="menuitemcheckbox" aria-checked="true">
+                            <span>Menu Item 2</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                <use xlink:href="#icon-tick-small"></use>
+                            </svg>
+                        </div>
+                        <div class="menu-button__item" role="menuitemcheckbox" aria-checked="true">
+                            <span>Menu Item 3</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                                <use xlink:href="#icon-tick-small"></use>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+            </span>
+        </div>
+    </div>
+
+    {% highlight html %}
+<span class="menu-button">
+    <button class="expand-btn" aria-expanded="false" aria-haspopup="true" type="button">
+        <span class="expand-btn__cell">
+            <span class="expand-btn__text">Button</span>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="menu-button__menu">
+        <div class="menu-button__items" role="menu">
+            <div class="menu-button__item" role="menuitem">
+                <span>Menu Item 1</span>
+            </div>
+            <hr class="menu-button__separator" role="separator" />
+            <div class="menu-button__item" role="menuitemcheckbox" aria-checked="true">
+                <span>Menu Item 2</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                    <use xlink:href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="menu-button__item" role="menuitemcheckbox" aria-checked="true">
+                <span>Menu Item 3</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                    <use xlink:href="#icon-tick-small"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+    {% endhighlight %}
+
+
     <h3 id="menu-button-fake">Fake Menu Button</h3>
     <p>At first glance, a fake menu button <em>appears</em> to be a normal menu button component, but it contains a list of hyperlinks and thus behaves more like a navigational component.</p>
     <p>Use the <span class="highlight">aria-current</span> attribute to denote the link that matches the current page URL (if applicable).</p>

--- a/docs/_includes/common/menu.html
+++ b/docs/_includes/common/menu.html
@@ -152,6 +152,59 @@
 </div>
     {% endhighlight %}
 
+    <h3 id="menu-grouped">Grouped Menu</h3>
+    <p>Menu items can be separated into groups, using the <span class="highlight">hr</span> tag.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="menu">
+                <div class="menu__items" role="menu">
+                    <div class="menu__item" role="menuitem">
+                        <span>Item 1</span>
+                    </div>
+                    <hr class="menu__separator" role="separator" />
+                    <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-menuitemcheckbox-name="sort">
+                        <span>Item 2</span>
+                        <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                            <use xlink:href="#icon-tick-small"></use>
+                        </svg>
+                    </div>
+                    <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-menuitemcheckbox-name="sort">
+                        <span>Item 3</span>
+                        <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                            <use xlink:href="#icon-tick-small"></use>
+                        </svg>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="menu">
+    <div class="menu__items" role="menu">
+        <div class="menu__items" role="menu">
+            <div class="menu__item" role="menuitem">
+                <span>Item 1</span>
+            </div>
+            <hr class="menu__separator" role="separator" />
+            <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-menuitemcheckbox-name="sort">
+                <span>Item 2</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                    <use xlink:href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-menuitemcheckbox-name="sort">
+                <span>Item 3</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">
+                    <use xlink:href="#icon-tick-small"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
     <h3 id="menu-fake">Fake Menu</h3>
 
     <div class="demo">

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -158,3 +158,7 @@ div.menu-button__item[role^="menuitem"] span.badge {
 .fake-menu button.expand-btn--borderless[aria-expanded="true"] ~ .menu-button__menu {
     top: 41px; // button height plus one px, to meet design guidelines
 }
+
+hr.menu-button__separator {
+    border: 1px solid @color-grey2;
+}

--- a/src/less/menu-button/menu-button.stories.js
+++ b/src/less/menu-button/menu-button.stories.js
@@ -437,3 +437,34 @@ export const defaultSizeLinksFixWidth = () => `
     </ul>
 </span>
 `;
+
+export const grouped = () => `
+<div class="demo" style="margin-bottom: 100px">
+    <div class="demo__inner">
+        <span class="menu-button">
+            <button class="expand-btn" type="button" aria-expanded="true" aria-haspopup="true">
+                <span class="expand-btn__cell">
+                    <span class="expand-btn__text">Button</span>
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </span>
+            </button>
+            <div class="menu-button__menu">
+                <div class="menu-button__items" role="menu">
+                    <div class="menu-button__item" role="menuitem" tabindex="0">
+                        <span>Item 10000</span>
+                    </div>
+                    <hr class="menu-button__separator" role="separator" />
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 20000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 30000</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </div>
+</div>
+`;

--- a/src/less/menu/base/menu.less
+++ b/src/less/menu/base/menu.less
@@ -109,3 +109,7 @@ div.menu__item[role^="menuitem"] span.badge {
         text-decoration: underline;
     }
 }
+
+hr.menu__separator {
+    border: 1px solid @color-grey2;
+}

--- a/src/less/menu/menu.stories.js
+++ b/src/less/menu/menu.stories.js
@@ -171,3 +171,14 @@ export const singleSelectSelectedInheritFontSize200PercentBrokenSpacingShouldNot
     </div>
 </span>
 `;
+
+export const grouped = () => `
+<span class="menu">
+    <div class="menu__items" role="menu">
+        <div class="menu__item" role="menuitem" tabindex="0"><span>Item 1</span></div>
+        <hr class="menu__separator" role="separator" />
+        <div class="menu__item" role="menuitem"><span>Item 2</span></div>
+        <div class="menu__item" role="menuitem"><span>Item 3</span></div>
+    </div>
+</span>
+`;


### PR DESCRIPTION
Issue #1006 

Adds a horizontal divider/separator to menu and menu button. The line looks a little chunky and heavy to me, although it is following the spec. We may want to check in with design before releasing. I might need to reduce the vertical margins a little bit.

![Screen Shot 2020-02-10 at 12 30 37 PM](https://user-images.githubusercontent.com/38065/74187516-92cfed80-4c01-11ea-9c29-3507ed93b9a9.png)
![Screen Shot 2020-02-10 at 12 29 37 PM](https://user-images.githubusercontent.com/38065/74187518-93688400-4c01-11ea-8397-fa091d2f8012.png)
![Screen Shot 2020-02-10 at 12 27 57 PM](https://user-images.githubusercontent.com/38065/74187532-99f6fb80-4c01-11ea-8f1a-5e372b60dce9.png)
