### PR TITLE
Website: update script to add skin version to jekyll defaults

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,3 +8,4 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       cdn_path: https://ir.ebaystatic.com/cr/v/c1/skin
+      version: 10.0.0

--- a/docs/ds4/index.html
+++ b/docs/ds4/index.html
@@ -1,5 +1,4 @@
 ---
-version: 10.0.0
 layout: default
 title: eBay Skin
 ds: 4

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,4 @@
 ---
-version: 10.0.0
 layout: default
 title: eBay Skin
 ds: 6

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "copy:variablesToDist": "mkdirp dist/variables && ncp src/less/variables dist/variables",
     "copy:mixinsToDist": "mkdirp dist/mixins && ncp src/less/mixins dist/mixins",
     "copy:svgToDist": "mkdirp dist/svg && ncp src/svg dist/svg",
-    "version": "node scripts/cdn-version && npm run storybook:build && npm run build && git add -A dist docs",
+    "version": "node scripts/jekyll-config && npm run storybook:build && npm run build && git add -A dist docs",
     "transpile": "babel docs/src/js --out-dir docs/_babel",
     "snapshot": "npm run snapshot:pages && npm run snapshot:modules",
     "snapshot:pages": "percy snapshot _site --snapshot-files=index.html,ds6/index.html",

--- a/scripts/jekyll-config.js
+++ b/scripts/jekyll-config.js
@@ -1,8 +1,8 @@
 /*
- * Updates the CDN paths with the current version of NPM
+ * Updates the Jekyll front matter defaults with the current skin package version from NPM.
  */
 const fs = require('fs');
-const files = ['./docs/index.html', './docs/ds4/index.html'];
+const files = ['./docs/_config.yml'];
 
 files.forEach(file => {
     const newContents = fs.readFileSync(file, 'utf8').replace(/version\:.*\n/gi, `version: ${process.env.npm_package_version}\n`);


### PR DESCRIPTION
The test pages are currently broken due to the CDN path missing the `version` configuration variable. I have moved this variable to the Jekyll default config from where all pages will inherit it. I also updated the script & renamed it to be more in line with its purpose.