### PR TITLE
Menu: too much spacing between separators #1043

### DIFF
--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -183,4 +183,5 @@ div.menu-button__item[role^="menuitem"] span.badge {
 }
 hr.menu-button__separator {
   border: 1px solid #ddd;
+  margin: 0;
 }

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -183,6 +183,7 @@ div.menu-button__item[role^="menuitem"] span.badge {
 }
 hr.menu-button__separator {
   border: 1px solid #e5e5e5;
+  margin: 0;
 }
 div.menu-button__option--active[role="option"] {
   font-weight: bold;

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -161,4 +161,5 @@ div.menu-button__item[role^="menuitem"] span.badge {
 
 hr.menu-button__separator {
     border: 1px solid @color-grey2;
+    margin: 0;
 }


### PR DESCRIPTION
Fixes: #1043 

Spacing looks better now. 

<img width="517" alt="Screen Shot 2020-02-27 at 10 16 44 AM" src="https://user-images.githubusercontent.com/38065/75473587-4b0fcc80-594a-11ea-8faf-6e5bb351f5ec.png">

<img width="479" alt="Screen Shot 2020-02-27 at 10 10 10 AM" src="https://user-images.githubusercontent.com/38065/75473579-48ad7280-594a-11ea-80af-2f161006e04c.png">




