### PR TITLE
Fix RTL for combobox

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -193,6 +193,14 @@ span.combobox {
     min-width: 100%;
   }
 }
+.combobox__control[dir="rtl"] > input {
+  padding: 0 16px 0 32px;
+}
+.combobox__control[dir="rtl"] > svg {
+  left: 17px;
+  margin-left: 0;
+  margin-right: 8px;
+}
 .combobox__control > input[disabled] {
   background-color: #eee;
 }

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -98,7 +98,7 @@ span.combobox {
   position: absolute;
   right: 0;
 }
-.combobox__control button.icon-btn svg.icon {
+.combobox__control button.icon-btn svg {
   left: 0;
   margin: 0;
   right: 0;
@@ -129,7 +129,6 @@ span.combobox {
   margin-left: 0;
   margin-right: 0;
   padding: 0 32px 0 16px;
-  text-align: left;
 }
 .combobox__control > input[readonly] {
   color: transparent;
@@ -196,7 +195,7 @@ span.combobox {
 [dir="rtl"] .combobox__control > input {
   padding: 0 16px 0 32px;
 }
-[dir="rtl"] .combobox__control > svg {
+[dir="rtl"] .combobox__control > svg.icon {
   left: 17px;
   margin-left: 0;
   margin-right: 8px;

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -195,11 +195,18 @@ span.combobox {
 [dir="rtl"] .combobox__control > input {
   padding: 0 16px 0 32px;
 }
-[dir="rtl"] .combobox__control > svg.icon {
-  left: 17px;
+[dir="rtl"] .combobox__control > svg.icon,
+[dir="rtl"] .combobox__control > button {
   margin-left: 0;
   margin-right: 8px;
   right: unset;
+}
+[dir="rtl"] .combobox__control > svg.icon {
+  left: 16px;
+  margin-top: 1.3px;
+}
+[dir="rtl"] .combobox__control > button {
+  left: 0;
 }
 .combobox__control > input[disabled] {
   background-color: #eee;

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -193,13 +193,14 @@ span.combobox {
     min-width: 100%;
   }
 }
-.combobox__control[dir="rtl"] > input {
+[dir="rtl"] .combobox__control > input {
   padding: 0 16px 0 32px;
 }
-.combobox__control[dir="rtl"] > svg {
+[dir="rtl"] .combobox__control > svg {
   left: 17px;
   margin-left: 0;
   margin-right: 8px;
+  right: unset;
 }
 .combobox__control > input[disabled] {
   background-color: #eee;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -98,7 +98,7 @@ span.combobox {
   position: absolute;
   right: 0;
 }
-.combobox__control button.icon-btn svg.icon {
+.combobox__control button.icon-btn svg {
   left: 0;
   margin: 0;
   right: 0;
@@ -129,7 +129,6 @@ span.combobox {
   margin-left: 0;
   margin-right: 0;
   padding: 0 32px 0 16px;
-  text-align: left;
 }
 .combobox__control > input[readonly] {
   color: transparent;
@@ -196,7 +195,7 @@ span.combobox {
 [dir="rtl"] .combobox__control > input {
   padding: 0 16px 0 32px;
 }
-[dir="rtl"] .combobox__control > svg {
+[dir="rtl"] .combobox__control > svg.icon {
   left: 17px;
   margin-left: 0;
   margin-right: 8px;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -193,13 +193,14 @@ span.combobox {
     min-width: 100%;
   }
 }
-.combobox__control[dir="rtl"] > input {
+[dir="rtl"] .combobox__control > input {
   padding: 0 16px 0 32px;
 }
-.combobox__control[dir="rtl"] > svg {
+[dir="rtl"] .combobox__control > svg {
   left: 17px;
   margin-left: 0;
   margin-right: 8px;
+  right: unset;
 }
 .combobox__option--active[role="option"] {
   font-weight: bold;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -195,11 +195,18 @@ span.combobox {
 [dir="rtl"] .combobox__control > input {
   padding: 0 16px 0 32px;
 }
-[dir="rtl"] .combobox__control > svg.icon {
-  left: 17px;
+[dir="rtl"] .combobox__control > svg.icon,
+[dir="rtl"] .combobox__control > button {
   margin-left: 0;
   margin-right: 8px;
   right: unset;
+}
+[dir="rtl"] .combobox__control > svg.icon {
+  left: 16px;
+  margin-top: 1.3px;
+}
+[dir="rtl"] .combobox__control > button {
+  left: 0;
 }
 .combobox__option--active[role="option"] {
   font-weight: bold;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -193,6 +193,14 @@ span.combobox {
     min-width: 100%;
   }
 }
+.combobox__control[dir="rtl"] > input {
+  padding: 0 16px 0 32px;
+}
+.combobox__control[dir="rtl"] > svg {
+  left: 17px;
+  margin-left: 0;
+  margin-right: 8px;
+}
 .combobox__option--active[role="option"] {
   font-weight: bold;
 }

--- a/docs/_includes/common/combobox.html
+++ b/docs/_includes/common/combobox.html
@@ -218,13 +218,13 @@
     {% endhighlight %}
 
     <h3>Actionable Combobox</h3>
-    <p>In some cases, the suggestion overlay might be controlled by a button.</p>
+    <p>In some cases, the suggestion overlay might be controlled by a button. Use an actionable <span class="highlight">icon-btn</span> and the <span class="highlight">combobox__control--actionable</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <form action="index.html">
                 <span class="combobox">
-                    <span class="combobox__control">
+                    <span class="combobox__control combobox__control--actionable">
                         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox5" />
                         <button class="icon-btn" type="button" aria-label="Expand Suggestions">
                             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
@@ -252,7 +252,7 @@
 
     {% highlight html %}
 <span class="combobox">
-    <span class="combobox__control">
+    <span class="combobox__control combobox__control--actionable">
         <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox5" />
         <button class="icon-btn" type="button" aria-label="Expand Suggestions">
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
@@ -262,60 +262,6 @@
     </span>
     <div class="combobox__listbox">
         <div id="listbox5" class="combobox__options" role="listbox">
-            <div class="combobox__option" role="option">
-                <span>Option 1</span>
-            </div>
-            <div class="combobox__option" role="option">
-                <span>Option 2</span>
-            </div>
-            <div class="combobox__option" role="option">
-                <span>Option 3</span>
-            </div>
-        </div>
-    </div>
-</span>
-    {% endhighlight %}
-
-    <h3>RTL Combobox</h3>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <form action="index.html">
-                <span class="combobox" dir="rtl">
-                    <span class="combobox__control">
-                        <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox1" />
-                        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                            <use xlink:href="#icon-dropdown"></use>
-                        </svg>
-                    </span>
-                    <div class="combobox__listbox">
-                        <div id="listbox1" class="combobox__options" role="listbox">
-                            <div class="combobox__option" role="option">
-                                <span>Option 1</span>
-                            </div>
-                            <div class="combobox__option" role="option">
-                                <span>Option 2</span>
-                            </div>
-                            <div class="combobox__option" role="option">
-                                <span>Option 3</span>
-                            </div>
-                        </div>
-                    </div>
-                </span>
-            </form>
-        </div>
-    </div>
-
-    {% highlight html %}
-<span class="combobox" dir="rtl">
-    <span class="combobox__control" dir="rtl">
-        <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox1" />
-        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-            <use xlink:href="#icon-dropdown"></use>
-        </svg>
-    </span>
-    <div class="combobox__listbox">
-        <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
             </div>

--- a/docs/_includes/common/combobox.html
+++ b/docs/_includes/common/combobox.html
@@ -277,13 +277,12 @@
     {% endhighlight %}
 
     <h3>RTL Combobox</h3>
-    <p>Add <em>dir="rtl"</em> to .combobox__control container triggers RTL flow for combobox.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <form action="index.html">
-                <span class="combobox">
-                    <span class="combobox__control" dir="rtl">
+                <span class="combobox" dir="rtl">
+                    <span class="combobox__control">
                         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox1" />
                         <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                             <use xlink:href="#icon-dropdown"></use>
@@ -308,7 +307,7 @@
     </div>
 
     {% highlight html %}
-<span class="combobox">
+<span class="combobox" dir="rtl">
     <span class="combobox__control" dir="rtl">
         <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox1" />
         <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">

--- a/docs/_includes/common/combobox.html
+++ b/docs/_includes/common/combobox.html
@@ -275,4 +275,59 @@
     </div>
 </span>
     {% endhighlight %}
+
+    <h3>RTL Combobox</h3>
+    <p>Add <em>dir="rtl"</em> to .combobox__control container triggers RTL flow for combobox.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <form action="index.html">
+                <span class="combobox">
+                    <span class="combobox__control" dir="rtl">
+                        <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox1" />
+                        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                            <use xlink:href="#icon-dropdown"></use>
+                        </svg>
+                    </span>
+                    <div class="combobox__listbox">
+                        <div id="listbox1" class="combobox__options" role="listbox">
+                            <div class="combobox__option" role="option">
+                                <span>Option 1</span>
+                            </div>
+                            <div class="combobox__option" role="option">
+                                <span>Option 2</span>
+                            </div>
+                            <div class="combobox__option" role="option">
+                                <span>Option 3</span>
+                            </div>
+                        </div>
+                    </div>
+                </span>
+            </form>
+        </div>
+    </div>
+
+    {% highlight html %}
+<span class="combobox">
+    <span class="combobox__control" dir="rtl">
+        <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox1" />
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+    <div class="combobox__listbox">
+        <div id="listbox1" class="combobox__options" role="listbox">
+            <div class="combobox__option" role="option">
+                <span>Option 1</span>
+            </div>
+            <div class="combobox__option" role="option">
+                <span>Option 2</span>
+            </div>
+            <div class="combobox__option" role="option">
+                <span>Option 3</span>
+            </div>
+        </div>
+    </div>
+</span>
+    {% endhighlight %}
 </div>

--- a/docs/_includes/tests/combobox.html
+++ b/docs/_includes/tests/combobox.html
@@ -136,6 +136,153 @@
   }
 </style>
 
+<h2>Default Size, Actionable</h2>
+<div class="demo" style="margin-bottom: 100px;">
+    <div class="demo__inner">
+        <span class="combobox">
+            <span class="combobox__control combobox__control--actionable">
+                <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox5" />
+                <button class="icon-btn" type="button" aria-label="Expand Suggestions">
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </button>
+            </span>
+            <div class="combobox__listbox">
+                <div id="listbox5" class="combobox__options" role="listbox">
+                    <div class="combobox__option" role="option">
+                        <span>Option 1</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 2</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 3</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+        <span class="combobox combobox--expanded">
+            <span class="combobox__control combobox__control--actionable">
+                <input placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" aria-owns="listbox5" />
+                <button class="icon-btn" type="button" aria-label="Expand Suggestions">
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </button>
+            </span>
+            <div class="combobox__listbox">
+                <div id="listbox5" class="combobox__options" role="listbox">
+                    <div class="combobox__option" role="option">
+                        <span>Option 1</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 2</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 3</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </div>
+</div>
+
+<h2>Default Size, RTL</h2>
+<div class="demo" dir="rtl" style="margin-bottom: 100px;">
+    <div class="demo__inner">
+        <form action="index.html">
+            <span class="combobox">
+                <span class="combobox__control">
+                    <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="false" aria-haspopup="listbox" />
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </span>
+                <div class="combobox__listbox">
+                    <div id="listbox1" class="combobox__options" role="listbox">
+                        <div class="combobox__option" role="option">
+                            <span>Option 1</span>
+                        </div>
+                        <div class="combobox__option" role="option">
+                            <span>Option 2</span>
+                        </div>
+                    </div>
+                </div>
+            </span>
+            <span class="combobox combobox--expanded">
+                <span class="combobox__control">
+                    <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </span>
+                <div class="combobox__listbox">
+                    <div id="listbox1" class="combobox__options" role="listbox">
+                        <div class="combobox__option" role="option">
+                            <span>Option 1</span>
+                        </div>
+                        <div class="combobox__option" role="option">
+                            <span>Option 2</span>
+                        </div>
+                    </div>
+                </div>
+            </span>
+        </form>
+    </div>
+</div>
+
+<h2>Default Size, Actionable, RTL (broken)</h2>
+<div class="demo" dir="rtl" style="margin-bottom: 100px;">
+    <div class="demo__inner">
+        <span class="combobox">
+            <span class="combobox__control combobox__control--actionable">
+                <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox5" />
+                <button class="icon-btn" type="button" aria-label="Expand Suggestions">
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </button>
+            </span>
+            <div class="combobox__listbox">
+                <div id="listbox5" class="combobox__options" role="listbox">
+                    <div class="combobox__option" role="option">
+                        <span>Option 1</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 2</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 3</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+        <span class="combobox combobox--expanded">
+            <span class="combobox__control combobox__control--actionable">
+                <input placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" aria-owns="listbox5" />
+                <button class="icon-btn" type="button" aria-label="Expand Suggestions">
+                    <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                        <use xlink:href="#icon-dropdown"></use>
+                    </svg>
+                </button>
+            </span>
+            <div class="combobox__listbox">
+                <div id="listbox5" class="combobox__options" role="listbox">
+                    <div class="combobox__option" role="option">
+                        <span>Option 1</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 2</span>
+                    </div>
+                    <div class="combobox__option" role="option">
+                        <span>Option 3</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </div>
+</div>
 
 <h2>Default Size, Inherit Colour (red)</h2>
 <div class="demo" style="margin-bottom: 100px;">

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -178,14 +178,17 @@ span.combobox {
 }
 
 // RTL
-.combobox__control[dir="rtl"] {
-    & > input {
-        padding: 0 16px 0 32px;
-    }
-
-    & > svg {
-        left: 17px;
-        margin-left: 0;
-        margin-right: 8px;
+[dir="rtl"] {
+    .combobox__control {
+        & > input {
+            padding: 0 16px 0 32px;
+        }
+    
+        & > svg {
+            left: 17px;
+            margin-left: 0;
+            margin-right: 8px;
+            right: unset;
+        }
     }
 }

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -62,13 +62,14 @@ span.combobox {
     }
 }
 
+// refactor in v11 to use .combobox__control--actionable (added in 10.3.0)
 .combobox__control {
     button.icon-btn {
         padding: 0;
         position: absolute;
         right: 0;
 
-        svg.icon {
+        svg {
             left: 0;
             margin: 0;
             right: 0;
@@ -101,7 +102,6 @@ span.combobox {
     margin-left: 0;
     margin-right: 0;
     padding: @combobox-input-padding;
-    text-align: left;
 
     &[readonly] {
         // fixes the cursor in firefox (1 of 2)
@@ -179,16 +179,14 @@ span.combobox {
 
 // RTL
 [dir="rtl"] {
-    .combobox__control {
-        & > input {
-            padding: 0 16px 0 32px;
-        }
-    
-        & > svg {
-            left: 17px;
-            margin-left: 0;
-            margin-right: 8px;
-            right: unset;
-        }
+    .combobox__control > input {
+        padding: 0 16px 0 32px;
+    }
+
+    .combobox__control > svg.icon {
+        left: 17px;
+        margin-left: 0;
+        margin-right: 8px;
+        right: unset;
     }
 }

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -176,3 +176,16 @@ span.combobox {
         min-width: 100%;
     }
 }
+
+// RTL
+.combobox__control[dir="rtl"] {
+    & > input {
+        padding: 0 16px 0 32px;
+    }
+
+    & > svg {
+        left: 17px;
+        margin-left: 0;
+        margin-right: 8px;
+    }
+}

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -183,10 +183,19 @@ span.combobox {
         padding: 0 16px 0 32px;
     }
 
-    .combobox__control > svg.icon {
-        left: 17px;
+    .combobox__control > svg.icon,
+    .combobox__control > button {
         margin-left: 0;
         margin-right: 8px;
         right: unset;
+    }
+
+    .combobox__control > svg.icon {
+        left: 16px;
+        margin-top: 1.3px;
+    }
+
+    .combobox__control > button {
+        left: 0;
     }
 }

--- a/src/less/combobox/combobox.stories.js
+++ b/src/less/combobox/combobox.stories.js
@@ -154,6 +154,34 @@ export const rtl = () => `
 </div>
 `;
 
+export const actionableIconRtl = () => `
+<div dir="rtl">
+    <span class="combobox combobox--expanded">
+        <span class="combobox__control combobox__control--actionable">
+            <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox5" />
+            <button class="icon-btn" type="button" aria-label="Expand Suggestions">
+                <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </button>
+        </span>
+        <div class="combobox__listbox">
+            <div id="listbox5" class="combobox__options" role="listbox">
+                <div class="combobox__option" role="option">
+                    <span>Option 1</span>
+                </div>
+                <div class="combobox__option" role="option">
+                    <span>Option 2</span>
+                </div>
+                <div class="combobox__option" role="option">
+                    <span>Option 3</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</div>
+`;
+
 export const inheritColour = () => `
 <div style="color: red">
     <span class="combobox combobox--expanded">


### PR DESCRIPTION
PLEASE SQUASH.

Fixes #1045

Because combobox uses absolute positioning for dropdown icon, RTL feature is broken. This PR adds CSS to RTL direction combobox that adjusts the placement of icon and text box.

![Kapture 2020-03-25 at 12 27 04](https://user-images.githubusercontent.com/23395619/77577485-1e40cd80-6e94-11ea-8960-3244d384f4b5.gif)


