### PR TITLE
Combobox: overlay position not aligned correctly (Safari) #936

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -116,6 +116,8 @@ span.combobox {
   font-family: inherit;
   font-size: inherit;
   height: 40px;
+  margin-left: 0;
+  margin-right: 0;
   padding: 0 32px 0 16px;
   text-align: left;
 }

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -116,6 +116,8 @@ span.combobox {
   font-family: inherit;
   font-size: inherit;
   height: 40px;
+  margin-left: 0;
+  margin-right: 0;
   padding: 0 32px 0 16px;
   text-align: left;
 }

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -86,6 +86,8 @@ span.combobox {
     height: @combobox-input-height;
     padding: @combobox-input-padding;
     text-align: left;
+    margin-left: 0;
+    margin-right: 0;
 
     &[readonly] {
         // fixes the cursor in firefox (1 of 2)

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -84,10 +84,10 @@ span.combobox {
     font-family: inherit;
     font-size: inherit;
     height: @combobox-input-height;
-    padding: @combobox-input-padding;
-    text-align: left;
     margin-left: 0;
     margin-right: 0;
+    padding: @combobox-input-padding;
+    text-align: left;
 
     &[readonly] {
         // fixes the cursor in firefox (1 of 2)


### PR DESCRIPTION


## Description

User agent stylesheets for safari adds margin left and right by default

Or make input width: 100%

## Context

combobox did not align with dropdown

## References

https://github.com/eBay/skin/issues/936

## Screenshots

<img width="287" alt="Screen Shot 2020-03-25 at 5 39 52 PM" src="https://user-images.githubusercontent.com/23155224/77606022-b14d2800-6ed3-11ea-845f-6de466798fd5.png">
