### PR TITLE
Refactor wizard-stepper markup #191

### DIFF
--- a/dist/wizard-stepper/ds4/wizard-stepper.css
+++ b/dist/wizard-stepper/ds4/wizard-stepper.css
@@ -8,37 +8,31 @@
   padding: 0;
 }
 hr.wizard-stepper__separator {
-  border: 0 none;
-  height: 24px;
-  margin: 0;
-  position: relative;
-  width: 100%;
-}
-hr.wizard-stepper__separator::after {
   background-color: green;
-  content: '';
+  border: 0 none;
   display: inline-block;
   height: 2px;
-  position: absolute;
+  margin: 0;
+  position: relative;
   top: 11px;
   width: 100%;
 }
-hr.wizard-stepper__separator--confirmation::after {
+hr.wizard-stepper__separator--confirmation {
   background-color: #3ac952 !important;
 }
-hr.wizard-stepper__separator--default::after {
+hr.wizard-stepper__separator--default {
   background-color: #111820 !important;
 }
-hr.wizard-stepper__separator--error::after {
+hr.wizard-stepper__separator--error {
   background-color: #e62048 !important;
 }
-hr.wizard-stepper__separator--insufficient::after {
+hr.wizard-stepper__separator--insufficient {
   background-color: #3665f3 !important;
 }
-hr.wizard-stepper__separator--inprogress::after {
+hr.wizard-stepper__separator--inprogress {
   background-color: #3ac952 !important;
 }
-hr.wizard-stepper__separator--upcoming::after {
+hr.wizard-stepper__separator--upcoming {
   background-color: #c7c7c7 !important;
 }
 .wizard-stepper__icon {
@@ -87,6 +81,7 @@ hr.wizard-stepper__separator--upcoming::after {
 }
 .wizard-stepper__item {
   margin: 0 auto;
+  min-width: 80px;
   position: relative;
   text-align: center;
 }
@@ -162,18 +157,14 @@ hr.wizard-stepper__separator--upcoming::after {
   display: block;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator {
-  display: block;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator::after {
-  height: 100%;
-  left: 11px;
-  top: 0;
-  width: 2px;
-  z-index: 1;
+  display: inline;
+  height: auto;
+  width: auto;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__item {
   display: -webkit-box;
   display: flex;
+  margin-bottom: 16px;
   margin-left: 0;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon {
@@ -182,7 +173,7 @@ hr.wizard-stepper__separator--upcoming::after {
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::after,
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::before {
-  height: 100%;
+  height: calc(100% - 8px);
   left: 11px;
   position: absolute;
   top: 24px;

--- a/dist/wizard-stepper/ds4/wizard-stepper.css
+++ b/dist/wizard-stepper/ds4/wizard-stepper.css
@@ -1,20 +1,52 @@
 .wizard-stepper__items {
   display: -webkit-box;
   display: flex;
-  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+          justify-content: space-between;
   list-style-type: none;
+  margin: 0;
   padding: 0;
+}
+hr.wizard-stepper__separator {
+  border: 0 none;
+  height: 24px;
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+hr.wizard-stepper__separator::after {
+  background-color: green;
+  content: '';
+  display: inline-block;
+  height: 2px;
+  position: absolute;
+  top: 11px;
+  width: 100%;
+}
+hr.wizard-stepper__separator--confirmation::after {
+  background-color: #3ac952 !important;
+}
+hr.wizard-stepper__separator--default::after {
+  background-color: #111820 !important;
+}
+hr.wizard-stepper__separator--error::after {
+  background-color: #e62048 !important;
+}
+hr.wizard-stepper__separator--insufficient::after {
+  background-color: #3665f3 !important;
+}
+hr.wizard-stepper__separator--inprogress::after {
+  background-color: #3ac952 !important;
+}
+hr.wizard-stepper__separator--upcoming::after {
+  background-color: #c7c7c7 !important;
 }
 .wizard-stepper__icon {
   -webkit-box-align: center;
           align-items: center;
   display: -webkit-box;
   display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-          flex-direction: row;
   padding-bottom: 8px;
-  position: relative;
   width: 100%;
 }
 .wizard-stepper__icon::after,
@@ -22,12 +54,6 @@
   content: '';
   height: 2px;
   width: 100%;
-}
-.wizard-stepper__icon::after {
-  margin-left: 5px;
-}
-.wizard-stepper__icon::before {
-  margin-right: 5px;
 }
 .wizard-stepper__icon .badge {
   background-color: white;
@@ -41,162 +67,147 @@
   min-height: 24px;
   min-width: 24px;
 }
-.wizard-stepper__transition--default .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-default .wizard-stepper__icon::after {
   background-color: #111820 !important;
 }
-.wizard-stepper__transition--upcoming .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-upcoming .wizard-stepper__icon::after {
   background-color: #c7c7c7 !important;
 }
-.wizard-stepper__transition--inprogress .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-inprogress .wizard-stepper__icon::after {
   background-color: #3ac952 !important;
 }
-.wizard-stepper__transition--confirmation .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-confirmation .wizard-stepper__icon::after {
   background-color: #3ac952 !important;
 }
-.wizard-stepper__transition--insufficient .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-insufficient .wizard-stepper__icon::after {
   background-color: #3665f3 !important;
 }
-.wizard-stepper__transition--error .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-error .wizard-stepper__icon::after {
   background-color: #e62048 !important;
 }
 .wizard-stepper__item {
-  min-width: 80px;
+  margin: 0 auto;
+  position: relative;
   text-align: center;
 }
 .wizard-stepper__item .wizard-stepper__text {
   margin-top: 8px;
 }
-.wizard-stepper__item.wizard-stepper__item--default {
+.wizard-stepper__item--default {
   color: #111820;
 }
-.wizard-stepper__item.wizard-stepper__item--default .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--default .wizard-stepper__icon::after {
+.wizard-stepper__item--default .wizard-stepper__icon::before,
+.wizard-stepper__item--default .wizard-stepper__icon::after {
   background-color: #111820;
 }
-.wizard-stepper__item.wizard-stepper__item--default .wizard-stepper__text {
+.wizard-stepper__item--default .wizard-stepper__text {
   color: #111820;
 }
-.wizard-stepper__item.wizard-stepper__item--upcoming {
+.wizard-stepper__item--upcoming {
   color: #c7c7c7;
 }
-.wizard-stepper__item.wizard-stepper__item--upcoming .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--upcoming .wizard-stepper__icon::after {
+.wizard-stepper__item--upcoming .wizard-stepper__icon::before,
+.wizard-stepper__item--upcoming .wizard-stepper__icon::after {
   background-color: #c7c7c7;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__text.wizard-stepper__text--bold {
+.wizard-stepper__item--confirmation .wizard-stepper__text.wizard-stepper__text--bold {
   color: #111820;
   font-weight: bold;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation {
+.wizard-stepper__item--confirmation {
   color: #767676;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--inprogress .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__icon::after,
-.wizard-stepper__item.wizard-stepper__item--inprogress .wizard-stepper__icon::after {
+.wizard-stepper__item--confirmation .wizard-stepper__icon::before,
+.wizard-stepper__item--inprogress .wizard-stepper__icon::before,
+.wizard-stepper__item--confirmation .wizard-stepper__icon::after,
+.wizard-stepper__item--inprogress .wizard-stepper__icon::after {
   background-color: #3ac952;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__text,
-.wizard-stepper__item.wizard-stepper__item--upcoming .wizard-stepper__text {
+.wizard-stepper__item--confirmation .wizard-stepper__text,
+.wizard-stepper__item--upcoming .wizard-stepper__text {
   color: #767676;
 }
-.wizard-stepper__item.wizard-stepper__item--inprogress svg.icon {
+.wizard-stepper__item--inprogress svg.icon {
   color: #3ac952;
 }
-.wizard-stepper__item.wizard-stepper__item--inprogress .wizard-stepper__text {
+.wizard-stepper__item--inprogress .wizard-stepper__text {
   color: #111820;
   font-weight: bold;
 }
-.wizard-stepper__item.wizard-stepper__item--insufficient .wizard-stepper__icon::before {
+.wizard-stepper__item--insufficient .wizard-stepper__icon::before {
   background-color: #3665f3;
 }
-.wizard-stepper__item.wizard-stepper__item--error .wizard-stepper__icon::before {
+.wizard-stepper__item--error .wizard-stepper__icon::before {
   background-color: #e62048;
 }
-.wizard-stepper__item:nth-child(1) {
+.wizard-stepper__item:first-child {
   margin-left: 0;
 }
-.wizard-stepper__item:nth-child(1) .wizard-stepper__icon::before {
+.wizard-stepper__item:first-child .wizard-stepper__icon::before {
   height: 0;
 }
-.wizard-stepper__item:nth-last-child(1) {
-  margin-left: 0;
+.wizard-stepper__item:last-child {
+  margin-right: 0;
 }
-.wizard-stepper__item:nth-last-child(1) .wizard-stepper__icon::after {
+.wizard-stepper__item:last-child .wizard-stepper__icon::after {
   height: 0;
 }
-.wizard-stepper__items--fluid > .wizard-stepper__item {
-  -webkit-box-flex: 1;
-          flex: 1;
-  max-width: 220px;
+.wizard-stepper {
+  margin: 16px 0;
+}
+.wizard-stepper.wizard-stepper--vertical {
+  display: block;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__items {
-  -webkit-box-align: start;
-          align-items: flex-start;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-          flex-direction: column;
-  padding: 0;
+  display: block;
+}
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator {
+  display: block;
+}
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator::after {
+  height: 100%;
+  left: 11px;
+  top: 0;
+  width: 2px;
+  z-index: 1;
+}
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item {
+  display: -webkit-box;
+  display: flex;
+  margin-left: 0;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-          flex-direction: column;
-  min-height: 80px;
-  padding-bottom: 0;
+  display: inline-block;
+  width: auto;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::after,
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::before {
-  content: '';
-  -webkit-box-flex: 1;
-          flex: 1;
-  margin: 0;
+  height: 100%;
+  left: 11px;
+  position: absolute;
+  top: 24px;
   width: 2px;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::after {
-  margin-top: 5px;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::before {
-  margin-bottom: 5px;
-}
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__text {
-  margin-top: 3px;
-  padding-left: 7px;
+  align-self: center;
+  margin-left: 8px;
+  margin-top: -4px;
+  text-align: left;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item {
-  -webkit-box-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-          flex-direction: row;
-  min-height: 80px;
-  min-width: auto;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__text p:first-child,
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__text h3:first-child {
+  margin-top: 8px;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-child(1) {
-  -webkit-box-align: start;
-          align-items: flex-start;
-  margin-left: 0;
-  min-height: 52px;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__text p:last-child {
+  margin-bottom: 0;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-child(1) .wizard-stepper__icon {
-  min-height: 52px;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:first-child .wizard-stepper__icon::before {
+  width: 0;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-child(1) .wizard-stepper__icon::before {
-  display: none;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:last-child {
+  margin-right: auto;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) {
-  -webkit-box-align: end;
-          align-items: flex-end;
-  min-height: 52px;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) .wizard-stepper__icon {
-  min-height: 52px;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) .wizard-stepper__icon::after {
-  display: none;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) .wizard-stepper__text {
-  margin-top: 0;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:last-child .wizard-stepper__icon::before,
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:last-child .wizard-stepper__icon::after {
+  height: 0;
 }

--- a/dist/wizard-stepper/ds6/wizard-stepper.css
+++ b/dist/wizard-stepper/ds6/wizard-stepper.css
@@ -8,37 +8,31 @@
   padding: 0;
 }
 hr.wizard-stepper__separator {
-  border: 0 none;
-  height: 24px;
-  margin: 0;
-  position: relative;
-  width: 100%;
-}
-hr.wizard-stepper__separator::after {
   background-color: green;
-  content: '';
+  border: 0 none;
   display: inline-block;
   height: 2px;
-  position: absolute;
+  margin: 0;
+  position: relative;
   top: 11px;
   width: 100%;
 }
-hr.wizard-stepper__separator--confirmation::after {
+hr.wizard-stepper__separator--confirmation {
   background-color: #3ac952 !important;
 }
-hr.wizard-stepper__separator--default::after {
+hr.wizard-stepper__separator--default {
   background-color: #111820 !important;
 }
-hr.wizard-stepper__separator--error::after {
+hr.wizard-stepper__separator--error {
   background-color: #e62048 !important;
 }
-hr.wizard-stepper__separator--insufficient::after {
+hr.wizard-stepper__separator--insufficient {
   background-color: #3665f3 !important;
 }
-hr.wizard-stepper__separator--inprogress::after {
+hr.wizard-stepper__separator--inprogress {
   background-color: #3ac952 !important;
 }
-hr.wizard-stepper__separator--upcoming::after {
+hr.wizard-stepper__separator--upcoming {
   background-color: #c7c7c7 !important;
 }
 .wizard-stepper__icon {
@@ -87,6 +81,7 @@ hr.wizard-stepper__separator--upcoming::after {
 }
 .wizard-stepper__item {
   margin: 0 auto;
+  min-width: 80px;
   position: relative;
   text-align: center;
 }
@@ -162,18 +157,14 @@ hr.wizard-stepper__separator--upcoming::after {
   display: block;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator {
-  display: block;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator::after {
-  height: 100%;
-  left: 11px;
-  top: 0;
-  width: 2px;
-  z-index: 1;
+  display: inline;
+  height: auto;
+  width: auto;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__item {
   display: -webkit-box;
   display: flex;
+  margin-bottom: 16px;
   margin-left: 0;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon {
@@ -182,7 +173,7 @@ hr.wizard-stepper__separator--upcoming::after {
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::after,
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::before {
-  height: 100%;
+  height: calc(100% - 8px);
   left: 11px;
   position: absolute;
   top: 24px;

--- a/dist/wizard-stepper/ds6/wizard-stepper.css
+++ b/dist/wizard-stepper/ds6/wizard-stepper.css
@@ -1,20 +1,52 @@
 .wizard-stepper__items {
   display: -webkit-box;
   display: flex;
-  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+          justify-content: space-between;
   list-style-type: none;
+  margin: 0;
   padding: 0;
+}
+hr.wizard-stepper__separator {
+  border: 0 none;
+  height: 24px;
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+hr.wizard-stepper__separator::after {
+  background-color: green;
+  content: '';
+  display: inline-block;
+  height: 2px;
+  position: absolute;
+  top: 11px;
+  width: 100%;
+}
+hr.wizard-stepper__separator--confirmation::after {
+  background-color: #3ac952 !important;
+}
+hr.wizard-stepper__separator--default::after {
+  background-color: #111820 !important;
+}
+hr.wizard-stepper__separator--error::after {
+  background-color: #e62048 !important;
+}
+hr.wizard-stepper__separator--insufficient::after {
+  background-color: #3665f3 !important;
+}
+hr.wizard-stepper__separator--inprogress::after {
+  background-color: #3ac952 !important;
+}
+hr.wizard-stepper__separator--upcoming::after {
+  background-color: #c7c7c7 !important;
 }
 .wizard-stepper__icon {
   -webkit-box-align: center;
           align-items: center;
   display: -webkit-box;
   display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-          flex-direction: row;
   padding-bottom: 8px;
-  position: relative;
   width: 100%;
 }
 .wizard-stepper__icon::after,
@@ -22,12 +54,6 @@
   content: '';
   height: 2px;
   width: 100%;
-}
-.wizard-stepper__icon::after {
-  margin-left: 5px;
-}
-.wizard-stepper__icon::before {
-  margin-right: 5px;
 }
 .wizard-stepper__icon .badge {
   background-color: white;
@@ -41,162 +67,147 @@
   min-height: 24px;
   min-width: 24px;
 }
-.wizard-stepper__transition--default .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-default .wizard-stepper__icon::after {
   background-color: #111820 !important;
 }
-.wizard-stepper__transition--upcoming .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-upcoming .wizard-stepper__icon::after {
   background-color: #c7c7c7 !important;
 }
-.wizard-stepper__transition--inprogress .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-inprogress .wizard-stepper__icon::after {
   background-color: #3ac952 !important;
 }
-.wizard-stepper__transition--confirmation .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-confirmation .wizard-stepper__icon::after {
   background-color: #3ac952 !important;
 }
-.wizard-stepper__transition--insufficient .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-insufficient .wizard-stepper__icon::after {
   background-color: #3665f3 !important;
 }
-.wizard-stepper__transition--error .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-error .wizard-stepper__icon::after {
   background-color: #e62048 !important;
 }
 .wizard-stepper__item {
-  min-width: 80px;
+  margin: 0 auto;
+  position: relative;
   text-align: center;
 }
 .wizard-stepper__item .wizard-stepper__text {
   margin-top: 8px;
 }
-.wizard-stepper__item.wizard-stepper__item--default {
+.wizard-stepper__item--default {
   color: #111820;
 }
-.wizard-stepper__item.wizard-stepper__item--default .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--default .wizard-stepper__icon::after {
+.wizard-stepper__item--default .wizard-stepper__icon::before,
+.wizard-stepper__item--default .wizard-stepper__icon::after {
   background-color: #111820;
 }
-.wizard-stepper__item.wizard-stepper__item--default .wizard-stepper__text {
+.wizard-stepper__item--default .wizard-stepper__text {
   color: #111820;
 }
-.wizard-stepper__item.wizard-stepper__item--upcoming {
+.wizard-stepper__item--upcoming {
   color: #c7c7c7;
 }
-.wizard-stepper__item.wizard-stepper__item--upcoming .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--upcoming .wizard-stepper__icon::after {
+.wizard-stepper__item--upcoming .wizard-stepper__icon::before,
+.wizard-stepper__item--upcoming .wizard-stepper__icon::after {
   background-color: #c7c7c7;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__text.wizard-stepper__text--bold {
+.wizard-stepper__item--confirmation .wizard-stepper__text.wizard-stepper__text--bold {
   color: #111820;
   font-weight: bold;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation {
+.wizard-stepper__item--confirmation {
   color: #767676;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--inprogress .wizard-stepper__icon::before,
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__icon::after,
-.wizard-stepper__item.wizard-stepper__item--inprogress .wizard-stepper__icon::after {
+.wizard-stepper__item--confirmation .wizard-stepper__icon::before,
+.wizard-stepper__item--inprogress .wizard-stepper__icon::before,
+.wizard-stepper__item--confirmation .wizard-stepper__icon::after,
+.wizard-stepper__item--inprogress .wizard-stepper__icon::after {
   background-color: #3ac952;
 }
-.wizard-stepper__item.wizard-stepper__item--confirmation .wizard-stepper__text,
-.wizard-stepper__item.wizard-stepper__item--upcoming .wizard-stepper__text {
+.wizard-stepper__item--confirmation .wizard-stepper__text,
+.wizard-stepper__item--upcoming .wizard-stepper__text {
   color: #767676;
 }
-.wizard-stepper__item.wizard-stepper__item--inprogress svg.icon {
+.wizard-stepper__item--inprogress svg.icon {
   color: #3ac952;
 }
-.wizard-stepper__item.wizard-stepper__item--inprogress .wizard-stepper__text {
+.wizard-stepper__item--inprogress .wizard-stepper__text {
   color: #111820;
   font-weight: bold;
 }
-.wizard-stepper__item.wizard-stepper__item--insufficient .wizard-stepper__icon::before {
+.wizard-stepper__item--insufficient .wizard-stepper__icon::before {
   background-color: #3665f3;
 }
-.wizard-stepper__item.wizard-stepper__item--error .wizard-stepper__icon::before {
+.wizard-stepper__item--error .wizard-stepper__icon::before {
   background-color: #e62048;
 }
-.wizard-stepper__item:nth-child(1) {
+.wizard-stepper__item:first-child {
   margin-left: 0;
 }
-.wizard-stepper__item:nth-child(1) .wizard-stepper__icon::before {
+.wizard-stepper__item:first-child .wizard-stepper__icon::before {
   height: 0;
 }
-.wizard-stepper__item:nth-last-child(1) {
-  margin-left: 0;
+.wizard-stepper__item:last-child {
+  margin-right: 0;
 }
-.wizard-stepper__item:nth-last-child(1) .wizard-stepper__icon::after {
+.wizard-stepper__item:last-child .wizard-stepper__icon::after {
   height: 0;
 }
-.wizard-stepper__items--fluid > .wizard-stepper__item {
-  -webkit-box-flex: 1;
-          flex: 1;
-  max-width: 220px;
+.wizard-stepper {
+  margin: 16px 0;
+}
+.wizard-stepper.wizard-stepper--vertical {
+  display: block;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__items {
-  -webkit-box-align: start;
-          align-items: flex-start;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-          flex-direction: column;
-  padding: 0;
+  display: block;
+}
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator {
+  display: block;
+}
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__separator::after {
+  height: 100%;
+  left: 11px;
+  top: 0;
+  width: 2px;
+  z-index: 1;
+}
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item {
+  display: -webkit-box;
+  display: flex;
+  margin-left: 0;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-          flex-direction: column;
-  min-height: 80px;
-  padding-bottom: 0;
+  display: inline-block;
+  width: auto;
 }
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::after,
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::before {
-  content: '';
-  -webkit-box-flex: 1;
-          flex: 1;
-  margin: 0;
+  height: 100%;
+  left: 11px;
+  position: absolute;
+  top: 24px;
   width: 2px;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::after {
-  margin-top: 5px;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__icon::before {
-  margin-bottom: 5px;
-}
 .wizard-stepper.wizard-stepper--vertical .wizard-stepper__text {
-  margin-top: 3px;
-  padding-left: 7px;
+  align-self: center;
+  margin-left: 8px;
+  margin-top: -4px;
+  text-align: left;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item {
-  -webkit-box-align: center;
-          align-items: center;
-  display: -webkit-box;
-  display: flex;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-          flex-direction: row;
-  min-height: 80px;
-  min-width: auto;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__text p:first-child,
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__text h3:first-child {
+  margin-top: 8px;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-child(1) {
-  -webkit-box-align: start;
-          align-items: flex-start;
-  margin-left: 0;
-  min-height: 52px;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__text p:last-child {
+  margin-bottom: 0;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-child(1) .wizard-stepper__icon {
-  min-height: 52px;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:first-child .wizard-stepper__icon::before {
+  width: 0;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-child(1) .wizard-stepper__icon::before {
-  display: none;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:last-child {
+  margin-right: auto;
 }
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) {
-  -webkit-box-align: end;
-          align-items: flex-end;
-  min-height: 52px;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) .wizard-stepper__icon {
-  min-height: 52px;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) .wizard-stepper__icon::after {
-  display: none;
-}
-.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:nth-last-child(1) .wizard-stepper__text {
-  margin-top: 0;
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:last-child .wizard-stepper__icon::before,
+.wizard-stepper.wizard-stepper--vertical .wizard-stepper__item:last-child .wizard-stepper__icon::after {
+  height: 0;
 }

--- a/docs/_includes/common/wizard-stepper.html
+++ b/docs/_includes/common/wizard-stepper.html
@@ -93,6 +93,94 @@
 </div>
     {% endhighlight %}
 
+    <p>The wizard stepper can be sized and aligned using standard CSS:</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="wizard-stepper" style="margin: 16px auto; width: 320px;">
+                <div class="wizard-stepper__items" role="list">
+                    <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-confirmation" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-confirmation-filled"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Started</span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--confirmation" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-inprogress" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-confirmation-filled"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Shipped</span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--inprogress" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__item--transition-upcoming" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-circle"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Transit</span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-circle"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Delivered</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="wizard-stepper" style="margin: 16px auto; width: 320px;">
+    <div class="wizard-stepper__items" role="list">
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-confirmation" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-confirmation-filled"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Started</span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--confirmation" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-inprogress" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-confirmation-filled"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Shipped</span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--inprogress" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__item--transition-upcoming" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-circle"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Transit</span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-circle"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Delivered</span>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
     <h3 id="wizard-stepper-vertical">Vertical Wizard Stepper</h3>
     <p>Use the <em>wizard-stepper--vertical</em> modifier for vertically aligned steps.</p>
 

--- a/docs/_includes/common/wizard-stepper.html
+++ b/docs/_includes/common/wizard-stepper.html
@@ -1,81 +1,256 @@
 <div id="wizard-stepper">
     {% include common/section-header.html name="wizard-stepper" version=page.versions.wizard-stepper %}
 
-    <p>
-        Wizard steppers potray progress through a sequence of steps or may also be used for navigation.
-    </p>
-    <p>
-        Wizard steppers are best used
-        <ol>
-            <li>Fixed sequence of data entry</li>
-            <li>Guiding untrained users through a stepper process</li>
-            <li>A series of independent branced data input</li>
-            <li>Accomplishing a user goal that relies on sub-task completion</li>
-        </ol>
-    </p>
+    <p>Wizard steppers portray progress through a sequence of steps.</p>
 
-    <h3 id="wizard-stepper-states">States of Wizard Stepper</h3>
-    <p>The default wizard stepper has <em>horizontally aligned</em> list of steps.</p>
+    <h3 id="wizard-stepper-default">Default Wizard Stepper</h3>
+    <p>The default wizard stepper has <em>horizontally aligned</em> steps. The wizard stepper fills all available space and evenly distributes its steps.</p>
+    <p>Note that we have <em>wizard-stepper__item--transition-*</em> for each of the steps. This will let the outgoing transition wizard step to match its color with the next wizard step state.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <div class="wizard-stepper">
-                <ul class="wizard-stepper-states">
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation">
+                <div class="wizard-stepper__items" role="list">
+                    <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-confirmation" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-confirmation-filled"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Started</span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--confirmation" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-inprogress" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-confirmation-filled"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Shipped</span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--inprogress" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__item--transition-upcoming" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-circle"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Transit</span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-circle"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">Delivered</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="wizard-stepper">
+    <div class="wizard-stepper__items" role="list">
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-confirmation" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-confirmation-filled"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Started</span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--confirmation" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-inprogress" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-confirmation-filled"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Shipped</span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--inprogress" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__item--transition-upcoming" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-circle"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Transit</span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-circle"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">Delivered</span>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+    <h3 id="wizard-stepper-vertical">Vertical Wizard Stepper</h3>
+    <p>Use the <em>wizard-stepper--vertical</em> modifier for vertically aligned steps.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="wizard-stepper wizard-stepper--vertical">
+                <div class="wizard-stepper__items" role="list">
+                    <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-upcoming" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-confirmation-filled"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">
+                            <h3>Order placed</h3>
+                            <p>New Mens Addidas Ultra Boost</p>
+                            <p>Order total $220</p>
+                        </span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--upcoming wizard-stepper__item--transition-upcoming" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-circle"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">
+                            <h3>Preparing for shipment</h3>
+                            <p>We will notify you once it ships.</p>
+                        </span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
+                        <span class="wizard-stepper__icon">
+                            <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                                <use xlink:href="#icon-circle"></use>
+                            </svg>
+                        </span>
+                        <span class="wizard-stepper__text">
+                            <h3>Delivered</h3>
+                            <p>Guaranteed Wednesday, October 09.</p>
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="wizard-stepper wizard-stepper--vertical">
+    <div class="wizard-stepper__items" role="list">
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-upcoming" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-confirmation-filled"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">
+                <h3>Order placed</h3>
+                <p>New Mens Addidas Ultra Boost</p>
+                <p>Order total $220</p>
+            </span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--upcoming wizard-stepper__item--transition-upcoming" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-circle"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">
+                <h3>Preparing for shipment</h3>
+                <p>We will notify you once it ships.</p>
+            </span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
+            <span class="wizard-stepper__icon">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-circle"></use>
+                </svg>
+            </span>
+            <span class="wizard-stepper__text">
+                <h3>Delivered</h3>
+                <p>Guaranteed Wednesday, October 09.</p>
+            </span>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+    <h3 id="wizard-stepper-states">States of Wizard Stepper</h3>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="wizard-stepper">
+                <div class="wizard-stepper__items" role="list">
+                    <div class="wizard-stepper__item wizard-stepper__item--confirmation" role="listitem">
                         <span class="wizard-stepper__icon">
                             <svg class="icon" focusable="false" height="24" width="24">
                                 <use xlink:href="#icon-confirmation-filled"></use>
                             </svg>
                         </span>
                         <span class="wizard-stepper__text">Confirmation</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation">
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--inprogress" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--confirmation" role="listitem">
                         <span class="wizard-stepper__icon">
                             <svg class="icon" focusable="false" height="24" width="24">
                                 <use xlink:href="#icon-confirmation-filled"></use>
                             </svg>
                         </span>
                         <span class="wizard-stepper__text wizard-stepper__text--bold">Confirmation Bold</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--inprogress">
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--inprogress" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__item--transition-upcoming" role="listitem">
                         <span class="wizard-stepper__icon">
                             <svg class="icon" focusable="false" height="24" width="24">
                                 <use xlink:href="#icon-circle"></use>
                             </svg>
                         </span>
-                        <span class="wizard-stepper__text">InProgress</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--upcoming">
+                        <span class="wizard-stepper__text">In Progress</span>
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--upcoming wizard-stepper__item--transition-default" role="listitem">
                         <span class="wizard-stepper__icon">
                             <svg class="icon" focusable="false" height="24" width="24">
                                 <use xlink:href="#icon-circle"></use>
                             </svg>
                         </span>
                         <span class="wizard-stepper__text">Upcoming</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--default">
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--default" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--default wizard-stepper__item--transition-insufficient" role="listitem">
                         <span class="wizard-stepper__icon">
                             <span class="badge" role="img" aria-label="1">1</span>
                         </span>
                         <span class="wizard-stepper__text">Default</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--insufficient">
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--insufficient" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--insufficient wizard-stepper__item--transition-error" role="listitem">
                         <span class="wizard-stepper__icon">
                             <svg class="icon" focusable="false" height="24" width="24">
                                 <use xlink:href="#icon-information-filled"></use>
                             </svg>
                         </span>
                         <span class="wizard-stepper__text">Insufficient</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--error">
+                    </div>
+                    <hr class="wizard-stepper__separator wizard-stepper__separator--error" role="presentation" />
+                    <div class="wizard-stepper__item wizard-stepper__item--error" role="listitem">
                         <span class="wizard-stepper__icon">
                             <svg class="icon" focusable="false" height="24" width="24">
                                 <use xlink:href="#icon-attention-filled"></use>
                             </svg>
                         </span>
                         <span class="wizard-stepper__text">Error</span>
-                    </li>
-                </ul>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -136,271 +311,6 @@
                 </svg>
             </span>
             <span class="wizard-stepper__text">Error</span>
-        </li>
-    </ul>
-</div>
-    {% endhighlight %}
-
-    <h3 id="wizard-stepper-default">Default Wizard Stepper</h3>
-    <p>
-        The default wizard stepper has <em>horizontally aligned</em> list of steps.
-    </p>
-    <p>
-        Note that we have <em>wizard-stepper__transition--*</em> for each of the step list items (<em>li.wizard-stepper__item</em>).
-        This will let the outgoing transition wizard step to match its color with the next wizard step state.
-    </p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <div class="wizard-stepper">
-                <ul class="wizard-stepper__items">
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-confirmation-filled"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Started</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-confirmation-filled"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Shipped</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-circle"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Transit</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--upcoming">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-circle"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Delivered</span>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </div>
-
-    {% highlight html %}
-<div class="wizard-stepper">
-    <ul class="wizard-stepper__items">
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Started</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Shipped</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Transit</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Delivered</span>
-        </li>
-    </ul>
-</div>
-    {% endhighlight %}
-
-    <h3 id="wizard-stepper-vertical">Vertical Wizard Stepper</h3>
-    <p>
-        The vertical wizard stepper has <em>vertically aligned</em> list of steps.
-    </p>
-    <p>
-        Just add <em>wizard-stepper--vertical</em> class to the <em>.wizard-stepper</em> container tag.
-    </p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <div class="wizard-stepper wizard-stepper--vertical">
-                <ul class="wizard-stepper__items">
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-confirmation-filled"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Started</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-confirmation-filled"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Shipped</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-circle"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Transit</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--upcoming">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-circle"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Delivered</span>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </div>
-
-    {% highlight html %}
-<div class="wizard-stepper wizard-stepper--vertical">
-    <ul class="wizard-stepper__items">
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Started</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Shipped</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Transit</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Delivered</span>
-        </li>
-    </ul>
-</div>
-    {% endhighlight %}
-
-    <h3 id="wizard-stepper-vertical">Fluid Wizard Stepper</h3>
-    <p>
-        Stepper width will increase as the screen size stretches with a maximum total individual step reaching 220px.
-    </p>
-    <p>
-        Just add <em>wizard-stepper__items--fluid</em> class to the <em>ul.wizard-stepper__items</em> tag.
-    </p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <div class="wizard-stepper">
-                <ul class="wizard-stepper__items wizard-stepper__items--fluid">
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-confirmation-filled"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Started</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-confirmation-filled"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Shipped</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-circle"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Transit</span>
-                    </li>
-                    <li class="wizard-stepper__item wizard-stepper__item--upcoming">
-                        <span class="wizard-stepper__icon">
-                            <svg class="icon" focusable="false" height="24" width="24">
-                                <use xlink:href="#icon-circle"></use>
-                            </svg>
-                        </span>
-                        <span class="wizard-stepper__text">Delivered</span>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </div>
-
-    {% highlight html %}
-<div class="wizard-stepper">
-    <ul class="wizard-stepper__items wizard-stepper__items--fluid">
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Started</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Shipped</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Transit</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Delivered</span>
         </li>
     </ul>
 </div>

--- a/src/less/wizard-stepper/base/wizard-stepper.less
+++ b/src/less/wizard-stepper/base/wizard-stepper.less
@@ -18,44 +18,37 @@
 }
 
 hr.wizard-stepper__separator {
-    border: 0 none;
-    height: 24px;
-    margin: 0;
-    position: relative;
-    width: 100%;
-}
-
-hr.wizard-stepper__separator::after {
     background-color: green;
-    content: '';
+    border: 0 none;
     display: inline-block;
     height: 2px;
-    position: absolute;
+    margin: 0;
+    position: relative;
     top: 11px;
     width: 100%;
 }
 
-hr.wizard-stepper__separator--confirmation::after {
+hr.wizard-stepper__separator--confirmation {
     background-color: @wizard-step-confirmation-color !important;
 }
 
-hr.wizard-stepper__separator--default::after {
+hr.wizard-stepper__separator--default {
     background-color: @wizard-step-default-color !important;
 }
 
-hr.wizard-stepper__separator--error::after {
+hr.wizard-stepper__separator--error {
     background-color: @wizard-step-error-color !important;
 }
 
-hr.wizard-stepper__separator--insufficient::after {
+hr.wizard-stepper__separator--insufficient {
     background-color: @wizard-step-insufficient-color !important;
 }
 
-hr.wizard-stepper__separator--inprogress::after {
+hr.wizard-stepper__separator--inprogress {
     background-color: @wizard-step-confirmation-color !important;
 }
 
-hr.wizard-stepper__separator--upcoming::after {
+hr.wizard-stepper__separator--upcoming {
     background-color: @wizard-step-upcoming-color !important;
 }
 
@@ -113,6 +106,7 @@ hr.wizard-stepper__separator--upcoming::after {
 
 .wizard-stepper__item {
     margin: 0 auto;
+    min-width: 80px;
     position: relative;
     text-align: center;
 
@@ -213,19 +207,14 @@ hr.wizard-stepper__separator--upcoming::after {
         }
 
         .wizard-stepper__separator {
-            display: block;
-        }
-
-        .wizard-stepper__separator::after {
-            height: 100%;
-            left: 11px;
-            top: 0;
-            width: 2px;
-            z-index: 1;
+            display: inline;
+            height: auto;
+            width: auto;
         }
 
         .wizard-stepper__item {
             display: flex;
+            margin-bottom: 16px;
             margin-left: 0;
         }
 
@@ -235,7 +224,7 @@ hr.wizard-stepper__separator--upcoming::after {
 
             &::after,
             &::before {
-                height: 100%;
+                height: calc(100% - 8px);
                 left: 11px;
                 position: absolute;
                 top: 24px;

--- a/src/less/wizard-stepper/base/wizard-stepper.less
+++ b/src/less/wizard-stepper/base/wizard-stepper.less
@@ -11,17 +11,58 @@
 
 .wizard-stepper__items {
     display: flex;
-    flex-wrap: wrap;
+    justify-content: space-between;
     list-style-type: none;
+    margin: 0;
     padding: 0;
+}
+
+hr.wizard-stepper__separator {
+    border: 0 none;
+    height: 24px;
+    margin: 0;
+    position: relative;
+    width: 100%;
+}
+
+hr.wizard-stepper__separator::after {
+    background-color: green;
+    content: '';
+    display: inline-block;
+    height: 2px;
+    position: absolute;
+    top: 11px;
+    width: 100%;
+}
+
+hr.wizard-stepper__separator--confirmation::after {
+    background-color: @wizard-step-confirmation-color !important;
+}
+
+hr.wizard-stepper__separator--default::after {
+    background-color: @wizard-step-default-color !important;
+}
+
+hr.wizard-stepper__separator--error::after {
+    background-color: @wizard-step-error-color !important;
+}
+
+hr.wizard-stepper__separator--insufficient::after {
+    background-color: @wizard-step-insufficient-color !important;
+}
+
+hr.wizard-stepper__separator--inprogress::after {
+    background-color: @wizard-step-confirmation-color !important;
+}
+
+hr.wizard-stepper__separator--upcoming::after {
+    background-color: @wizard-step-upcoming-color !important;
 }
 
 .wizard-stepper__icon {
     align-items: center;
     display: flex;
-    flex-direction: row;
     padding-bottom: 8px;
-    position: relative;
     width: 100%;
 
     &::after,
@@ -29,14 +70,6 @@
         content: '';
         height: 2px;
         width: 100%;
-    }
-
-    &::after {
-        margin-left: @wizard-stepper-list-line-spacing;
-    }
-
-    &::before {
-        margin-right: @wizard-stepper-list-line-spacing;
     }
 
     .badge {
@@ -54,39 +87,40 @@
     }
 }
 
-.wizard-stepper__transition--default .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-default .wizard-stepper__icon::after {
     background-color: @wizard-step-default-color !important;
 }
 
-.wizard-stepper__transition--upcoming .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-upcoming .wizard-stepper__icon::after {
     background-color: @wizard-step-upcoming-color !important;
 }
 
-.wizard-stepper__transition--inprogress .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-inprogress .wizard-stepper__icon::after {
     background-color: @wizard-step-confirmation-color !important;
 }
 
-.wizard-stepper__transition--confirmation .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-confirmation .wizard-stepper__icon::after {
     background-color: @wizard-step-confirmation-color !important;
 }
 
-.wizard-stepper__transition--insufficient .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-insufficient .wizard-stepper__icon::after {
     background-color: @wizard-step-insufficient-color !important;
 }
 
-.wizard-stepper__transition--error .wizard-stepper__icon::after {
+.wizard-stepper__item--transition-error .wizard-stepper__icon::after {
     background-color: @wizard-step-error-color !important;
 }
 
 .wizard-stepper__item {
-    min-width: 80px;
+    margin: 0 auto;
+    position: relative;
     text-align: center;
 
     .wizard-stepper__text {
         margin-top: 8px;
     }
 
-    &&--default {
+    &--default {
         color: @wizard-step-default-color;
 
         .wizard-stepper__icon::before,
@@ -99,7 +133,7 @@
         }
     }
 
-    &&--upcoming {
+    &--upcoming {
         color: @wizard-step-upcoming-color;
 
         .wizard-stepper__icon::before,
@@ -108,31 +142,31 @@
         }
     }
 
-    &&--confirmation .wizard-stepper__text.wizard-stepper__text--bold {
+    &--confirmation .wizard-stepper__text.wizard-stepper__text--bold {
         color: @wizard-step-default-color;
         font-weight: bold;
     }
 
-    &&--confirmation {
+    &--confirmation {
         color: @wizard-step-title-light-color;
     }
 
-    &&--confirmation,
-    &&--inprogress {
+    &--confirmation,
+    &--inprogress {
         .wizard-stepper__icon::before,
         .wizard-stepper__icon::after {
             background-color: @wizard-step-confirmation-color;
         }
     }
 
-    &&--confirmation,
-    &&--upcoming {
+    &--confirmation,
+    &--upcoming {
         .wizard-stepper__text {
             color: @wizard-step-title-light-color;
         }
     }
 
-    &&--inprogress {
+    &--inprogress {
         svg.icon {
             color: @wizard-step-confirmation-color;
         }
@@ -143,15 +177,15 @@
         }
     }
 
-    &&--insufficient .wizard-stepper__icon::before {
+    &--insufficient .wizard-stepper__icon::before {
         background-color: @wizard-step-insufficient-color;
     }
 
-    &&--error .wizard-stepper__icon::before {
+    &--error .wizard-stepper__icon::before {
         background-color: @wizard-step-error-color;
     }
 
-    &:nth-child(1) {
+    &:first-child {
         margin-left: 0;
 
         .wizard-stepper__icon::before {
@@ -159,8 +193,8 @@
         }
     }
 
-    &:nth-last-child(1) {
-        margin-left: 0;
+    &:last-child {
+        margin-right: 0;
 
         .wizard-stepper__icon::after {
             height: 0;
@@ -168,82 +202,73 @@
     }
 }
 
-.wizard-stepper__items--fluid {
-    & > .wizard-stepper__item {
-        flex: 1;
-        max-width: 220px;
-    }
-}
+.wizard-stepper {
+    margin: 16px 0;
 
-.wizard-stepper.wizard-stepper--vertical {
-    .wizard-stepper__items {
-        align-items: flex-start;
-        flex-direction: column;
-        padding: 0;
-    }
+    &.wizard-stepper--vertical {
+        display: block;
 
-    .wizard-stepper__icon {
-        flex-direction: column;
-        min-height: 80px;
-        padding-bottom: 0;
+        .wizard-stepper__items {
+            display: block;
+        }
 
-        &::after,
-        &::before {
-            content: '';
-            flex: 1;
-            margin: 0;
+        .wizard-stepper__separator {
+            display: block;
+        }
+
+        .wizard-stepper__separator::after {
+            height: 100%;
+            left: 11px;
+            top: 0;
             width: 2px;
+            z-index: 1;
         }
 
-        &::after {
-            margin-top: 5px;
-        }
-
-        &::before {
-            margin-bottom: 5px;
-        }
-    }
-
-    .wizard-stepper__text {
-        margin-top: 3px;
-        padding-left: 7px;
-    }
-
-    .wizard-stepper__item {
-        align-items: center;
-        display: flex;
-        flex-direction: row;
-        min-height: 80px;
-        min-width: auto;
-
-        &:nth-child(1) {
-            align-items: flex-start;
+        .wizard-stepper__item {
+            display: flex;
             margin-left: 0;
-            min-height: 52px;
+        }
 
-            .wizard-stepper__icon {
-                min-height: 52px;
-            }
+        .wizard-stepper__icon {
+            display: inline-block;
+            width: auto;
 
-            .wizard-stepper__icon::before {
-                display: none;
+            &::after,
+            &::before {
+                height: 100%;
+                left: 11px;
+                position: absolute;
+                top: 24px;
+                width: 2px;
             }
         }
 
-        &:nth-last-child(1) {
-            align-items: flex-end;
-            min-height: 52px;
+        .wizard-stepper__text {
+            align-self: center;
+            margin-left: 8px;
+            margin-top: -4px;
+            text-align: left;
+        }
 
-            .wizard-stepper__icon {
-                min-height: 52px;
-            }
+        .wizard-stepper__text p:first-child,
+        .wizard-stepper__text h3:first-child {
+            margin-top: 8px;
+        }
 
+        .wizard-stepper__text p:last-child {
+            margin-bottom: 0;
+        }
+
+        .wizard-stepper__item:first-child .wizard-stepper__icon::before {
+            width: 0;
+        }
+
+        .wizard-stepper__item:last-child {
+            margin-right: auto;
+
+            .wizard-stepper__icon::before,
             .wizard-stepper__icon::after {
-                display: none;
-            }
-
-            .wizard-stepper__text {
-                margin-top: 0;
+                height: 0;
             }
         }
     }

--- a/src/less/wizard-stepper/wizard-stepper.stories.js
+++ b/src/less/wizard-stepper/wizard-stepper.stories.js
@@ -2,118 +2,85 @@ export default { title: 'WizardStepper' };
 
 export const wizardStepperDefault = () => `
 <div class="wizard-stepper">
-    <ul class="wizard-stepper__items">
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
+    <div class="wizard-stepper__items" role="list">
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-confirmation" role="listitem">
             <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-confirmation-filled"></use>
                 </svg>
             </span>
             <span class="wizard-stepper__text">Started</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--confirmation" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-inprogress" role="listitem">
             <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-confirmation-filled"></use>
                 </svg>
             </span>
             <span class="wizard-stepper__text">Shipped</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--inprogress" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__item--transition-upcoming" role="listitem">
             <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-circle"></use>
                 </svg>
             </span>
             <span class="wizard-stepper__text">Transit</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--upcoming">
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
             <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-circle"></use>
                 </svg>
             </span>
             <span class="wizard-stepper__text">Delivered</span>
-        </li>
-    </ul>
+        </div>
+    </div>
 </div>
 `;
 
 export const wizardStepperVertical = () => `
 <div class="wizard-stepper wizard-stepper--vertical">
-    <ul class="wizard-stepper__items">
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
+    <div class="wizard-stepper__items" role="list">
+        <div class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__item--transition-upcoming" role="listitem">
             <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-confirmation-filled"></use>
                 </svg>
             </span>
-            <span class="wizard-stepper__text">Started</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
+            <span class="wizard-stepper__text">
+                <h3>Order placed</h3>
+                <p>New Mens Addidas Ultra Boost</p>
+                <p>Order total $220</p>
             </span>
-            <span class="wizard-stepper__text">Shipped</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--upcoming wizard-stepper__item--transition-upcoming" role="listitem">
             <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-circle"></use>
                 </svg>
             </span>
-            <span class="wizard-stepper__text">Transit</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--upcoming">
+            <span class="wizard-stepper__text">
+                <h3>Preparing for shipment</h3>
+                <p>We will notify you once it ships.</p>
+            </span>
+        </div>
+        <hr class="wizard-stepper__separator wizard-stepper__separator--upcoming" role="presentation" />
+        <div class="wizard-stepper__item wizard-stepper__item--upcoming" role="listitem">
             <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
+                <svg aria-hidden="true" class="icon" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-circle"></use>
                 </svg>
             </span>
-            <span class="wizard-stepper__text">Delivered</span>
-        </li>
-    </ul>
-</div>
-`;
-
-export const wizardStepperFluid = () => `
-<div class="wizard-stepper">
-    <ul class="wizard-stepper__items wizard-stepper--fluid">
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--confirmation">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
+            <span class="wizard-stepper__text">
+                <h3>Delivered</h3>
+                <p>Guaranteed Wednesday, October 09.</p>
             </span>
-            <span class="wizard-stepper__text">Started</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--confirmation wizard-stepper__transition--inprogress">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-confirmation-filled"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Shipped</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--inprogress wizard-stepper__transition--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Transit</span>
-        </li>
-        <li class="wizard-stepper__item wizard-stepper__item--upcoming">
-            <span class="wizard-stepper__icon">
-                <svg class="icon" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-circle"></use>
-                </svg>
-            </span>
-            <span class="wizard-stepper__text">Delivered</span>
-        </li>
-    </ul>
-</div>
+        </div>
+    </div>
 </div>
 `;


### PR DESCRIPTION
So I was playing around with the wizard stepper, and I couldn't get it to behave like I wanted to with the existing markup that I originally was hoping for. So I tried adding an additional separator element for the lines between the steps and it now seems to behave. It also much simplified the CSS for the vertical stepper, as that can now use block level layout instead of flex.

With this new approach I would expect the app to add a constrained width and/or `margin: 0 auto` to center (I guess we could add a modifier to do that centering too).

If we are good with this new approach, before we can release, I recommend another follow-up PR with some further cleanup:

* refactor LESS to remove concatenated class names. All class names should be fully searchable.
* remove all instances of `!important`
* LESS variable declarations should be moved out of base and into ds4 and ds6 
* try and combine the wizard-stepper__item modifier classes into one, e.g. `wizard-stepper__item--confirmation wizard-stepper__item--transition-upcoming` could be `wizard-stepper__item--confirmation-to-upcoming`
* or,  if that doesn't work then maybe rename to `wizard-stepper__item--in-confirmation wizard-stepper__item--out-upcoming` as I find that a bit easier to follow

<img width="1108" alt="Screen Shot 2020-03-28 at 9 25 01 PM" src="https://user-images.githubusercontent.com/38065/77840343-4c940680-713b-11ea-9680-a4eb0a37bee2.png">

<img width="1108" alt="Screen Shot 2020-03-28 at 9 25 15 PM" src="https://user-images.githubusercontent.com/38065/77840346-50c02400-713b-11ea-8d5c-88d4b5ceaf5a.png">

<img width="1104" alt="Screen Shot 2020-03-28 at 9 25 23 PM" src="https://user-images.githubusercontent.com/38065/77840348-53bb1480-713b-11ea-857a-7a65e437494e.png">


