### PR TITLE
Fix Textbox and Label discrepancies with Playbook #1075

### DIFF
--- a/dist/label/ds4/label.css
+++ b/dist/label/ds4/label.css
@@ -1,5 +1,5 @@
 .floating-label {
-  margin-top: 10px;
+  margin-top: 14px;
   position: relative;
 }
 span.floating-label {
@@ -9,20 +9,20 @@ div.floating-label {
   display: block;
 }
 label.floating-label__label {
-  bottom: 0.375rem;
   color: #767676;
   display: block;
   left: 0;
   pointer-events: none;
   position: absolute;
-  -webkit-transform: scale(0.75, 0.75) translate(0, -26px);
-          transform: scale(0.75, 0.75) translate(0, -26px);
+  -webkit-transform: scale(0.75, 0.75) translate(0, -24px);
+          transform: scale(0.75, 0.75) translate(0, -24px);
   -webkit-transform-origin: left;
           transform-origin: left;
   z-index: 1;
 }
 label.floating-label__label--inline {
-  font-size: 1rem;
+  bottom: 0.4375rem;
+  font-size: 0.875rem;
   -webkit-transform: none;
           transform: none;
 }

--- a/dist/label/ds6/label.css
+++ b/dist/label/ds6/label.css
@@ -1,5 +1,5 @@
 .floating-label {
-  margin-top: 10px;
+  margin-top: 14px;
   position: relative;
 }
 span.floating-label {
@@ -9,20 +9,20 @@ div.floating-label {
   display: block;
 }
 label.floating-label__label {
-  bottom: 0.375rem;
   color: #767676;
   display: block;
   left: 0;
   pointer-events: none;
   position: absolute;
-  -webkit-transform: scale(0.75, 0.75) translate(0, -26px);
-          transform: scale(0.75, 0.75) translate(0, -26px);
+  -webkit-transform: scale(0.75, 0.75) translate(0, -24px);
+          transform: scale(0.75, 0.75) translate(0, -24px);
   -webkit-transform-origin: left;
           transform-origin: left;
   z-index: 1;
 }
 label.floating-label__label--inline {
-  font-size: 1rem;
+  bottom: 0.4375rem;
+  font-size: 0.875rem;
   -webkit-transform: none;
           transform: none;
 }

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -90,8 +90,9 @@ textarea.textbox__control:focus {
 input.textbox__control--underline {
   border: none;
   border-bottom: 1px solid #ccc;
+  font-weight: bold;
   height: 1.875rem;
-  padding: 0;
+  padding: 0 0 1px 0;
 }
 input.textbox__control--underline::-webkit-input-placeholder {
   color: transparent;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -89,9 +89,10 @@ textarea.textbox__control:focus {
 }
 input.textbox__control--underline {
   border: none;
-  border-bottom: 1px solid #a2a2a2;
+  border-bottom: 1px solid #767676;
+  font-weight: bold;
   height: 1.875rem;
-  padding: 0;
+  padding: 0 0 1px 0;
 }
 input.textbox__control--underline::-webkit-input-placeholder {
   color: transparent;

--- a/src/less/label/base/label.less
+++ b/src/less/label/base/label.less
@@ -1,5 +1,5 @@
 .floating-label {
-    margin-top: 10px;
+    margin-top: 14px;
     position: relative;
 }
 
@@ -12,18 +12,18 @@ div.floating-label {
 }
 
 label.floating-label__label {
-    bottom: 0.375rem; // a11y: the position has to be relative to the text zoom level
     color: @label-floating-label-color;
     display: block;
     left: 0;
     pointer-events: none;
     position: absolute;
-    transform: scale(0.75, 0.75) translate(0, -26px);
+    transform: scale(0.75, 0.75) translate(0, -24px);
     transform-origin: left;
     z-index: 1;
 }
 
 label.floating-label__label--inline {
+    bottom: 0.4375rem; // a11y: the position must be relative to the text size
     font-size: @label-floating-label-inline-font-size;
     transform: none;
 }

--- a/src/less/label/ds4/label.less
+++ b/src/less/label/ds4/label.less
@@ -3,7 +3,7 @@
 @import "../../variables/ds4/typography-variables.less";
 
 @label-floating-label-color: @color-core-gray-dim;
-@label-floating-label-inline-font-size: @font-size-16;
+@label-floating-label-inline-font-size: @font-size-14;
 @label-floating-label-disabled-color: @color-core-gray-davys;
 @label-floating-label-disabled-left: 4px;
 

--- a/src/less/label/ds6/label.less
+++ b/src/less/label/ds6/label.less
@@ -3,7 +3,7 @@
 @import "../../variables/ds6/typography-variables.less";
 
 @label-floating-label-color: @color-grey5;
-@label-floating-label-inline-font-size: @font-size-16;
+@label-floating-label-inline-font-size: @font-size-14;
 @label-floating-label-disabled-color: @color-grey2;
 @label-floating-label-disabled-left: auto;
 

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -81,8 +81,9 @@ input.textbox__control--underline {
 
     border: none;
     border-bottom: 1px solid @textbox-control-underline-border-bottom-color;
-    height: 1.875rem; // a11y: has to be relative to the text zoom level;
-    padding: 0;
+    font-weight: bold;
+    height: 1.875rem; // a11y: has to be relative to the text size
+    padding: 0 0 1px 0;
 }
 
 .textbox svg {

--- a/src/less/textbox/ds6/textbox.less
+++ b/src/less/textbox/ds6/textbox.less
@@ -82,7 +82,7 @@
 @textbox-control-invalid-color: @color-r4;
 @textbox-control-focus-border-color: @color-b4;
 
-@textbox-control-underline-border-bottom-color: @color-grey4;
+@textbox-control-underline-border-bottom-color: @color-grey5;
 
 @textbox-icon-color: @color-grey3;
 @textbox-icon-fill: @color-grey3;


### PR DESCRIPTION
Fixes #1075 

![DS6 Forms Library vs Live Notes](https://user-images.githubusercontent.com/38065/78814947-624bcc00-7984-11ea-94be-23e26ea7d908.png)


After updates new distances are 12px and 25px (increased from 10px and 21px). It is a little dependent on how the measurement is done. We could potentially increase the space by another pixel, but it currently looks pretty good to me.

If I were to refactor I would try and create some kind of distance variables or mixins, as it currently does require a bit of head scratching to figure out what is going.

Also:

* Label font size decreased to 14px
* Underline textbox font weight changed to bold
* Underline colour changed to #767676.

<img width="1417" alt="Screen Shot 2020-04-09 at 9 50 06 AM" src="https://user-images.githubusercontent.com/38065/78920357-1eba9600-7a48-11ea-9fde-638aec12100e.png">
<img width="1418" alt="Screen Shot 2020-04-09 at 9 50 47 AM" src="https://user-images.githubusercontent.com/38065/78920360-224e1d00-7a48-11ea-8ce5-58bcbdbb4743.png">
<img width="1420" alt="Screen Shot 2020-04-09 at 9 51 17 AM" src="https://user-images.githubusercontent.com/38065/78920367-237f4a00-7a48-11ea-8866-102539d57485.png">
