### PR TITLE
Wizard Stepper: remove min-width on items

### DIFF
--- a/dist/wizard-stepper/ds4/wizard-stepper.css
+++ b/dist/wizard-stepper/ds4/wizard-stepper.css
@@ -81,7 +81,6 @@ hr.wizard-stepper__separator--upcoming {
 }
 .wizard-stepper__item {
   margin: 0 auto;
-  min-width: 80px;
   position: relative;
   text-align: center;
 }

--- a/dist/wizard-stepper/ds6/wizard-stepper.css
+++ b/dist/wizard-stepper/ds6/wizard-stepper.css
@@ -81,7 +81,6 @@ hr.wizard-stepper__separator--upcoming {
 }
 .wizard-stepper__item {
   margin: 0 auto;
-  min-width: 80px;
   position: relative;
   text-align: center;
 }

--- a/src/less/wizard-stepper/base/wizard-stepper.less
+++ b/src/less/wizard-stepper/base/wizard-stepper.less
@@ -106,7 +106,6 @@ hr.wizard-stepper__separator--upcoming {
 
 .wizard-stepper__item {
     margin: 0 auto;
-    min-width: 80px;
     position: relative;
     text-align: center;
 


### PR DESCRIPTION
Small fix to make a correction to the spacing on either side of the wizard stepper and allow more fine-grained control with margin left & right.

Playbook, showing that text-size is what determines the width and spacing at either end.

<img width="562" alt="Screen Shot 2020-04-11 at 11 18 57 AM" src="https://user-images.githubusercontent.com/38065/79051774-f4530f00-7be6-11ea-90d6-deea1100c0af.png">

Min-width now removed:

<img width="1111" alt="Screen Shot 2020-04-11 at 11 24 38 AM" src="https://user-images.githubusercontent.com/38065/79051795-0e8ced00-7be7-11ea-9c12-dea4c612c770.png">

Margins can be added by the page layout / grid system:

<img width="1128" alt="Screen Shot 2020-04-11 at 11 11 38 AM" src="https://user-images.githubusercontent.com/38065/79051800-15b3fb00-7be7-11ea-9d1b-86c11f0c166e.png">

@agliga if you are still working on the cleanup, feel free to make this change in your PR if you approve of it and close this one.

