### PR TITLE
Added carousel transition to non autoplay carousel

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -117,8 +117,10 @@ span.carousel__container {
     scroll-snap-type: mandatory;
     scroll-snap-type: x mandatory;
     scrollbar-width: thin;
-    -webkit-transition: border-color 0.5s;
-    transition: border-color 0.5s;
+    -webkit-transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, transform 0.45s ease-in-out;
+    transition: border-color 0.5s, transform 0.45s ease-in-out, -webkit-transform 0.45s ease-in-out;
   }
   .carousel:not(.carousel__autoplay) .carousel__list:hover {
     border-color: rgba(0, 0, 0, 0.4);

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -117,8 +117,10 @@ span.carousel__container {
     scroll-snap-type: mandatory;
     scroll-snap-type: x mandatory;
     scrollbar-width: thin;
-    -webkit-transition: border-color 0.5s;
-    transition: border-color 0.5s;
+    -webkit-transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, transform 0.45s ease-in-out;
+    transition: border-color 0.5s, transform 0.45s ease-in-out, -webkit-transform 0.45s ease-in-out;
   }
   .carousel:not(.carousel__autoplay) .carousel__list:hover {
     border-color: rgba(0, 0, 0, 0.4);

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -126,7 +126,7 @@ span.carousel__container {
             scroll-snap-type: mandatory;
             scroll-snap-type: x mandatory;
             scrollbar-width: thin; // Firefox scrollbar
-            transition: border-color 0.5s;
+            transition: border-color 0.5s, transform @ebay-carousel-transition-time @ebay-carousel-transition-function;
 
             &:hover {
                 border-color: rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
## Description
There was a bug where the non carousel autoplay would take precedence in styles and override the transition property. This seems to be only an edge case in some places where the styles aren't being loaded the normal way. So a fix would be to add the translate property together with border-color in transition. 