### PR TITLE
Fixed toast transitions and anchor tag color

### DIFF
--- a/dist/toast/ds4/toast.css
+++ b/dist/toast/ds4/toast.css
@@ -6,6 +6,8 @@
   max-height: 40vh;
   min-width: 320px;
   position: fixed;
+  -webkit-transform: translateY(0);
+          transform: translateY(0);
   width: 100vw;
   will-change: opacity, transform;
   z-index: 1;

--- a/dist/toast/ds4/toast.css
+++ b/dist/toast/ds4/toast.css
@@ -6,15 +6,12 @@
   max-height: 40vh;
   min-width: 320px;
   position: fixed;
-  -webkit-transform: translateY(110%);
-          transform: translateY(110%);
   width: 100vw;
   will-change: opacity, transform;
   z-index: 1;
 }
-.toast[role="dialog"]:not([hidden]) {
-  -webkit-transform: translateY(0);
-          transform: translateY(0);
+.toast a {
+  color: #fff;
 }
 .toast--transition {
   -webkit-transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
@@ -22,20 +19,16 @@
   transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
   transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
 }
-.toast--show-init {
-  display: block;
-  opacity: 0;
-}
-.toast--show {
+.toast--show,
+.toast--hide-init {
   display: block;
   opacity: 1;
   -webkit-transform: translateY(0);
           transform: translateY(0);
 }
-.toast--hide-init {
-  opacity: 1;
-}
+.toast--show-init,
 .toast--hide {
+  display: block;
   opacity: 0;
   -webkit-transform: translateY(110%);
           transform: translateY(110%);

--- a/dist/toast/ds4/toast.css
+++ b/dist/toast/ds4/toast.css
@@ -15,6 +15,10 @@
 .toast a {
   color: #fff;
 }
+.toast a:focus {
+  outline: 1px dotted #fff;
+  outline-offset: 4px;
+}
 .toast--transition {
   -webkit-transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
   transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;

--- a/dist/toast/ds6/toast.css
+++ b/dist/toast/ds6/toast.css
@@ -6,6 +6,8 @@
   max-height: 40vh;
   min-width: 320px;
   position: fixed;
+  -webkit-transform: translateY(0);
+          transform: translateY(0);
   width: 100vw;
   will-change: opacity, transform;
   z-index: 1;

--- a/dist/toast/ds6/toast.css
+++ b/dist/toast/ds6/toast.css
@@ -6,15 +6,12 @@
   max-height: 40vh;
   min-width: 320px;
   position: fixed;
-  -webkit-transform: translateY(110%);
-          transform: translateY(110%);
   width: 100vw;
   will-change: opacity, transform;
   z-index: 1;
 }
-.toast[role="dialog"]:not([hidden]) {
-  -webkit-transform: translateY(0);
-          transform: translateY(0);
+.toast a {
+  color: #fff;
 }
 .toast--transition {
   -webkit-transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
@@ -22,20 +19,16 @@
   transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
   transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
 }
-.toast--show-init {
-  display: block;
-  opacity: 0;
-}
-.toast--show {
+.toast--show,
+.toast--hide-init {
   display: block;
   opacity: 1;
   -webkit-transform: translateY(0);
           transform: translateY(0);
 }
-.toast--hide-init {
-  opacity: 1;
-}
+.toast--show-init,
 .toast--hide {
+  display: block;
   opacity: 0;
   -webkit-transform: translateY(110%);
           transform: translateY(110%);

--- a/dist/toast/ds6/toast.css
+++ b/dist/toast/ds6/toast.css
@@ -15,6 +15,10 @@
 .toast a {
   color: #fff;
 }
+.toast a:focus {
+  outline: 1px dotted #fff;
+  outline-offset: 4px;
+}
 .toast--transition {
   -webkit-transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
   transition: opacity 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s, -webkit-transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;

--- a/src/less/toast/base/toast.less
+++ b/src/less/toast/base/toast.less
@@ -6,14 +6,13 @@
     max-height: 40vh;
     min-width: 320px;
     position: fixed;
-    transform: translateY(110%);
     width: 100vw;
     will-change: opacity, transform;
     z-index: 1;
 }
 
-.toast[role="dialog"]:not([hidden]) {
-    transform: translateY(0);
+.toast a {
+    color: @toast-foreground-color;
 }
 
 .toast--transition {
@@ -22,22 +21,16 @@
         transform 0.2s cubic-bezier(0.21, 0.31, 1, 1.22) 0s;
 }
 
-.toast--show-init {
-    display: block;
-    opacity: 0;
-}
-
-.toast--show {
+.toast--show,
+.toast--hide-init {
     display: block;
     opacity: 1;
     transform: translateY(0);
 }
 
-.toast--hide-init {
-    opacity: 1;
-}
-
+.toast--show-init,
 .toast--hide {
+    display: block;
     opacity: 0;
     transform: translateY(110%);
 }

--- a/src/less/toast/base/toast.less
+++ b/src/less/toast/base/toast.less
@@ -1,3 +1,8 @@
+.toast-outline() {
+    outline: 1px dotted @toast-foreground-color;
+    outline-offset: 4px;
+}
+
 .toast {
     background-color: @toast-background-color;
     bottom: 0;
@@ -15,6 +20,10 @@
 
 .toast a {
     color: @toast-foreground-color;
+
+    &:focus {
+        .toast-outline();
+    }
 }
 
 .toast--transition {
@@ -58,8 +67,7 @@
     padding: 0;
 
     &:focus {
-        outline: 1px dotted @toast-foreground-color;
-        outline-offset: 4px;
+        .toast-outline();
     }
 }
 
@@ -83,8 +91,7 @@
         }
 
         &:focus {
-            outline: 1px dotted @toast-foreground-color;
-            outline-offset: 4px;
+            .toast-outline();
         }
     }
 

--- a/src/less/toast/base/toast.less
+++ b/src/less/toast/base/toast.less
@@ -6,6 +6,8 @@
     max-height: 40vh;
     min-width: 320px;
     position: fixed;
+    // Setting translateY to 0 to fix a bug in safari which does a double transform
+    transform: translateY(0);
     width: 100vw;
     will-change: opacity, transform;
     z-index: 1;


### PR DESCRIPTION
## Description
When doing ebayui I ran into two issues
* Anchor tag was colored the same as background
* Leaving transitions were not working
This pr fixes that. 

## Context
* Made `show-init` and `hide` do the same as well as `hide-init` and `show`. (This is in line with dialog)
* Removed the `.toast[type=dialog]:not(:hidden)`. This was overriding styles and taking precedence in styles over the hide. (and it's not needed). 
* Added outline to anchor focus (and made a mixin for it)

Tested in ebayui also with the toast branch and was working fine. 