### PR TITLE
Root: convert hex values to LESS variables

### DIFF
--- a/dist/variables/ds6/color-variables.less
+++ b/dist/variables/ds6/color-variables.less
@@ -106,6 +106,10 @@
 @color-attention-text: @color-r4;
 @color-attention-icon: @color-r4;
 
+// DARK MODE
+@dark-mode-color-background-default: #171717;
+@dark-mode-color-text-default: #dcdcdc;
+
 // MISC (candidates for deprecation)
 @color-item-tile-background-visited: @color-grey1;
 @color-button-disabled-background: @color-grey3;

--- a/dist/variables/ds6/color-variables.less
+++ b/dist/variables/ds6/color-variables.less
@@ -70,6 +70,7 @@
 
 // Grey
 @color-white: #fff;
+@color-white-dark-mode: #dcdcdc;
 @color-grey1: #f5f5f5;
 @color-grey2: #e5e5e5;
 @color-grey3: #c7c7c7;
@@ -77,14 +78,17 @@
 @color-grey5: #767676;
 @color-grey6: #41413f;
 @color-black: #111820;
+@color-black-dark-mode: #171717;
 
 // PRODUCT COLORS
 @color-text-default: @color-black;
+@color-text-default-dark-mode: @color-white-dark-mode;
 @color-text-secondary: @color-grey5;
 @color-text-disabled: @color-grey3;
 @color-image-border: @color-grey2;
 @color-divider: @color-grey2;
 @color-background-default: @color-white;
+@color-background-default-dark-mode: @color-black-dark-mode;
 
 @color-action-secondary: @color-grey5;
 @color-action-primary: @color-b4;
@@ -105,10 +109,6 @@
 @color-attention-background: #fff5f8; // secret colour
 @color-attention-text: @color-r4;
 @color-attention-icon: @color-r4;
-
-// DARK MODE
-@dark-mode-color-background-default: #171717;
-@dark-mode-color-text-default: #dcdcdc;
 
 // MISC (candidates for deprecation)
 @color-item-tile-background-visited: @color-grey1;

--- a/src/less/root/ds6/root.less
+++ b/src/less/root/ds6/root.less
@@ -7,7 +7,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --color-background-default: #171717;
-        --color-text-default: #dcdcdc;
+        --color-background-default: @dark-mode-color-background-default;
+        --color-text-default: @dark-mode-color-text-default;
     }
 }

--- a/src/less/root/ds6/root.less
+++ b/src/less/root/ds6/root.less
@@ -7,7 +7,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --color-background-default: @dark-mode-color-background-default;
-        --color-text-default: @dark-mode-color-text-default;
+        --color-background-default: @color-background-default-dark-mode;
+        --color-text-default: @color-text-default-dark-mode;
     }
 }

--- a/src/less/variables/ds6/color-variables.less
+++ b/src/less/variables/ds6/color-variables.less
@@ -106,6 +106,10 @@
 @color-attention-text: @color-r4;
 @color-attention-icon: @color-r4;
 
+// DARK MODE
+@dark-mode-color-background-default: #171717;
+@dark-mode-color-text-default: #dcdcdc;
+
 // MISC (candidates for deprecation)
 @color-item-tile-background-visited: @color-grey1;
 @color-button-disabled-background: @color-grey3;

--- a/src/less/variables/ds6/color-variables.less
+++ b/src/less/variables/ds6/color-variables.less
@@ -70,6 +70,7 @@
 
 // Grey
 @color-white: #fff;
+@color-white-dark-mode: #dcdcdc;
 @color-grey1: #f5f5f5;
 @color-grey2: #e5e5e5;
 @color-grey3: #c7c7c7;
@@ -77,14 +78,17 @@
 @color-grey5: #767676;
 @color-grey6: #41413f;
 @color-black: #111820;
+@color-black-dark-mode: #171717;
 
 // PRODUCT COLORS
 @color-text-default: @color-black;
+@color-text-default-dark-mode: @color-white-dark-mode;
 @color-text-secondary: @color-grey5;
 @color-text-disabled: @color-grey3;
 @color-image-border: @color-grey2;
 @color-divider: @color-grey2;
 @color-background-default: @color-white;
+@color-background-default-dark-mode: @color-black-dark-mode;
 
 @color-action-secondary: @color-grey5;
 @color-action-primary: @color-b4;
@@ -105,10 +109,6 @@
 @color-attention-background: #fff5f8; // secret colour
 @color-attention-text: @color-r4;
 @color-attention-icon: @color-r4;
-
-// DARK MODE
-@dark-mode-color-background-default: #171717;
-@dark-mode-color-text-default: #dcdcdc;
 
 // MISC (candidates for deprecation)
 @color-item-tile-background-visited: @color-grey1;


### PR DESCRIPTION
PLEASE SQUASH

Just a small, quick PR to show how the dark mode color variables will be named. In my initial commit I went with pre-fixing the `dark-mode-`, but then realised that not every light mode color will have a dark mode equal, and therefore postfixing makes more sense, so I made another commit to change that.