### PR TITLE
Actionable: custom properties

### DIFF
--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -21,14 +21,20 @@ a.icon-link {
 }
 button.icon-btn > svg,
 a.icon-link > svg {
-  color: #555;
+  fill: #555;
+  fill: var(--actionable-icon-foreground-color, #555);
   height: 100%;
   max-width: 100%;
   position: relative;
 }
 button.icon-btn:active > svg,
 a.icon-link:active > svg {
-  color: #555;
+  fill: #555;
+  fill: var(--actionable-icon-foreground-color-active, #555);
+}
+a.icon-link:visited > svg {
+  fill: #333;
+  fill: var(--actionable-icon-foreground-color-visited, #333);
 }
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
@@ -50,6 +56,7 @@ a.icon-link--badged {
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
   border: 2px solid #fff;
+  border: 2px solid var(--actionable-badge-border-color, #fff);
   display: block;
   height: 24px;
   left: 16px;
@@ -64,12 +71,14 @@ a.icon-link--badged .badge {
 a.img-link[href]:hover,
 a.img-link[href]:focus {
   border-color: #999;
+  border-color: var(--actionable-image-border-color-hover, #999);
 }
 a.img-link[href]:active {
   border-color: #767676;
 }
 a.img-link--visit:visited {
   background-color: #eee;
+  background-color: var(--actionable-image-background-color-visited, #eee);
 }
 a.img-link,
 button.img-btn {
@@ -84,9 +93,11 @@ button.img-btn {
 button.img-btn:not([disabled]):hover,
 button.img-btn:not([disabled]):focus {
   border-color: #999;
+  border-color: var(--actionable-image-border-color-hover, #999);
 }
 button.img-btn:not([disabled]):active {
   border-color: #767676;
+  border-color: var(--actionable-image-border-color-active, #767676);
 }
 button.icon-btn:focus,
 a.icon-link:focus,

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -130,10 +130,11 @@ button.img-btn:not([disabled]):active {
   border-color: #767676;
   border-color: var(--actionable-image-border-color-active, #767676);
 }
+/* stylelint-disable-next-line no-duplicate-selectors */
 button.icon-btn:focus svg,
 a.icon-link:focus svg,
 button.icon-btn:hover svg,
 a.icon-link:hover svg {
-  fill: #111820;
-  fill: var(--actionable-icon-foreground-color-hover, #111820);
+  fill: #3665f3;
+  fill: var(--actionable-icon-foreground-color-hover, #3665f3);
 }

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -1,3 +1,34 @@
+a.icon-link,
+button.icon-btn {
+  --actionable-icon-foreground-color: #111820;
+  --actionable-icon-foreground-color-active: #111820;
+  --actionable-icon-foreground-color-visited: #111820;
+  --actionable-icon-foreground-color-hover: #3665f3;
+  --actionable-badge-border-color: #fff;
+  --actionable-image-border-color-hover: #767676;
+}
+a.img-link,
+button.img-btn {
+  --actionable-image-border-color-hover: #767676;
+  --actionable-image-border-color-active: #767676;
+  --actionable-image-background-color-visited: #e5e5e5;
+}
+@media (prefers-color-scheme: dark) {
+  a.icon-link,
+  button.icon-btn {
+    --actionable-icon-foreground-color: #dcdcdc;
+    --actionable-icon-foreground-color-active: #dcdcdc;
+    --actionable-icon-foreground-color-visited: #dcdcdc;
+    --actionable-icon-foreground-color-hover: #5192ff;
+    --actionable-badge-border-color: #171717;
+  }
+  a.img-link,
+  button.img-btn {
+    --actionable-image-border-color-hover: #5192ff;
+    --actionable-image-border-color-active: #767676;
+    --actionable-image-background-color-visited: #e5e5e5;
+  }
+}
 a.icon-link {
   -webkit-box-align: center;
           align-items: center;
@@ -21,14 +52,20 @@ a.icon-link {
 }
 button.icon-btn > svg,
 a.icon-link > svg {
-  color: #111820;
+  fill: #111820;
+  fill: var(--actionable-icon-foreground-color, #111820);
   height: 100%;
   max-width: 100%;
   position: relative;
 }
 button.icon-btn:active > svg,
 a.icon-link:active > svg {
-  color: #111820;
+  fill: #111820;
+  fill: var(--actionable-icon-foreground-color-active, #111820);
+}
+a.icon-link:visited > svg {
+  fill: #111820;
+  fill: var(--actionable-icon-foreground-color-visited, #111820);
 }
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
@@ -50,6 +87,7 @@ a.icon-link--badged {
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
   border: 2px solid #fff;
+  border: 2px solid var(--actionable-badge-border-color, #fff);
   display: block;
   height: 24px;
   left: 16px;
@@ -64,12 +102,14 @@ a.icon-link--badged .badge {
 a.img-link[href]:hover,
 a.img-link[href]:focus {
   border-color: #767676;
+  border-color: var(--actionable-image-border-color-hover, #767676);
 }
 a.img-link[href]:active {
   border-color: #767676;
 }
 a.img-link--visit:visited {
   background-color: #e5e5e5;
+  background-color: var(--actionable-image-background-color-visited, #e5e5e5);
 }
 a.img-link,
 button.img-btn {
@@ -84,13 +124,16 @@ button.img-btn {
 button.img-btn:not([disabled]):hover,
 button.img-btn:not([disabled]):focus {
   border-color: #767676;
+  border-color: var(--actionable-image-border-color-hover, #767676);
 }
 button.img-btn:not([disabled]):active {
   border-color: #767676;
+  border-color: var(--actionable-image-border-color-active, #767676);
 }
 button.icon-btn:focus svg,
 a.icon-link:focus svg,
 button.icon-btn:hover svg,
 a.icon-link:hover svg {
-  fill: #3665f3;
+  fill: #111820;
+  fill: var(--actionable-icon-foreground-color-hover, #111820);
 }

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -2,10 +2,12 @@
   -webkit-box-align: center;
           align-items: center;
   background-color: #dd1e31;
+  background-color: var(--badge-background-color, #dd1e31);
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   color: #fff;
+  color: var(--badge-foreground-color, #fff);
   display: -webkit-inline-box;
   display: inline-flex;
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,11 +1,23 @@
+.switch {
+  --badge-background-color: #e62048;
+  --badge-foreground-color: #fff;
+}
+@media (prefers-color-scheme: dark) {
+  .switch {
+    --badge-background-color: #e62048;
+    --badge-foreground-color: #fff;
+  }
+}
 .badge {
   -webkit-box-align: center;
           align-items: center;
   background-color: #e62048;
+  background-color: var(--badge-background-color, #e62048);
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   color: #fff;
+  color: var(--badge-foreground-color, #fff);
   display: -webkit-inline-box;
   display: inline-flex;
   font-family: "Market Sans", Arial, sans-serif;

--- a/dist/variables/ds6/color-variables.less
+++ b/dist/variables/ds6/color-variables.less
@@ -40,6 +40,7 @@
 @color-b2: #93c9ff;
 @color-b3: #659eff;
 @color-b4: #3665f3;
+@color-b4-dark-mode: #5192ff;
 @color-b5: #382aef;
 @color-b6: #2b0eaf;
 @color-b7: #121258;

--- a/src/less/actionable/base/actionable.less
+++ b/src/less/actionable/base/actionable.less
@@ -22,15 +22,22 @@ a.icon-link {
     width: 40px;
 
     > svg {
-        color: @actionable-icon-color-active;
+        fill: @actionable-icon-foreground-color;
+        fill: var(--actionable-icon-foreground-color, @actionable-icon-foreground-color);
         height: 100%; // vertical centering
         max-width: 100%; // helps when width & height HTML attrs not set
         position: relative; // Safari centering
     }
 
     &:active > svg {
-        color: @actionable-icon-color-active;
+        fill: @actionable-icon-foreground-color-active;
+        fill: var(--actionable-icon-foreground-color-active, @actionable-icon-foreground-color-active);
     }
+}
+
+a.icon-link:visited > svg {
+    fill: @actionable-icon-foreground-color-visited;
+    fill: var(--actionable-icon-foreground-color-visited, @actionable-icon-foreground-color-visited);
 }
 
 // disabled & partially disabled states
@@ -55,6 +62,7 @@ a.icon-link--badged {
 
     .badge {
         border: 2px solid @actionable-badge-border-color;
+        border: 2px solid var(--actionable-badge-border-color, @actionable-badge-border-color);
         display: block;
         height: 24px;
         left: 16px;
@@ -75,17 +83,19 @@ a.img-link {
     &[href] {
         &:hover,
         &:focus {
-            border-color: @actionable-image-link-border-color-hover;
+            border-color: @actionable-image-border-color-hover;
+            border-color: var(--actionable-image-border-color-hover, @actionable-image-border-color-hover);
         }
 
         &:active {
-            border-color: @actionable-image-link-border-color-active;
+            border-color: @actionable-image-border-color-active;
         }
     }
 }
 
 a.img-link--visit:visited {
-    background-color: @actionable-image-link-background-color-visited;
+    background-color: @actionable-image-background-color-visited;
+    background-color: var(--actionable-image-background-color-visited, @actionable-image-background-color-visited);
 }
 
 a.img-link,
@@ -101,11 +111,13 @@ button.img-btn {
     &:not([disabled]) {
         &:hover,
         &:focus {
-            border-color: @actionable-image-button-border-color-hover;
+            border-color: @actionable-image-border-color-hover;
+            border-color: var(--actionable-image-border-color-hover, @actionable-image-border-color-hover);
         }
 
         &:active {
-            border-color: @actionable-image-button-border-color-active;
+            border-color: @actionable-image-border-color-active;
+            border-color: var(--actionable-image-border-color-active, @actionable-image-border-color-active);
         }
     }
 }

--- a/src/less/actionable/ds4/actionable.less
+++ b/src/less/actionable/ds4/actionable.less
@@ -14,6 +14,7 @@
 
 @import "../base/actionable.less";
 
+// todo: normalize ds4 & ds6
 button.icon-btn,
 a.icon-link {
     &:focus,

--- a/src/less/actionable/ds4/actionable.less
+++ b/src/less/actionable/ds4/actionable.less
@@ -2,14 +2,15 @@
 @import "../../variables/ds4/icon-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 
-@actionable-icon-color-active: @color-icon-actionable-default;
-@actionable-badge-border-color: @color-core-white;
+@actionable-icon-foreground-color: @color-icon-actionable-default;
+@actionable-icon-foreground-color-active: @color-icon-actionable-default;
+@actionable-icon-foreground-color-visited: @color-text-default;
+@actionable-icon-foreground-color-hover: @color-text-default;
+@actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
-@actionable-image-link-border-color-hover: @color-core-gray-spanish;
-@actionable-image-link-border-color-active: @color-core-gray-dim;
-@actionable-image-link-background-color-visited: @color-core-gray-light;
-@actionable-image-button-border-color-hover: @color-core-gray-spanish;
-@actionable-image-button-border-color-active: @color-core-gray-dim;
+@actionable-image-border-color-hover: @color-core-gray-spanish;
+@actionable-image-border-color-active: @color-core-gray-dim;
+@actionable-image-background-color-visited: @color-core-gray-light;
 
 @import "../base/actionable.less";
 

--- a/src/less/actionable/ds6/actionable.less
+++ b/src/less/actionable/ds6/actionable.less
@@ -2,14 +2,51 @@
 @import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 
-@actionable-icon-color-active: @color-text-default;
-@actionable-badge-border-color: @color-badge-text;
+// custom properties (ds6 only)
+a.icon-link,
+button.icon-btn {
+    --actionable-icon-foreground-color: @color-text-default;
+    --actionable-icon-foreground-color-active: @color-text-default;
+    --actionable-icon-foreground-color-visited: @color-text-default;
+    --actionable-icon-foreground-color-hover: #3665f3;
+    --actionable-badge-border-color: @color-background-default;
+    --actionable-image-border-color-hover: @color-grey5;
+}
+
+a.img-link,
+button.img-btn {
+    --actionable-image-border-color-hover: @color-grey5;
+    --actionable-image-border-color-active: @color-text-secondary;
+    --actionable-image-background-color-visited: @color-grey2;
+}
+
+@media (prefers-color-scheme: dark) {
+    a.icon-link,
+    button.icon-btn {
+        --actionable-icon-foreground-color: @color-text-default-dark-mode;
+        --actionable-icon-foreground-color-active: @color-text-default-dark-mode;
+        --actionable-icon-foreground-color-visited: @color-text-default-dark-mode;
+        --actionable-icon-foreground-color-hover: @color-b4-dark-mode;
+        --actionable-badge-border-color: @color-background-default-dark-mode;
+    }
+
+    a.img-link,
+    button.img-btn {
+        --actionable-image-border-color-hover: @color-b4-dark-mode;
+        --actionable-image-border-color-active: @color-text-secondary; //tbc
+        --actionable-image-background-color-visited: @color-grey2; // tbc
+    }
+}
+
+@actionable-icon-foreground-color: @color-text-default;
+@actionable-icon-foreground-color-active: @color-text-default;
+@actionable-icon-foreground-color-visited: @color-text-default;
+@actionable-icon-foreground-color-hover: @color-text-default;
+@actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
-@actionable-image-link-border-color-hover: @color-grey5;
-@actionable-image-link-border-color-active: @color-text-secondary;
-@actionable-image-link-background-color-visited: @color-grey2;
-@actionable-image-button-border-color-hover: @color-grey5;
-@actionable-image-button-border-color-active: @color-text-secondary;
+@actionable-image-border-color-hover: @color-grey5;
+@actionable-image-border-color-active: @color-text-secondary;
+@actionable-image-background-color-visited: @color-grey2;
 
 @import "../base/actionable.less";
 
@@ -17,6 +54,7 @@ button.icon-btn,
 a.icon-link {
     &:focus svg,
     &:hover svg {
-        fill: #3665f3;
+        fill: @actionable-icon-foreground-color-hover;
+        fill: var(--actionable-icon-foreground-color-hover, @actionable-icon-foreground-color-hover);
     }
 }

--- a/src/less/actionable/ds6/actionable.less
+++ b/src/less/actionable/ds6/actionable.less
@@ -2,13 +2,13 @@
 @import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 
-// custom properties (ds6 only)
+// CSS Custom properties (DS6 only)
 a.icon-link,
 button.icon-btn {
     --actionable-icon-foreground-color: @color-text-default;
     --actionable-icon-foreground-color-active: @color-text-default;
     --actionable-icon-foreground-color-visited: @color-text-default;
-    --actionable-icon-foreground-color-hover: #3665f3;
+    --actionable-icon-foreground-color-hover: @color-b4;
     --actionable-badge-border-color: @color-background-default;
     --actionable-image-border-color-hover: @color-grey5;
 }
@@ -38,10 +38,11 @@ button.img-btn {
     }
 }
 
+// IE11 fallbacks
 @actionable-icon-foreground-color: @color-text-default;
 @actionable-icon-foreground-color-active: @color-text-default;
 @actionable-icon-foreground-color-visited: @color-text-default;
-@actionable-icon-foreground-color-hover: @color-text-default;
+@actionable-icon-foreground-color-hover: @color-b4;
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
 @actionable-image-border-color-hover: @color-grey5;
@@ -50,6 +51,7 @@ button.img-btn {
 
 @import "../base/actionable.less";
 
+/* stylelint-disable-next-line no-duplicate-selectors */
 button.icon-btn,
 a.icon-link {
     &:focus svg,

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -1,9 +1,11 @@
 .badge {
     align-items: center;
     background-color: @badge-background-color;
+    background-color: var(--badge-background-color, @badge-background-color);
     border-radius: 20px;
     box-sizing: border-box;
-    color: @badge-color;
+    color: @badge-foreground-color;
+    color: var(--badge-foreground-color, @badge-foreground-color);
     display: inline-flex;
     font-family: @badge-font-family;
     font-size: @font-size-12;

--- a/src/less/badge/ds4/badge.less
+++ b/src/less/badge/ds4/badge.less
@@ -4,6 +4,6 @@
 
 @badge-font-family: @font-family-base;
 @badge-background-color: @color-core-red;
-@badge-color: @color-core-white;
+@badge-foreground-color: @color-core-white;
 
 @import '../base/badge.less';

--- a/src/less/badge/ds6/badge.less
+++ b/src/less/badge/ds6/badge.less
@@ -2,8 +2,21 @@
 @import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 
+// custom properties (ds6 only)
+.switch {
+    --badge-background-color: @color-badge-background;
+    --badge-foreground-color: @color-badge-text;
+}
+
+@media (prefers-color-scheme: dark) {
+    .switch {
+        --badge-background-color: @color-badge-background;
+        --badge-foreground-color: @color-badge-text;
+    }
+}
+
 @badge-font-family: @font-family-custom;
 @badge-background-color: @color-badge-background;
-@badge-color: @color-badge-text;
+@badge-foreground-color: @color-badge-text;
 
 @import '../base/badge.less';

--- a/src/less/switch/ds6/switch.less
+++ b/src/less/switch/ds6/switch.less
@@ -12,7 +12,7 @@
 
 @media (prefers-color-scheme: dark) {
     .switch {
-        --switch-background-color-checked: #5192ff;
+        --switch-background-color-checked: @color-b4-dark-mode;
     }
 }
 

--- a/src/less/switch/ds6/switch.less
+++ b/src/less/switch/ds6/switch.less
@@ -2,7 +2,7 @@
 @import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 
-// custom properties (ds6 only)
+// CSS Custom properties (DS6 only)
 .switch {
     --switch-background-color-unchecked: @color-grey5;
     --switch-background-color-checked: @color-b5;
@@ -16,7 +16,7 @@
     }
 }
 
-// ie11 fallbacks
+// IE11 fallbacks
 @switch-background-color-unchecked: @color-grey5;
 @switch-background-color-checked: @color-b4;
 @switch-background-color-disabled: @color-grey3;

--- a/src/less/variables/ds6/color-variables.less
+++ b/src/less/variables/ds6/color-variables.less
@@ -40,6 +40,7 @@
 @color-b2: #93c9ff;
 @color-b3: #659eff;
 @color-b4: #3665f3;
+@color-b4-dark-mode: #5192ff;
 @color-b5: #382aef;
 @color-b6: #2b0eaf;
 @color-b7: #121258;


### PR DESCRIPTION
PLEASE SQUASH

ISSUE #1098

This PR adds custom properties to the actionable and badge modules. However, I would first like some discussion on the potential bloat impact of the custom variables in the dist CSS (pasted below).  Should we include these var declarations by default for every module, or setup our build in such a way so they are opt-in only? I'm feeling like it should be optional, but on the flip-side the gzip impact could be negligible...

```css
a.icon-link,
button.icon-btn {
  --actionable-icon-foreground-color: #111820;
  --actionable-icon-foreground-color-active: #111820;
  --actionable-icon-foreground-color-visited: #111820;
  --actionable-icon-foreground-color-hover: #3665f3;
  --actionable-badge-border-color: #fff;
  --actionable-image-border-color-hover: #767676;
}
a.img-link,
button.img-btn {
  --actionable-image-border-color-hover: #767676;
  --actionable-image-border-color-active: #767676;
  --actionable-image-background-color-visited: #e5e5e5;
}
@media (prefers-color-scheme: dark) {
  a.icon-link,
  button.icon-btn {
    --actionable-icon-foreground-color: #dcdcdc;
    --actionable-icon-foreground-color-active: #dcdcdc;
    --actionable-icon-foreground-color-visited: #dcdcdc;
    --actionable-icon-foreground-color-hover: #5192ff;
    --actionable-badge-border-color: #171717;
  }
  a.img-link,
  button.img-btn {
    --actionable-image-border-color-hover: #5192ff;
    --actionable-image-border-color-active: #767676;
    --actionable-image-background-color-visited: #e5e5e5;
  }
}
```

And here's what we already have for switch:

```css
.switch {
  --switch-background-color-unchecked: #767676;
  --switch-background-color-checked: #382aef;
  --switch-background-color-disabled: #c7c7c7;
  --switch-foreground-color: #fff;
}
@media (prefers-color-scheme: dark) {
  .switch {
    --switch-background-color-checked: #5192ff;
  }
}
```

<img width="1111" alt="Screen Shot 2020-05-06 at 2 37 32 PM" src="https://user-images.githubusercontent.com/38065/81232244-65e56980-8fa9-11ea-8d32-23fe614f2299.png">
<img width="1099" alt="Screen Shot 2020-05-06 at 2 41 02 PM" src="https://user-images.githubusercontent.com/38065/81232256-6aaa1d80-8fa9-11ea-9047-62e59b5aa42c.png">
<img width="1110" alt="Screen Shot 2020-05-06 at 2 38 47 PM" src="https://user-images.githubusercontent.com/38065/81232267-6da50e00-8fa9-11ea-949f-d4fc679e3fa7.png">
