### PR TITLE
Fixed carousel-controls-disabled to do display:none

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -9,7 +9,7 @@
   width: 100%;
 }
 .carousel__container--controls-disabled .carousel__control.carousel__control {
-  opacity: 0;
+  display: none;
 }
 .carousel__list {
   display: -webkit-box;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -9,7 +9,7 @@
   width: 100%;
 }
 .carousel__container--controls-disabled .carousel__control.carousel__control {
-  opacity: 0;
+  display: none;
 }
 .carousel__list {
   display: -webkit-box;

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -13,7 +13,9 @@
         width: 100%;
 
         &--controls-disabled .carousel__control.carousel__control {
-            opacity: 0;
+            // When controls are disabled, should hide them
+            // If we set opacity to 0, this is removed when we :hover
+            display: none;
         }
     }
 


### PR DESCRIPTION
## Description
Seems like something changed and caused `opacity:0` to have lower specificity than `:hover` opacity. Then paddles were being shown.
Changed to do display none so they are hidden.

![carousel](https://user-images.githubusercontent.com/1755269/82013328-eef64380-962e-11ea-96b2-68a81331bd95.gif)
