### PR TITLE
Refactor radio to use Custom Mixin and added Dark Mode Colors as needed

### DIFF
--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -25,9 +25,11 @@ svg.radio__unchecked {
 }
 svg.radio__checked {
   color: #0654ba;
+  color: var(--radio-checked-color, #0654ba);
 }
 svg.radio__unchecked {
   color: #ccc;
+  color: var(--radio-unchecked-color, #ccc);
 }
 input.radio__control[type="radio"] {
   font-size: 100%;

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -25,9 +25,11 @@ svg.radio__unchecked {
 }
 svg.radio__checked {
   color: #3665f3;
+  color: var(--radio-checked-color, #3665f3);
 }
 svg.radio__unchecked {
   color: #111820;
+  color: var(--radio-unchecked-color, #111820);
 }
 input.radio__control[type="radio"] {
   font-size: 100%;
@@ -60,6 +62,14 @@ input.radio__control[type="radio"][disabled] + span.radio__icon {
   height: 24px;
   min-width: 24px;
   width: 24px;
+}
+@media (prefers-color-scheme: dark) {
+  .radio__checked {
+    --radio-checked-color: #5192ff;
+  }
+  .radio__unchecked {
+    --radio-unchecked-color: #171717;
+  }
 }
 @media (min-width: 601px) {
   .radio__icon svg,

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -57,6 +57,10 @@ input.radio__control[type="radio"]:focus + span.radio__icon {
 input.radio__control[type="radio"][disabled] + span.radio__icon {
   opacity: 0.25;
 }
+.radio {
+  --radio-checked-color: #3665f3;
+  --radio-unchecked-color: #111820;
+}
 .radio__icon svg,
 .radio__control[type="radio"] {
   height: 24px;
@@ -64,10 +68,8 @@ input.radio__control[type="radio"][disabled] + span.radio__icon {
   width: 24px;
 }
 @media (prefers-color-scheme: dark) {
-  .radio__checked {
+  .radio {
     --radio-checked-color: #5192ff;
-  }
-  .radio__unchecked {
     --radio-unchecked-color: #171717;
   }
 }

--- a/dist/variables/ds6/radio-variables.less
+++ b/dist/variables/ds6/radio-variables.less
@@ -6,4 +6,4 @@
 @radio-disabled-opacity: 0.25;
 
 @radio-checked-color-dark-mode: @color-b4-dark-mode;
-@radio-unchecked-color-dark-mode: @color-black-dark-mode;
+@radio-unchecked-color-dark-mode: @color-black-dark-mode; // TBD, not final

--- a/dist/variables/ds6/radio-variables.less
+++ b/dist/variables/ds6/radio-variables.less
@@ -4,3 +4,6 @@
 @radio-checked-color: @color-b4;
 @radio-unchecked-color: @color-black;
 @radio-disabled-opacity: 0.25;
+
+@radio-checked-color-dark-mode: @color-b4-dark-mode;
+@radio-unchecked-color-dark-mode: @color-black-dark-mode;

--- a/docs/archive/v9.5/index.html
+++ b/docs/archive/v9.5/index.html
@@ -738,7 +738,7 @@
 <span class="nt">&lt;/button&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -819,7 +819,7 @@
 <span class="nt">&lt;/nav&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -1093,7 +1093,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -1492,7 +1492,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -1694,7 +1694,7 @@
 
     <p>Be careful when using a custom checkbox; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -1719,7 +1719,7 @@
         </div>
     </div>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -1791,207 +1791,207 @@
                     </span>
                     <div class="combobox__listbox">
                         <div id="listbox2" class="combobox__options" role="listbox">
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 1</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 2</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 3</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 4</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 5</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 6</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 7</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 8</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 9</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 10</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 11</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 12</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 13</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 14</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 15</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 16</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 17</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 18</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 19</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 20</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 21</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 22</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 23</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 24</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 25</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 26</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 27</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 28</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 29</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 30</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 31</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 32</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 33</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 34</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 35</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 36</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 37</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 38</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 39</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 40</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 41</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 42</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 43</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 44</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 45</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 46</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 47</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 48</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 49</span>
                             </div>
-
+                            
                             <div class="combobox__option" role="option">
                                 <span>Option 50</span>
                             </div>
-
+                            
                         </div>
                     </div>
                 </span>
@@ -2108,7 +2108,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -2142,9 +2142,9 @@
     </code></pre></figure>
 
     <!-- Deviation! DS6 supports coloured CTA buttons -->
+    
 
-
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -2295,7 +2295,7 @@
 <span class="nt">&lt;/details&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -2526,307 +2526,307 @@
                     </button>
                     <div class="dialog__body">
                         <h2 id="dialog-title">Heading</h2>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
+                        
                         <p><a href="http://www.ebay.com">www.ebay.com</a></p>
                     </div>
                 </div>
@@ -3053,7 +3053,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -3097,7 +3097,7 @@
 <span class="nt">&lt;/button&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -3999,7 +3999,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -4160,7 +4160,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -4487,7 +4487,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -4555,16 +4555,16 @@
 
     <p>Before a foreground icon can be used, its <a href="https://raw.githubusercontent.com/eBay/skin/master/src/svg/ds4/icons.svg">symbol</a> must be stamped on the page inside of a hidden SVG block.</p>
 
-
+    
     <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;svg</span> <span class="na">hidden</span><span class="nt">&gt;</span>
     <span class="nt">&lt;symbol</span> <span class="na">id=</span><span class="s">"icon-information"</span> <span class="na">viewBox=</span><span class="s">"0 0 24 24"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;path</span> <span class="na">fill=</span><span class="s">"#0654ba"</span> <span class="na">d=</span><span class="s">"M12.007 9.753a.849.849 0 00-.849.849v6.553a.85.85 0 001.683.004v-6.557a.849.849 0 00-.834-.849zm1.057-2.88a1.016 1.016 0 11-2.032 0 1.016 1.016 0 012.032 0zm-1.057 17.141C5.376 24.014 0 18.638 0 12.007 0 5.376 5.376 0 12.007 0c6.631 0 12.007 5.376 12.007 12.007v.015c-.008 6.625-5.381 11.992-12.007 11.992zm0-22.261c-5.671 0-10.268 4.597-10.268 10.268s4.597 10.268 10.268 10.268 10.268-4.597 10.268-10.268S17.678 1.753 12.007 1.753z"</span><span class="nt">/&gt;</span>
     <span class="nt">&lt;/symbol&gt;</span>
 <span class="nt">&lt;/svg&gt;</span>
     </code></pre></figure>
+    
 
-
-
+    
 
     <p><strong>NOTE:</strong> Skin removes all pointer events on foreground icons (via <span class="highlight">pointer-events: none</span>) due to a bug in IE. To add events to these icons you should wrap them in another element and attach your events there.</p>
 
@@ -4601,24 +4601,24 @@
 
     <h3 id="icon-icons">The Icons</h3>
     <p>The table below displays all available icons for the currently selected design system version (DS4). An empty box indicates that the icon is not available, and/or not relevant, to this system.</p>
-
+    
     <p><strong>NOTE: </strong> DS4 does not have small versions of icons.</p>
-
-
+    
+    
 
     <table cellpadding="0" cellspacing="0" class="icon-table">
         <thead>
             <tr>
                 <th>NAME</th>
-
+                
                 <th>ICON</th>
-
-
+                
+                
             </tr>
         </thead>
         <tbody>
-
-
+            
+            
             <tr>
                 <td>add</td>
                 <td>
@@ -4630,9 +4630,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>arrow-left</td>
                 <td>
@@ -4644,9 +4644,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>arrow-move</td>
                 <td>
@@ -4658,9 +4658,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>arrow-right</td>
                 <td>
@@ -4672,9 +4672,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>arrow-right-bold</td>
                 <td>
@@ -4686,9 +4686,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>attention</td>
                 <td>
@@ -4700,9 +4700,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>attention-filled</td>
                 <td>
@@ -4714,9 +4714,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>bids</td>
                 <td>
@@ -4728,9 +4728,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>camera</td>
                 <td>
@@ -4742,9 +4742,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>categories</td>
                 <td>
@@ -4756,9 +4756,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>close</td>
                 <td>
@@ -4770,9 +4770,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>cart</td>
                 <td>
@@ -4784,9 +4784,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>checkbox-checked</td>
                 <td>
@@ -4798,9 +4798,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>checkbox-unchecked</td>
                 <td>
@@ -4812,9 +4812,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>chevron-down</td>
                 <td>
@@ -4826,9 +4826,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>chevron-down-bold</td>
                 <td>
@@ -4840,9 +4840,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>chevron-left</td>
                 <td>
@@ -4854,9 +4854,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>chevron-right</td>
                 <td>
@@ -4868,9 +4868,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>chevron-up</td>
                 <td>
@@ -4882,9 +4882,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>chevron-up-bold</td>
                 <td>
@@ -4896,9 +4896,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>clear</td>
                 <td>
@@ -4910,9 +4910,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>clock</td>
                 <td>
@@ -4924,9 +4924,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>confirmation</td>
                 <td>
@@ -4938,9 +4938,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>confirmation-filled</td>
                 <td>
@@ -4952,9 +4952,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>delete</td>
                 <td>
@@ -4966,9 +4966,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>edit</td>
                 <td>
@@ -4980,9 +4980,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>deals</td>
                 <td>
@@ -4994,9 +4994,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>download</td>
                 <td>
@@ -5008,9 +5008,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>event</td>
                 <td>
@@ -5022,9 +5022,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>fast-n-free</td>
                 <td>
@@ -5036,9 +5036,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>filter-gallery</td>
                 <td>
@@ -5050,9 +5050,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>filter-list</td>
                 <td>
@@ -5064,9 +5064,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>filter-single</td>
                 <td>
@@ -5078,9 +5078,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>following</td>
                 <td>
@@ -5092,9 +5092,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>information</td>
                 <td>
@@ -5106,9 +5106,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>information-filled</td>
                 <td>
@@ -5120,9 +5120,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>help</td>
                 <td>
@@ -5134,9 +5134,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>home</td>
                 <td>
@@ -5148,9 +5148,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>menu</td>
                 <td>
@@ -5162,9 +5162,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>messages</td>
                 <td>
@@ -5176,9 +5176,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>mic</td>
                 <td>
@@ -5190,9 +5190,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>notification</td>
                 <td>
@@ -5204,9 +5204,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>overflow</td>
                 <td>
@@ -5218,9 +5218,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>pause</td>
                 <td>
@@ -5232,9 +5232,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>photo-brightness</td>
                 <td>
@@ -5246,9 +5246,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>photo-crop</td>
                 <td>
@@ -5260,9 +5260,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>photo-gallery</td>
                 <td>
@@ -5274,9 +5274,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>photo-gallery-more</td>
                 <td>
@@ -5288,9 +5288,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>photo-rotate</td>
                 <td>
@@ -5302,9 +5302,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>photo-select-all</td>
                 <td>
@@ -5316,9 +5316,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>photo-select-none</td>
                 <td>
@@ -5330,9 +5330,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>play</td>
                 <td>
@@ -5344,9 +5344,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>profile</td>
                 <td>
@@ -5358,9 +5358,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>purchases</td>
                 <td>
@@ -5372,9 +5372,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>radio-checked</td>
                 <td>
@@ -5386,9 +5386,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>radio-unchecked</td>
                 <td>
@@ -5400,9 +5400,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>red-laser</td>
                 <td>
@@ -5414,9 +5414,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>refresh</td>
                 <td>
@@ -5428,9 +5428,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>save</td>
                 <td>
@@ -5442,9 +5442,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>save-bold</td>
                 <td>
@@ -5456,9 +5456,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>save-selected</td>
                 <td>
@@ -5470,9 +5470,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>search</td>
                 <td>
@@ -5484,9 +5484,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>search-bold</td>
                 <td>
@@ -5498,9 +5498,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>selling</td>
                 <td>
@@ -5512,9 +5512,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>send</td>
                 <td>
@@ -5526,9 +5526,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>settings</td>
                 <td>
@@ -5540,9 +5540,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>star-empty</td>
                 <td>
@@ -5554,9 +5554,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>star-filled</td>
                 <td>
@@ -5568,9 +5568,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>star-filled-grey</td>
                 <td>
@@ -5582,9 +5582,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>star-half</td>
                 <td>
@@ -5596,9 +5596,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>star-undefined</td>
                 <td>
@@ -5610,9 +5610,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>thumbs-up</td>
                 <td>
@@ -5624,9 +5624,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>thumbs-up-selected</td>
                 <td>
@@ -5638,9 +5638,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>thumbs-down</td>
                 <td>
@@ -5652,9 +5652,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>thumbs-down-selected</td>
                 <td>
@@ -5666,9 +5666,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>tick</td>
                 <td>
@@ -5680,9 +5680,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>top-seller</td>
                 <td>
@@ -5694,9 +5694,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>truck</td>
                 <td>
@@ -5708,9 +5708,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>watch</td>
                 <td>
@@ -5722,9 +5722,9 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
             <tr>
                 <td>window</td>
                 <td>
@@ -5736,15 +5736,15 @@
                         </span>
                     </span>
                 </td>
-
+                
             </tr>
-
+            
         </tbody>
     </table>
 
-
+    
     <p>For a full list of DS4 icons, please <a href="archive/index.html">visit the archive</a>.</p>
-
+    
 
     <h3 id="icon-aliases">Icon Aliases</h3>
 
@@ -5758,8 +5758,8 @@
             </tr>
         </thead>
         <tbody>
-
-
+            
+            
             <tr>
                 <td>carousel-prev</td>
                 <td>
@@ -5772,7 +5772,7 @@
                     </span>
                 </td>
             </tr>
-
+            
             <tr>
                 <td>carousel-next</td>
                 <td>
@@ -5785,7 +5785,7 @@
                     </span>
                 </td>
             </tr>
-
+            
             <tr>
                 <td>pagination-prev</td>
                 <td>
@@ -5798,7 +5798,7 @@
                     </span>
                 </td>
             </tr>
-
+            
             <tr>
                 <td>pagination-next</td>
                 <td>
@@ -5811,12 +5811,12 @@
                     </span>
                 </td>
             </tr>
-
+            
         </tbody>
     </table>
 
 
-
+    
 
 </div>
 
@@ -5941,7 +5941,7 @@
     <p>To opt into transitions after the initial render is complete, add the  <span class="highlight">floating-label__label--animate</span> modifier when the textbox receives focus.</p>
     <p>The examples above use <a href="https://github.com/makeup-js/makeup-floating-label">makeup-floating-label</a>, a simple JavaScript module that adds the aforementioned logic. Feel free to use this module or use it as the basis to roll your own.</p>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -6018,7 +6018,7 @@
         </div>
     </div>
 
-
+    
 
     <h3 id="less-core-colors">Core Color Variables</h3>
     <div class="demo">
@@ -6039,11 +6039,11 @@
 
     <p>For a full list of DS4 colour variables, please <a href="archive/index.html">visit the archive</a>.</p>
 
+    
 
+    
 
-
-
-
+    
 
 </div>
 
@@ -6130,7 +6130,7 @@
     <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;button</span> <span class="na">class=</span><span class="s">"fake-link fake-link--action"</span> <span class="na">type=</span><span class="s">"button"</span><span class="nt">&gt;</span>Button<span class="nt">&lt;/button&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -6226,7 +6226,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -6469,7 +6469,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -6612,7 +6612,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -6681,207 +6681,207 @@
                 </button>
                 <div class="menu-button__menu">
                     <div class="menu-button__items" role="menu">
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 1</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 2</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 3</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 4</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 5</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 6</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 7</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 8</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 9</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 10</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 11</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 12</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 13</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 14</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 15</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 16</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 17</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 18</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 19</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 20</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 21</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 22</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 23</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 24</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 25</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 26</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 27</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 28</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 29</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 30</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 31</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 32</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 33</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 34</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 35</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 36</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 37</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 38</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 39</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 40</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 41</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 42</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 43</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 44</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 45</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 46</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 47</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 48</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 49</span>
                         </div>
-
+                        
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 50</span>
                         </div>
-
+                        
                     </div>
                 </div>
             </span>
@@ -7337,7 +7337,7 @@
 
     <p><strong>TIP:</strong> The positions of the status icon and label have been reversed in this example, simply by flipping their DOM order.</p>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -7714,7 +7714,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -7912,7 +7912,7 @@
     </code></pre></figure>
     <p><strong>NOTE:</strong> The heading wrapper only needs these two ARIA live-region related attributes if client-side pagination is implemented (i.e. partial page updates).</p>
 
-
+    
 
 </div>
 
@@ -8113,7 +8113,7 @@
 
     <p>Be careful when using a custom radio; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -8317,7 +8317,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -8561,7 +8561,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 
     <h3 id="select-small">Small Select (DS4 Only)</h3>
     <p>For a small select, apply the <span class="highlight">select--small</span> modifier.</p>
@@ -8619,9 +8619,9 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
+    
 
-
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -8738,7 +8738,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -8888,7 +8888,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-
+    
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -9037,7 +9037,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-
+    
 
 </div>
 
@@ -9258,7 +9258,7 @@
     <span class="nt">&lt;/div&gt;</span>
 <span class="nt">&lt;/div&gt;</span></code></pre></figure>
 
-
+    
 
 </div>
 
@@ -9308,7 +9308,7 @@
         </div>
     </div>
 
-
+    
 
 </div>
 

--- a/docs/archive/v9.5/index.html
+++ b/docs/archive/v9.5/index.html
@@ -738,7 +738,7 @@
 <span class="nt">&lt;/button&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -819,7 +819,7 @@
 <span class="nt">&lt;/nav&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -1093,7 +1093,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -1492,7 +1492,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -1694,7 +1694,7 @@
 
     <p>Be careful when using a custom checkbox; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -1719,7 +1719,7 @@
         </div>
     </div>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -1791,207 +1791,207 @@
                     </span>
                     <div class="combobox__listbox">
                         <div id="listbox2" class="combobox__options" role="listbox">
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 1</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 2</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 3</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 4</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 5</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 6</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 7</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 8</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 9</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 10</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 11</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 12</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 13</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 14</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 15</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 16</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 17</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 18</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 19</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 20</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 21</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 22</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 23</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 24</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 25</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 26</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 27</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 28</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 29</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 30</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 31</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 32</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 33</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 34</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 35</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 36</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 37</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 38</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 39</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 40</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 41</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 42</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 43</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 44</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 45</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 46</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 47</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 48</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 49</span>
                             </div>
-                            
+
                             <div class="combobox__option" role="option">
                                 <span>Option 50</span>
                             </div>
-                            
+
                         </div>
                     </div>
                 </span>
@@ -2108,7 +2108,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -2142,9 +2142,9 @@
     </code></pre></figure>
 
     <!-- Deviation! DS6 supports coloured CTA buttons -->
-    
 
-    
+
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -2295,7 +2295,7 @@
 <span class="nt">&lt;/details&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -2526,307 +2526,307 @@
                     </button>
                     <div class="dialog__body">
                         <h2 id="dialog-title">Heading</h2>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
                             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        
+
                         <p><a href="http://www.ebay.com">www.ebay.com</a></p>
                     </div>
                 </div>
@@ -3053,7 +3053,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -3097,7 +3097,7 @@
 <span class="nt">&lt;/button&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -3999,7 +3999,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -4160,7 +4160,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -4487,7 +4487,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -4555,16 +4555,16 @@
 
     <p>Before a foreground icon can be used, its <a href="https://raw.githubusercontent.com/eBay/skin/master/src/svg/ds4/icons.svg">symbol</a> must be stamped on the page inside of a hidden SVG block.</p>
 
-    
+
     <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;svg</span> <span class="na">hidden</span><span class="nt">&gt;</span>
     <span class="nt">&lt;symbol</span> <span class="na">id=</span><span class="s">"icon-information"</span> <span class="na">viewBox=</span><span class="s">"0 0 24 24"</span><span class="nt">&gt;</span>
         <span class="nt">&lt;path</span> <span class="na">fill=</span><span class="s">"#0654ba"</span> <span class="na">d=</span><span class="s">"M12.007 9.753a.849.849 0 00-.849.849v6.553a.85.85 0 001.683.004v-6.557a.849.849 0 00-.834-.849zm1.057-2.88a1.016 1.016 0 11-2.032 0 1.016 1.016 0 012.032 0zm-1.057 17.141C5.376 24.014 0 18.638 0 12.007 0 5.376 5.376 0 12.007 0c6.631 0 12.007 5.376 12.007 12.007v.015c-.008 6.625-5.381 11.992-12.007 11.992zm0-22.261c-5.671 0-10.268 4.597-10.268 10.268s4.597 10.268 10.268 10.268 10.268-4.597 10.268-10.268S17.678 1.753 12.007 1.753z"</span><span class="nt">/&gt;</span>
     <span class="nt">&lt;/symbol&gt;</span>
 <span class="nt">&lt;/svg&gt;</span>
     </code></pre></figure>
-    
 
-    
+
+
 
     <p><strong>NOTE:</strong> Skin removes all pointer events on foreground icons (via <span class="highlight">pointer-events: none</span>) due to a bug in IE. To add events to these icons you should wrap them in another element and attach your events there.</p>
 
@@ -4601,24 +4601,24 @@
 
     <h3 id="icon-icons">The Icons</h3>
     <p>The table below displays all available icons for the currently selected design system version (DS4). An empty box indicates that the icon is not available, and/or not relevant, to this system.</p>
-    
+
     <p><strong>NOTE: </strong> DS4 does not have small versions of icons.</p>
-    
-    
+
+
 
     <table cellpadding="0" cellspacing="0" class="icon-table">
         <thead>
             <tr>
                 <th>NAME</th>
-                
+
                 <th>ICON</th>
-                
-                
+
+
             </tr>
         </thead>
         <tbody>
-            
-            
+
+
             <tr>
                 <td>add</td>
                 <td>
@@ -4630,9 +4630,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>arrow-left</td>
                 <td>
@@ -4644,9 +4644,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>arrow-move</td>
                 <td>
@@ -4658,9 +4658,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>arrow-right</td>
                 <td>
@@ -4672,9 +4672,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>arrow-right-bold</td>
                 <td>
@@ -4686,9 +4686,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>attention</td>
                 <td>
@@ -4700,9 +4700,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>attention-filled</td>
                 <td>
@@ -4714,9 +4714,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>bids</td>
                 <td>
@@ -4728,9 +4728,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>camera</td>
                 <td>
@@ -4742,9 +4742,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>categories</td>
                 <td>
@@ -4756,9 +4756,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>close</td>
                 <td>
@@ -4770,9 +4770,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>cart</td>
                 <td>
@@ -4784,9 +4784,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>checkbox-checked</td>
                 <td>
@@ -4798,9 +4798,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>checkbox-unchecked</td>
                 <td>
@@ -4812,9 +4812,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>chevron-down</td>
                 <td>
@@ -4826,9 +4826,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>chevron-down-bold</td>
                 <td>
@@ -4840,9 +4840,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>chevron-left</td>
                 <td>
@@ -4854,9 +4854,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>chevron-right</td>
                 <td>
@@ -4868,9 +4868,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>chevron-up</td>
                 <td>
@@ -4882,9 +4882,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>chevron-up-bold</td>
                 <td>
@@ -4896,9 +4896,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>clear</td>
                 <td>
@@ -4910,9 +4910,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>clock</td>
                 <td>
@@ -4924,9 +4924,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>confirmation</td>
                 <td>
@@ -4938,9 +4938,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>confirmation-filled</td>
                 <td>
@@ -4952,9 +4952,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>delete</td>
                 <td>
@@ -4966,9 +4966,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>edit</td>
                 <td>
@@ -4980,9 +4980,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>deals</td>
                 <td>
@@ -4994,9 +4994,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>download</td>
                 <td>
@@ -5008,9 +5008,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>event</td>
                 <td>
@@ -5022,9 +5022,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>fast-n-free</td>
                 <td>
@@ -5036,9 +5036,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>filter-gallery</td>
                 <td>
@@ -5050,9 +5050,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>filter-list</td>
                 <td>
@@ -5064,9 +5064,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>filter-single</td>
                 <td>
@@ -5078,9 +5078,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>following</td>
                 <td>
@@ -5092,9 +5092,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>information</td>
                 <td>
@@ -5106,9 +5106,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>information-filled</td>
                 <td>
@@ -5120,9 +5120,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>help</td>
                 <td>
@@ -5134,9 +5134,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>home</td>
                 <td>
@@ -5148,9 +5148,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>menu</td>
                 <td>
@@ -5162,9 +5162,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>messages</td>
                 <td>
@@ -5176,9 +5176,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>mic</td>
                 <td>
@@ -5190,9 +5190,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>notification</td>
                 <td>
@@ -5204,9 +5204,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>overflow</td>
                 <td>
@@ -5218,9 +5218,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>pause</td>
                 <td>
@@ -5232,9 +5232,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>photo-brightness</td>
                 <td>
@@ -5246,9 +5246,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>photo-crop</td>
                 <td>
@@ -5260,9 +5260,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>photo-gallery</td>
                 <td>
@@ -5274,9 +5274,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>photo-gallery-more</td>
                 <td>
@@ -5288,9 +5288,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>photo-rotate</td>
                 <td>
@@ -5302,9 +5302,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>photo-select-all</td>
                 <td>
@@ -5316,9 +5316,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>photo-select-none</td>
                 <td>
@@ -5330,9 +5330,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>play</td>
                 <td>
@@ -5344,9 +5344,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>profile</td>
                 <td>
@@ -5358,9 +5358,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>purchases</td>
                 <td>
@@ -5372,9 +5372,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>radio-checked</td>
                 <td>
@@ -5386,9 +5386,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>radio-unchecked</td>
                 <td>
@@ -5400,9 +5400,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>red-laser</td>
                 <td>
@@ -5414,9 +5414,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>refresh</td>
                 <td>
@@ -5428,9 +5428,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>save</td>
                 <td>
@@ -5442,9 +5442,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>save-bold</td>
                 <td>
@@ -5456,9 +5456,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>save-selected</td>
                 <td>
@@ -5470,9 +5470,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>search</td>
                 <td>
@@ -5484,9 +5484,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>search-bold</td>
                 <td>
@@ -5498,9 +5498,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>selling</td>
                 <td>
@@ -5512,9 +5512,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>send</td>
                 <td>
@@ -5526,9 +5526,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>settings</td>
                 <td>
@@ -5540,9 +5540,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>star-empty</td>
                 <td>
@@ -5554,9 +5554,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>star-filled</td>
                 <td>
@@ -5568,9 +5568,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>star-filled-grey</td>
                 <td>
@@ -5582,9 +5582,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>star-half</td>
                 <td>
@@ -5596,9 +5596,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>star-undefined</td>
                 <td>
@@ -5610,9 +5610,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>thumbs-up</td>
                 <td>
@@ -5624,9 +5624,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>thumbs-up-selected</td>
                 <td>
@@ -5638,9 +5638,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>thumbs-down</td>
                 <td>
@@ -5652,9 +5652,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>thumbs-down-selected</td>
                 <td>
@@ -5666,9 +5666,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>tick</td>
                 <td>
@@ -5680,9 +5680,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>top-seller</td>
                 <td>
@@ -5694,9 +5694,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>truck</td>
                 <td>
@@ -5708,9 +5708,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>watch</td>
                 <td>
@@ -5722,9 +5722,9 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
             <tr>
                 <td>window</td>
                 <td>
@@ -5736,15 +5736,15 @@
                         </span>
                     </span>
                 </td>
-                
+
             </tr>
-            
+
         </tbody>
     </table>
 
-    
+
     <p>For a full list of DS4 icons, please <a href="archive/index.html">visit the archive</a>.</p>
-    
+
 
     <h3 id="icon-aliases">Icon Aliases</h3>
 
@@ -5758,8 +5758,8 @@
             </tr>
         </thead>
         <tbody>
-            
-            
+
+
             <tr>
                 <td>carousel-prev</td>
                 <td>
@@ -5772,7 +5772,7 @@
                     </span>
                 </td>
             </tr>
-            
+
             <tr>
                 <td>carousel-next</td>
                 <td>
@@ -5785,7 +5785,7 @@
                     </span>
                 </td>
             </tr>
-            
+
             <tr>
                 <td>pagination-prev</td>
                 <td>
@@ -5798,7 +5798,7 @@
                     </span>
                 </td>
             </tr>
-            
+
             <tr>
                 <td>pagination-next</td>
                 <td>
@@ -5811,12 +5811,12 @@
                     </span>
                 </td>
             </tr>
-            
+
         </tbody>
     </table>
 
 
-    
+
 
 </div>
 
@@ -5941,7 +5941,7 @@
     <p>To opt into transitions after the initial render is complete, add the  <span class="highlight">floating-label__label--animate</span> modifier when the textbox receives focus.</p>
     <p>The examples above use <a href="https://github.com/makeup-js/makeup-floating-label">makeup-floating-label</a>, a simple JavaScript module that adds the aforementioned logic. Feel free to use this module or use it as the basis to roll your own.</p>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -6018,7 +6018,7 @@
         </div>
     </div>
 
-    
+
 
     <h3 id="less-core-colors">Core Color Variables</h3>
     <div class="demo">
@@ -6039,11 +6039,11 @@
 
     <p>For a full list of DS4 colour variables, please <a href="archive/index.html">visit the archive</a>.</p>
 
-    
 
-    
 
-    
+
+
+
 
 </div>
 
@@ -6130,7 +6130,7 @@
     <figure class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;button</span> <span class="na">class=</span><span class="s">"fake-link fake-link--action"</span> <span class="na">type=</span><span class="s">"button"</span><span class="nt">&gt;</span>Button<span class="nt">&lt;/button&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -6226,7 +6226,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -6469,7 +6469,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -6612,7 +6612,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -6681,207 +6681,207 @@
                 </button>
                 <div class="menu-button__menu">
                     <div class="menu-button__items" role="menu">
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 1</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 2</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 3</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 4</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 5</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 6</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 7</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 8</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 9</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 10</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 11</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 12</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 13</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 14</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 15</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 16</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 17</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 18</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 19</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 20</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 21</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 22</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 23</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 24</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 25</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 26</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 27</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 28</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 29</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 30</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 31</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 32</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 33</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 34</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 35</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 36</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 37</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 38</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 39</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 40</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 41</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 42</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 43</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 44</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 45</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 46</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 47</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 48</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 49</span>
                         </div>
-                        
+
                         <div class="menu-button__item" role="menuitem">
                             <span>Menu item 50</span>
                         </div>
-                        
+
                     </div>
                 </div>
             </span>
@@ -7337,7 +7337,7 @@
 
     <p><strong>TIP:</strong> The positions of the status icon and label have been reversed in this example, simply by flipping their DOM order.</p>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -7714,7 +7714,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -7912,7 +7912,7 @@
     </code></pre></figure>
     <p><strong>NOTE:</strong> The heading wrapper only needs these two ARIA live-region related attributes if client-side pagination is implemented (i.e. partial page updates).</p>
 
-    
+
 
 </div>
 
@@ -8113,7 +8113,7 @@
 
     <p>Be careful when using a custom radio; the icon for each state must still give enough <em>affordance</em> to a user that it represents an interactive control.</p>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -8317,7 +8317,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -8561,7 +8561,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 
     <h3 id="select-small">Small Select (DS4 Only)</h3>
     <p>For a small select, apply the <span class="highlight">select--small</span> modifier.</p>
@@ -8619,9 +8619,9 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
 
-    
+
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -8738,7 +8738,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -8888,7 +8888,7 @@
 <span class="nt">&lt;/div&gt;</span>
     </code></pre></figure>
 
-    
+
 </div>
 
 <img class="skin-graphic" src="static/skin-graphic.png" alt="" />
@@ -9037,7 +9037,7 @@
 <span class="nt">&lt;/span&gt;</span>
     </code></pre></figure>
 
-    
+
 
 </div>
 
@@ -9258,7 +9258,7 @@
     <span class="nt">&lt;/div&gt;</span>
 <span class="nt">&lt;/div&gt;</span></code></pre></figure>
 
-    
+
 
 </div>
 
@@ -9308,7 +9308,7 @@
         </div>
     </div>
 
-    
+
 
 </div>
 

--- a/src/less/radio/base/radio.less
+++ b/src/less/radio/base/radio.less
@@ -23,12 +23,10 @@ svg.radio__unchecked {
 }
 
 svg.radio__checked {
-    // color: @radio-checked-color;
     .customColorProperty('radio-checked-color');
 }
 
 svg.radio__unchecked {
-    // color: @radio-unchecked-color;
     .customColorProperty('radio-unchecked-color');
 }
 

--- a/src/less/radio/base/radio.less
+++ b/src/less/radio/base/radio.less
@@ -1,3 +1,5 @@
+@import "src/less/mixins/utility/utility-mixins.less";
+
 .radio {
     display: inline-flex;
     font-size: @font-size-16;
@@ -21,11 +23,13 @@ svg.radio__unchecked {
 }
 
 svg.radio__checked {
-    color: @radio-checked-color;
+    // color: @radio-checked-color;
+    .customColorProperty('radio-checked-color');
 }
 
 svg.radio__unchecked {
-    color: @radio-unchecked-color;
+    // color: @radio-unchecked-color;
+    .customColorProperty('radio-unchecked-color');
 }
 
 input.radio__control[type="radio"] {

--- a/src/less/radio/ds6/radio.less
+++ b/src/less/radio/ds6/radio.less
@@ -19,7 +19,7 @@
 @media (prefers-color-scheme: dark) {
     .radio {
         --radio-checked-color: @radio-checked-color-dark-mode;
-        --radio-unchecked-color: @radio-unchecked-color-dark-mode;
+        --radio-unchecked-color: @radio-unchecked-color-dark-mode;// TBD
     }
 }
 

--- a/src/less/radio/ds6/radio.less
+++ b/src/less/radio/ds6/radio.less
@@ -4,6 +4,11 @@
 @import "../../mixins/icon/ds6/icon-mixins.less";
 @import "../base/radio.less";
 
+.radio {
+    --radio-checked-color: @radio-checked-color;
+    --radio-unchecked-color: @radio-unchecked-color;
+}
+
 .radio__icon svg,
 .radio__control[type="radio"] {
     height: 24px;
@@ -12,11 +17,8 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .radio__checked {
+    .radio {
         --radio-checked-color: @radio-checked-color-dark-mode;
-    }
-
-    .radio__unchecked {
         --radio-unchecked-color: @radio-unchecked-color-dark-mode;
     }
 }

--- a/src/less/radio/ds6/radio.less
+++ b/src/less/radio/ds6/radio.less
@@ -11,6 +11,16 @@
     width: 24px;
 }
 
+@media (prefers-color-scheme: dark) {
+    .radio__checked {
+        --radio-checked-color: @radio-checked-color-dark-mode;
+    }
+
+    .radio__unchecked {
+        --radio-unchecked-color: @radio-unchecked-color-dark-mode;
+    }
+}
+
 // refactor. this media query needs revisiting in v11
 // we need an adaptive approach that loads a different sized icon
 @media (min-width: 601px) {

--- a/src/less/variables/ds6/radio-variables.less
+++ b/src/less/variables/ds6/radio-variables.less
@@ -6,4 +6,4 @@
 @radio-disabled-opacity: 0.25;
 
 @radio-checked-color-dark-mode: @color-b4-dark-mode;
-@radio-unchecked-color-dark-mode: @color-black-dark-mode;
+@radio-unchecked-color-dark-mode: @color-black-dark-mode; // TBD, not final

--- a/src/less/variables/ds6/radio-variables.less
+++ b/src/less/variables/ds6/radio-variables.less
@@ -4,3 +4,6 @@
 @radio-checked-color: @color-b4;
 @radio-unchecked-color: @color-black;
 @radio-disabled-opacity: 0.25;
+
+@radio-checked-color-dark-mode: @color-b4-dark-mode;
+@radio-unchecked-color-dark-mode: @color-black-dark-mode;


### PR DESCRIPTION
Hey Skins Team, 

Basically what I have done was switch out some of the CSS code for Radio for the CustomColor mixin utility that we introduced. I also added the corresponding light mode colors to dark mode for radio as well when they would be switched. 

I can remove the commented out CSS once you guys think it's good. It's just there for my reference when I do diff. 

Screenshots of the Dark Mode: 

<img width="1101" alt="Screen Shot 2020-05-19 at 11 41 24" src="https://user-images.githubusercontent.com/9060271/82365579-b1464180-99c5-11ea-98e0-c753d8dad7df.png">

I think we are gonna need to figure out what should be the dark mode equal to `@color-control-outline: @color-grey5;` since `color-grey-5` doesn't have a dark mode equal. 