### PR TITLE
Refactor Checkbox Component to use CustomColor and Dark Mode

### DIFF
--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -25,9 +25,11 @@ svg.checkbox__unchecked {
 }
 svg.checkbox__checked {
   color: #0654ba;
+  color: var(--checkbox-checked-color, #0654ba);
 }
 svg.checkbox__unchecked {
   color: #767676;
+  color: var(--checkbox-unchecked-color, #767676);
 }
 input.checkbox__control[type="checkbox"] {
   font-size: 100%;

--- a/dist/checkbox/ds6/checkbox.css
+++ b/dist/checkbox/ds6/checkbox.css
@@ -25,9 +25,11 @@ svg.checkbox__unchecked {
 }
 svg.checkbox__checked {
   color: #3665f3;
+  color: var(--checkbox-checked-color, #3665f3);
 }
 svg.checkbox__unchecked {
   color: #111820;
+  color: var(--checkbox-unchecked-color, #111820);
 }
 input.checkbox__control[type="checkbox"] {
   font-size: 100%;
@@ -54,6 +56,16 @@ input.checkbox__control[type="checkbox"]:focus + span.checkbox__icon {
 }
 input.checkbox__control[type="checkbox"][disabled] + span.checkbox__icon {
   opacity: 0.25;
+}
+.checkbox {
+  --checkbox-checked-color: #3665f3;
+  --checkbox-unchecked-color: #111820;
+}
+@media (prefers-color-scheme: dark) {
+  .checkbox {
+    --checkbox-checked-color: #5192ff;
+    --checkbox-unchecked-color: #171717;
+  }
 }
 .checkbox__icon svg,
 .checkbox__control[type="checkbox"] {

--- a/dist/variables/ds6/checkbox-variables.less
+++ b/dist/variables/ds6/checkbox-variables.less
@@ -4,3 +4,6 @@
 @checkbox-checked-color: @color-b4;
 @checkbox-unchecked-color: @color-black;
 @checkbox-disabled-opacity: 0.25;
+
+@checkbox-checked-color-dark-mode: @color-b4-dark-mode;
+@checkbox-unchecked-color-dark-mode: @color-black-dark-mode; // TBD: Not Final

--- a/src/less/checkbox/base/checkbox.less
+++ b/src/less/checkbox/base/checkbox.less
@@ -23,12 +23,10 @@ svg.checkbox__unchecked {
 }
 
 svg.checkbox__checked {
-    // color: @checkbox-checked-color;
     .customColorProperty('checkbox-checked-color');
 }
 
 svg.checkbox__unchecked {
-    // color: @checkbox-unchecked-color;
     .customColorProperty('checkbox-unchecked-color');
 }
 

--- a/src/less/checkbox/base/checkbox.less
+++ b/src/less/checkbox/base/checkbox.less
@@ -1,3 +1,5 @@
+@import "src/less/mixins/utility/utility-mixins.less";
+
 .checkbox {
     display: inline-flex;
     font-size: @font-size-16;
@@ -21,11 +23,13 @@ svg.checkbox__unchecked {
 }
 
 svg.checkbox__checked {
-    color: @checkbox-checked-color;
+    // color: @checkbox-checked-color;
+    .customColorProperty('checkbox-checked-color');
 }
 
 svg.checkbox__unchecked {
-    color: @checkbox-unchecked-color;
+    // color: @checkbox-unchecked-color;
+    .customColorProperty('checkbox-unchecked-color');
 }
 
 input.checkbox__control[type="checkbox"] {

--- a/src/less/checkbox/base/checkbox.less
+++ b/src/less/checkbox/base/checkbox.less
@@ -23,11 +23,11 @@ svg.checkbox__unchecked {
 }
 
 svg.checkbox__checked {
-    .customColorProperty('checkbox-checked-color');
+    .customColorProperty(checkbox-checked-color);
 }
 
 svg.checkbox__unchecked {
-    .customColorProperty('checkbox-unchecked-color');
+    .customColorProperty(checkbox-unchecked-color);
 }
 
 input.checkbox__control[type="checkbox"] {

--- a/src/less/checkbox/ds6/checkbox.less
+++ b/src/less/checkbox/ds6/checkbox.less
@@ -4,6 +4,18 @@
 @import "../../mixins/icon/base/icon-mixins.less";
 @import "../base/checkbox.less";
 
+.checkbox {
+    --checkbox-checked-color: @checkbox-checked-color;
+    --checkbox-unchecked-color: @checkbox-unchecked-color;
+}
+
+@media (prefers-color-scheme: dark) {
+    .checkbox {
+        --checkbox-checked-color: @checkbox-checked-color-dark-mode;
+        --checkbox-unchecked-color: @checkbox-unchecked-color-dark-mode;
+    }
+}
+
 .checkbox__icon svg,
 .checkbox__control[type="checkbox"] {
     height: 24px;

--- a/src/less/variables/ds6/checkbox-variables.less
+++ b/src/less/variables/ds6/checkbox-variables.less
@@ -4,3 +4,6 @@
 @checkbox-checked-color: @color-b4;
 @checkbox-unchecked-color: @color-black;
 @checkbox-disabled-opacity: 0.25;
+
+@checkbox-checked-color-dark-mode: @color-b4-dark-mode;
+@checkbox-unchecked-color-dark-mode: @color-black-dark-mode; // TBD: Not Final


### PR DESCRIPTION
Hey everyone, 

So I have refactored the checkbox component that uses the customColors mixin (basically exposes the color properties) and I have added the corresponding dark mode colors, though they might change. 

Screenshots: 

With the `skins-experiment-1` class in the <body> tag of `docs/_layouts/default.html`

<img width="1100" alt="Screen Shot 2020-05-19 at 15 28 20" src="https://user-images.githubusercontent.com/9060271/82384809-8966d600-99e5-11ea-8576-abc10d0e298d.png">