### PR TITLE
Custom Properties for DS4 for potential new build & delivery system

### DIFF
--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -1,3 +1,18 @@
+a.icon-link,
+button.icon-btn {
+  --actionable-badge-border-color: #fff;
+  --actionable-icon-foreground-color: #555;
+  --actionable-icon-foreground-color-active: #555;
+  --actionable-icon-foreground-color-hover: #333;
+  --actionable-icon-foreground-color-visited: #333;
+  --actionable-image-border-color-hover: #999;
+}
+a.img-link,
+button.img-btn {
+  --actionable-image-background-color-visited: #ddd;
+  --actionable-image-border-color-active: #767676;
+  --actionable-image-border-color-hover: #767676;
+}
 a.icon-link {
   -webkit-box-align: center;
           align-items: center;
@@ -55,8 +70,10 @@ a.icon-link--badged {
 }
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
-  border: 2px solid #fff;
-  border: 2px solid var(--actionable-badge-border-color, #fff);
+  border-color: #fff;
+  border-color: var(--actionable-badge-border-color, #fff);
+  border-style: solid;
+  border-width: 2px;
   display: block;
   height: 24px;
   left: 16px;
@@ -99,6 +116,7 @@ button.img-btn:not([disabled]):active {
   border-color: #767676;
   border-color: var(--actionable-image-border-color-active, #767676);
 }
+/* stylelint-disable-next-line no-duplicate-selectors */
 button.icon-btn:focus,
 a.icon-link:focus,
 button.icon-btn:hover,

--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -3,8 +3,7 @@ button.icon-btn {
   --actionable-badge-border-color: #fff;
   --actionable-icon-foreground-color: #555;
   --actionable-icon-foreground-color-active: #555;
-  --actionable-icon-foreground-color-hover: #333;
-  --actionable-icon-foreground-color-visited: #333;
+  --actionable-icon-foreground-color-hover: #767676;
   --actionable-image-border-color-hover: #999;
 }
 a.img-link,
@@ -47,9 +46,12 @@ a.icon-link:active > svg {
   fill: #555;
   fill: var(--actionable-icon-foreground-color-active, #555);
 }
-a.icon-link:visited > svg {
+button.icon-btn:focus > svg,
+a.icon-link:focus > svg,
+button.icon-btn:hover > svg,
+a.icon-link:hover > svg {
   fill: #333;
-  fill: var(--actionable-icon-foreground-color-visited, #333);
+  fill: var(--actionable-icon-foreground-color-hover, #333);
 }
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
@@ -62,6 +64,15 @@ button[aria-disabled="true"].icon-btn > svg,
 a:not([href]).icon-link > svg,
 a[aria-disabled="true"].icon-link > svg {
   background-color: transparent;
+}
+a.icon-link:visited > svg {
+  fill: #555;
+  fill: var(--actionable-icon-foreground-color, #555);
+}
+a.icon-link:visited:hover > svg,
+a.icon-link:visited:focus > svg {
+  fill: #333;
+  fill: var(--actionable-icon-foreground-color-hover, #333);
 }
 button.icon-btn--badged,
 a.icon-link--badged {
@@ -115,11 +126,4 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
   border-color: var(--actionable-image-border-color-active, #767676);
-}
-/* stylelint-disable-next-line no-duplicate-selectors */
-button.icon-btn:focus,
-a.icon-link:focus,
-button.icon-btn:hover,
-a.icon-link:hover {
-  opacity: 0.65;
 }

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -1,32 +1,32 @@
 a.icon-link,
 button.icon-btn {
+  --actionable-badge-border-color: #fff;
   --actionable-icon-foreground-color: #111820;
   --actionable-icon-foreground-color-active: #111820;
-  --actionable-icon-foreground-color-visited: #111820;
   --actionable-icon-foreground-color-hover: #3665f3;
-  --actionable-badge-border-color: #fff;
+  --actionable-icon-foreground-color-visited: #111820;
   --actionable-image-border-color-hover: #767676;
 }
 a.img-link,
 button.img-btn {
-  --actionable-image-border-color-hover: #767676;
-  --actionable-image-border-color-active: #767676;
   --actionable-image-background-color-visited: #e5e5e5;
+  --actionable-image-border-color-active: #767676;
+  --actionable-image-border-color-hover: #767676;
 }
 @media (prefers-color-scheme: dark) {
   a.icon-link,
   button.icon-btn {
+    --actionable-badge-border-color: #171717;
     --actionable-icon-foreground-color: #dcdcdc;
     --actionable-icon-foreground-color-active: #dcdcdc;
-    --actionable-icon-foreground-color-visited: #dcdcdc;
     --actionable-icon-foreground-color-hover: #5192ff;
-    --actionable-badge-border-color: #171717;
+    --actionable-icon-foreground-color-visited: #dcdcdc;
   }
   a.img-link,
   button.img-btn {
+    --actionable-image-background-color-visited: #e5e5e5;
     --actionable-image-border-color-hover: #5192ff;
     --actionable-image-border-color-active: #767676;
-    --actionable-image-background-color-visited: #e5e5e5;
   }
 }
 a.icon-link {
@@ -86,8 +86,10 @@ a.icon-link--badged {
 }
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
-  border: 2px solid #fff;
-  border: 2px solid var(--actionable-badge-border-color, #fff);
+  border-color: #fff;
+  border-color: var(--actionable-badge-border-color, #fff);
+  border-style: solid;
+  border-width: 2px;
   display: block;
   height: 24px;
   left: 16px;

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -4,7 +4,6 @@ button.icon-btn {
   --actionable-icon-foreground-color: #111820;
   --actionable-icon-foreground-color-active: #111820;
   --actionable-icon-foreground-color-hover: #3665f3;
-  --actionable-icon-foreground-color-visited: #111820;
   --actionable-image-border-color-hover: #767676;
 }
 a.img-link,
@@ -20,7 +19,6 @@ button.img-btn {
     --actionable-icon-foreground-color: #dcdcdc;
     --actionable-icon-foreground-color-active: #dcdcdc;
     --actionable-icon-foreground-color-hover: #5192ff;
-    --actionable-icon-foreground-color-visited: #dcdcdc;
   }
   a.img-link,
   button.img-btn {
@@ -63,9 +61,12 @@ a.icon-link:active > svg {
   fill: #111820;
   fill: var(--actionable-icon-foreground-color-active, #111820);
 }
-a.icon-link:visited > svg {
-  fill: #111820;
-  fill: var(--actionable-icon-foreground-color-visited, #111820);
+button.icon-btn:focus > svg,
+a.icon-link:focus > svg,
+button.icon-btn:hover > svg,
+a.icon-link:hover > svg {
+  fill: #3665f3;
+  fill: var(--actionable-icon-foreground-color-hover, #3665f3);
 }
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
@@ -78,6 +79,15 @@ button[aria-disabled="true"].icon-btn > svg,
 a:not([href]).icon-link > svg,
 a[aria-disabled="true"].icon-link > svg {
   background-color: transparent;
+}
+a.icon-link:visited > svg {
+  fill: #111820;
+  fill: var(--actionable-icon-foreground-color, #111820);
+}
+a.icon-link:visited:hover > svg,
+a.icon-link:visited:focus > svg {
+  fill: #3665f3;
+  fill: var(--actionable-icon-foreground-color-hover, #3665f3);
 }
 button.icon-btn--badged,
 a.icon-link--badged {
@@ -131,12 +141,4 @@ button.img-btn:not([disabled]):focus {
 button.img-btn:not([disabled]):active {
   border-color: #767676;
   border-color: var(--actionable-image-border-color-active, #767676);
-}
-/* stylelint-disable-next-line no-duplicate-selectors */
-button.icon-btn:focus svg,
-a.icon-link:focus svg,
-button.icon-btn:hover svg,
-a.icon-link:hover svg {
-  fill: #3665f3;
-  fill: var(--actionable-icon-foreground-color-hover, #3665f3);
 }

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,13 +1,17 @@
+.switch {
+  --badge-background-color: #dd1e31;
+  --badge-foreground-color: #fff;
+}
 .badge {
+  border-color: #dd1e31;
+  border-color: var(--badge-background-color, #dd1e31);
+  color: #fff;
+  color: var(--badge-foreground-color, #fff);
   -webkit-box-align: center;
           align-items: center;
-  background-color: #dd1e31;
-  background-color: var(--badge-background-color, #dd1e31);
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
-  color: #fff;
-  color: var(--badge-foreground-color, #fff);
   display: -webkit-inline-box;
   display: inline-flex;
   font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -9,15 +9,15 @@
   }
 }
 .badge {
+  border-color: #e62048;
+  border-color: var(--badge-background-color, #e62048);
+  color: #fff;
+  color: var(--badge-foreground-color, #fff);
   -webkit-box-align: center;
           align-items: center;
-  background-color: #e62048;
-  background-color: var(--badge-background-color, #e62048);
   border-radius: 20px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
-  color: #fff;
-  color: var(--badge-foreground-color, #fff);
   display: -webkit-inline-box;
   display: inline-flex;
   font-family: "Market Sans", Arial, sans-serif;

--- a/dist/breadcrumbs/ds4/breadcrumbs.css
+++ b/dist/breadcrumbs/ds4/breadcrumbs.css
@@ -1,3 +1,8 @@
+.breadcrumbs {
+  --breadcrumbs-item-color: #333;
+  --breadcrumbs-item-current-color: #767676;
+  --breadcrumbs-item-focus-hover-color: #0654ba;
+}
 nav.breadcrumb,
 nav.breadcrumbs {
   color: #333;

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -31,3 +31,15 @@
 .customColorProperty(@token) {
     .customProperty(color, @token);
 }
+
+.customBackgroundColorProperty(@token) {
+    .customProperty(background-color, @token);
+}
+
+.customBorderColorProperty(@token) {
+    .customProperty(border-color, @token);
+}
+
+.customFillProperty(@token) {
+    .customProperty(fill, @token);
+}

--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -1,4 +1,10 @@
 .switch {
+  --switch-background-color-checked: #0654ba;
+  --switch-background-color-disabled: #ccc;
+  --switch-background-color-unchecked: #767676;
+  --switch-foreground-color: #fff;
+}
+.switch {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   height: 40px;
@@ -14,10 +20,9 @@ span.switch {
   display: inline-flex;
 }
 span.switch__button {
-  align-self: center;
-  background: gray none repeat scroll 0 0;
   background-color: #767676;
   background-color: var(--switch-background-color-unchecked, #767676);
+  align-self: center;
   border-radius: 400px;
   color: transparent;
   display: inline-block;

--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -34,7 +34,6 @@ span.switch__button {
   width: 40px;
 }
 span.switch__button::after {
-  background: white none repeat scroll 0 0;
   background-color: #fff;
   background-color: var(--switch-foreground-color, #fff);
   border-radius: 50%;

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -39,7 +39,6 @@ span.switch__button {
   width: 40px;
 }
 span.switch__button::after {
-  background: white none repeat scroll 0 0;
   background-color: #fff;
   background-color: var(--switch-foreground-color, #fff);
   border-radius: 50%;

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -1,7 +1,7 @@
 .switch {
-  --switch-background-color-unchecked: #767676;
   --switch-background-color-checked: #382aef;
   --switch-background-color-disabled: #c7c7c7;
+  --switch-background-color-unchecked: #767676;
   --switch-foreground-color: #fff;
 }
 @media (prefers-color-scheme: dark) {
@@ -25,10 +25,9 @@ span.switch {
   display: inline-flex;
 }
 span.switch__button {
-  align-self: center;
-  background: gray none repeat scroll 0 0;
   background-color: #767676;
   background-color: var(--switch-background-color-unchecked, #767676);
+  align-self: center;
   border-radius: 400px;
   color: transparent;
   display: inline-block;

--- a/src/less/actionable/base/actionable.less
+++ b/src/less/actionable/base/actionable.less
@@ -1,3 +1,5 @@
+@import "src/less/mixins/utility/utility-mixins.less";
+
 // icons
 //-----------------------------
 
@@ -22,22 +24,20 @@ a.icon-link {
     width: 40px;
 
     > svg {
-        fill: @actionable-icon-foreground-color;
-        fill: var(--actionable-icon-foreground-color, @actionable-icon-foreground-color);
+        .customFillProperty('actionable-icon-foreground-color');
+
         height: 100%; // vertical centering
         max-width: 100%; // helps when width & height HTML attrs not set
         position: relative; // Safari centering
     }
 
     &:active > svg {
-        fill: @actionable-icon-foreground-color-active;
-        fill: var(--actionable-icon-foreground-color-active, @actionable-icon-foreground-color-active);
+        .customFillProperty('actionable-icon-foreground-color-active');
     }
 }
 
 a.icon-link:visited > svg {
-    fill: @actionable-icon-foreground-color-visited;
-    fill: var(--actionable-icon-foreground-color-visited, @actionable-icon-foreground-color-visited);
+    .customFillProperty('actionable-icon-foreground-color-visited');
 }
 
 // disabled & partially disabled states
@@ -61,8 +61,10 @@ a.icon-link--badged {
     position: relative;
 
     .badge {
-        border: 2px solid @actionable-badge-border-color;
-        border: 2px solid var(--actionable-badge-border-color, @actionable-badge-border-color);
+        .customBorderColorProperty('actionable-badge-border-color');
+
+        border-style: solid;
+        border-width: 2px;
         display: block;
         height: 24px;
         left: 16px;
@@ -83,8 +85,7 @@ a.img-link {
     &[href] {
         &:hover,
         &:focus {
-            border-color: @actionable-image-border-color-hover;
-            border-color: var(--actionable-image-border-color-hover, @actionable-image-border-color-hover);
+            .customBorderColorProperty('actionable-image-border-color-hover');
         }
 
         &:active {
@@ -94,8 +95,7 @@ a.img-link {
 }
 
 a.img-link--visit:visited {
-    background-color: @actionable-image-background-color-visited;
-    background-color: var(--actionable-image-background-color-visited, @actionable-image-background-color-visited);
+    .customBackgroundColorProperty('actionable-image-background-color-visited');
 }
 
 a.img-link,
@@ -111,13 +111,11 @@ button.img-btn {
     &:not([disabled]) {
         &:hover,
         &:focus {
-            border-color: @actionable-image-border-color-hover;
-            border-color: var(--actionable-image-border-color-hover, @actionable-image-border-color-hover);
+            .customBorderColorProperty('actionable-image-border-color-hover');
         }
 
         &:active {
-            border-color: @actionable-image-border-color-active;
-            border-color: var(--actionable-image-border-color-active, @actionable-image-border-color-active);
+            .customBorderColorProperty('actionable-image-border-color-active');
         }
     }
 }

--- a/src/less/actionable/base/actionable.less
+++ b/src/less/actionable/base/actionable.less
@@ -34,13 +34,15 @@ a.icon-link {
     &:active > svg {
         .customFillProperty('actionable-icon-foreground-color-active');
     }
-}
 
-a.icon-link:visited > svg {
-    .customFillProperty('actionable-icon-foreground-color-visited');
+    &:focus > svg,
+    &:hover > svg {
+        .customFillProperty('actionable-icon-foreground-color-hover');
+    }
 }
 
 // disabled & partially disabled states
+// todo: change opacity to a color
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
 a:not([href]).icon-link,
@@ -49,6 +51,18 @@ a[aria-disabled="true"].icon-link {
 
     > svg {
         background-color: transparent;
+    }
+}
+
+// visited link state
+a.icon-link:visited {
+    & > svg {
+        .customFillProperty('actionable-icon-foreground-color');
+    }
+
+    &:hover > svg,
+    &:focus > svg {
+        .customFillProperty('actionable-icon-foreground-color-hover');
     }
 }
 

--- a/src/less/actionable/base/actionable.less
+++ b/src/less/actionable/base/actionable.less
@@ -24,7 +24,7 @@ a.icon-link {
     width: 40px;
 
     > svg {
-        .customFillProperty('actionable-icon-foreground-color');
+        .customFillProperty(actionable-icon-foreground-color);
 
         height: 100%; // vertical centering
         max-width: 100%; // helps when width & height HTML attrs not set
@@ -32,12 +32,12 @@ a.icon-link {
     }
 
     &:active > svg {
-        .customFillProperty('actionable-icon-foreground-color-active');
+        .customFillProperty(actionable-icon-foreground-color-active);
     }
 
     &:focus > svg,
     &:hover > svg {
-        .customFillProperty('actionable-icon-foreground-color-hover');
+        .customFillProperty(actionable-icon-foreground-color-hover);
     }
 }
 
@@ -57,12 +57,12 @@ a[aria-disabled="true"].icon-link {
 // visited link state
 a.icon-link:visited {
     & > svg {
-        .customFillProperty('actionable-icon-foreground-color');
+        .customFillProperty(actionable-icon-foreground-color);
     }
 
     &:hover > svg,
     &:focus > svg {
-        .customFillProperty('actionable-icon-foreground-color-hover');
+        .customFillProperty(actionable-icon-foreground-color-hover);
     }
 }
 
@@ -75,7 +75,7 @@ a.icon-link--badged {
     position: relative;
 
     .badge {
-        .customBorderColorProperty('actionable-badge-border-color');
+        .customBorderColorProperty(actionable-badge-border-color);
 
         border-style: solid;
         border-width: 2px;
@@ -99,7 +99,7 @@ a.img-link {
     &[href] {
         &:hover,
         &:focus {
-            .customBorderColorProperty('actionable-image-border-color-hover');
+            .customBorderColorProperty(actionable-image-border-color-hover);
         }
 
         &:active {
@@ -109,7 +109,7 @@ a.img-link {
 }
 
 a.img-link--visit:visited {
-    .customBackgroundColorProperty('actionable-image-background-color-visited');
+    .customBackgroundColorProperty(actionable-image-background-color-visited);
 }
 
 a.img-link,
@@ -125,11 +125,11 @@ button.img-btn {
     &:not([disabled]) {
         &:hover,
         &:focus {
-            .customBorderColorProperty('actionable-image-border-color-hover');
+            .customBorderColorProperty(actionable-image-border-color-hover);
         }
 
         &:active {
-            .customBorderColorProperty('actionable-image-border-color-active');
+            .customBorderColorProperty(actionable-image-border-color-active);
         }
     }
 }

--- a/src/less/actionable/ds4/actionable.less
+++ b/src/less/actionable/ds4/actionable.less
@@ -1,20 +1,39 @@
 @import "../../variables/ds4/color-variables.less";
-@import "../../variables/ds4/icon-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 
-@actionable-icon-foreground-color: @color-icon-actionable-default;
-@actionable-icon-foreground-color-active: @color-icon-actionable-default;
-@actionable-icon-foreground-color-visited: @color-text-default;
-@actionable-icon-foreground-color-hover: @color-text-default;
+// CSS Custom properties
+a.icon-link,
+button.icon-btn {
+    --actionable-badge-border-color: @color-background-default;
+    --actionable-icon-foreground-color: @color-icon-actionable-default;
+    --actionable-icon-foreground-color-active: @color-icon-actionable-default;
+    --actionable-icon-foreground-color-hover: @color-text-default;
+    --actionable-icon-foreground-color-visited: @color-text-default;
+    --actionable-image-border-color-hover: @color-core-gray-spanish;
+}
+
+a.img-link,
+button.img-btn {
+    --actionable-image-background-color-visited: @color-grey2;
+    --actionable-image-border-color-active: @color-text-secondary;
+    --actionable-image-border-color-hover: @color-grey5;
+}
+
+// IE11 fallbacks
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
+@actionable-icon-foreground-color: @color-icon-actionable-default;
+@actionable-icon-foreground-color-active: @color-icon-actionable-default;
+@actionable-icon-foreground-color-hover: @color-text-default;
+@actionable-icon-foreground-color-visited: @color-text-default;
+@actionable-image-background-color-visited: @color-core-gray-light;
 @actionable-image-border-color-hover: @color-core-gray-spanish;
 @actionable-image-border-color-active: @color-core-gray-dim;
-@actionable-image-background-color-visited: @color-core-gray-light;
 
 @import "../base/actionable.less";
 
 // todo: normalize ds4 & ds6
+/* stylelint-disable-next-line no-duplicate-selectors */
 button.icon-btn,
 a.icon-link {
     &:focus,

--- a/src/less/actionable/ds4/actionable.less
+++ b/src/less/actionable/ds4/actionable.less
@@ -7,8 +7,7 @@ button.icon-btn {
     --actionable-badge-border-color: @color-background-default;
     --actionable-icon-foreground-color: @color-icon-actionable-default;
     --actionable-icon-foreground-color-active: @color-icon-actionable-default;
-    --actionable-icon-foreground-color-hover: @color-text-default;
-    --actionable-icon-foreground-color-visited: @color-text-default;
+    --actionable-icon-foreground-color-hover: @color-core-gray-dim;
     --actionable-image-border-color-hover: @color-core-gray-spanish;
 }
 
@@ -25,19 +24,8 @@ button.img-btn {
 @actionable-icon-foreground-color: @color-icon-actionable-default;
 @actionable-icon-foreground-color-active: @color-icon-actionable-default;
 @actionable-icon-foreground-color-hover: @color-text-default;
-@actionable-icon-foreground-color-visited: @color-text-default;
 @actionable-image-background-color-visited: @color-core-gray-light;
 @actionable-image-border-color-hover: @color-core-gray-spanish;
 @actionable-image-border-color-active: @color-core-gray-dim;
 
 @import "../base/actionable.less";
-
-// todo: normalize ds4 & ds6
-/* stylelint-disable-next-line no-duplicate-selectors */
-button.icon-btn,
-a.icon-link {
-    &:focus,
-    &:hover {
-        opacity: 0.65;
-    }
-}

--- a/src/less/actionable/ds6/actionable.less
+++ b/src/less/actionable/ds6/actionable.less
@@ -1,53 +1,53 @@
 @import "../../variables/ds6/color-variables.less";
-@import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 
-// CSS Custom properties (DS6 only)
+// CSS Custom properties
 a.icon-link,
 button.icon-btn {
+    --actionable-badge-border-color: @color-background-default;
     --actionable-icon-foreground-color: @color-text-default;
     --actionable-icon-foreground-color-active: @color-text-default;
-    --actionable-icon-foreground-color-visited: @color-text-default;
     --actionable-icon-foreground-color-hover: @color-b4;
-    --actionable-badge-border-color: @color-background-default;
+    --actionable-icon-foreground-color-visited: @color-text-default;
     --actionable-image-border-color-hover: @color-grey5;
 }
 
 a.img-link,
 button.img-btn {
-    --actionable-image-border-color-hover: @color-grey5;
-    --actionable-image-border-color-active: @color-text-secondary;
     --actionable-image-background-color-visited: @color-grey2;
+    --actionable-image-border-color-active: @color-text-secondary;
+    --actionable-image-border-color-hover: @color-grey5;
 }
 
+// Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {
     a.icon-link,
     button.icon-btn {
+        --actionable-badge-border-color: @color-background-default-dark-mode;
         --actionable-icon-foreground-color: @color-text-default-dark-mode;
         --actionable-icon-foreground-color-active: @color-text-default-dark-mode;
-        --actionable-icon-foreground-color-visited: @color-text-default-dark-mode;
         --actionable-icon-foreground-color-hover: @color-b4-dark-mode;
-        --actionable-badge-border-color: @color-background-default-dark-mode;
+        --actionable-icon-foreground-color-visited: @color-text-default-dark-mode;
     }
 
     a.img-link,
     button.img-btn {
+        --actionable-image-background-color-visited: @color-grey2; // tbc
         --actionable-image-border-color-hover: @color-b4-dark-mode;
         --actionable-image-border-color-active: @color-text-secondary; //tbc
-        --actionable-image-background-color-visited: @color-grey2; // tbc
     }
 }
 
 // IE11 fallbacks
-@actionable-icon-foreground-color: @color-text-default;
-@actionable-icon-foreground-color-active: @color-text-default;
-@actionable-icon-foreground-color-visited: @color-text-default;
-@actionable-icon-foreground-color-hover: @color-b4;
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
-@actionable-image-border-color-hover: @color-grey5;
-@actionable-image-border-color-active: @color-text-secondary;
+@actionable-icon-foreground-color: @color-text-default;
+@actionable-icon-foreground-color-active: @color-text-default;
+@actionable-icon-foreground-color-hover: @color-b4;
+@actionable-icon-foreground-color-visited: @color-text-default;
 @actionable-image-background-color-visited: @color-grey2;
+@actionable-image-border-color-active: @color-text-secondary;
+@actionable-image-border-color-hover: @color-grey5;
 
 @import "../base/actionable.less";
 

--- a/src/less/actionable/ds6/actionable.less
+++ b/src/less/actionable/ds6/actionable.less
@@ -8,7 +8,6 @@ button.icon-btn {
     --actionable-icon-foreground-color: @color-text-default;
     --actionable-icon-foreground-color-active: @color-text-default;
     --actionable-icon-foreground-color-hover: @color-b4;
-    --actionable-icon-foreground-color-visited: @color-text-default;
     --actionable-image-border-color-hover: @color-grey5;
 }
 
@@ -27,7 +26,6 @@ button.img-btn {
         --actionable-icon-foreground-color: @color-text-default-dark-mode;
         --actionable-icon-foreground-color-active: @color-text-default-dark-mode;
         --actionable-icon-foreground-color-hover: @color-b4-dark-mode;
-        --actionable-icon-foreground-color-visited: @color-text-default-dark-mode;
     }
 
     a.img-link,
@@ -44,19 +42,8 @@ button.img-btn {
 @actionable-icon-foreground-color: @color-text-default;
 @actionable-icon-foreground-color-active: @color-text-default;
 @actionable-icon-foreground-color-hover: @color-b4;
-@actionable-icon-foreground-color-visited: @color-text-default;
 @actionable-image-background-color-visited: @color-grey2;
 @actionable-image-border-color-active: @color-text-secondary;
 @actionable-image-border-color-hover: @color-grey5;
 
 @import "../base/actionable.less";
-
-/* stylelint-disable-next-line no-duplicate-selectors */
-button.icon-btn,
-a.icon-link {
-    &:focus svg,
-    &:hover svg {
-        fill: @actionable-icon-foreground-color-hover;
-        fill: var(--actionable-icon-foreground-color-hover, @actionable-icon-foreground-color-hover);
-    }
-}

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -1,11 +1,12 @@
+@import "src/less/mixins/utility/utility-mixins.less";
+
 .badge {
+    .customBorderColorProperty('badge-background-color');
+    .customColorProperty('badge-foreground-color');
+
     align-items: center;
-    background-color: @badge-background-color;
-    background-color: var(--badge-background-color, @badge-background-color);
     border-radius: 20px;
     box-sizing: border-box;
-    color: @badge-foreground-color;
-    color: var(--badge-foreground-color, @badge-foreground-color);
     display: inline-flex;
     font-family: @badge-font-family;
     font-size: @font-size-12;

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -1,8 +1,8 @@
 @import "src/less/mixins/utility/utility-mixins.less";
 
 .badge {
-    .customBorderColorProperty('badge-background-color');
-    .customColorProperty('badge-foreground-color');
+    .customBorderColorProperty(badge-background-color);
+    .customColorProperty(badge-foreground-color);
 
     align-items: center;
     border-radius: 20px;

--- a/src/less/badge/ds4/badge.less
+++ b/src/less/badge/ds4/badge.less
@@ -1,7 +1,13 @@
 @import "../../variables/ds4/color-variables.less";
-@import "../../variables/ds4/icon-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 
+// Custom properties
+.switch {
+    --badge-background-color: @color-core-red;
+    --badge-foreground-color: @color-core-white;
+}
+
+// IE11 fallbacks
 @badge-font-family: @font-family-base;
 @badge-background-color: @color-core-red;
 @badge-foreground-color: @color-core-white;

--- a/src/less/badge/ds6/badge.less
+++ b/src/less/badge/ds6/badge.less
@@ -1,13 +1,13 @@
 @import "../../variables/ds6/color-variables.less";
-@import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 
-// custom properties (ds6 only)
+// Custom properties
 .switch {
     --badge-background-color: @color-badge-background;
     --badge-foreground-color: @color-badge-text;
 }
 
+// Dark-mode (ds6 only)
 @media (prefers-color-scheme: dark) {
     .switch {
         --badge-background-color: @color-badge-background;
@@ -15,6 +15,7 @@
     }
 }
 
+// IE11 fallbacks
 @badge-font-family: @font-family-custom;
 @badge-background-color: @color-badge-background;
 @badge-foreground-color: @color-badge-text;

--- a/src/less/breadcrumbs/base/breadcrumbs.less
+++ b/src/less/breadcrumbs/base/breadcrumbs.less
@@ -3,7 +3,7 @@
 // the non-plural classname is deprecated in v10
 nav.breadcrumb,
 nav.breadcrumbs {
-    .customColorProperty('breadcrumbs-item-color');
+    .customColorProperty(breadcrumbs-item-color);
 
     font-size: @font-size-12;
     height: fit-content;
@@ -49,13 +49,13 @@ nav.breadcrumbs {
 
         &:focus,
         &:hover {
-            .customColorProperty('breadcrumbs-item-focus-hover-color');
+            .customColorProperty(breadcrumbs-item-focus-hover-color);
 
             text-decoration: underline;
         }
 
         &[aria-current] {
-            .customColorProperty('breadcrumbs-item-current-color');
+            .customColorProperty(breadcrumbs-item-current-color);
 
             text-decoration: none;
         }

--- a/src/less/breadcrumbs/ds4/breadcrumbs.less
+++ b/src/less/breadcrumbs/ds4/breadcrumbs.less
@@ -1,10 +1,16 @@
 @import "../../variables/ds4/color-variables.less";
-@import "../../variables/ds4/icon-variables.less";
 @import "../../variables/ds4/typography-variables.less";
-@import "../../mixins/icon/ds4/icon-mixins.less";
 
+// CSS Custom Properties
+.breadcrumbs {
+    --breadcrumbs-item-color: @color-text-default;
+    --breadcrumbs-item-current-color: @color-core-gray-dim;
+    --breadcrumbs-item-focus-hover-color: @color-core-blue;
+}
+
+// IE11 fallbacks
 @breadcrumbs-item-color: @color-text-default;
-@breadcrumbs-item-focus-hover-color: @color-core-blue;
 @breadcrumbs-item-current-color: @color-core-gray-dim;
+@breadcrumbs-item-focus-hover-color: @color-core-blue;
 
 @import "../base/breadcrumbs.less";

--- a/src/less/breadcrumbs/ds6/breadcrumbs.less
+++ b/src/less/breadcrumbs/ds6/breadcrumbs.less
@@ -1,15 +1,14 @@
 @import "../../variables/ds6/color-variables.less";
-@import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
-@import "../../mixins/icon/ds6/icon-mixins.less";
 
-// CSS Custom Properties for DS6 only
+// CSS Custom Properties
 .breadcrumbs {
     --breadcrumbs-item-color: @color-text-default;
-    --breadcrumbs-item-current-color: @breadcrumbs-item-current-color;
+    --breadcrumbs-item-current-color: @color-grey5;
     --breadcrumbs-item-focus-hover-color: @color-link-default;
 }
 
+// Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {
     .breadcrumbs {
         --breadcrumbs-item-color: @color-text-default-dark-mode;
@@ -20,7 +19,7 @@
 
 // IE11 fallbacks
 @breadcrumbs-item-color: @color-text-default;
-@breadcrumbs-item-focus-hover-color: @color-link-default;
 @breadcrumbs-item-current-color: @color-grey5;
+@breadcrumbs-item-focus-hover-color: @color-link-default;
 
 @import "../base/breadcrumbs.less";

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -31,3 +31,15 @@
 .customColorProperty(@token) {
     .customProperty(color, @token);
 }
+
+.customBackgroundColorProperty(@token) {
+    .customProperty(background-color, @token);
+}
+
+.customBorderColorProperty(@token) {
+    .customProperty(border-color, @token);
+}
+
+.customFillProperty(@token) {
+    .customProperty(fill, @token);
+}

--- a/src/less/switch/base/switch.less
+++ b/src/less/switch/base/switch.less
@@ -1,3 +1,5 @@
+@import "src/less/mixins/utility/utility-mixins.less";
+
 .switch {
     box-sizing: border-box;
     height: 40px;
@@ -14,10 +16,9 @@ span.switch {
 }
 
 span.switch__button {
+    .customBackgroundColorProperty('switch-background-color-unchecked');
+
     align-self: center;
-    background: gray none repeat scroll 0 0;
-    background-color: @switch-background-color-unchecked; // ie11
-    background-color: var(--switch-background-color-unchecked, @switch-background-color-unchecked);
     border-radius: 400px;
     color: transparent;
     display: inline-block;
@@ -65,8 +66,7 @@ input.switch__control {
 }
 
 input.switch__control[disabled] + span.switch__button {
-    background-color: @switch-background-color-disabled; // ie11
-    background-color: var(--switch-background-color-disabled, @switch-background-color-disabled);
+    .customBackgroundColorProperty('switch-background-color-disabled');
 }
 
 input.switch__control:checked + span.switch__button::after {
@@ -74,8 +74,7 @@ input.switch__control:checked + span.switch__button::after {
 }
 
 span.switch__control[aria-disabled="true"] + span.switch__button {
-    background-color: @switch-background-color-disabled; // ie11
-    background-color: var(--switch-background-color-disabled, @switch-background-color-disabled);
+    .customBackgroundColorProperty('switch-background-color-disabled');
 }
 
 span.switch__control[aria-checked="true"] + span.switch__button::after {
@@ -84,8 +83,7 @@ span.switch__control[aria-checked="true"] + span.switch__button::after {
 
 input.switch__control:not([disabled]):checked + span.switch__button,
 span.switch__control:not([aria-disabled="true"])[aria-checked="true"] + span.switch__button {
-    background-color: @switch-background-color-checked; // ie11
-    background-color: var(--switch-background-color-checked, @switch-background-color-checked);
+    .customBackgroundColorProperty('switch-background-color-checked');
 }
 
 @media screen and (-ms-high-contrast: active) {

--- a/src/less/switch/base/switch.less
+++ b/src/less/switch/base/switch.less
@@ -16,7 +16,7 @@ span.switch {
 }
 
 span.switch__button {
-    .customBackgroundColorProperty('switch-background-color-unchecked');
+    .customBackgroundColorProperty(switch-background-color-unchecked);
 
     align-self: center;
     border-radius: 400px;
@@ -29,9 +29,8 @@ span.switch__button {
     width: 40px;
 
     &::after {
-        background: white none repeat scroll 0 0;
-        background-color: @switch-foreground-color; // ie11
-        background-color: var(--switch-foreground-color, @switch-foreground-color);
+        .customBackgroundColorProperty(switch-foreground-color);
+
         border-radius: 50%;
         content: "";
         display: block;
@@ -66,7 +65,7 @@ input.switch__control {
 }
 
 input.switch__control[disabled] + span.switch__button {
-    .customBackgroundColorProperty('switch-background-color-disabled');
+    .customBackgroundColorProperty(switch-background-color-disabled);
 }
 
 input.switch__control:checked + span.switch__button::after {
@@ -74,7 +73,7 @@ input.switch__control:checked + span.switch__button::after {
 }
 
 span.switch__control[aria-disabled="true"] + span.switch__button {
-    .customBackgroundColorProperty('switch-background-color-disabled');
+    .customBackgroundColorProperty(switch-background-color-disabled);
 }
 
 span.switch__control[aria-checked="true"] + span.switch__button::after {
@@ -83,7 +82,7 @@ span.switch__control[aria-checked="true"] + span.switch__button::after {
 
 input.switch__control:not([disabled]):checked + span.switch__button,
 span.switch__control:not([aria-disabled="true"])[aria-checked="true"] + span.switch__button {
-    .customBackgroundColorProperty('switch-background-color-checked');
+    .customBackgroundColorProperty(switch-background-color-checked);
 }
 
 @media screen and (-ms-high-contrast: active) {

--- a/src/less/switch/ds4/switch.less
+++ b/src/less/switch/ds4/switch.less
@@ -1,11 +1,19 @@
 @import "../../variables/ds4/color-variables.less";
-@import "../../variables/ds4/icon-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 
-@switch-background-color-unchecked: @color-core-gray-dim;
-@switch-foreground-color: @color-core-white;
+// CSS Custom properties
+.switch {
+    --switch-background-color-checked: @color-interface-cta;
+    --switch-background-color-disabled: @color-core-gray-silver;
+    --switch-background-color-unchecked: @color-core-gray-dim;
+    --switch-foreground-color: @color-core-white;
+}
+
+// IE11 fallbacks
 @switch-background-color-disabled: @color-core-gray-silver;
 @switch-background-color-checked: @color-interface-cta;
+@switch-background-color-unchecked: @color-core-gray-dim;
+@switch-foreground-color: @color-core-white;
 @switch-outline-color: @color-control-outline;
 
 @import "../base/switch.less";

--- a/src/less/switch/ds6/switch.less
+++ b/src/less/switch/ds6/switch.less
@@ -1,15 +1,15 @@
 @import "../../variables/ds6/color-variables.less";
-@import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 
-// CSS Custom properties (DS6 only)
+// CSS Custom properties
 .switch {
-    --switch-background-color-unchecked: @color-grey5;
     --switch-background-color-checked: @color-b5;
     --switch-background-color-disabled: @color-grey3;
+    --switch-background-color-unchecked: @color-grey5;
     --switch-foreground-color: @color-white;
 }
 
+// Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {
     .switch {
         --switch-background-color-checked: @color-b4-dark-mode;
@@ -17,9 +17,9 @@
 }
 
 // IE11 fallbacks
-@switch-background-color-unchecked: @color-grey5;
 @switch-background-color-checked: @color-b4;
 @switch-background-color-disabled: @color-grey3;
+@switch-background-color-unchecked: @color-grey5;
 @switch-foreground-color: @color-white;
 @switch-outline-color: @color-control-outline;
 


### PR DESCRIPTION
Issue #1098

I have decided to add support for custom properties to DS4. This allows us to move towards a new much simplified build and delivery system that can leverage the power of CSS Custom Properties.

(I also did a bit of alphabetical reordering of property names, not out of OCD, but because we are trying to do a global cleanup of all "design tokens" across all 3 platforms and so this helps visualise them)

--

I've not yet totally committed to this new system, but to have any possibility of it, we need to define the DS4 custom properties values, as I've done in this PR.

We have already, over time, normalised the DS4 and DS6 markup so that it is identical. With custom properties we could now abolish the ds4 and ds6 dist directories and just build a single dist css file.

Essentially DS4, DS6, and any other design system just becomes a bundle of CSS Custom Properties:

* module.css (ds6 default)
* module-vars.css (optional, e.g. DS4, Northstar)
* module-color-scheme.css (optional, e.g. a seasonal theme or custom color-mode)

For CDN users the default property values would be DS6. A separate HTTP request could be made for a different bundle of variables (e.g. DS4, or a holiday/seasonal theme) to override those defaults.

IE11 users would always get the default LESS variable values as fallback (DS6). Or we could come up with a "special" IE11 design system just for them, which is so horrendous they have to upgrade ;-)