### PR TITLE
Updated toast__title to also include h2

### DIFF
--- a/dist/toast/ds4/toast.css
+++ b/dist/toast/ds4/toast.css
@@ -46,6 +46,7 @@
   display: -webkit-box;
   display: flex;
 }
+.toast__header h2,
 .toast__title {
   margin: 0;
 }

--- a/dist/toast/ds6/toast.css
+++ b/dist/toast/ds6/toast.css
@@ -46,6 +46,7 @@
   display: -webkit-box;
   display: flex;
 }
+.toast__header h2,
 .toast__title {
   margin: 0;
 }

--- a/src/less/toast/base/toast.less
+++ b/src/less/toast/base/toast.less
@@ -54,6 +54,7 @@
     display: flex;
 }
 
+// Can remove h2 selector after API change in ebayui
 .toast__header h2,
 .toast__title {
     margin: 0;

--- a/src/less/toast/base/toast.less
+++ b/src/less/toast/base/toast.less
@@ -54,6 +54,7 @@
     display: flex;
 }
 
+.toast__header h2,
 .toast__title {
     margin: 0;
 }


### PR DESCRIPTION
## Description
In ebayui we need to add `toast__title` class to h2 in order for this to work. However this is not possible with the current API. Added an h2 in order to support this (however this can be removed after api change in ebayui)