### PR TITLE
Button: create custom properties #1098

### DIFF
--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -2,15 +2,15 @@ a.icon-link,
 button.icon-btn {
   --actionable-badge-border-color: #fff;
   --actionable-icon-foreground-color: #555;
-  --actionable-icon-foreground-color-active: #555;
-  --actionable-icon-foreground-color-hover: #767676;
-  --actionable-image-border-color-hover: #999;
+  --actionable-icon-active-foreground-color: #555;
+  --actionable-icon-hover-foreground-color: #333;
+  --actionable-image-hover-border-color: #999;
 }
 a.img-link,
 button.img-btn {
-  --actionable-image-background-color-visited: #ddd;
-  --actionable-image-border-color-active: #767676;
-  --actionable-image-border-color-hover: #767676;
+  --actionable-image-visited-background-color: #ddd;
+  --actionable-image-active-border-color: #767676;
+  --actionable-image-hover-border-color: #767676;
 }
 a.icon-link {
   -webkit-box-align: center;
@@ -44,14 +44,14 @@ a.icon-link > svg {
 button.icon-btn:active > svg,
 a.icon-link:active > svg {
   fill: #555;
-  fill: var(--actionable-icon-foreground-color-active, #555);
+  fill: var(--actionable-icon-active-foreground-color, #555);
 }
 button.icon-btn:focus > svg,
 a.icon-link:focus > svg,
 button.icon-btn:hover > svg,
 a.icon-link:hover > svg {
   fill: #333;
-  fill: var(--actionable-icon-foreground-color-hover, #333);
+  fill: var(--actionable-icon-hover-foreground-color, #333);
 }
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
@@ -72,7 +72,7 @@ a.icon-link:visited > svg {
 a.icon-link:visited:hover > svg,
 a.icon-link:visited:focus > svg {
   fill: #333;
-  fill: var(--actionable-icon-foreground-color-hover, #333);
+  fill: var(--actionable-icon-hover-foreground-color, #333);
 }
 button.icon-btn--badged,
 a.icon-link--badged {
@@ -99,14 +99,14 @@ a.icon-link--badged .badge {
 a.img-link[href]:hover,
 a.img-link[href]:focus {
   border-color: #999;
-  border-color: var(--actionable-image-border-color-hover, #999);
+  border-color: var(--actionable-image-hover-border-color, #999);
 }
 a.img-link[href]:active {
   border-color: #767676;
 }
 a.img-link--visit:visited {
   background-color: #eee;
-  background-color: var(--actionable-image-background-color-visited, #eee);
+  background-color: var(--actionable-image-visited-background-color, #eee);
 }
 a.img-link,
 button.img-btn {
@@ -121,9 +121,9 @@ button.img-btn {
 button.img-btn:not([disabled]):hover,
 button.img-btn:not([disabled]):focus {
   border-color: #999;
-  border-color: var(--actionable-image-border-color-hover, #999);
+  border-color: var(--actionable-image-hover-border-color, #999);
 }
 button.img-btn:not([disabled]):active {
   border-color: #767676;
-  border-color: var(--actionable-image-border-color-active, #767676);
+  border-color: var(--actionable-image-active-border-color, #767676);
 }

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -2,29 +2,29 @@ a.icon-link,
 button.icon-btn {
   --actionable-badge-border-color: #fff;
   --actionable-icon-foreground-color: #111820;
-  --actionable-icon-foreground-color-active: #111820;
-  --actionable-icon-foreground-color-hover: #3665f3;
-  --actionable-image-border-color-hover: #767676;
+  --actionable-icon-active-foreground-color: #111820;
+  --actionable-icon-hover-foreground-color: #3665f3;
+  --actionable-image-hover-border-color: #767676;
 }
 a.img-link,
 button.img-btn {
-  --actionable-image-background-color-visited: #e5e5e5;
-  --actionable-image-border-color-active: #767676;
-  --actionable-image-border-color-hover: #767676;
+  --actionable-image-visited-background-color: #e5e5e5;
+  --actionable-image-active-border-color: #767676;
+  --actionable-image-hover-border-color: #767676;
 }
 @media (prefers-color-scheme: dark) {
   a.icon-link,
   button.icon-btn {
     --actionable-badge-border-color: #171717;
     --actionable-icon-foreground-color: #dcdcdc;
-    --actionable-icon-foreground-color-active: #dcdcdc;
-    --actionable-icon-foreground-color-hover: #5192ff;
+    --actionable-icon-active-foreground-color: #dcdcdc;
+    --actionable-icon-hover-foreground-color: #5192ff;
   }
   a.img-link,
   button.img-btn {
-    --actionable-image-background-color-visited: #e5e5e5;
-    --actionable-image-border-color-hover: #5192ff;
-    --actionable-image-border-color-active: #767676;
+    --actionable-image-visited-background-color: #e5e5e5;
+    --actionable-image-hover-border-color: #5192ff;
+    --actionable-image-active-border-color: #767676;
   }
 }
 a.icon-link {
@@ -59,14 +59,14 @@ a.icon-link > svg {
 button.icon-btn:active > svg,
 a.icon-link:active > svg {
   fill: #111820;
-  fill: var(--actionable-icon-foreground-color-active, #111820);
+  fill: var(--actionable-icon-active-foreground-color, #111820);
 }
 button.icon-btn:focus > svg,
 a.icon-link:focus > svg,
 button.icon-btn:hover > svg,
 a.icon-link:hover > svg {
   fill: #3665f3;
-  fill: var(--actionable-icon-foreground-color-hover, #3665f3);
+  fill: var(--actionable-icon-hover-foreground-color, #3665f3);
 }
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
@@ -87,7 +87,7 @@ a.icon-link:visited > svg {
 a.icon-link:visited:hover > svg,
 a.icon-link:visited:focus > svg {
   fill: #3665f3;
-  fill: var(--actionable-icon-foreground-color-hover, #3665f3);
+  fill: var(--actionable-icon-hover-foreground-color, #3665f3);
 }
 button.icon-btn--badged,
 a.icon-link--badged {
@@ -114,14 +114,14 @@ a.icon-link--badged .badge {
 a.img-link[href]:hover,
 a.img-link[href]:focus {
   border-color: #767676;
-  border-color: var(--actionable-image-border-color-hover, #767676);
+  border-color: var(--actionable-image-hover-border-color, #767676);
 }
 a.img-link[href]:active {
   border-color: #767676;
 }
 a.img-link--visit:visited {
   background-color: #e5e5e5;
-  background-color: var(--actionable-image-background-color-visited, #e5e5e5);
+  background-color: var(--actionable-image-visited-background-color, #e5e5e5);
 }
 a.img-link,
 button.img-btn {
@@ -136,9 +136,9 @@ button.img-btn {
 button.img-btn:not([disabled]):hover,
 button.img-btn:not([disabled]):focus {
   border-color: #767676;
-  border-color: var(--actionable-image-border-color-hover, #767676);
+  border-color: var(--actionable-image-hover-border-color, #767676);
 }
 button.img-btn:not([disabled]):active {
   border-color: #767676;
-  border-color: var(--actionable-image-border-color-active, #767676);
+  border-color: var(--actionable-image-active-border-color, #767676);
 }

--- a/dist/breadcrumbs/ds4/breadcrumbs.css
+++ b/dist/breadcrumbs/ds4/breadcrumbs.css
@@ -1,12 +1,12 @@
 .breadcrumbs {
-  --breadcrumbs-item-color: #333;
-  --breadcrumbs-item-current-color: #767676;
-  --breadcrumbs-item-focus-hover-color: #0654ba;
+  --breadcrumbs-item-foreground-color: #333;
+  --breadcrumbs-item-current-foreground-color: #767676;
+  --breadcrumbs-item-hover-foreground-color: #0654ba;
 }
 nav.breadcrumb,
 nav.breadcrumbs {
   color: #333;
-  color: var(--breadcrumbs-item-color, #333);
+  color: var(--breadcrumbs-item-foreground-color, #333);
   font-size: 0.75rem;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -62,7 +62,7 @@ nav.breadcrumbs a:hover,
 nav.breadcrumb button:hover,
 nav.breadcrumbs button:hover {
   color: #0654ba;
-  color: var(--breadcrumbs-item-focus-hover-color, #0654ba);
+  color: var(--breadcrumbs-item-hover-foreground-color, #0654ba);
   text-decoration: underline;
 }
 nav.breadcrumb a[aria-current],
@@ -70,7 +70,7 @@ nav.breadcrumbs a[aria-current],
 nav.breadcrumb button[aria-current],
 nav.breadcrumbs button[aria-current] {
   color: #767676;
-  color: var(--breadcrumbs-item-current-color, #767676);
+  color: var(--breadcrumbs-item-current-foreground-color, #767676);
   text-decoration: none;
 }
 nav.breadcrumb a:visited,

--- a/dist/breadcrumbs/ds6/breadcrumbs.css
+++ b/dist/breadcrumbs/ds6/breadcrumbs.css
@@ -1,19 +1,19 @@
 .breadcrumbs {
-  --breadcrumbs-item-color: #111820;
-  --breadcrumbs-item-current-color: #767676;
-  --breadcrumbs-item-focus-hover-color: #3665f3;
+  --breadcrumbs-item-foreground-color: #111820;
+  --breadcrumbs-item-current-foreground-color: #767676;
+  --breadcrumbs-item-hover-foreground-color: #3665f3;
 }
 @media (prefers-color-scheme: dark) {
   .breadcrumbs {
-    --breadcrumbs-item-color: #dcdcdc;
-    --breadcrumbs-item-current-color: #767676;
-    --breadcrumbs-item-focus-hover-color: #5192ff;
+    --breadcrumbs-item-foreground-color: #dcdcdc;
+    --breadcrumbs-item-current-foreground-color: #767676;
+    --breadcrumbs-item-hover-foreground-color: #5192ff;
   }
 }
 nav.breadcrumb,
 nav.breadcrumbs {
   color: #111820;
-  color: var(--breadcrumbs-item-color, #111820);
+  color: var(--breadcrumbs-item-foreground-color, #111820);
   font-size: 0.75rem;
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -69,7 +69,7 @@ nav.breadcrumbs a:hover,
 nav.breadcrumb button:hover,
 nav.breadcrumbs button:hover {
   color: #3665f3;
-  color: var(--breadcrumbs-item-focus-hover-color, #3665f3);
+  color: var(--breadcrumbs-item-hover-foreground-color, #3665f3);
   text-decoration: underline;
 }
 nav.breadcrumb a[aria-current],
@@ -77,7 +77,7 @@ nav.breadcrumbs a[aria-current],
 nav.breadcrumb button[aria-current],
 nav.breadcrumbs button[aria-current] {
   color: #767676;
-  color: var(--breadcrumbs-item-current-color, #767676);
+  color: var(--breadcrumbs-item-current-foreground-color, #767676);
   text-decoration: none;
 }
 nav.breadcrumb a:visited,

--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -1,3 +1,22 @@
+button.button,
+a.fake-button {
+  --button-border-radius: 3px;
+  --button-primary-background-color: #0654ba;
+  --button-primary-border-color: #0654ba;
+  --button-primary-foreground-color: #fff;
+  --button-primary-disabled-background-color: #0654ba;
+  --button-primary-disabled-border-color: #0654ba;
+  --button-primary-disabled-foreground-color: #fff;
+  --button-secondary-background-color: rgba(240, 238, 236, 0.5);
+  --button-secondary-border-color: #999;
+  --button-secondary-foreground-color: #555;
+  --button-secondary-disabled-background-color: #0654ba;
+  --button-secondary-disabled-border-color: #999;
+  --button-secondary-disabled-foreground-color: #555;
+  --button-delete-background-color: #fff;
+  --button-delete-border-color: #dd1e31;
+  --button-delete-foreground-color: #dd1e31;
+}
 button.btn,
 a.fake-btn {
   border: 1px solid;
@@ -8,9 +27,10 @@ a.fake-btn {
   text-align: center;
   text-decoration: none;
   vertical-align: bottom;
+  border-radius: 3px;
+  border-radius: var(--button-border-radius, 3px);
   background-color: transparent;
   border-color: inherit;
-  border-radius: 3px;
   color: inherit;
   display: inline-block;
   font-size: 0.875rem;
@@ -96,49 +116,69 @@ a.fake-btn__cell--fixed-height svg.icon {
 button.btn--primary,
 a.fake-btn--primary {
   background-color: #0654ba;
+  background-color: var(--button-primary-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-border-color, #0654ba);
   color: #fff;
+  color: var(--button-primary-foreground-color, #fff);
 }
 a.fake-btn--primary:visited {
   color: #fff;
+  color: var(--button-primary-foreground-color, #fff);
 }
 button.btn--primary[disabled],
 button.btn--primary[aria-disabled="true"] {
   background-color: #0654ba;
+  background-color: var(--button-primary-disabled-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-disabled-border-color, #0654ba);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.btn--primary[disabled] svg.icon,
 button.btn--primary[aria-disabled="true"] svg.icon {
-  color: #fff;
+  fill: #fff;
+  fill: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.btn--primary[disabled]:hover,
 button.btn--primary[aria-disabled="true"]:hover,
 button.btn--primary[disabled]:focus,
 button.btn--primary[aria-disabled="true"]:focus {
   background-color: #0654ba;
+  background-color: var(--button-primary-disabled-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-disabled-border-color, #0654ba);
 }
 a.fake-btn--primary:not([href]),
 a.fake-btn--primary[aria-disabled="true"] {
   background-color: #0654ba;
+  background-color: var(--button-primary-disabled-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-disabled-border-color, #0654ba);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.btn--secondary,
 a.fake-btn--secondary {
   background-color: rgba(240, 238, 236, 0.5);
+  background-color: var(--button-secondary-background-color, rgba(240, 238, 236, 0.5));
   border-color: #999;
+  border-color: var(--button-secondary-border-color, #999);
   color: #555;
+  color: var(--button-secondary-foreground-color, #555);
 }
 a.fake-btn--secondary:visited {
   color: #555;
+  color: var(--button-secondary-foreground-color, #555);
 }
 button.btn--delete,
 a.fake-btn--delete {
   background-color: #fff;
+  background-color: var(--button-delete-background-color, #fff);
   border-color: #dd1e31;
+  border-color: var(--button-delete-border-color, #dd1e31);
   color: #dd1e31;
+  color: var(--button-delete-foreground-color, #dd1e31);
 }
 button.btn--delete:focus,
 a.fake-btn--delete:focus,
@@ -149,21 +189,27 @@ a.fake-btn--delete:active,
 button.btn--delete:visited,
 a.fake-btn--delete:visited {
   border-color: #dd1e31;
+  border-color: var(--button-delete-border-color, #dd1e31);
   color: #dd1e31;
+  color: var(--button-delete-foreground-color, #dd1e31);
 }
 button.btn--secondary[disabled],
 button.btn--secondary[aria-disabled="true"],
 button.btn--delete[disabled],
 button.btn--delete[aria-disabled="true"] {
   background-color: #0654ba;
+  background-color: var(--button-secondary-disabled-background-color, #0654ba);
   border-color: #999;
+  border-color: var(--button-secondary-disabled-border-color, #999);
   color: #555;
+  color: var(--button-secondary-disabled-foreground-color, #555);
 }
 button.btn--secondary[disabled] svg.icon,
 button.btn--secondary[aria-disabled="true"] svg.icon,
 button.btn--delete[disabled] svg.icon,
 button.btn--delete[aria-disabled="true"] svg.icon {
-  color: #555;
+  fill: #555;
+  fill: var(--button-secondary-disabled-foreground-color, #555);
 }
 button.btn--secondary[disabled]:hover,
 button.btn--secondary[aria-disabled="true"]:hover,
@@ -178,14 +224,18 @@ button.btn--secondary[aria-disabled="true"]:active,
 button.btn--delete[disabled]:active,
 button.btn--delete[aria-disabled="true"]:active {
   background-color: #0654ba;
-  border-color: #0654ba;
+  background-color: var(--button-secondary-disabled-background-color, #0654ba);
+  border-color: #999;
+  border-color: var(--button-secondary-disabled-border-color, #999);
 }
 a.fake-btn--secondary:not([href]),
 a.fake-btn--secondary[aria-disabled="true"],
 a.fake-btn--delete:not([href]),
 a.fake-btn--delete[aria-disabled="true"] {
   border-color: #999;
+  border-color: var(--button-secondary-disabled-border-color, #999);
   color: #555;
+  color: var(--button-secondary-disabled-foreground-color, #555);
 }
 button.btn--large,
 a.fake-btn--large {

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -1,3 +1,22 @@
+button.button,
+a.fake-button {
+  --button-border-radius: 0;
+  --button-primary-background-color: #3665f3;
+  --button-primary-border-color: #3665f3;
+  --button-primary-foreground-color: #fff;
+  --button-primary-disabled-background-color: #c7c7c7;
+  --button-primary-disabled-border-color: #c7c7c7;
+  --button-primary-disabled-foreground-color: #fff;
+  --button-secondary-background-color: #fff;
+  --button-secondary-border-color: #3665f3;
+  --button-secondary-foreground-color: #3665f3;
+  --button-secondary-disabled-background-color: #fff;
+  --button-secondary-disabled-border-color: #c7c7c7;
+  --button-secondary-disabled-foreground-color: #c7c7c7;
+  --button-delete-background-color: #fff;
+  --button-delete-border-color: #e62048;
+  --button-delete-foreground-color: #e62048;
+}
 button.btn,
 a.fake-btn {
   border: 1px solid;
@@ -8,9 +27,10 @@ a.fake-btn {
   text-align: center;
   text-decoration: none;
   vertical-align: bottom;
+  border-radius: 0;
+  border-radius: var(--button-border-radius, 0);
   background-color: transparent;
   border-color: inherit;
-  border-radius: 0;
   color: inherit;
   display: inline-block;
   font-size: 0.875rem;
@@ -96,49 +116,69 @@ a.fake-btn__cell--fixed-height svg.icon {
 button.btn--primary,
 a.fake-btn--primary {
   background-color: #3665f3;
+  background-color: var(--button-primary-background-color, #3665f3);
   border-color: #3665f3;
+  border-color: var(--button-primary-border-color, #3665f3);
   color: #fff;
+  color: var(--button-primary-foreground-color, #fff);
 }
 a.fake-btn--primary:visited {
   color: #fff;
+  color: var(--button-primary-foreground-color, #fff);
 }
 button.btn--primary[disabled],
 button.btn--primary[aria-disabled="true"] {
   background-color: #c7c7c7;
+  background-color: var(--button-primary-disabled-background-color, #c7c7c7);
   border-color: #c7c7c7;
+  border-color: var(--button-primary-disabled-border-color, #c7c7c7);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.btn--primary[disabled] svg.icon,
 button.btn--primary[aria-disabled="true"] svg.icon {
-  color: #fff;
+  fill: #fff;
+  fill: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.btn--primary[disabled]:hover,
 button.btn--primary[aria-disabled="true"]:hover,
 button.btn--primary[disabled]:focus,
 button.btn--primary[aria-disabled="true"]:focus {
   background-color: #c7c7c7;
+  background-color: var(--button-primary-disabled-background-color, #c7c7c7);
   border-color: #c7c7c7;
+  border-color: var(--button-primary-disabled-border-color, #c7c7c7);
 }
 a.fake-btn--primary:not([href]),
 a.fake-btn--primary[aria-disabled="true"] {
   background-color: #c7c7c7;
+  background-color: var(--button-primary-disabled-background-color, #c7c7c7);
   border-color: #c7c7c7;
+  border-color: var(--button-primary-disabled-border-color, #c7c7c7);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.btn--secondary,
 a.fake-btn--secondary {
   background-color: #fff;
+  background-color: var(--button-secondary-background-color, #fff);
   border-color: #3665f3;
+  border-color: var(--button-secondary-border-color, #3665f3);
   color: #3665f3;
+  color: var(--button-secondary-foreground-color, #3665f3);
 }
 a.fake-btn--secondary:visited {
   color: #3665f3;
+  color: var(--button-secondary-foreground-color, #3665f3);
 }
 button.btn--delete,
 a.fake-btn--delete {
   background-color: #fff;
+  background-color: var(--button-delete-background-color, #fff);
   border-color: #e62048;
+  border-color: var(--button-delete-border-color, #e62048);
   color: #e62048;
+  color: var(--button-delete-foreground-color, #e62048);
 }
 button.btn--delete:focus,
 a.fake-btn--delete:focus,
@@ -149,21 +189,27 @@ a.fake-btn--delete:active,
 button.btn--delete:visited,
 a.fake-btn--delete:visited {
   border-color: #e62048;
+  border-color: var(--button-delete-border-color, #e62048);
   color: #e62048;
+  color: var(--button-delete-foreground-color, #e62048);
 }
 button.btn--secondary[disabled],
 button.btn--secondary[aria-disabled="true"],
 button.btn--delete[disabled],
 button.btn--delete[aria-disabled="true"] {
   background-color: #fff;
+  background-color: var(--button-secondary-disabled-background-color, #fff);
   border-color: #c7c7c7;
+  border-color: var(--button-secondary-disabled-border-color, #c7c7c7);
   color: #c7c7c7;
+  color: var(--button-secondary-disabled-foreground-color, #c7c7c7);
 }
 button.btn--secondary[disabled] svg.icon,
 button.btn--secondary[aria-disabled="true"] svg.icon,
 button.btn--delete[disabled] svg.icon,
 button.btn--delete[aria-disabled="true"] svg.icon {
-  color: #c7c7c7;
+  fill: #c7c7c7;
+  fill: var(--button-secondary-disabled-foreground-color, #c7c7c7);
 }
 button.btn--secondary[disabled]:hover,
 button.btn--secondary[aria-disabled="true"]:hover,
@@ -178,14 +224,18 @@ button.btn--secondary[aria-disabled="true"]:active,
 button.btn--delete[disabled]:active,
 button.btn--delete[aria-disabled="true"]:active {
   background-color: #fff;
+  background-color: var(--button-secondary-disabled-background-color, #fff);
   border-color: #c7c7c7;
+  border-color: var(--button-secondary-disabled-border-color, #c7c7c7);
 }
 a.fake-btn--secondary:not([href]),
 a.fake-btn--secondary[aria-disabled="true"],
 a.fake-btn--delete:not([href]),
 a.fake-btn--delete[aria-disabled="true"] {
   border-color: #c7c7c7;
+  border-color: var(--button-secondary-disabled-border-color, #c7c7c7);
   color: #c7c7c7;
+  color: var(--button-secondary-disabled-foreground-color, #c7c7c7);
 }
 button.btn--large,
 a.fake-btn--large {

--- a/dist/cta-button/ds4/cta-button.css
+++ b/dist/cta-button/ds4/cta-button.css
@@ -8,9 +8,12 @@ a.cta-btn {
   text-decoration: none;
   vertical-align: bottom;
   background-color: #fff;
-  border-color: currentColor;
+  background-color: var(--cta-button-background-color, #fff);
   border-radius: 3px;
+  border-radius: var(--button-border-radius, 3px);
   color: #0654ba;
+  color: var(--cta-button-foreground-color, #0654ba);
+  border-color: currentColor;
   display: inline-block;
   font-size: 0.875rem;
   max-width: 100%;
@@ -31,20 +34,27 @@ a.cta-btn--truncated span {
 }
 a.cta-btn:visited {
   color: #0654ba;
+  color: var(--cta-button-visited-foreground-color, #0654ba);
 }
 a.cta-btn:focus,
 a.cta-btn:hover {
   background-color: #00489f;
+  background-color: var(--cta-button-hover-background-color, #00489f);
   border-color: #00489f;
+  border-color: var(--cta-button-hover-border-color, #00489f);
   color: #fff;
+  color: var(--cta-button-hover-foreground-color, #fff);
 }
 a.cta-btn:not([href]),
 a.cta-btn[aria-disabled="true"] {
   background-color: #fff;
+  background-color: var(--cta-button-disabled-background-color, #fff);
   border-color: #ccc;
+  border-color: var(--cta-button-disabled-border-color, #ccc);
   color: #ccc;
+  color: var(--cta-button-disabled-foreground-color, #ccc);
 }
-a.cta-btn--fluid {
+a.cta-button--fluid {
   width: 100%;
 }
 span.cta-btn__cell {
@@ -88,20 +98,20 @@ span.cta-btn__cell--fixed-height svg.icon {
   overflow: visible;
   width: 1rem;
 }
-a.cta-btn--large {
+a.cta-button--large {
   min-height: 48px;
 }
-a.cta-btn--large-truncated {
+a.cta-button--large-truncated {
   height: 48px;
 }
-a.cta-btn--large-truncated,
-a.cta-btn--large-truncated span {
+a.cta-button--large-truncated,
+a.cta-button--large-truncated span {
   line-height: 1.4em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-a.cta-btn--large-fixed-height {
+a.cta-button--large-fixed-height {
   height: 48px;
 }
 a.cta-btn svg.icon {

--- a/dist/cta-button/ds6/cta-button.css
+++ b/dist/cta-button/ds6/cta-button.css
@@ -8,9 +8,12 @@ a.cta-btn {
   text-decoration: none;
   vertical-align: bottom;
   background-color: #fff;
-  border-color: currentColor;
+  background-color: var(--cta-button-background-color, #fff);
   border-radius: 0;
+  border-radius: var(--button-border-radius, 0);
   color: #111820;
+  color: var(--cta-button-foreground-color, #111820);
+  border-color: currentColor;
   display: inline-block;
   font-size: 0.875rem;
   max-width: 100%;
@@ -31,20 +34,27 @@ a.cta-btn--truncated span {
 }
 a.cta-btn:visited {
   color: #3665f3;
+  color: var(--cta-button-visited-foreground-color, #3665f3);
 }
 a.cta-btn:focus,
 a.cta-btn:hover {
   background-color: #111820;
+  background-color: var(--cta-button-hover-background-color, #111820);
   border-color: #111820;
+  border-color: var(--cta-button-hover-border-color, #111820);
   color: #fff;
+  color: var(--cta-button-hover-foreground-color, #fff);
 }
 a.cta-btn:not([href]),
 a.cta-btn[aria-disabled="true"] {
   background-color: #fff;
+  background-color: var(--cta-button-disabled-background-color, #fff);
   border-color: #c7c7c7;
+  border-color: var(--cta-button-disabled-border-color, #c7c7c7);
   color: #c7c7c7;
+  color: var(--cta-button-disabled-foreground-color, #c7c7c7);
 }
-a.cta-btn--fluid {
+a.cta-button--fluid {
   width: 100%;
 }
 span.cta-btn__cell {
@@ -88,20 +98,20 @@ span.cta-btn__cell--fixed-height svg.icon {
   overflow: visible;
   width: 1rem;
 }
-a.cta-btn--large {
+a.cta-button--large {
   min-height: 48px;
 }
-a.cta-btn--large-truncated {
+a.cta-button--large-truncated {
   height: 48px;
 }
-a.cta-btn--large-truncated,
-a.cta-btn--large-truncated span {
+a.cta-button--large-truncated,
+a.cta-button--large-truncated span {
   line-height: 1.4em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-a.cta-btn--large-fixed-height {
+a.cta-button--large-fixed-height {
   height: 48px;
 }
 a.cta-btn--b4 {

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -40,6 +40,10 @@
     .customProperty(border-color, @token);
 }
 
+.customBorderRadiusProperty(@token) {
+    .customProperty(border-radius, @token);
+}
+
 .customFillProperty(@token) {
     .customProperty(fill, @token);
 }

--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -21,7 +21,7 @@ span.switch {
 }
 span.switch__button {
   background-color: #767676;
-  background-color: var(--switch-background-color-unchecked, #767676);
+  background-color: var(--switch-unchecked-background-color, #767676);
   align-self: center;
   border-radius: 400px;
   color: transparent;
@@ -68,14 +68,14 @@ input.switch__control:focus + span.switch__button {
 }
 input.switch__control[disabled] + span.switch__button {
   background-color: #ccc;
-  background-color: var(--switch-background-color-disabled, #ccc);
+  background-color: var(--switch-disabled-background-color, #ccc);
 }
 input.switch__control:checked + span.switch__button::after {
   left: 19px;
 }
 span.switch__control[aria-disabled="true"] + span.switch__button {
   background-color: #ccc;
-  background-color: var(--switch-background-color-disabled, #ccc);
+  background-color: var(--switch-disabled-background-color, #ccc);
 }
 span.switch__control[aria-checked="true"] + span.switch__button::after {
   left: 19px;
@@ -83,7 +83,7 @@ span.switch__control[aria-checked="true"] + span.switch__button::after {
 input.switch__control:not([disabled]):checked + span.switch__button,
 span.switch__control:not([aria-disabled="true"])[aria-checked="true"] + span.switch__button {
   background-color: #0654ba;
-  background-color: var(--switch-background-color-checked, #0654ba);
+  background-color: var(--switch-checked-background-color, #0654ba);
 }
 @media screen and (-ms-high-contrast: active) {
   input.switch__control {

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -1,12 +1,12 @@
 .switch {
-  --switch-background-color-checked: #382aef;
+  --switch-background-color-checked: #3665f3;
   --switch-background-color-disabled: #c7c7c7;
   --switch-background-color-unchecked: #767676;
   --switch-foreground-color: #fff;
 }
 @media (prefers-color-scheme: dark) {
   .switch {
-    --switch-background-color-checked: #5192ff;
+    --switch-checked-background-color: #5192ff;
   }
 }
 .switch {
@@ -26,7 +26,7 @@ span.switch {
 }
 span.switch__button {
   background-color: #767676;
-  background-color: var(--switch-background-color-unchecked, #767676);
+  background-color: var(--switch-unchecked-background-color, #767676);
   align-self: center;
   border-radius: 400px;
   color: transparent;
@@ -73,14 +73,14 @@ input.switch__control:focus + span.switch__button {
 }
 input.switch__control[disabled] + span.switch__button {
   background-color: #c7c7c7;
-  background-color: var(--switch-background-color-disabled, #c7c7c7);
+  background-color: var(--switch-disabled-background-color, #c7c7c7);
 }
 input.switch__control:checked + span.switch__button::after {
   left: 19px;
 }
 span.switch__control[aria-disabled="true"] + span.switch__button {
   background-color: #c7c7c7;
-  background-color: var(--switch-background-color-disabled, #c7c7c7);
+  background-color: var(--switch-disabled-background-color, #c7c7c7);
 }
 span.switch__control[aria-checked="true"] + span.switch__button::after {
   left: 19px;
@@ -88,7 +88,7 @@ span.switch__control[aria-checked="true"] + span.switch__button::after {
 input.switch__control:not([disabled]):checked + span.switch__button,
 span.switch__control:not([aria-disabled="true"])[aria-checked="true"] + span.switch__button {
   background-color: #3665f3;
-  background-color: var(--switch-background-color-checked, #3665f3);
+  background-color: var(--switch-checked-background-color, #3665f3);
 }
 @media screen and (-ms-high-contrast: active) {
   input.switch__control {

--- a/dist/variables/ds4/actionable-variables.less
+++ b/dist/variables/ds4/actionable-variables.less
@@ -1,8 +1,8 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
 @actionable-icon-foreground-color: @color-icon-actionable-default;
-@actionable-icon-foreground-color-active: @color-icon-actionable-default;
-@actionable-icon-foreground-color-hover: @color-text-default;
-@actionable-image-background-color-visited: @color-core-gray-light;
-@actionable-image-border-color-hover: @color-core-gray-spanish;
-@actionable-image-border-color-active: @color-core-gray-dim;
+@actionable-icon-active-foreground-color: @color-icon-actionable-default;
+@actionable-icon-hover-foreground-color: @color-text-default;
+@actionable-image-visited-background-color: @color-core-gray-light;
+@actionable-image-hover-border-color: @color-core-gray-spanish;
+@actionable-image-active-border-color: @color-core-gray-dim;

--- a/dist/variables/ds4/breadcrumbs-variables.less
+++ b/dist/variables/ds4/breadcrumbs-variables.less
@@ -1,3 +1,3 @@
-@breadcrumbs-item-color: @color-text-default;
-@breadcrumbs-item-current-color: @color-core-gray-dim;
-@breadcrumbs-item-focus-hover-color: @color-core-blue;
+@breadcrumbs-item-foreground-color: @color-text-default;
+@breadcrumbs-item-current-foreground-color: @color-core-gray-dim;
+@breadcrumbs-item-hover-foreground-color: @color-core-blue;

--- a/dist/variables/ds4/button-variables.less
+++ b/dist/variables/ds4/button-variables.less
@@ -1,59 +1,32 @@
 @import "color-variables.less";
 
-@btn-border-radius: 3px;
-@btn-font-size: @font-size-14;
-@btn-padding: 11px 48px;
-
-@button-regular-background-color: @color-core-white;
-@button-regular-border-color: @color-core-gray-silver;
-@button-regular-color: @color-interface-cta;
-
-@button-regular-active-color: @color-core-gray-davys;
-@button-regular-fake-visited-color: @color-interface-cta;
-
-@button-regular-disabled-background-color: @color-core-gray-silver;
-@button-regular-disabled-border-color: @color-core-gray-dim;
-@button-regular-disabled-color: @color-core-gray-dim;
-@button-regular-disabled-svg-color: @color-core-gray-dim;
-@button-regular-disabled-hover-background-color: @color-core-gray-silver;
-@button-regular-disabled-hover-border-color: @color-core-gray-dim;
-
-@button-regular-partially-disabled-background-color: @color-core-gray-silver;
-@button-regular-partially-disabled-color: @color-core-gray-dim;
-
+@button-border-radius: 3px;
+@button-font-size: @font-size-14;
+@button-padding: 11px 48px;
 @button-primary-background-color: @color-interface-cta;
 @button-primary-border-color: @color-interface-cta;
-@button-primary-color: @color-core-white;
-
-@button-primary-fake-visited-color: @color-core-white;
-
+@button-primary-foreground-color: @color-core-white;
 @button-primary-disabled-background-color: @color-interface-cta;
 @button-primary-disabled-border-color: @color-interface-cta;
-@button-primary-disabled-color: @color-core-white;
-@button-primary-disabled-svg-color: @color-core-white;
-@button-primary-disabled-hover-background-color: @color-interface-cta;
-@button-primary-disabled-hover-border-color: @color-interface-cta;
-
-@button-primary-partially-disabled-background-color: @color-interface-cta;
-@button-primary-partially-disabled-border-color: @color-interface-cta;
-@button-primary-partially-disabled-color: @color-core-white;
-
+@button-primary-disabled-foreground-color: @color-core-white;
 @button-secondary-background-color: fade(@color-interface-view-background, 50%);
 @button-secondary-border-color: @color-text-disabled;
-@button-secondary-color: @color-core-gray-davys;
-
-@button-secondary-fake-visited-color: @color-core-gray-davys;
-
+@button-secondary-foreground-color: @color-core-gray-davys;
 @button-secondary-disabled-background-color: @color-interface-cta;
 @button-secondary-disabled-border-color: @color-text-disabled;
-@button-secondary-disabled-color: @color-core-gray-davys;
-@button-secondary-disabled-svg-color: @color-core-gray-davys;
-@button-secondary-disabled-hover-background-color: @color-interface-cta;
-@button-secondary-disabled-hover-border-color: @color-interface-cta;
-
-@button-secondary-partially-disabled-border-color: @color-text-disabled;
-@button-secondary-partially-disabled-color: @color-core-gray-davys;
-
+@button-secondary-disabled-foreground-color: @color-core-gray-davys;
 @button-delete-background-color: @color-core-white;
 @button-delete-border-color: @color-core-red;
-@button-delete-color: @color-core-red;
+@button-delete-foreground-color: @color-core-red;
+
+// deprecated aliases
+@btn-border-radius: @button-border-radius;
+@btn-font-size: @button-font-size;
+@btn-padding: @button-padding;
+@button-primary-color: @button-primary-foreground-color;
+@button-secondary-fake-visited-color: @color-core-gray-davys;
+@button-regular-fake-visited-color: @color-interface-cta;
+@button-primary-disabled-color: @button-primary-disabled-foreground-color;
+@button-secondary-color: @button-secondary-foreground-color;
+@button-secondary-disabled-color: @button-secondary-disabled-foreground-color;
+@button-delete-color: @button-delete-foreground-color;

--- a/dist/variables/ds4/cta-button-variables.less
+++ b/dist/variables/ds4/cta-button-variables.less
@@ -1,10 +1,16 @@
-@btn-cta-background-color: @color-core-white;
-@btn-cta-color: @color-interface-cta;
-@btn-cta-visited-color: @color-interface-cta;
-@btn-cta-focus-hover-background-color: @color-interface-cta-dark;
-@btn-cta-focus-hover-border-color: @color-interface-cta-dark;
-@btn-cta-focus-hover-color: @color-core-white;
+@cta-button-background-color: @color-core-white;
+@cta-button-foreground-color: @color-interface-cta;
+@cta-button-hover-background-color: @color-interface-cta-dark;
+@cta-button-hover-border-color: @color-interface-cta-dark;
+@cta-button-hover-foreground-color: @color-core-white;
+@cta-button-visited-foreground-color: @color-interface-cta;
 
-@btn-cta-no-href-background-color: @color-core-white;
-@btn-cta-no-href-border-color: @color-core-gray-silver;
-@btn-cta-no-href-color: @color-core-gray-silver;
+@cta-button-disabled-background-color: @color-core-white;
+@cta-button-disabled-border-color: @color-core-gray-silver;
+@cta-button-disabled-foreground-color: @color-core-gray-silver;
+
+// deprecated aliases
+@cta-button-color: @cta-button-foreground-color;
+@cta-button-visited-color: @cta-button-visited-foreground-color;
+@cta-button-hover-color: @cta-button-hover-foreground-color;
+@cta-button-disabled-color: @cta-button-disabled-foreground-color;

--- a/dist/variables/ds4/expand-button-variables.less
+++ b/dist/variables/ds4/expand-button-variables.less
@@ -1,0 +1,16 @@
+@import "color-variables.less";
+
+// "regular" button is a leftover from old ds4
+@button-regular-background-color: @color-core-white;
+@button-regular-border-color: @color-core-gray-silver;
+@button-regular-color: @color-interface-cta;
+@button-regular-active-color: @color-core-gray-davys;
+@button-regular-disabled-background-color: @color-core-gray-silver;
+@button-regular-disabled-border-color: @color-core-gray-dim;
+@button-regular-disabled-color: @color-core-gray-dim;
+@button-regular-disabled-svg-color: @color-core-gray-dim;
+@button-regular-disabled-hover-background-color: @color-core-gray-silver;
+@button-regular-disabled-hover-border-color: @color-core-gray-dim;
+@button-regular-partially-disabled-background-color: @color-core-gray-silver;
+@button-regular-partially-disabled-color: @color-core-gray-dim;
+@expand-button-secondary-disabled-border-color: @color-core-blue;

--- a/dist/variables/ds4/switch-variables.less
+++ b/dist/variables/ds4/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-background-color-checked: @color-interface-cta;
-@switch-background-color-disabled: @color-core-gray-silver;
-@switch-background-color-unchecked: @color-core-gray-dim;
+@switch-checked-background-color: @color-interface-cta;
+@switch-disabled-background-color: @color-core-gray-silver;
+@switch-unchecked-background-color: @color-core-gray-dim;
 @switch-foreground-color: @color-core-white;
 @switch-outline-color: @color-control-outline;

--- a/dist/variables/ds6/actionable-variables.less
+++ b/dist/variables/ds6/actionable-variables.less
@@ -1,8 +1,8 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
 @actionable-icon-foreground-color: @color-text-default;
-@actionable-icon-foreground-color-active: @color-text-default;
-@actionable-icon-foreground-color-hover: @color-b4;
-@actionable-image-background-color-visited: @color-grey2;
-@actionable-image-border-color-active: @color-text-secondary;
-@actionable-image-border-color-hover: @color-grey5;
+@actionable-icon-active-foreground-color: @color-text-default;
+@actionable-icon-hover-foreground-color: @color-b4;
+@actionable-image-visited-background-color: @color-grey2;
+@actionable-image-active-border-color: @color-text-secondary;
+@actionable-image-hover-border-color: @color-grey5;

--- a/dist/variables/ds6/breadcrumbs-variables.less
+++ b/dist/variables/ds6/breadcrumbs-variables.less
@@ -1,3 +1,3 @@
-@breadcrumbs-item-color: @color-text-default;
-@breadcrumbs-item-current-color: @color-grey5;
-@breadcrumbs-item-focus-hover-color: @color-link-default;
+@breadcrumbs-item-foreground-color: @color-text-default;
+@breadcrumbs-item-current-foreground-color: @color-grey5;
+@breadcrumbs-item-hover-foreground-color: @color-link-default;

--- a/dist/variables/ds6/button-variables.less
+++ b/dist/variables/ds6/button-variables.less
@@ -1,59 +1,32 @@
 @import "color-variables.less";
 
-@btn-border-radius: 0;
-@btn-font-size: @font-size-14;
-@btn-padding: 9.5px 16px;
-
-@button-regular-background-color: @color-white;
-@button-regular-border-color: @color-grey3;
-@button-regular-color: @color-black;
-
-@button-regular-active-color: @color-black;
-@button-regular-fake-visited-color: @color-black;
-
-@button-regular-disabled-background-color: @color-disabled;
-@button-regular-disabled-border-color: @color-disabled;
-@button-regular-disabled-color: @color-white;
-@button-regular-disabled-svg-color: @color-white;
-@button-regular-disabled-hover-background-color: @color-disabled;
-@button-regular-disabled-hover-border-color: @color-disabled;
-
-@button-regular-partially-disabled-background-color: @color-disabled;
-@button-regular-partially-disabled-color: @color-disabled;
-
+@button-border-radius: 0;
+@button-font-size: @font-size-14;
+@button-padding: 9.5px 16px;
 @button-primary-background-color: @color-b4;
 @button-primary-border-color: @color-b4;
-@button-primary-color: @color-white;
-
-@button-primary-fake-visited-color: @color-white;
-
+@button-primary-foreground-color: @color-white;
 @button-primary-disabled-background-color: @color-disabled;
 @button-primary-disabled-border-color: @color-disabled;
-@button-primary-disabled-color: @color-white;
-@button-primary-disabled-svg-color: @color-white;
-@button-primary-disabled-hover-background-color: @color-disabled;
-@button-primary-disabled-hover-border-color: @color-disabled;
-
-@button-primary-partially-disabled-background-color: @color-disabled;
-@button-primary-partially-disabled-border-color: @color-disabled;
-@button-primary-partially-disabled-color: @color-white;
-
+@button-primary-disabled-foreground-color: @color-white;
 @button-secondary-background-color: @color-white;
 @button-secondary-border-color: @color-b4;
-@button-secondary-color: @color-b4;
-
-@button-secondary-fake-visited-color: @color-b4;
-
+@button-secondary-foreground-color: @color-b4;
 @button-secondary-disabled-background-color: @color-white;
 @button-secondary-disabled-border-color: @color-disabled;
-@button-secondary-disabled-color: @color-disabled;
-@button-secondary-disabled-svg-color: @color-disabled;
-@button-secondary-disabled-hover-background-color: @color-white;
-@button-secondary-disabled-hover-border-color: @color-disabled;
-
-@button-secondary-partially-disabled-border-color: @color-disabled;
-@button-secondary-partially-disabled-color: @color-disabled;
-
+@button-secondary-disabled-foreground-color: @color-disabled;
 @button-delete-background-color: @color-white;
 @button-delete-border-color: @color-r4;
-@button-delete-color: @color-r4;
+@button-delete-foreground-color: @color-r4;
+
+// deprecated aliases
+@btn-border-radius: @button-border-radius;
+@btn-font-size: @button-font-size;
+@btn-padding: @button-padding;
+@button-primary-color: @button-primary-foreground-color;
+@button-secondary-fake-visited-color: @color-b4;
+@button-regular-fake-visited-color: @color-black;
+@button-primary-disabled-color: @button-primary-disabled-foreground-color;
+@button-secondary-color: @button-secondary-foreground-color;
+@button-secondary-disabled-color: @button-secondary-disabled-foreground-color;
+@button-delete-color: @button-delete-foreground-color;

--- a/dist/variables/ds6/cta-button-variables.less
+++ b/dist/variables/ds6/cta-button-variables.less
@@ -1,10 +1,16 @@
-@btn-cta-background-color: @color-background-default;
-@btn-cta-color: @color-text-default;
-@btn-cta-visited-color: @color-b4;
-@btn-cta-focus-hover-background-color: @color-text-default;
-@btn-cta-focus-hover-border-color: @color-text-default;
-@btn-cta-focus-hover-color: @color-white;
+@cta-button-background-color: @color-background-default;
+@cta-button-foreground-color: @color-text-default;
+@cta-button-hover-background-color: @color-text-default;
+@cta-button-hover-border-color: @color-text-default;
+@cta-button-hover-foreground-color: @color-white;
+@cta-button-visited-foreground-color: @color-b4;
 
-@btn-cta-no-href-background-color: @color-white;
-@btn-cta-no-href-border-color: @color-disabled;
-@btn-cta-no-href-color: @color-disabled;
+@cta-button-disabled-background-color: @color-white;
+@cta-button-disabled-border-color: @color-disabled;
+@cta-button-disabled-foreground-color: @color-disabled;
+
+// deprecated aliases
+@cta-button-color: @cta-button-foreground-color;
+@cta-button-visited-color: @cta-button-visited-foreground-color;
+@cta-button-hover-color: @cta-button-hover-foreground-color;
+@cta-button-disabled-color: @cta-button-disabled-foreground-color;

--- a/dist/variables/ds6/expand-button-variables.less
+++ b/dist/variables/ds6/expand-button-variables.less
@@ -1,0 +1,16 @@
+@import "color-variables.less";
+
+// "regular" button is a leftover from old ds4
+@button-regular-background-color: @color-white;
+@button-regular-border-color: @color-grey3;
+@button-regular-color: @color-black;
+@button-regular-active-color: @color-black;
+@button-regular-disabled-background-color: @color-disabled;
+@button-regular-disabled-border-color: @color-disabled;
+@button-regular-disabled-color: @color-white;
+@button-regular-disabled-svg-color: @color-white;
+@button-regular-disabled-hover-background-color: @color-disabled;
+@button-regular-disabled-hover-border-color: @color-disabled;
+@button-regular-partially-disabled-background-color: @color-disabled;
+@button-regular-partially-disabled-color: @color-disabled;
+@expand-button-secondary-disabled-border-color: @color-grey3;

--- a/dist/variables/ds6/switch-variables.less
+++ b/dist/variables/ds6/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-background-color-checked: @color-b4;
-@switch-background-color-disabled: @color-grey3;
-@switch-background-color-unchecked: @color-grey5;
+@switch-checked-background-color: @color-b4;
+@switch-disabled-background-color: @color-grey3;
+@switch-unchecked-background-color: @color-grey5;
 @switch-foreground-color: @color-white;
 @switch-outline-color: @color-control-outline;

--- a/docs/_includes/common/switch.html
+++ b/docs/_includes/common/switch.html
@@ -85,16 +85,16 @@
     <p>The following custom properties (aka CSS Variables) are available for color scheme &amp; theming purposes:</p>
 
     <ul>
-        <li>--switch-background-color-unchecked (<i>color</i>)</li>
-        <li>--switch-background-color-checked (<i>color</i>)</li>
-        <li>--switch-background-color-disabled (<i>color</i>)</li>
-        <li>--switch-foreground-color (<i>color</i>)</li>
+        <li>--switch-unchecked-background-color</li>
+        <li>--switch-checked-background-color</li>
+        <li>--switch-disabled-background-color</li>
+        <li>--switch-foreground-color</li>
     </ul>
 
     <style>
         .switch--theme1 {
-            --switch-background-color-unchecked: orange;
-            --switch-background-color-checked: green;
+            --switch-unchecked-background-color: orange;
+            --switch-checked-background-color: green;
         }
     </style>
 
@@ -110,8 +110,8 @@
     {% highlight html %}
 <style>
     .switch--theme1 {
-        --switch-background-color-unchecked: orange;
-        --switch-background-color-checked: green;
+        --switch-unchecked-background-color: orange;
+        --switch-checked-background-color: green;
     }
 </style>
 <span class="switch switch--theme1">

--- a/src/less/actionable/base/actionable.less
+++ b/src/less/actionable/base/actionable.less
@@ -32,12 +32,12 @@ a.icon-link {
     }
 
     &:active > svg {
-        .customFillProperty(actionable-icon-foreground-color-active);
+        .customFillProperty(actionable-icon-active-foreground-color);
     }
 
     &:focus > svg,
     &:hover > svg {
-        .customFillProperty(actionable-icon-foreground-color-hover);
+        .customFillProperty(actionable-icon-hover-foreground-color);
     }
 }
 
@@ -62,7 +62,7 @@ a.icon-link:visited {
 
     &:hover > svg,
     &:focus > svg {
-        .customFillProperty(actionable-icon-foreground-color-hover);
+        .customFillProperty(actionable-icon-hover-foreground-color);
     }
 }
 
@@ -99,17 +99,17 @@ a.img-link {
     &[href] {
         &:hover,
         &:focus {
-            .customBorderColorProperty(actionable-image-border-color-hover);
+            .customBorderColorProperty(actionable-image-hover-border-color);
         }
 
         &:active {
-            border-color: @actionable-image-border-color-active;
+            border-color: @actionable-image-active-border-color;
         }
     }
 }
 
 a.img-link--visit:visited {
-    .customBackgroundColorProperty(actionable-image-background-color-visited);
+    .customBackgroundColorProperty(actionable-image-visited-background-color);
 }
 
 a.img-link,
@@ -125,11 +125,11 @@ button.img-btn {
     &:not([disabled]) {
         &:hover,
         &:focus {
-            .customBorderColorProperty(actionable-image-border-color-hover);
+            .customBorderColorProperty(actionable-image-hover-border-color);
         }
 
         &:active {
-            .customBorderColorProperty(actionable-image-border-color-active);
+            .customBorderColorProperty(actionable-image-active-border-color);
         }
     }
 }

--- a/src/less/breadcrumbs/base/breadcrumbs.less
+++ b/src/less/breadcrumbs/base/breadcrumbs.less
@@ -3,7 +3,7 @@
 // the non-plural classname is deprecated in v10
 nav.breadcrumb,
 nav.breadcrumbs {
-    .customColorProperty(breadcrumbs-item-color);
+    .customColorProperty(breadcrumbs-item-foreground-color);
 
     font-size: @font-size-12;
     height: fit-content;
@@ -49,13 +49,13 @@ nav.breadcrumbs {
 
         &:focus,
         &:hover {
-            .customColorProperty(breadcrumbs-item-focus-hover-color);
+            .customColorProperty(breadcrumbs-item-hover-foreground-color);
 
             text-decoration: underline;
         }
 
         &[aria-current] {
-            .customColorProperty(breadcrumbs-item-current-color);
+            .customColorProperty(breadcrumbs-item-current-foreground-color);
 
             text-decoration: none;
         }

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -1,16 +1,18 @@
+@import "../../mixins/utility/utility-mixins.less";
+
 button.btn,
 a.fake-btn {
     .btn-base();
+    .customBorderRadiusProperty(button-border-radius);
 
     background-color: transparent;
     border-color: inherit;
-    border-radius: @btn-border-radius;
     color: inherit;
     display: inline-block;
     font-size: @font-size-14;
     max-width: 100%;
     min-height: 40px;
-    padding: @btn-padding;
+    padding: @button-padding;
 }
 
 a.fake-btn:visited {
@@ -47,62 +49,62 @@ a.fake-btn__cell--fixed-height svg.icon {
 
 button.btn--primary,
 a.fake-btn--primary {
-    background-color: @button-primary-background-color;
-    border-color: @button-primary-border-color;
-    color: @button-primary-color;
+    .customBackgroundColorProperty(button-primary-background-color);
+    .customBorderColorProperty(button-primary-border-color);
+    .customColorProperty(button-primary-foreground-color);
 }
 
 a.fake-btn--primary:visited {
-    color: @button-primary-fake-visited-color;
+    .customColorProperty(button-primary-foreground-color);
 }
 
 button.btn--primary[disabled],
 button.btn--primary[aria-disabled="true"] {
-    background-color: @button-primary-disabled-background-color;
-    border-color: @button-primary-disabled-border-color;
-    color: @button-primary-disabled-color;
+    .customBackgroundColorProperty(button-primary-disabled-background-color);
+    .customBorderColorProperty(button-primary-disabled-border-color);
+    .customColorProperty(button-primary-disabled-foreground-color);
 
     svg.icon {
-        color: @button-primary-disabled-svg-color;
+        .customFillProperty(button-primary-disabled-foreground-color);
     }
 
     &:hover,
     &:focus {
-        background-color: @button-primary-disabled-hover-background-color;
-        border-color: @button-primary-disabled-hover-border-color;
+        .customBackgroundColorProperty(button-primary-disabled-background-color);
+        .customBorderColorProperty(button-primary-disabled-border-color);
     }
 }
 
 a.fake-btn--primary:not([href]),
 a.fake-btn--primary[aria-disabled="true"] {
-    background-color: @button-primary-partially-disabled-background-color;
-    border-color: @button-primary-partially-disabled-border-color;
-    color: @button-primary-partially-disabled-color;
+    .customBackgroundColorProperty(button-primary-disabled-background-color);
+    .customBorderColorProperty(button-primary-disabled-border-color);
+    .customColorProperty(button-primary-disabled-foreground-color);
 }
 
 button.btn--secondary,
 a.fake-btn--secondary {
-    background-color: @button-secondary-background-color;
-    border-color: @button-secondary-border-color;
-    color: @button-secondary-color;
+    .customBackgroundColorProperty(button-secondary-background-color);
+    .customBorderColorProperty(button-secondary-border-color);
+    .customColorProperty(button-secondary-foreground-color);
 }
 
 a.fake-btn--secondary:visited {
-    color: @button-secondary-fake-visited-color;
+    .customColorProperty(button-secondary-foreground-color);
 }
 
 button.btn--delete,
 a.fake-btn--delete {
-    background-color: @button-delete-background-color;
-    border-color: @button-delete-border-color;
-    color: @button-delete-color;
+    .customBackgroundColorProperty(button-delete-background-color);
+    .customBorderColorProperty(button-delete-border-color);
+    .customColorProperty(button-delete-foreground-color);
 
     &:focus,
     &:hover,
     &:active,
     &:visited {
-        border-color: @button-delete-border-color;
-        color: @button-delete-color;
+        .customBorderColorProperty(button-delete-border-color);
+        .customColorProperty(button-delete-foreground-color);
     }
 }
 
@@ -110,19 +112,19 @@ button.btn--secondary[disabled],
 button.btn--secondary[aria-disabled="true"],
 button.btn--delete[disabled],
 button.btn--delete[aria-disabled="true"] {
-    background-color: @button-secondary-disabled-background-color;
-    border-color: @button-secondary-disabled-border-color;
-    color: @button-secondary-disabled-color;
+    .customBackgroundColorProperty(button-secondary-disabled-background-color);
+    .customBorderColorProperty(button-secondary-disabled-border-color);
+    .customColorProperty(button-secondary-disabled-foreground-color);
 
     svg.icon {
-        color: @button-secondary-disabled-svg-color;
+        .customFillProperty(button-secondary-disabled-foreground-color);
     }
 
     &:hover,
     &:focus,
     &:active {
-        background-color: @button-secondary-disabled-hover-background-color;
-        border-color: @button-secondary-disabled-hover-border-color;
+        .customBackgroundColorProperty(button-secondary-disabled-background-color);
+        .customBorderColorProperty(button-secondary-disabled-border-color);
     }
 }
 
@@ -130,8 +132,8 @@ a.fake-btn--secondary:not([href]),
 a.fake-btn--secondary[aria-disabled="true"],
 a.fake-btn--delete:not([href]),
 a.fake-btn--delete[aria-disabled="true"] {
-    border-color: @button-secondary-partially-disabled-border-color;
-    color: @button-secondary-partially-disabled-color;
+    .customBorderColorProperty(button-secondary-disabled-border-color);
+    .customColorProperty(button-secondary-disabled-foreground-color);
 }
 
 button.btn--large,

--- a/src/less/button/ds4/button.less
+++ b/src/less/button/ds4/button.less
@@ -1,9 +1,12 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/button-variables.less";
+@import "../../properties/ds4/button-properties.less";
 @import "../../mixins/button/ds4/button-mixins.less";
 @import "../../mixins/icon/ds4/icon-mixins.less";
 @import "../base/button.less";
+
+// todo: normalise these rules
 
 button.btn,
 a.fake-btn {

--- a/src/less/button/ds6/button.less
+++ b/src/less/button/ds6/button.less
@@ -1,9 +1,12 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/button-variables.less";
+@import "../../properties/ds6/button-properties.less";
 @import "../../mixins/button/ds6/button-mixins.less";
 @import "../../mixins/icon/ds6/icon-mixins.less";
 @import "../base/button.less";
+
+// todo: normalise these rules
 
 button.btn--primary,
 a.fake-btn--primary {
@@ -22,9 +25,9 @@ a.fake-btn--primary[aria-disabled="true"] {
     &:focus,
     &:hover,
     &:active {
-        background-color: @button-primary-partially-disabled-background-color;
-        border-color: @button-primary-partially-disabled-border-color;
-        color: @button-primary-partially-disabled-color;
+        background-color: @button-primary-disabled-background-color;
+        border-color: @button-primary-disabled-border-color;
+        color: @button-primary-disabled-color;
     }
 }
 

--- a/src/less/cta-button/base/cta-button.less
+++ b/src/less/cta-button/base/cta-button.less
@@ -1,35 +1,37 @@
+@import "../../mixins/utility/utility-mixins.less";
+
 a.cta-btn {
     .btn-base();
+    .customBackgroundColorProperty(cta-button-background-color);
+    .customBorderRadiusProperty(button-border-radius);
+    .customColorProperty(cta-button-foreground-color);
 
-    background-color: @btn-cta-background-color;
     border-color: currentColor;
-    border-radius: @btn-border-radius;
-    color: @btn-cta-color;
     display: inline-block;
-    font-size: @btn-font-size;
+    font-size: @button-font-size;
     max-width: 100%;
-    padding: @btn-padding;
+    padding: @button-padding;
 }
 
 a.cta-btn:visited {
-    color: @btn-cta-visited-color;
+    .customColorProperty(cta-button-visited-foreground-color);
 }
 
 a.cta-btn:focus,
 a.cta-btn:hover {
-    background-color: @btn-cta-focus-hover-background-color;
-    border-color: @btn-cta-focus-hover-border-color;
-    color: @btn-cta-focus-hover-color;
+    .customBackgroundColorProperty(cta-button-hover-background-color);
+    .customBorderColorProperty(cta-button-hover-border-color);
+    .customColorProperty(cta-button-hover-foreground-color);
 }
 
 a.cta-btn:not([href]),
 a.cta-btn[aria-disabled="true"] {
-    background-color: @btn-cta-no-href-background-color;
-    border-color: @btn-cta-no-href-border-color;
-    color: @btn-cta-no-href-color;
+    .customBackgroundColorProperty(cta-button-disabled-background-color);
+    .customBorderColorProperty(cta-button-disabled-border-color);
+    .customColorProperty(cta-button-disabled-foreground-color);
 }
 
-a.cta-btn--fluid {
+a.cta-button--fluid {
     width: 100%;
 }
 
@@ -52,16 +54,16 @@ span.cta-btn__cell--fixed-height svg.icon {
     width: 1rem;
 }
 
-a.cta-btn--large {
+a.cta-button--large {
     min-height: 48px;
 }
 
-a.cta-btn--large-truncated {
+a.cta-button--large-truncated {
     .btn-truncate();
 
     height: 48px;
 }
 
-a.cta-btn--large-fixed-height {
+a.cta-button--large-fixed-height {
     height: 48px;
 }

--- a/src/less/expand-button/base/expand-button.less
+++ b/src/less/expand-button/base/expand-button.less
@@ -4,12 +4,12 @@ button.expand-btn {
     background-color: transparent;
     border: 1px solid;
     border-color: inherit;
-    border-radius: @btn-border-radius;
+    border-radius: @button-border-radius;
     color: inherit;
     display: inline-block;
     font-size: 1em;
     max-width: 100%;
-    padding: @btn-padding;
+    padding: @button-padding;
 }
 
 button.expand-btn svg.icon {
@@ -53,8 +53,8 @@ button.expand-btn--primary[aria-disabled="true"] {
 
     &:hover,
     &:focus {
-        background-color: @button-primary-disabled-hover-background-color;
-        border-color: @button-primary-disabled-hover-border-color;
+        background-color: @button-primary-disabled-background-color;
+        border-color: @button-primary-disabled-border-color;
     }
 }
 
@@ -73,8 +73,8 @@ button.expand-btn--secondary[aria-disabled="true"] {
     &:hover,
     &:focus,
     &:active {
-        background-color: @button-secondary-disabled-hover-background-color;
-        border-color: @button-secondary-disabled-hover-border-color;
+        background-color: @button-secondary-disabled-background-color;
+        border-color: @expand-button-secondary-disabled-border-color;
     }
 }
 

--- a/src/less/expand-button/ds4/expand-button.less
+++ b/src/less/expand-button/ds4/expand-button.less
@@ -1,5 +1,6 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
+@import "../../variables/ds4/expand-button-variables.less";
 @import "../../variables/ds4/button-variables.less";
 @import "../../mixins/button/ds4/button-mixins.less";
 @import "../../mixins/icon/ds4/icon-mixins.less";

--- a/src/less/expand-button/ds6/expand-button.less
+++ b/src/less/expand-button/ds6/expand-button.less
@@ -1,5 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
+@import "../../variables/ds6/expand-button-variables.less";
 @import "../../variables/ds6/button-variables.less";
 @import "../../mixins/button/ds6/button-mixins.less";
 @import "../../mixins/icon/ds6/icon-mixins.less";

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -40,6 +40,10 @@
     .customProperty(border-color, @token);
 }
 
+.customBorderRadiusProperty(@token) {
+    .customProperty(border-radius, @token);
+}
+
 .customFillProperty(@token) {
     .customProperty(fill, @token);
 }

--- a/src/less/properties/base/actionable-properties.less
+++ b/src/less/properties/base/actionable-properties.less
@@ -1,0 +1,15 @@
+a.icon-link,
+button.icon-btn {
+    --actionable-badge-border-color: @actionable-badge-border-color;
+    --actionable-icon-foreground-color: @actionable-icon-foreground-color;
+    --actionable-icon-active-foreground-color: @actionable-icon-active-foreground-color;
+    --actionable-icon-hover-foreground-color: @actionable-icon-hover-foreground-color;
+    --actionable-image-hover-border-color: @actionable-image-hover-border-color;
+}
+
+a.img-link,
+button.img-btn {
+    --actionable-image-visited-background-color: @color-grey2;
+    --actionable-image-active-border-color: @color-text-secondary;
+    --actionable-image-hover-border-color: @color-grey5;
+}

--- a/src/less/properties/base/badge-properties.less
+++ b/src/less/properties/base/badge-properties.less
@@ -1,0 +1,4 @@
+.badge {
+    --badge-background-color: @badge-background-color;
+    --badge-foreground-color: @badge-foreground-color;
+}

--- a/src/less/properties/base/breadcrumbs-properties.less
+++ b/src/less/properties/base/breadcrumbs-properties.less
@@ -1,0 +1,5 @@
+.breadcrumbs {
+    --breadcrumbs-item-foreground-color: @breadcrumbs-item-foreground-color;
+    --breadcrumbs-item-current-foreground-color: @breadcrumbs-item-current-foreground-color;
+    --breadcrumbs-item-hover-foreground-color: @breadcrumbs-item-hover-foreground-color;
+}

--- a/src/less/properties/base/button-properties.less
+++ b/src/less/properties/base/button-properties.less
@@ -1,0 +1,19 @@
+button.button,
+a.fake-button {
+    --button-border-radius: @button-border-radius;
+    --button-primary-background-color: @button-primary-background-color;
+    --button-primary-border-color: @button-primary-border-color;
+    --button-primary-foreground-color: @button-primary-foreground-color;
+    --button-primary-disabled-background-color: @button-primary-disabled-background-color;
+    --button-primary-disabled-border-color: @button-primary-disabled-border-color;
+    --button-primary-disabled-foreground-color: @button-primary-disabled-foreground-color;
+    --button-secondary-background-color: @button-secondary-background-color;
+    --button-secondary-border-color: @button-secondary-border-color;
+    --button-secondary-foreground-color: @button-secondary-foreground-color;
+    --button-secondary-disabled-background-color: @button-secondary-disabled-background-color;
+    --button-secondary-disabled-border-color: @button-secondary-disabled-border-color;
+    --button-secondary-disabled-foreground-color: @button-secondary-disabled-foreground-color;
+    --button-delete-background-color: @button-delete-background-color;
+    --button-delete-border-color: @button-delete-border-color;
+    --button-delete-foreground-color: @button-delete-foreground-color;
+}

--- a/src/less/properties/base/checkbox-properties.less
+++ b/src/less/properties/base/checkbox-properties.less
@@ -1,0 +1,4 @@
+.checkbox {
+    --checkbox-checked-color: @checkbox-checked-color;
+    --checkbox-unchecked-color: @checkbox-unchecked-color;
+}

--- a/src/less/properties/base/cta-button-properties.less
+++ b/src/less/properties/base/cta-button-properties.less
@@ -1,0 +1,11 @@
+a.cta-btn {
+    --cta-button-background-color: @cta-button-background-color;
+    --cta-button-foreground-color: @cta-button-foreground-color;
+    --cta-button-disabled-background-color: @cta-button-disabled-background-color;
+    --cta-button-disabled-border-color: @cta-button-disabled-background-color;
+    --cta-button-disabled-foreground-color: @cta-button-disabled-background-color;
+    --cta-button-hover-background-color: @cta-button-hover-background-color;
+    --cta-button-hover-border-color: @cta-button-hover-border-color;
+    --cta-button-hover-foreground-color: @cta-button-hover-foreground-color;
+    --cta-button-visited-foreground-color: @cta-button-visited-foreground-color;
+}

--- a/src/less/properties/base/radio-properties.less
+++ b/src/less/properties/base/radio-properties.less
@@ -1,0 +1,4 @@
+.radio {
+    --radio-checked-color: @radio-checked-color;
+    --radio-unchecked-color: @radio-unchecked-color;
+}

--- a/src/less/properties/base/switch-properties.less
+++ b/src/less/properties/base/switch-properties.less
@@ -1,0 +1,6 @@
+.switch {
+    --switch-background-color-checked: @switch-checked-background-color;
+    --switch-background-color-disabled: @switch-disabled-background-color;
+    --switch-background-color-unchecked: @switch-unchecked-background-color;
+    --switch-foreground-color: @switch-foreground-color;
+}

--- a/src/less/properties/ds4/actionable-properties.less
+++ b/src/less/properties/ds4/actionable-properties.less
@@ -1,19 +1,4 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/actionable-variables.less";
-
-a.icon-link,
-button.icon-btn {
-    --actionable-badge-border-color: @color-background-default;
-    --actionable-icon-foreground-color: @color-icon-actionable-default;
-    --actionable-icon-foreground-color-active: @color-icon-actionable-default;
-    --actionable-icon-foreground-color-hover: @color-core-gray-dim;
-    --actionable-image-border-color-hover: @color-core-gray-spanish;
-}
-
-a.img-link,
-button.img-btn {
-    --actionable-image-background-color-visited: @color-grey2;
-    --actionable-image-border-color-active: @color-text-secondary;
-    --actionable-image-border-color-hover: @color-grey5;
-}
+@import "../base/actionable-properties.less";

--- a/src/less/properties/ds4/badge-properties.less
+++ b/src/less/properties/ds4/badge-properties.less
@@ -1,8 +1,4 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/badge-variables.less";
-
-.badge {
-    --badge-background-color: @color-core-red;
-    --badge-foreground-color: @color-core-white;
-}
+@import "../base/badge-properties.less";

--- a/src/less/properties/ds4/breadcrumbs-properties.less
+++ b/src/less/properties/ds4/breadcrumbs-properties.less
@@ -1,9 +1,4 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/breadcrumbs-variables.less";
-
-.breadcrumbs {
-    --breadcrumbs-item-color: @color-text-default;
-    --breadcrumbs-item-current-color: @color-core-gray-dim;
-    --breadcrumbs-item-focus-hover-color: @color-core-blue;
-}
+@import "../base/breadcrumbs-properties.less";

--- a/src/less/properties/ds4/button-properties.less
+++ b/src/less/properties/ds4/button-properties.less
@@ -1,0 +1,23 @@
+@import "../../variables/ds4/color-variables.less";
+@import "../../variables/ds4/typography-variables.less";
+@import "../../variables/ds4/button-variables.less";
+
+button.button,
+a.fake-button {
+    --button-border-radius: @button-border-radius;
+    --button-primary-background-color: @button-primary-background-color;
+    --button-primary-border-color: @button-primary-border-color;
+    --button-primary-foreground-color: @button-primary-foreground-color;
+    --button-primary-disabled-background-color: @button-primary-disabled-background-color;
+    --button-primary-disabled-border-color: @button-primary-disabled-border-color;
+    --button-primary-disabled-foreground-color: @button-primary-disabled-foreground-color;
+    --button-secondary-background-color: @button-secondary-background-color;
+    --button-secondary-border-color: @button-secondary-border-color;
+    --button-secondary-foreground-color: @button-secondary-foreground-color;
+    --button-secondary-disabled-background-color: @button-secondary-disabled-background-color;
+    --button-secondary-disabled-border-color: @button-secondary-disabled-border-color;
+    --button-secondary-disabled-foreground-color: @button-secondary-disabled-foreground-color;
+    --button-delete-background-color: @button-delete-background-color;
+    --button-delete-border-color: @button-delete-border-color;
+    --button-delete-foreground-color: @button-delete-foreground-color;
+}

--- a/src/less/properties/ds4/checkbox-properties.less
+++ b/src/less/properties/ds4/checkbox-properties.less
@@ -1,8 +1,4 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/checkbox-variables.less";
-
-.checkbox {
-    --checkbox-checked-color: @checkbox-checked-color;
-    --checkbox-unchecked-color: @checkbox-unchecked-color;
-}
+@import "../base/checkbox-properties.less";

--- a/src/less/properties/ds4/cta-button-properties.less
+++ b/src/less/properties/ds4/cta-button-properties.less
@@ -1,4 +1,4 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
-@import "../../variables/ds4/button-variables.less";
-@import "../base/button-properties.less";
+@import "../../variables/ds4/cta-button-variables.less";
+@import "../base/cta-button-properties.less";

--- a/src/less/properties/ds4/radio-properties.less
+++ b/src/less/properties/ds4/radio-properties.less
@@ -1,8 +1,4 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/radio-variables.less";
-
-.radio {
-    --radio-checked-color: @radio-checked-color;
-    --radio-unchecked-color: @radio-unchecked-color;
-}
+@import "../base/radio-properties.less";

--- a/src/less/properties/ds4/switch-properties.less
+++ b/src/less/properties/ds4/switch-properties.less
@@ -1,10 +1,4 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/switch-variables.less";
-
-.switch {
-    --switch-background-color-checked: @color-interface-cta;
-    --switch-background-color-disabled: @color-core-gray-silver;
-    --switch-background-color-unchecked: @color-core-gray-dim;
-    --switch-foreground-color: @color-core-white;
-}
+@import "../base/switch-properties.less";

--- a/src/less/properties/ds6/actionable-properties.less
+++ b/src/less/properties/ds6/actionable-properties.less
@@ -1,22 +1,7 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/actionable-variables.less";
-
-a.icon-link,
-button.icon-btn {
-    --actionable-badge-border-color: @color-background-default;
-    --actionable-icon-foreground-color: @color-text-default;
-    --actionable-icon-foreground-color-active: @color-text-default;
-    --actionable-icon-foreground-color-hover: @color-b4;
-    --actionable-image-border-color-hover: @color-grey5;
-}
-
-a.img-link,
-button.img-btn {
-    --actionable-image-background-color-visited: @color-grey2;
-    --actionable-image-border-color-active: @color-text-secondary;
-    --actionable-image-border-color-hover: @color-grey5;
-}
+@import "../base/actionable-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {
@@ -24,14 +9,14 @@ button.img-btn {
     button.icon-btn {
         --actionable-badge-border-color: @color-background-default-dark-mode;
         --actionable-icon-foreground-color: @color-text-default-dark-mode;
-        --actionable-icon-foreground-color-active: @color-text-default-dark-mode;
-        --actionable-icon-foreground-color-hover: @color-b4-dark-mode;
+        --actionable-icon-active-foreground-color: @color-text-default-dark-mode;
+        --actionable-icon-hover-foreground-color: @color-b4-dark-mode;
     }
 
     a.img-link,
     button.img-btn {
-        --actionable-image-background-color-visited: @color-grey2; // tbc
-        --actionable-image-border-color-hover: @color-b4-dark-mode;
-        --actionable-image-border-color-active: @color-text-secondary; //tbc
+        --actionable-image-visited-background-color: @color-grey2; // tbc
+        --actionable-image-hover-border-color: @color-b4-dark-mode;
+        --actionable-image-active-border-color: @color-text-secondary; //tbc
     }
 }

--- a/src/less/properties/ds6/badge-properties.less
+++ b/src/less/properties/ds6/badge-properties.less
@@ -1,11 +1,7 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/badge-variables.less";
-
-.badge {
-    --badge-background-color: @color-badge-background;
-    --badge-foreground-color: @color-badge-text;
-}
+@import "../base/badge-properties.less";
 
 // Dark-mode (ds6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/breadcrumbs-properties.less
+++ b/src/less/properties/ds6/breadcrumbs-properties.less
@@ -1,18 +1,13 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/breadcrumbs-variables.less";
-
-.breadcrumbs {
-    --breadcrumbs-item-color: @color-text-default;
-    --breadcrumbs-item-current-color: @color-grey5;
-    --breadcrumbs-item-focus-hover-color: @color-link-default;
-}
+@import "../base/breadcrumbs-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {
     .breadcrumbs {
-        --breadcrumbs-item-color: @color-text-default-dark-mode;
-        --breadcrumbs-item-current-color: @breadcrumbs-item-current-color; // dark-mode color TBD
-        --breadcrumbs-item-focus-hover-color: @color-link-default-dark-mode;
+        --breadcrumbs-item-foreground-color: @color-text-default-dark-mode;
+        --breadcrumbs-item-current-foreground-color: @breadcrumbs-item-current-foreground-color; // dark-mode color TBD
+        --breadcrumbs-item-hover-foreground-color: @color-link-default-dark-mode;
     }
 }

--- a/src/less/properties/ds6/button-properties.less
+++ b/src/less/properties/ds6/button-properties.less
@@ -1,0 +1,23 @@
+@import "../../variables/ds6/color-variables.less";
+@import "../../variables/ds6/typography-variables.less";
+@import "../../variables/ds6/button-variables.less";
+
+button.button,
+a.fake-button {
+    --button-border-radius: @button-border-radius;
+    --button-primary-background-color: @button-primary-background-color;
+    --button-primary-border-color: @button-primary-border-color;
+    --button-primary-foreground-color: @button-primary-foreground-color;
+    --button-primary-disabled-background-color: @button-primary-disabled-background-color;
+    --button-primary-disabled-border-color: @button-primary-disabled-border-color;
+    --button-primary-disabled-foreground-color: @button-primary-disabled-foreground-color;
+    --button-secondary-background-color: @button-secondary-background-color;
+    --button-secondary-border-color: @button-secondary-border-color;
+    --button-secondary-foreground-color: @button-secondary-foreground-color;
+    --button-secondary-disabled-background-color: @button-secondary-disabled-background-color;
+    --button-secondary-disabled-border-color: @button-secondary-disabled-border-color;
+    --button-secondary-disabled-foreground-color: @button-secondary-disabled-foreground-color;
+    --button-delete-background-color: @button-delete-background-color;
+    --button-delete-border-color: @button-delete-border-color;
+    --button-delete-foreground-color: @button-delete-foreground-color;
+}

--- a/src/less/properties/ds6/checkbox-properties.less
+++ b/src/less/properties/ds6/checkbox-properties.less
@@ -1,11 +1,7 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/checkbox-variables.less";
-
-.checkbox {
-    --checkbox-checked-color: @checkbox-checked-color;
-    --checkbox-unchecked-color: @checkbox-unchecked-color;
-}
+@import "../base/checkbox-properties.less";
 
 // Dark-mode (ds6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/cta-button-properties.less
+++ b/src/less/properties/ds6/cta-button-properties.less
@@ -1,4 +1,4 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
-@import "../../variables/ds6/button-variables.less";
-@import "../base/button-properties.less";
+@import "../../variables/ds6/cta-button-variables.less";
+@import "../base/cta-button-properties.less";

--- a/src/less/properties/ds6/radio-properties.less
+++ b/src/less/properties/ds6/radio-properties.less
@@ -1,15 +1,11 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/radio-variables.less";
-
-.radio {
-    --radio-checked-color: @radio-checked-color;
-    --radio-unchecked-color: @radio-unchecked-color;
-}
+@import "../base/radio-properties.less";
 
 @media (prefers-color-scheme: dark) {
     .radio {
         --radio-checked-color: @radio-checked-color-dark-mode;
-        --radio-unchecked-color: @radio-unchecked-color-dark-mode;// TBD
+        --radio-unchecked-color: @radio-unchecked-color-dark-mode; // TBD
     }
 }

--- a/src/less/properties/ds6/switch-properties.less
+++ b/src/less/properties/ds6/switch-properties.less
@@ -1,17 +1,11 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/switch-variables.less";
-
-.switch {
-    --switch-background-color-checked: @color-b5;
-    --switch-background-color-disabled: @color-grey3;
-    --switch-background-color-unchecked: @color-grey5;
-    --switch-foreground-color: @color-white;
-}
+@import "../base/switch-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {
     .switch {
-        --switch-background-color-checked: @color-b4-dark-mode;
+        --switch-checked-background-color: @color-b4-dark-mode;
     }
 }

--- a/src/less/switch/base/switch.less
+++ b/src/less/switch/base/switch.less
@@ -16,7 +16,7 @@ span.switch {
 }
 
 span.switch__button {
-    .customBackgroundColorProperty(switch-background-color-unchecked);
+    .customBackgroundColorProperty(switch-unchecked-background-color);
 
     align-self: center;
     border-radius: 400px;
@@ -65,7 +65,7 @@ input.switch__control {
 }
 
 input.switch__control[disabled] + span.switch__button {
-    .customBackgroundColorProperty(switch-background-color-disabled);
+    .customBackgroundColorProperty(switch-disabled-background-color);
 }
 
 input.switch__control:checked + span.switch__button::after {
@@ -73,7 +73,7 @@ input.switch__control:checked + span.switch__button::after {
 }
 
 span.switch__control[aria-disabled="true"] + span.switch__button {
-    .customBackgroundColorProperty(switch-background-color-disabled);
+    .customBackgroundColorProperty(switch-disabled-background-color);
 }
 
 span.switch__control[aria-checked="true"] + span.switch__button::after {
@@ -82,7 +82,7 @@ span.switch__control[aria-checked="true"] + span.switch__button::after {
 
 input.switch__control:not([disabled]):checked + span.switch__button,
 span.switch__control:not([aria-disabled="true"])[aria-checked="true"] + span.switch__button {
-    .customBackgroundColorProperty(switch-background-color-checked);
+    .customBackgroundColorProperty(switch-checked-background-color);
 }
 
 @media screen and (-ms-high-contrast: active) {

--- a/src/less/variables/ds4/actionable-variables.less
+++ b/src/less/variables/ds4/actionable-variables.less
@@ -1,8 +1,8 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
 @actionable-icon-foreground-color: @color-icon-actionable-default;
-@actionable-icon-foreground-color-active: @color-icon-actionable-default;
-@actionable-icon-foreground-color-hover: @color-text-default;
-@actionable-image-background-color-visited: @color-core-gray-light;
-@actionable-image-border-color-hover: @color-core-gray-spanish;
-@actionable-image-border-color-active: @color-core-gray-dim;
+@actionable-icon-active-foreground-color: @color-icon-actionable-default;
+@actionable-icon-hover-foreground-color: @color-text-default;
+@actionable-image-visited-background-color: @color-core-gray-light;
+@actionable-image-hover-border-color: @color-core-gray-spanish;
+@actionable-image-active-border-color: @color-core-gray-dim;

--- a/src/less/variables/ds4/breadcrumbs-variables.less
+++ b/src/less/variables/ds4/breadcrumbs-variables.less
@@ -1,3 +1,3 @@
-@breadcrumbs-item-color: @color-text-default;
-@breadcrumbs-item-current-color: @color-core-gray-dim;
-@breadcrumbs-item-focus-hover-color: @color-core-blue;
+@breadcrumbs-item-foreground-color: @color-text-default;
+@breadcrumbs-item-current-foreground-color: @color-core-gray-dim;
+@breadcrumbs-item-hover-foreground-color: @color-core-blue;

--- a/src/less/variables/ds4/button-variables.less
+++ b/src/less/variables/ds4/button-variables.less
@@ -1,59 +1,32 @@
 @import "color-variables.less";
 
-@btn-border-radius: 3px;
-@btn-font-size: @font-size-14;
-@btn-padding: 11px 48px;
-
-@button-regular-background-color: @color-core-white;
-@button-regular-border-color: @color-core-gray-silver;
-@button-regular-color: @color-interface-cta;
-
-@button-regular-active-color: @color-core-gray-davys;
-@button-regular-fake-visited-color: @color-interface-cta;
-
-@button-regular-disabled-background-color: @color-core-gray-silver;
-@button-regular-disabled-border-color: @color-core-gray-dim;
-@button-regular-disabled-color: @color-core-gray-dim;
-@button-regular-disabled-svg-color: @color-core-gray-dim;
-@button-regular-disabled-hover-background-color: @color-core-gray-silver;
-@button-regular-disabled-hover-border-color: @color-core-gray-dim;
-
-@button-regular-partially-disabled-background-color: @color-core-gray-silver;
-@button-regular-partially-disabled-color: @color-core-gray-dim;
-
+@button-border-radius: 3px;
+@button-font-size: @font-size-14;
+@button-padding: 11px 48px;
 @button-primary-background-color: @color-interface-cta;
 @button-primary-border-color: @color-interface-cta;
-@button-primary-color: @color-core-white;
-
-@button-primary-fake-visited-color: @color-core-white;
-
+@button-primary-foreground-color: @color-core-white;
 @button-primary-disabled-background-color: @color-interface-cta;
 @button-primary-disabled-border-color: @color-interface-cta;
-@button-primary-disabled-color: @color-core-white;
-@button-primary-disabled-svg-color: @color-core-white;
-@button-primary-disabled-hover-background-color: @color-interface-cta;
-@button-primary-disabled-hover-border-color: @color-interface-cta;
-
-@button-primary-partially-disabled-background-color: @color-interface-cta;
-@button-primary-partially-disabled-border-color: @color-interface-cta;
-@button-primary-partially-disabled-color: @color-core-white;
-
+@button-primary-disabled-foreground-color: @color-core-white;
 @button-secondary-background-color: fade(@color-interface-view-background, 50%);
 @button-secondary-border-color: @color-text-disabled;
-@button-secondary-color: @color-core-gray-davys;
-
-@button-secondary-fake-visited-color: @color-core-gray-davys;
-
+@button-secondary-foreground-color: @color-core-gray-davys;
 @button-secondary-disabled-background-color: @color-interface-cta;
 @button-secondary-disabled-border-color: @color-text-disabled;
-@button-secondary-disabled-color: @color-core-gray-davys;
-@button-secondary-disabled-svg-color: @color-core-gray-davys;
-@button-secondary-disabled-hover-background-color: @color-interface-cta;
-@button-secondary-disabled-hover-border-color: @color-interface-cta;
-
-@button-secondary-partially-disabled-border-color: @color-text-disabled;
-@button-secondary-partially-disabled-color: @color-core-gray-davys;
-
+@button-secondary-disabled-foreground-color: @color-core-gray-davys;
 @button-delete-background-color: @color-core-white;
 @button-delete-border-color: @color-core-red;
-@button-delete-color: @color-core-red;
+@button-delete-foreground-color: @color-core-red;
+
+// deprecated aliases
+@btn-border-radius: @button-border-radius;
+@btn-font-size: @button-font-size;
+@btn-padding: @button-padding;
+@button-primary-color: @button-primary-foreground-color;
+@button-secondary-fake-visited-color: @color-core-gray-davys;
+@button-regular-fake-visited-color: @color-interface-cta;
+@button-primary-disabled-color: @button-primary-disabled-foreground-color;
+@button-secondary-color: @button-secondary-foreground-color;
+@button-secondary-disabled-color: @button-secondary-disabled-foreground-color;
+@button-delete-color: @button-delete-foreground-color;

--- a/src/less/variables/ds4/cta-button-variables.less
+++ b/src/less/variables/ds4/cta-button-variables.less
@@ -1,10 +1,16 @@
-@btn-cta-background-color: @color-core-white;
-@btn-cta-color: @color-interface-cta;
-@btn-cta-visited-color: @color-interface-cta;
-@btn-cta-focus-hover-background-color: @color-interface-cta-dark;
-@btn-cta-focus-hover-border-color: @color-interface-cta-dark;
-@btn-cta-focus-hover-color: @color-core-white;
+@cta-button-background-color: @color-core-white;
+@cta-button-foreground-color: @color-interface-cta;
+@cta-button-hover-background-color: @color-interface-cta-dark;
+@cta-button-hover-border-color: @color-interface-cta-dark;
+@cta-button-hover-foreground-color: @color-core-white;
+@cta-button-visited-foreground-color: @color-interface-cta;
 
-@btn-cta-no-href-background-color: @color-core-white;
-@btn-cta-no-href-border-color: @color-core-gray-silver;
-@btn-cta-no-href-color: @color-core-gray-silver;
+@cta-button-disabled-background-color: @color-core-white;
+@cta-button-disabled-border-color: @color-core-gray-silver;
+@cta-button-disabled-foreground-color: @color-core-gray-silver;
+
+// deprecated aliases
+@cta-button-color: @cta-button-foreground-color;
+@cta-button-visited-color: @cta-button-visited-foreground-color;
+@cta-button-hover-color: @cta-button-hover-foreground-color;
+@cta-button-disabled-color: @cta-button-disabled-foreground-color;

--- a/src/less/variables/ds4/expand-button-variables.less
+++ b/src/less/variables/ds4/expand-button-variables.less
@@ -1,0 +1,16 @@
+@import "color-variables.less";
+
+// "regular" button is a leftover from old ds4
+@button-regular-background-color: @color-core-white;
+@button-regular-border-color: @color-core-gray-silver;
+@button-regular-color: @color-interface-cta;
+@button-regular-active-color: @color-core-gray-davys;
+@button-regular-disabled-background-color: @color-core-gray-silver;
+@button-regular-disabled-border-color: @color-core-gray-dim;
+@button-regular-disabled-color: @color-core-gray-dim;
+@button-regular-disabled-svg-color: @color-core-gray-dim;
+@button-regular-disabled-hover-background-color: @color-core-gray-silver;
+@button-regular-disabled-hover-border-color: @color-core-gray-dim;
+@button-regular-partially-disabled-background-color: @color-core-gray-silver;
+@button-regular-partially-disabled-color: @color-core-gray-dim;
+@expand-button-secondary-disabled-border-color: @color-core-blue;

--- a/src/less/variables/ds4/switch-variables.less
+++ b/src/less/variables/ds4/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-background-color-checked: @color-interface-cta;
-@switch-background-color-disabled: @color-core-gray-silver;
-@switch-background-color-unchecked: @color-core-gray-dim;
+@switch-checked-background-color: @color-interface-cta;
+@switch-disabled-background-color: @color-core-gray-silver;
+@switch-unchecked-background-color: @color-core-gray-dim;
 @switch-foreground-color: @color-core-white;
 @switch-outline-color: @color-control-outline;

--- a/src/less/variables/ds6/actionable-variables.less
+++ b/src/less/variables/ds6/actionable-variables.less
@@ -1,8 +1,8 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
 @actionable-icon-foreground-color: @color-text-default;
-@actionable-icon-foreground-color-active: @color-text-default;
-@actionable-icon-foreground-color-hover: @color-b4;
-@actionable-image-background-color-visited: @color-grey2;
-@actionable-image-border-color-active: @color-text-secondary;
-@actionable-image-border-color-hover: @color-grey5;
+@actionable-icon-active-foreground-color: @color-text-default;
+@actionable-icon-hover-foreground-color: @color-b4;
+@actionable-image-visited-background-color: @color-grey2;
+@actionable-image-active-border-color: @color-text-secondary;
+@actionable-image-hover-border-color: @color-grey5;

--- a/src/less/variables/ds6/breadcrumbs-variables.less
+++ b/src/less/variables/ds6/breadcrumbs-variables.less
@@ -1,3 +1,3 @@
-@breadcrumbs-item-color: @color-text-default;
-@breadcrumbs-item-current-color: @color-grey5;
-@breadcrumbs-item-focus-hover-color: @color-link-default;
+@breadcrumbs-item-foreground-color: @color-text-default;
+@breadcrumbs-item-current-foreground-color: @color-grey5;
+@breadcrumbs-item-hover-foreground-color: @color-link-default;

--- a/src/less/variables/ds6/button-variables.less
+++ b/src/less/variables/ds6/button-variables.less
@@ -1,59 +1,32 @@
 @import "color-variables.less";
 
-@btn-border-radius: 0;
-@btn-font-size: @font-size-14;
-@btn-padding: 9.5px 16px;
-
-@button-regular-background-color: @color-white;
-@button-regular-border-color: @color-grey3;
-@button-regular-color: @color-black;
-
-@button-regular-active-color: @color-black;
-@button-regular-fake-visited-color: @color-black;
-
-@button-regular-disabled-background-color: @color-disabled;
-@button-regular-disabled-border-color: @color-disabled;
-@button-regular-disabled-color: @color-white;
-@button-regular-disabled-svg-color: @color-white;
-@button-regular-disabled-hover-background-color: @color-disabled;
-@button-regular-disabled-hover-border-color: @color-disabled;
-
-@button-regular-partially-disabled-background-color: @color-disabled;
-@button-regular-partially-disabled-color: @color-disabled;
-
+@button-border-radius: 0;
+@button-font-size: @font-size-14;
+@button-padding: 9.5px 16px;
 @button-primary-background-color: @color-b4;
 @button-primary-border-color: @color-b4;
-@button-primary-color: @color-white;
-
-@button-primary-fake-visited-color: @color-white;
-
+@button-primary-foreground-color: @color-white;
 @button-primary-disabled-background-color: @color-disabled;
 @button-primary-disabled-border-color: @color-disabled;
-@button-primary-disabled-color: @color-white;
-@button-primary-disabled-svg-color: @color-white;
-@button-primary-disabled-hover-background-color: @color-disabled;
-@button-primary-disabled-hover-border-color: @color-disabled;
-
-@button-primary-partially-disabled-background-color: @color-disabled;
-@button-primary-partially-disabled-border-color: @color-disabled;
-@button-primary-partially-disabled-color: @color-white;
-
+@button-primary-disabled-foreground-color: @color-white;
 @button-secondary-background-color: @color-white;
 @button-secondary-border-color: @color-b4;
-@button-secondary-color: @color-b4;
-
-@button-secondary-fake-visited-color: @color-b4;
-
+@button-secondary-foreground-color: @color-b4;
 @button-secondary-disabled-background-color: @color-white;
 @button-secondary-disabled-border-color: @color-disabled;
-@button-secondary-disabled-color: @color-disabled;
-@button-secondary-disabled-svg-color: @color-disabled;
-@button-secondary-disabled-hover-background-color: @color-white;
-@button-secondary-disabled-hover-border-color: @color-disabled;
-
-@button-secondary-partially-disabled-border-color: @color-disabled;
-@button-secondary-partially-disabled-color: @color-disabled;
-
+@button-secondary-disabled-foreground-color: @color-disabled;
 @button-delete-background-color: @color-white;
 @button-delete-border-color: @color-r4;
-@button-delete-color: @color-r4;
+@button-delete-foreground-color: @color-r4;
+
+// deprecated aliases
+@btn-border-radius: @button-border-radius;
+@btn-font-size: @button-font-size;
+@btn-padding: @button-padding;
+@button-primary-color: @button-primary-foreground-color;
+@button-secondary-fake-visited-color: @color-b4;
+@button-regular-fake-visited-color: @color-black;
+@button-primary-disabled-color: @button-primary-disabled-foreground-color;
+@button-secondary-color: @button-secondary-foreground-color;
+@button-secondary-disabled-color: @button-secondary-disabled-foreground-color;
+@button-delete-color: @button-delete-foreground-color;

--- a/src/less/variables/ds6/cta-button-variables.less
+++ b/src/less/variables/ds6/cta-button-variables.less
@@ -1,10 +1,16 @@
-@btn-cta-background-color: @color-background-default;
-@btn-cta-color: @color-text-default;
-@btn-cta-visited-color: @color-b4;
-@btn-cta-focus-hover-background-color: @color-text-default;
-@btn-cta-focus-hover-border-color: @color-text-default;
-@btn-cta-focus-hover-color: @color-white;
+@cta-button-background-color: @color-background-default;
+@cta-button-foreground-color: @color-text-default;
+@cta-button-hover-background-color: @color-text-default;
+@cta-button-hover-border-color: @color-text-default;
+@cta-button-hover-foreground-color: @color-white;
+@cta-button-visited-foreground-color: @color-b4;
 
-@btn-cta-no-href-background-color: @color-white;
-@btn-cta-no-href-border-color: @color-disabled;
-@btn-cta-no-href-color: @color-disabled;
+@cta-button-disabled-background-color: @color-white;
+@cta-button-disabled-border-color: @color-disabled;
+@cta-button-disabled-foreground-color: @color-disabled;
+
+// deprecated aliases
+@cta-button-color: @cta-button-foreground-color;
+@cta-button-visited-color: @cta-button-visited-foreground-color;
+@cta-button-hover-color: @cta-button-hover-foreground-color;
+@cta-button-disabled-color: @cta-button-disabled-foreground-color;

--- a/src/less/variables/ds6/expand-button-variables.less
+++ b/src/less/variables/ds6/expand-button-variables.less
@@ -1,0 +1,16 @@
+@import "color-variables.less";
+
+// "regular" button is a leftover from old ds4
+@button-regular-background-color: @color-white;
+@button-regular-border-color: @color-grey3;
+@button-regular-color: @color-black;
+@button-regular-active-color: @color-black;
+@button-regular-disabled-background-color: @color-disabled;
+@button-regular-disabled-border-color: @color-disabled;
+@button-regular-disabled-color: @color-white;
+@button-regular-disabled-svg-color: @color-white;
+@button-regular-disabled-hover-background-color: @color-disabled;
+@button-regular-disabled-hover-border-color: @color-disabled;
+@button-regular-partially-disabled-background-color: @color-disabled;
+@button-regular-partially-disabled-color: @color-disabled;
+@expand-button-secondary-disabled-border-color: @color-grey3;

--- a/src/less/variables/ds6/switch-variables.less
+++ b/src/less/variables/ds6/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-background-color-checked: @color-b4;
-@switch-background-color-disabled: @color-grey3;
-@switch-background-color-unchecked: @color-grey5;
+@switch-checked-background-color: @color-b4;
+@switch-disabled-background-color: @color-grey3;
+@switch-unchecked-background-color: @color-grey5;
 @switch-foreground-color: @color-white;
 @switch-outline-color: @color-control-outline;


### PR DESCRIPTION
Issue #1098

* Button color variables exposed as custom properties
* Removed some redundant variables (for active, hover, partially-disabled, svg states)
* Separated expand button variables into new file (expand button needs some cleanup/simplifying in v11)

I will convert expand-button in a follow up PR.

UPDATE:

I added a second commit with the following:

* Add cta-button properties
* Reogranies custom properties into a base file (avoids duplication in ds4 and ds6 folders)
* Fixes a small switch background color bug
* Renamed switch custom properties

A naming convention is starting to establish itself:

`module name` - `state` (optional) - `property`

I renamed the switch properties to follow suit. I will document this soon in the style guide.

ANOTHER (FINAL) UPDATE:

* Normalised other custom properties into a single base file per module.
* Fixed a small bug with ds4 actionable hover colour
