### PR TITLE
Actionable button fixes

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -26,13 +26,6 @@ span.combobox {
   -webkit-box-flex: 1;
           flex: 1 0 auto;
 }
-.combobox svg {
-  margin-left: 8px;
-  pointer-events: none;
-  position: absolute;
-  right: 17px;
-  top: calc(50% - 4px);
-}
 .combobox__options--fix-width[role="listbox"] {
   width: 100%;
 }
@@ -137,6 +130,13 @@ span.combobox {
 .combobox--expanded svg.icon--dropdown {
   -webkit-transform: rotate(180deg);
           transform: rotate(180deg);
+}
+.combobox__control > svg.icon--dropdown {
+  margin-left: 8px;
+  pointer-events: none;
+  position: absolute;
+  right: 17px;
+  top: calc(50% - 4px);
 }
 .combobox__control > input {
   background-color: #fff;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -38,13 +38,6 @@ span.combobox {
   -webkit-box-flex: 1;
           flex: 1 0 auto;
 }
-.combobox svg {
-  margin-left: 8px;
-  pointer-events: none;
-  position: absolute;
-  right: 17px;
-  top: calc(50% - 4px);
-}
 .combobox__options--fix-width[role="listbox"] {
   width: 100%;
 }
@@ -149,6 +142,13 @@ span.combobox {
 .combobox--expanded svg.icon--dropdown {
   -webkit-transform: rotate(180deg);
           transform: rotate(180deg);
+}
+.combobox__control > svg.icon--dropdown {
+  margin-left: 8px;
+  pointer-events: none;
+  position: absolute;
+  right: 17px;
+  top: calc(50% - 4px);
 }
 .combobox__control > input {
   background-color: #fff;

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -214,6 +214,10 @@ input.textbox__control--underline:focus::placeholder {
 [dir="rtl"] .textbox--icon-end textarea.textbox__control {
   padding-left: 40px;
 }
+[dir="rtl"] .textbox--icon-end button.icon-btn {
+  left: 0;
+  right: auto;
+}
 [dir="rtl"] .textbox--icon-end > svg:last-child {
   left: 16px;
   right: auto;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -222,6 +222,10 @@ input.textbox__control--underline:focus::placeholder {
 [dir="rtl"] .textbox--icon-end textarea.textbox__control {
   padding-left: 40px;
 }
+[dir="rtl"] .textbox--icon-end button.icon-btn {
+  left: 0;
+  right: auto;
+}
 [dir="rtl"] .textbox--icon-end > svg:last-child {
   left: 16px;
   right: auto;

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -183,7 +183,10 @@
 
     {% highlight html %}
 <span class="textbox textbox--icon-end">
-    <input class="textbox__control" type="text" placeholder="placeholder text" />
+    <svg class="icon icon--search" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="#icon-search"></use>
+    </svg>
+    <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
     <button class="icon-btn" type="button" aria-label="Choose Contact">
         <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
             <use xlink:href="#icon-messages"></use>

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -162,6 +162,38 @@
 </span>
     {% endhighlight %}
 
+    <h3 id="textbox-icon-actionable">Textbox with two icons, one actionable</h3>
+    <p>Single-line textboxes also support to have two icons, with the last one being an <a href="#actionable">actionable</a> icon.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="textbox textbox--icon-end">
+                <svg class="icon icon--search" focusable="false" width="16" height="16" aria-hidden="true">
+                    <use xlink:href="#icon-search"></use>
+                </svg>
+                <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
+                <button class="icon-btn" type="button" aria-label="Choose Contact">
+                    <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
+                        <use xlink:href="#icon-messages"></use>
+                    </svg>
+                </button>
+            </span>
+        </div>
+    </div>
+
+    {% highlight html %}
+<span class="textbox textbox--icon-end">
+    <input class="textbox__control" type="text" placeholder="placeholder text" />
+    <button class="icon-btn" type="button" aria-label="Choose Contact">
+        <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
+            <use xlink:href="#icon-messages"></use>
+        </svg>
+    </button>
+</span>
+    {% endhighlight %}
+
+
+
     <h3 id="textbox-underline">Underline Textbox</h3>
     <p>Use <span class="highlight">textbox__control--underline</span> modifier to style the textbox with only a bottom border to be used in conjuction with floating labels.</p>
     <p>Please see the <a href="#label">label</a> module for details on labelling controls. Remember: every textbox requires a label!</p>

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -17,14 +17,6 @@ span.combobox {
     flex: 1 0 auto;
 }
 
-.combobox svg {
-    margin-left: 8px;
-    pointer-events: none;
-    position: absolute;
-    right: 17px; // +1 px for the border on the input box
-    top: calc(50% - 4px); // 4px is half the height of dropdown icon size
-}
-
 .combobox__options--fix-width[role="listbox"] {
     width: 100%;
 }
@@ -89,6 +81,14 @@ span.combobox {
 
 .combobox--expanded svg.icon--dropdown {
     transform: rotate(180deg);
+}
+
+.combobox__control > svg.icon--dropdown {
+    margin-left: 8px;
+    pointer-events: none;
+    position: absolute;
+    right: 17px; // +1 px for the border on the input box
+    top: calc(50% - 4px); // 4px is half the height of dropdown icon size
 }
 
 .combobox__control > input {

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -230,6 +230,11 @@ input.textbox__control--underline {
             padding-left: 40px;
         }
 
+        button.icon-btn {
+            left: 0;
+            right: auto;
+        }
+
         > svg:last-child {
             left: 16px;
             right: auto;

--- a/src/less/textbox/textbox.stories.js
+++ b/src/less/textbox/textbox.stories.js
@@ -30,6 +30,32 @@ export const iconEnd = () => `
 </span>
 `;
 
+export const iconDual = () => `
+<span class="textbox textbox--icon-end">
+    <svg class="icon icon--search" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="#icon-search"></use>
+    </svg>
+    <input class="textbox__control" type="text" placeholder="placeholder text" />
+    <svg class="icon icon--messages" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="#icon-messages"></use>
+    </svg>
+</span>
+`;
+
+export const iconDualActionable = () => `
+<span class="textbox textbox--icon-end">
+    <svg class="icon icon--search" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="#icon-search"></use>
+    </svg>
+    <input class="textbox__control" type="text" placeholder="placeholder text" />
+    <button class="icon-btn" type="button" aria-label="Choose Contact">
+        <svg class="icon icon--messages" focusable="false" width="16" height="16" aria-hidden="true">
+            <use xlink:href="#icon-messages"></use>
+        </svg>
+    </button>
+</span>
+`;
+
 export const Large = () => `
 <span class="textbox textbox--large">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
@@ -108,6 +134,38 @@ export const iconEndRTL = () => `
 </div>
 `;
 
+export const iconBothRTL = () => `
+<div dir="rtl">
+    <span class="textbox textbox--icon-end">
+        <svg class="icon icon--search" focusable="false" width="16" height="16" aria-hidden="true">
+            <use xlink:href="#icon-search"></use>
+        </svg>
+
+        <input class="textbox__control" type="text" placeholder="placeholder text" />
+        <svg class="icon icon--messages" focusable="false" width="16" height="16" aria-hidden="true">
+            <use xlink:href="#icon-messages"></use>
+        </svg>
+    </span>
+</div>
+`;
+
+export const iconBothActionableRTL = () => `
+<div dir="rtl">
+    <span class="textbox textbox--icon-end">
+        <svg class="icon icon--search" focusable="false" width="16" height="16" aria-hidden="true">
+            <use xlink:href="#icon-search"></use>
+        </svg>
+
+        <input class="textbox__control" type="text" placeholder="placeholder text" />
+        <button class="icon-btn" type="button" aria-label="Choose Contact">
+            <svg class="icon icon--messages" focusable="false" width="16" height="16" aria-hidden="true">
+                <use xlink:href="#icon-messages"></use>
+            </svg>
+        </button>
+    </span>
+</div>
+`;
+
 export const actionableIcon = () => `
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
@@ -117,4 +175,17 @@ export const actionableIcon = () => `
         </svg>
     </button>
 </span>
+`;
+
+export const actionableIconRTL = () => `
+<div dir="rtl">
+    <span class="textbox textbox--icon-end">
+        <input class="textbox__control" type="text" placeholder="placeholder text" />
+        <button class="icon-btn" type="button" aria-label="Choose Contact">
+            <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
+                <use xlink:href="#icon-messages"></use>
+            </svg>
+        </button>
+    </span>
+</div>
 `;


### PR DESCRIPTION
## Description
* Fixed combobox actionable svg position by making the non actionable styles ignored in actionable (added adjacent rules)
* Added example for textbox dual icons

## References
#1129 

## Screenshots
<img width="1141" alt="Screen Shot 2020-06-18 at 2 38 32 PM" src="https://user-images.githubusercontent.com/1755269/85074469-70328000-b171-11ea-85b1-ac3273bf1a2d.png">
<img width="1129" alt="Screen Shot 2020-06-18 at 2 38 44 PM" src="https://user-images.githubusercontent.com/1755269/85074472-71fc4380-b171-11ea-83d3-97494a193f0a.png">
