### PR TITLE
Updated dialog to support end text and DS4 drawer handle

### DIFF
--- a/dist/dialog/ds4/dialog.css
+++ b/dist/dialog/ds4/dialog.css
@@ -94,6 +94,12 @@
   padding: 0;
   position: relative;
 }
+.dialog__title:not(:first-child) {
+  margin-left: 16px;
+}
+.dialog__title--center {
+  text-align: center;
+}
 .dialog__window {
   display: -webkit-box;
   display: flex;

--- a/dist/dialog/ds4/dialog.css
+++ b/dist/dialog/ds4/dialog.css
@@ -94,6 +94,10 @@
   padding: 0;
   position: relative;
 }
+.dialog__header .dialog__end-btn {
+  border: none;
+  padding: 0;
+}
 .dialog__title:not(:first-child) {
   margin-left: 16px;
 }

--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -100,6 +100,12 @@
   padding: 0;
   position: relative;
 }
+.dialog__title:not(:first-child) {
+  margin-left: 16px;
+}
+.dialog__title--center {
+  text-align: center;
+}
 .dialog__window {
   display: -webkit-box;
   display: flex;

--- a/dist/dialog/ds6/dialog.css
+++ b/dist/dialog/ds6/dialog.css
@@ -100,6 +100,10 @@
   padding: 0;
   position: relative;
 }
+.dialog__header .dialog__end-btn {
+  border: none;
+  padding: 0;
+}
 .dialog__title:not(:first-child) {
   margin-left: 16px;
 }

--- a/dist/drawer/ds4/drawer.css
+++ b/dist/drawer/ds4/drawer.css
@@ -196,6 +196,10 @@
   -webkit-transform: translateX(0);
           transform: translateX(0);
 }
+.drawer__handle {
+  top: 8px;
+  z-index: 2;
+}
 .drawer__header {
   background-color: white;
   margin: 0;
@@ -213,4 +217,9 @@
   text-overflow: ellipsis;
   top: 0;
   white-space: nowrap;
+}
+.drawer__header > .drawer__close {
+  position: absolute;
+  right: 3px;
+  top: 16px;
 }

--- a/docs/_includes/common/dialog.html
+++ b/docs/_includes/common/dialog.html
@@ -207,6 +207,63 @@
 </div>
     {% endhighlight %}
 
+    {% if page.ds == 6 %}
+    <h3>Right Panel Dialog with header link (DS6 only)</h3>
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-right-panel-1" type="button">Preview</button>
+            <div aria-labelledby="dialog-title-right" aria-modal="true" class="dialog" hidden id="dialog-right-panel-1" role="dialog">
+                <div class="dialog__window dialog__window--right">
+                    <div class="dialog__header">
+                        <button aria-label="Close dialog" class="dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                                <use xlink:href="#icon-close"></use>
+                            </svg>
+                        </button>
+                        <h2 id="dialog-title-default" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
+                        <a class="dialog__end-text">
+                            Reset
+                        </a>
+                    </div>
+                    <div class="dialog__main">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div aria-labelledby="dialog-title-right" aria-modal="true" class="dialog" hidden id="dialog-right-panel-1" role="dialog">
+    <div class="dialog__window dialog__window--right">
+        <div class="dialog__header">
+            <button aria-label="Close dialog" class="dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close"></use>
+                </svg>
+            </button>
+            <h2 id="dialog-title-default" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
+            <a class="dialog__end-text">
+                Reset
+            </a>
+        </div>
+        <div class="dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+    {% endif %}
+
     <h3>Dialog with Footer</h3>
     <p>Add a dialog footer in order to have a footer shown at bottom where you can add buttons</p>
 

--- a/docs/_includes/common/dialog.html
+++ b/docs/_includes/common/dialog.html
@@ -208,7 +208,7 @@
     {% endhighlight %}
 
     {% if page.ds == 6 %}
-    <h3>Right Panel Dialog with header link (DS6 only)</h3>
+    <h3>Right Panel Dialog with end button (DS6 only)</h3>
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-right-panel-1" type="button">Preview</button>
@@ -221,9 +221,9 @@
                             </svg>
                         </button>
                         <h2 id="dialog-title-default" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
-                        <a class="dialog__end-text">
+                        <button class="btn btn--secondary dialog__end-btn">
                             Reset
-                        </a>
+                        </button>
                     </div>
                     <div class="dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -247,9 +247,9 @@
                 </svg>
             </button>
             <h2 id="dialog-title-default" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
-            <a class="dialog__end-text">
+            <button class="btn btn--secondary dialog__end-btn">
                 Reset
-            </a>
+            </button>
         </div>
         <div class="dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore

--- a/src/less/dialog/base/dialog.less
+++ b/src/less/dialog/base/dialog.less
@@ -58,6 +58,16 @@
     position: relative;
 }
 
+.dialog__title {
+    &:not(:first-child) {
+        margin-left: 16px;
+    }
+}
+
+.dialog__title--center {
+    text-align: center;
+}
+
 .dialog__window {
     .dialog-window();
 

--- a/src/less/dialog/base/dialog.less
+++ b/src/less/dialog/base/dialog.less
@@ -58,6 +58,11 @@
     position: relative;
 }
 
+.dialog__header .dialog__end-btn {
+    border: none;
+    padding: 0;
+}
+
 .dialog__title {
     &:not(:first-child) {
         margin-left: 16px;

--- a/src/less/drawer/ds4/drawer.less
+++ b/src/less/drawer/ds4/drawer.less
@@ -2,6 +2,11 @@
 @import "../../mixins/dialog/ds4/dialog-mixins.less";
 @import "../base/drawer.less";
 
+.drawer__handle {
+    top: 8px;
+    z-index: 2;
+}
+
 .drawer__header {
     background-color: white;
     margin: 0;
@@ -19,4 +24,10 @@
     text-overflow: ellipsis;
     top: 0;
     white-space: nowrap;
+}
+
+.drawer__header > .drawer__close {
+    position: absolute;
+    right: 3px;
+    top: 16px;
 }


### PR DESCRIPTION
## Description
* Updated dialog to support end text and center header. Added for ds6 only because DS4 close button is always on right. 
* Also fixed DS4 drawer to show handle

## Context
* For dialog end text, added example to show it. 

## References
#1115
#1105

## Screenshots
<img width="562" alt="Screen Shot 2020-06-18 at 5 11 21 PM" src="https://user-images.githubusercontent.com/1755269/85083638-2e143900-b187-11ea-810f-322e4954811f.png">
<img width="707" alt="Screen Shot 2020-06-18 at 5 13 37 PM" src="https://user-images.githubusercontent.com/1755269/85083641-30769300-b187-11ea-916f-0f9c6f94fcc0.png">
