### PR TITLE
Reset vendor margins for headings in notice

### DIFF
--- a/dist/notice/ds4/notice.css
+++ b/dist/notice/ds4/notice.css
@@ -281,6 +281,10 @@ a.section-notice--attention {
     width: auto;
   }
   .page-notice--celebration .page-notice__status {
+    -webkit-box-align: center;
+            align-items: center;
+    display: -webkit-box;
+    display: flex;
     padding: 24px 0 24px 24px;
   }
   .page-notice--celebration .page-notice__title {

--- a/dist/notice/ds4/notice.css
+++ b/dist/notice/ds4/notice.css
@@ -139,6 +139,14 @@ span[role="region"].section-notice {
 .section-notice__status {
   -webkit-box-align: center;
           align-items: center;
+  -webkit-margin-after: 0;
+          margin-block-end: 0;
+  -webkit-margin-before: 0;
+          margin-block-start: 0;
+  -webkit-margin-end: 0;
+          margin-inline-end: 0;
+  -webkit-margin-start: 0;
+          margin-inline-start: 0;
   padding: 16px 0 16px 16px;
 }
 .page-notice__content p,

--- a/dist/notice/ds6/notice.css
+++ b/dist/notice/ds6/notice.css
@@ -286,6 +286,10 @@ a.section-notice--attention {
     width: auto;
   }
   .page-notice--celebration .page-notice__status {
+    -webkit-box-align: center;
+            align-items: center;
+    display: -webkit-box;
+    display: flex;
     padding: 24px 0 24px 24px;
   }
   .page-notice--celebration .page-notice__title {

--- a/dist/notice/ds6/notice.css
+++ b/dist/notice/ds6/notice.css
@@ -144,6 +144,14 @@ span[role="region"].section-notice {
 .section-notice__status {
   -webkit-box-align: center;
           align-items: center;
+  -webkit-margin-after: 0;
+          margin-block-end: 0;
+  -webkit-margin-before: 0;
+          margin-block-start: 0;
+  -webkit-margin-end: 0;
+          margin-inline-end: 0;
+  -webkit-margin-start: 0;
+          margin-inline-start: 0;
   padding: 16px 0 16px 16px;
 }
 .page-notice__content p,

--- a/src/less/notice/base/notice.less
+++ b/src/less/notice/base/notice.less
@@ -268,6 +268,8 @@ a.section-notice--attention {
     }
 
     .page-notice--celebration .page-notice__status {
+        align-items: center;
+        display: flex;
         padding: 24px 0 24px 24px;
     }
 

--- a/src/less/notice/base/notice.less
+++ b/src/less/notice/base/notice.less
@@ -122,6 +122,10 @@ span[role="region"].section-notice {
 .page-notice__status,
 .section-notice__status {
     align-items: center;
+    margin-block-end: 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-inline-start: 0;
     padding: 16px 0 16px 16px;
 }
 


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
Chrome adds extra margins to headings in notices. They should remain 16px regardless of the a11y tag passed to notice.

## References
https://github.com/eBay/skin/issues/1143
