### PR TITLE
Breadcrumbs: fix hover colour #1112

### DIFF
--- a/dist/breadcrumbs/ds4/breadcrumbs.css
+++ b/dist/breadcrumbs/ds4/breadcrumbs.css
@@ -46,6 +46,10 @@ nav.breadcrumbs button {
   margin: 0;
   padding: 0;
 }
+nav.breadcrumb a:visited,
+nav.breadcrumbs a:visited {
+  color: inherit;
+}
 nav.breadcrumb a,
 nav.breadcrumbs a,
 nav.breadcrumb button,
@@ -72,10 +76,6 @@ nav.breadcrumbs button[aria-current] {
   color: #767676;
   color: var(--breadcrumbs-item-current-foreground-color, #767676);
   text-decoration: none;
-}
-nav.breadcrumb a:visited,
-nav.breadcrumbs a:visited {
-  color: inherit;
 }
 @media (min-width: 601px) {
   nav.breadcrumb,

--- a/dist/breadcrumbs/ds6/breadcrumbs.css
+++ b/dist/breadcrumbs/ds6/breadcrumbs.css
@@ -53,6 +53,10 @@ nav.breadcrumbs button {
   margin: 0;
   padding: 0;
 }
+nav.breadcrumb a:visited,
+nav.breadcrumbs a:visited {
+  color: inherit;
+}
 nav.breadcrumb a,
 nav.breadcrumbs a,
 nav.breadcrumb button,
@@ -79,10 +83,6 @@ nav.breadcrumbs button[aria-current] {
   color: #767676;
   color: var(--breadcrumbs-item-current-foreground-color, #767676);
   text-decoration: none;
-}
-nav.breadcrumb a:visited,
-nav.breadcrumbs a:visited {
-  color: inherit;
 }
 @media (min-width: 601px) {
   nav.breadcrumb,

--- a/src/less/breadcrumbs/base/breadcrumbs.less
+++ b/src/less/breadcrumbs/base/breadcrumbs.less
@@ -42,6 +42,11 @@ nav.breadcrumbs {
         padding: 0;
     }
 
+    // stylelint-disable no-descending-specificity
+    a:visited {
+        color: inherit;
+    }
+
     a,
     button {
         color: inherit;
@@ -60,10 +65,7 @@ nav.breadcrumbs {
             text-decoration: none;
         }
     }
-
-    a:visited {
-        color: inherit;
-    }
+    // stylelint-enable no-descending-specificity
 }
 
 // the non-plural classname is deprecated in v10


### PR DESCRIPTION
Fixes #1112

Just a simple cascade fix so that visited links get the correct colour (blue) on hover & focus. I could have made it more specific with `a:visited:hover`, but I prefer to use the natural cascade wherever possible, so it required the stylelint disable.