### PR TITLE
Added a -5px margin for controls

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -102,7 +102,7 @@ span.carousel__container {
     overflow: visible;
   }
   .carousel:not(.carousel__autoplay) .carousel__control {
-    margin-top: 0;
+    margin-top: -5px;
   }
   .carousel:not(.carousel__autoplay) .carousel__list {
     border-color: rgba(0, 0, 0, 0);

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -102,7 +102,7 @@ span.carousel__container {
     overflow: visible;
   }
   .carousel:not(.carousel__autoplay) .carousel__control {
-    margin-top: 0;
+    margin-top: -5px;
   }
   .carousel:not(.carousel__autoplay) .carousel__list {
     border-color: rgba(0, 0, 0, 0);

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -111,7 +111,7 @@ span.carousel__container {
         overflow: visible;
 
         .carousel__control {
-            margin-top: 0;
+            margin-top: -5px;
         }
 
         .carousel__list {


### PR DESCRIPTION
## Description
Controls are centered according to the main content. However the carousel__list has a padding-bottom of 10 in order to support the scrollbar. This makes the controls offcenter. I removed 5px margin in order to center align (1/2 of the offset)
I tried to remove the padding but it looks off with the scrollbar. 

## Screenshots
<img width="1792" alt="Screen Shot 2020-06-30 at 9 01 58 PM" src="https://user-images.githubusercontent.com/1755269/86201945-c4e0de00-bb15-11ea-945d-07b5df622364.png">

Alignment shown with tools:
<img width="1792" alt="Screen Shot 2020-06-30 at 9 01 55 PM" src="https://user-images.githubusercontent.com/1755269/86201949-c7433800-bb15-11ea-9dcd-0db2afdf0727.png">
