### PR TITLE
Added center modifier for expand button

### DIFF
--- a/dist/expand-button/ds4/expand-button.css
+++ b/dist/expand-button/ds4/expand-button.css
@@ -76,6 +76,20 @@ span.expand-btn__cell--fixed-height svg.icon {
   align-self: center;
   overflow: visible;
 }
+span.expand-btn__cell--center span {
+  -webkit-box-flex: 0;
+          flex: 0 1 auto;
+  left: 50%;
+  padding: 0 20px;
+  position: relative;
+  -webkit-transform: translateX(-50%);
+          transform: translateX(-50%);
+}
+span.expand-btn__cell--center svg.icon:last-child {
+  -webkit-box-flex: 0;
+          flex: 0 1 auto;
+  margin-left: auto;
+}
 button.expand-btn[disabled],
 button.expand-btn[aria-disabled="true"] {
   border-color: #999;
@@ -130,6 +144,16 @@ button.expand-btn[aria-expanded="true"] svg.icon--dropdown {
 [dir="rtl"] button.expand-btn svg.icon:last-child {
   margin-left: 0;
   margin-right: 8px;
+}
+[dir="rtl"] button.expand-btn span.expand-btn__cell--center span {
+  left: auto;
+  right: 50%;
+  -webkit-transform: translateX(50%);
+          transform: translateX(50%);
+}
+[dir="rtl"] button.expand-btn span.expand-btn__cell--center svg.icon:last-child {
+  margin-left: 0;
+  margin-right: auto;
 }
 button.expand-btn--large {
   min-height: 48px;

--- a/dist/expand-button/ds6/expand-button.css
+++ b/dist/expand-button/ds6/expand-button.css
@@ -76,6 +76,20 @@ span.expand-btn__cell--fixed-height svg.icon {
   align-self: center;
   overflow: visible;
 }
+span.expand-btn__cell--center span {
+  -webkit-box-flex: 0;
+          flex: 0 1 auto;
+  left: 50%;
+  padding: 0 20px;
+  position: relative;
+  -webkit-transform: translateX(-50%);
+          transform: translateX(-50%);
+}
+span.expand-btn__cell--center svg.icon:last-child {
+  -webkit-box-flex: 0;
+          flex: 0 1 auto;
+  margin-left: auto;
+}
 button.expand-btn[disabled],
 button.expand-btn[aria-disabled="true"] {
   border-color: #c7c7c7;
@@ -130,6 +144,16 @@ button.expand-btn[aria-expanded="true"] svg.icon--dropdown {
 [dir="rtl"] button.expand-btn svg.icon:last-child {
   margin-left: 0;
   margin-right: 8px;
+}
+[dir="rtl"] button.expand-btn span.expand-btn__cell--center span {
+  left: auto;
+  right: 50%;
+  -webkit-transform: translateX(50%);
+          transform: translateX(50%);
+}
+[dir="rtl"] button.expand-btn span.expand-btn__cell--center svg.icon:last-child {
+  margin-left: 0;
+  margin-right: auto;
 }
 button.expand-btn--large {
   min-height: 48px;

--- a/src/less/expand-button/base/expand-button.less
+++ b/src/less/expand-button/base/expand-button.less
@@ -39,6 +39,19 @@ span.expand-btn__cell--fixed-height svg.icon {
     overflow: visible;
 }
 
+span.expand-btn__cell--center span {
+    flex: 0 1 auto;
+    left: 50%;
+    padding: 0 20px;
+    position: relative;
+    transform: translateX(-50%);
+}
+
+span.expand-btn__cell--center svg.icon:last-child {
+    flex: 0 1 auto;
+    margin-left: auto;
+}
+
 button.expand-btn[disabled],
 button.expand-btn[aria-disabled="true"] {
     border-color: @button-secondary-disabled-border-color;
@@ -96,6 +109,19 @@ button.expand-btn[aria-expanded="true"] svg.icon--dropdown {
     &:last-child {
         margin-left: 0;
         margin-right: 8px;
+    }
+}
+
+[dir="rtl"] button.expand-btn span.expand-btn__cell--center {
+    span {
+        left: auto;
+        right: 50%;
+        transform: translateX(50%);
+    }
+
+    svg.icon:last-child {
+        margin-left: 0;
+        margin-right: auto;
     }
 }
 

--- a/src/less/expand-button/expand-button.stories.js
+++ b/src/less/expand-button/expand-button.stories.js
@@ -227,3 +227,28 @@ export const iconRTL = () => `
     </button>
 </div>
 `;
+
+export const centered = () => `
+<button type="button" class="expand-btn" style="width: 200px;">
+    <span class="expand-btn__cell expand-btn__cell--center">
+        <span>Button</span>
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</button>
+`;
+
+export const centeredRtl = () => `
+<div dir="rtl">
+    <button type="button" class="expand-btn" style="width: 200px;">
+        <span class="expand-btn__cell expand-btn__cell--center">
+            <span>Button</span>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+</div>
+`;
+


### PR DESCRIPTION
## Description
Added a modifier to center expand button
I used position relative in order to not lose the hight but be able to center the text. 
Added some padding so buttons do not overlap in case the button is small.
Also added RTL styles

## Screenshots
### Standard
<img width="262" alt="Screen Shot 2020-07-10 at 10 42 57 AM" src="https://user-images.githubusercontent.com/1755269/87183480-0f432700-c29b-11ea-9c0d-21f83eedb968.png">

### RTL
<img width="239" alt="Screen Shot 2020-07-10 at 10 43 01 AM" src="https://user-images.githubusercontent.com/1755269/87183470-0c483680-c29b-11ea-80d2-f4d6f7089c44.png">
