### PR TITLE
Global|Typography: use Market Sans for titles only #1046

### DIFF
--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -27,6 +27,7 @@ a.icon-link {
   border: 2px solid transparent;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
+  font-family: inherit;
   height: 40px;
   margin: 0;
   padding: 0;

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -42,6 +42,7 @@ a.icon-link {
   border: 2px solid transparent;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
+  font-family: inherit;
   height: 40px;
   margin: 0;
   padding: 0;

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -14,7 +14,6 @@
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.75rem;
   font-weight: 500;
   height: 20px;

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -20,7 +20,6 @@
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.75rem;
   font-weight: 700;
   height: 20px;

--- a/dist/filter-menu-button/ds4/filter-menu-button.css
+++ b/dist/filter-menu-button/ds4/filter-menu-button.css
@@ -206,7 +206,6 @@ span.filter-menu-button__radio svg.icon--radio-checked {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;
@@ -274,7 +273,6 @@ button.filter-menu-button__footer {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;

--- a/dist/filter-menu-button/ds6/filter-menu-button.css
+++ b/dist/filter-menu-button/ds6/filter-menu-button.css
@@ -206,7 +206,6 @@ span.filter-menu-button__radio svg.icon--radio-checked {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;
@@ -274,7 +273,6 @@ button.filter-menu-button__footer {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;

--- a/dist/filter-menu/ds4/filter-menu.css
+++ b/dist/filter-menu/ds4/filter-menu.css
@@ -117,7 +117,6 @@ span.filter-menu-form__item {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;
@@ -171,7 +170,6 @@ button.filter-menu-form__footer[type="submit"] {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;

--- a/dist/filter-menu/ds6/filter-menu.css
+++ b/dist/filter-menu/ds6/filter-menu.css
@@ -125,7 +125,6 @@ span.filter-menu-form__item {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;
@@ -179,7 +178,6 @@ button.filter-menu-form__footer[type="submit"] {
           box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   -webkit-box-pack: justify;
           justify-content: space-between;

--- a/dist/global/ds4/global.css
+++ b/dist/global/ds4/global.css
@@ -3,15 +3,9 @@ body {
   background-color: var(--color-background-default, #fff);
   color: #333;
   color: var(--color-text-default, #333);
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
+  font-family: Arial, sans-serif;
   font-size: 0.875rem;
   -webkit-text-size-adjust: 100%;
-}
-a,
-a:focus,
-a:visited {
-  color: #0654ba;
-  color: var(--color-link-hover, #0654ba);
 }
 fieldset {
   border: 0;
@@ -19,4 +13,10 @@ fieldset {
 }
 legend {
   margin-bottom: 8px;
+}
+a,
+a:focus,
+a:visited {
+  color: #0654ba;
+  color: var(--color-link-hover, #0654ba);
 }

--- a/dist/global/ds6/global.css
+++ b/dist/global/ds6/global.css
@@ -7,6 +7,13 @@ body {
   font-size: 0.875rem;
   -webkit-text-size-adjust: 100%;
 }
+fieldset {
+  border: 0;
+  padding: 0;
+}
+legend {
+  margin-bottom: 8px;
+}
 a {
   color: #3665f3;
   color: var(--color-link-default, #3665f3);
@@ -18,11 +25,4 @@ a:visited {
 a:hover {
   color: #2b0eaf;
   color: var(--color-link-hover, #2b0eaf);
-}
-fieldset {
-  border: 0;
-  padding: 0;
-}
-legend {
-  margin-bottom: 8px;
 }

--- a/dist/mixins/filter-menu/base/filter-menu-mixins.less
+++ b/dist/mixins/filter-menu/base/filter-menu-mixins.less
@@ -4,7 +4,6 @@
 
     box-sizing: border-box;
     display: inline-flex;
-    font-family: @filter-menu-font-family;
     font-size: @font-size-14;
     justify-content: space-between;
     line-height: 1.4em;

--- a/dist/mixins/typography/base/typography-mixins.less
+++ b/dist/mixins/typography/base/typography-mixins.less
@@ -35,7 +35,7 @@
 .typography-large-1-bold() {
     .typography-large-1();
 
-    font-weight: @font-weight-medium;
+    font-weight: @font-weight-bold;
 }
 
 .typography-large-1-secondary() {
@@ -86,7 +86,7 @@
 .typography-small-bold() {
     .typography-small();
 
-    font-weight: @font-weight-medium;
+    font-weight: @font-weight-bold;
 }
 
 .typography-small-secondary() {

--- a/dist/section-title/ds4/section-title.css
+++ b/dist/section-title/ds4/section-title.css
@@ -15,6 +15,7 @@
   font-size: 1rem;
   line-height: 24px;
   font-weight: 500;
+  font-family: "Market Sans", Arial, sans-serif;
   margin: 0;
 }
 .section-title__subtitle {

--- a/dist/section-title/ds6/section-title.css
+++ b/dist/section-title/ds6/section-title.css
@@ -20,6 +20,7 @@
   font-size: 1rem;
   line-height: 24px;
   font-weight: 700;
+  font-family: "Market Sans", Arial, sans-serif;
   margin: 0;
 }
 .section-title__subtitle {

--- a/dist/select/ds4/select.css
+++ b/dist/select/ds4/select.css
@@ -27,7 +27,7 @@ span.select {
   border-style: solid;
   border-width: 1px;
   color: inherit;
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
+  font-family: inherit;
   font-size: 1em;
   height: 40px;
   padding: 0 40px 0 16px;

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -34,7 +34,7 @@ span.select {
   border-style: solid;
   border-width: 1px;
   color: inherit;
-  font-family: "Market Sans", Arial, sans-serif;
+  font-family: inherit;
   font-size: 1em;
   height: 40px;
   padding: 0 32px 0 16px;

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -50,7 +50,6 @@ textarea.textbox__control {
   border-width: 1px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
-  font-family: "Helvetica Neue", Helvetica, Arial, Roboto, sans-serif;
   font-size: 1em;
   height: 40px;
   margin: 0;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -58,7 +58,6 @@ textarea.textbox__control {
   border-width: 1px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
-  font-family: inherit;
   font-size: 1em;
   height: 40px;
   margin: 0;

--- a/dist/typography/ds4/typography.css
+++ b/dist/typography/ds4/typography.css
@@ -52,25 +52,31 @@
 }
 .giant-product-title,
 .giant-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.5rem;
   line-height: 36px;
 }
 .large-product-title,
 .large-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.25rem;
   line-height: 30px;
 }
 .medium-product-title,
 .medium-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1rem;
   line-height: 24px;
 }
 .small-product-title,
 .small-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   line-height: 24px;
 }
+/* code smell - obfuscated classname selector */
 [class$='-section-title'] {
+  font-family: "Market Sans", Arial, sans-serif;
   font-weight: 500;
 }
 @media (min-width: 601px) {

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -57,25 +57,31 @@
 }
 .giant-product-title,
 .giant-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.5rem;
   line-height: 36px;
 }
 .large-product-title,
 .large-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.25rem;
   line-height: 30px;
 }
 .medium-product-title,
 .medium-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1rem;
   line-height: 24px;
 }
 .small-product-title,
 .small-section-title {
+  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   line-height: 24px;
 }
+/* code smell - obfuscated classname selector */
 [class$='-section-title'] {
+  font-family: "Market Sans", Arial, sans-serif;
   font-weight: 700;
 }
 @media (min-width: 601px) {

--- a/dist/variables/base/typography-variables.less
+++ b/dist/variables/base/typography-variables.less
@@ -1,14 +1,10 @@
-// typography common to ds4 & ds6
-
-@font-family-default: Arial, sans-serif;
-
 @marketsans-url: "https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/";
 @marketsans-fontname: "Market Sans";
 @marketsans-filename-regular: "MarketSans-Regular-WebS";
 @marketsans-filename-bold: "MarketSans-SemiBold-WebS";
 
-@font-size-12: 0.75rem;
-@font-size-16: 1rem;
+@font-family-default: Arial, sans-serif;
+@font-family-market-sans: @marketsans-fontname, @font-family-default;
 
 @font-size-12: 0.75rem;
 @font-size-13: 0.8125rem;
@@ -17,6 +13,7 @@
 @font-size-18: 1.125rem;
 @font-size-20: 1.25rem;
 @font-size-24: 1.5rem;
+@font-size-28: 1.75rem;
 @font-size-30: 1.875rem;
 @font-size-36: 2.25rem;
 

--- a/dist/variables/ds4/badge-variables.less
+++ b/dist/variables/ds4/badge-variables.less
@@ -1,3 +1,2 @@
-@badge-font-family: @font-family-base;
 @badge-background-color: @color-core-red;
 @badge-foreground-color: @color-core-white;

--- a/dist/variables/ds4/filter-menu-variables.less
+++ b/dist/variables/ds4/filter-menu-variables.less
@@ -1,4 +1,3 @@
-@filter-menu-font-family: @font-family-base;
 @filter-menu-border-color: @color-core-gray-silver;
 @filter-menu-checkbox-unchecked-color: @color-core-gray-dim;
 @filter-menu-checkbox-checked-color: @color-core-blue;

--- a/dist/variables/ds4/pagination-variables.less
+++ b/dist/variables/ds4/pagination-variables.less
@@ -5,6 +5,6 @@
 @pagination-item-current-background-color: @color-core-gray-light;
 @pagination-item-current-border-color: transparent;
 @pagination-item-current-foreground-color: @color-core-gray-jet;
-@pagination-item-current-font-weight: @font-weight-medium;
+@pagination-item-current-font-weight: @font-weight-bold;
 @pagination-paddle-disabled-foreground-color: @color-core-gray-silver;
 @pagination-paddle-hover-foreground-color: #a3a3a3;

--- a/dist/variables/ds4/select-variables.less
+++ b/dist/variables/ds4/select-variables.less
@@ -2,7 +2,6 @@
 @select-border-color: @color-core-gray-silver;
 @select-border-radius: 3px;
 @select-foreground-color: @color-core-gray-davys;
-@select-font-family: @font-family-base;
 @select-font-size: @font-size-14;
 @select-large-font-size: @font-size-16;
 @select-padding: 0 40px 0 16px;

--- a/dist/variables/ds4/textbox-variables.less
+++ b/dist/variables/ds4/textbox-variables.less
@@ -2,7 +2,6 @@
 @textbox-foreground-color: @color-core-gray-davys;
 @textbox-border-color: @color-core-gray-silver;
 @textbox-border-radius: 3px;
-@textbox-font-family: @font-family-base;
 @textbox-font-size: inherit;
 @textbox-height: @ds4-height-control-medium;
 @textbox-disabled-background-color: @color-core-gray-light;

--- a/dist/variables/ds4/typography-variables.less
+++ b/dist/variables/ds4/typography-variables.less
@@ -1,27 +1,10 @@
 @import "../base/typography-variables.less";
 @import "color-variables.less";
 
-@font-family-osx: "Helvetica Neue", Helvetica;
-@font-family-windows: Arial;
-@font-family-android: Roboto;
-@font-family-sans-serif: @font-family-osx, @font-family-windows, @font-family-android, sans-serif;
-@font-family-base: @font-family-sans-serif;
-@font-family-market-sans: @marketsans-fontname, @font-family-sans-serif;
-
-@font-size-15: 0.9375rem;
-@font-size-17: 1.062rem;
-@font-size-28: 1.75rem;
-@font-size-44: 2.75rem;
-@font-size-50: 3.125rem;
-@font-size-56: 3.5rem;
-
-@font-weight-thin: 100;
-@font-weight-light: 200;
 @font-weight-regular: 400;
-@font-weight-medium: 500;
-@font-weight-bold: @font-weight-medium;
+@font-weight-bold: 500;
 
-@typography-bold-text-font-weight: @font-weight-medium;
+@typography-bold-text-font-weight: @font-weight-bold;
 @typography-secondary-text-color: @color-core-gray-davys;
 @typography-emphasis-color: @color-core-red;
 @typography-negative-color: @color-core-red;

--- a/dist/variables/ds6/badge-variables.less
+++ b/dist/variables/ds6/badge-variables.less
@@ -1,3 +1,2 @@
-@badge-font-family: @font-family-custom;
 @badge-background-color: @color-badge-background;
 @badge-foreground-color: @color-badge-text;

--- a/dist/variables/ds6/filter-menu-variables.less
+++ b/dist/variables/ds6/filter-menu-variables.less
@@ -1,4 +1,3 @@
-@filter-menu-font-family: @font-family-custom;
 @filter-menu-border-color: #e1e1e1;
 @filter-menu-checkbox-unchecked-color: @color-grey5;
 @filter-menu-checkbox-checked-color: @color-b4;

--- a/dist/variables/ds6/select-variables.less
+++ b/dist/variables/ds6/select-variables.less
@@ -2,7 +2,6 @@
 @select-border-color: @color-grey4;
 @select-border-radius: initial;
 @select-foreground-color: @color-black;
-@select-font-family: @font-family-custom;
 @select-font-size: @font-size-14;
 @select-large-font-size: @font-size-18;
 @select-padding: 0 32px 0 16px;

--- a/dist/variables/ds6/textbox-variables.less
+++ b/dist/variables/ds6/textbox-variables.less
@@ -2,8 +2,7 @@
 @textbox-foreground-color: @color-black;
 @textbox-border-color: @color-grey4;
 @textbox-border-radius: 0;
-@textbox-font-family: inherit;
-@textbox-font-size: @font-size-14; // for Market Sans to align with buttons and select, it needs same font-size
+@textbox-font-size: @font-size-14; // to align with buttons and select, it needs same font-size
 @textbox-height: 40px;
 @textbox-disabled-background-color: @textbox-background-color;
 @textbox-disabled-foreground-color: @color-grey3;

--- a/dist/variables/ds6/typography-variables.less
+++ b/dist/variables/ds6/typography-variables.less
@@ -1,18 +1,8 @@
 @import "../base/typography-variables.less";
 @import "color-variables.less";
 
-// typography unique to ds6
-
-@font-family-custom: @marketsans-fontname, @font-family-default;
-
-@font-size-10: 0.6125rem;
-@font-size-22: 1.375rem;
-@font-size-26: 1.625rem;
-@font-size-28: 1.75rem;
-
-@font-weight-bold: 700;
-@font-weight-medium: @font-weight-bold;
 @font-weight-regular: 500;
+@font-weight-bold: 700;
 
 @typography-bold-text-font-weight: @font-weight-bold;
 @typography-secondary-text-color: @color-text-secondary;

--- a/docs/_includes/common/section-title.html
+++ b/docs/_includes/common/section-title.html
@@ -1,7 +1,7 @@
 <div id="section-title">
     {% include common/section-header.html name="section-title" version=page.versions.section-title %}
 
-    <p>Section titles function as identifiers for groups of elements. They are used in a bold font weight, and should be used when you have a layout that has narrow space, or where the left hand rail is exposed. It's designed to have low impact on vertical space, but still help drive visual hierarchy of the page.</p>
+    <p>Section titles function as identifiers for groups of elements. They utilize the Market Sans font, with a bold font weight. Section titles have low impact on vertical space, but still help drive visual hierarchy of the page.</p>
 
     <h3>Section title</h3>
     <p>The standard top heading is designed to support a single line on desktop and wrap only when displayed on narrow screens such as mweb or native.</p>

--- a/docs/_includes/common/typography.html
+++ b/docs/_includes/common/typography.html
@@ -27,7 +27,7 @@
         </div>
     </div>
 
-    <p>The following helper classes have been defined specifically for Titles. They use media queries to resize the element based on current design system guidelines.</p>
+    <p>The following helper classes have been defined specifically for titles. All titles use the Market Sans font and are responsive based on screen size.</p>
 
     <div class="demo">
         <div class="demo__inner">

--- a/src/less/actionable/base/actionable.less
+++ b/src/less/actionable/base/actionable.less
@@ -17,6 +17,7 @@ a.icon-link {
     background-color: transparent;
     border: 2px solid transparent;
     box-sizing: border-box;
+    font-family: inherit;
     height: 40px;
     margin: 0;
     padding: 0;

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -8,7 +8,6 @@
     border-radius: 20px;
     box-sizing: border-box;
     display: inline-flex;
-    font-family: @badge-font-family;
     font-size: @font-size-12;
     font-weight: @font-weight-bold;
     height: 20px;

--- a/src/less/bundles/skin/ds4/skin.less
+++ b/src/less/bundles/skin/ds4/skin.less
@@ -1,7 +1,7 @@
 // Source file for generated skin.min.css (used by website and CDN)
 
 @import "../../../root/ds4/root.less";
-@import "../../../global/ds4/global-static.less";
+@import "../../../global/ds4/global.less";
 @import "../../../utility/ds4/utility.less";
 @import "../../../actionable/ds4/actionable.less";
 @import "../../../badge/ds4/badge.less";

--- a/src/less/bundles/skin/ds6/skin.less
+++ b/src/less/bundles/skin/ds6/skin.less
@@ -2,7 +2,7 @@
 
 @import "../../../root/ds6/root.less";
 @import "../../../marketsans/marketsans.less";
-@import "../../../global/ds6/global-static.less";
+@import "../../../global/ds6/global.less";
 @import "../../../actionable/ds6/actionable.less";
 @import "../../../badge/ds6/badge.less";
 @import "../../../breadcrumbs/ds6/breadcrumbs.less";

--- a/src/less/global/base/global.less
+++ b/src/less/global/base/global.less
@@ -1,0 +1,17 @@
+body {
+    .customBackgroundColorProperty(color-background-default);
+    .customColorProperty(color-text-default);
+
+    font-family: @font-family-default;
+    font-size: @font-size-regular;
+    -webkit-text-size-adjust: 100%;
+}
+
+fieldset {
+    border: 0;
+    padding: 0;
+}
+
+legend {
+    margin-bottom: 8px;
+}

--- a/src/less/global/ds4/global-static.less
+++ b/src/less/global/ds4/global-static.less
@@ -1,5 +1,0 @@
-@import "global.less";
-
-body {
-    font-family: @font-family-base; // change to @font-family-market-sans if/when we get DS approval
-}

--- a/src/less/global/ds4/global.less
+++ b/src/less/global/ds4/global.less
@@ -2,27 +2,10 @@
 @import "../../variables/ds4/icon-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../mixins/utility/utility-mixins.less";
-
-body {
-    .customBackgroundColorProperty(color-background-default);
-    .customColorProperty(color-text-default);
-
-    font-family: @font-family-base;
-    font-size: @font-size-regular;
-    -webkit-text-size-adjust: 100%;
-}
+@import "../base/global.less";
 
 a,
 a:focus,
 a:visited {
     .customColorProperty(color-link-hover);
-}
-
-fieldset {
-    border: 0;
-    padding: 0;
-}
-
-legend {
-    margin-bottom: 8px;
 }

--- a/src/less/global/ds6/global-static.less
+++ b/src/less/global/ds6/global-static.less
@@ -1,5 +1,0 @@
-@import "global.less";
-
-body {
-    font-family: @font-family-custom;
-}

--- a/src/less/global/ds6/global.less
+++ b/src/less/global/ds6/global.less
@@ -2,15 +2,7 @@
 @import "../../variables/ds6/icon-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../mixins/utility/utility-mixins.less";
-
-body {
-    .customBackgroundColorProperty(color-background-default);
-    .customColorProperty(color-text-default);
-
-    font-family: @font-family-default;
-    font-size: @font-size-14;
-    -webkit-text-size-adjust: 100%;
-}
+@import "../base/global.less";
 
 a {
     .customColorProperty(color-link-default);
@@ -22,13 +14,4 @@ a {
     &:hover {
         .customColorProperty(color-link-hover);
     }
-}
-
-fieldset {
-    border: 0;
-    padding: 0;
-}
-
-legend {
-    margin-bottom: 8px;
 }

--- a/src/less/mixins/filter-menu/base/filter-menu-mixins.less
+++ b/src/less/mixins/filter-menu/base/filter-menu-mixins.less
@@ -4,7 +4,6 @@
 
     box-sizing: border-box;
     display: inline-flex;
-    font-family: @filter-menu-font-family;
     font-size: @font-size-14;
     justify-content: space-between;
     line-height: 1.4em;

--- a/src/less/mixins/typography/base/typography-mixins.less
+++ b/src/less/mixins/typography/base/typography-mixins.less
@@ -35,7 +35,7 @@
 .typography-large-1-bold() {
     .typography-large-1();
 
-    font-weight: @font-weight-medium;
+    font-weight: @font-weight-bold;
 }
 
 .typography-large-1-secondary() {
@@ -86,7 +86,7 @@
 .typography-small-bold() {
     .typography-small();
 
-    font-weight: @font-weight-medium;
+    font-weight: @font-weight-bold;
 }
 
 .typography-small-secondary() {

--- a/src/less/section-title/base/section-title.less
+++ b/src/less/section-title/base/section-title.less
@@ -12,6 +12,7 @@
 .section-title__title {
     .typography-medium-bold();
 
+    font-family: @font-family-market-sans;
     margin: 0;
 }
 

--- a/src/less/select/base/select.less
+++ b/src/less/select/base/select.less
@@ -20,7 +20,7 @@ span.select {
     border-style: solid;
     border-width: 1px;
     color: inherit;
-    font-family: @select-font-family;
+    font-family: inherit;
     font-size: 1em;
     height: 40px;
     padding: @select-padding;

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -48,7 +48,6 @@ textarea.textbox__control {
     border-style: solid;
     border-width: 1px;
     box-sizing: border-box;
-    font-family: @textbox-font-family;
     font-size: 1em;
     height: @textbox-height;
     margin: 0; // Remove the margin in Firefox and Safari.

--- a/src/less/typography/base/typography.less
+++ b/src/less/typography/base/typography.less
@@ -54,29 +54,35 @@
 
 .giant-product-title,
 .giant-section-title {
+    font-family: @font-family-market-sans;
     font-size: @font-size-24;
     line-height: 36px;
 }
 
 .large-product-title,
 .large-section-title {
+    font-family: @font-family-market-sans;
     font-size: @font-size-20;
     line-height: 30px;
 }
 
 .medium-product-title,
 .medium-section-title {
+    font-family: @font-family-market-sans;
     font-size: @font-size-16;
     line-height: 24px;
 }
 
 .small-product-title,
 .small-section-title {
+    font-family: @font-family-market-sans;
     font-size: @font-size-14;
     line-height: 24px;
 }
 
+/* code smell - obfuscated classname selector */
 [class$='-section-title'] {
+    font-family: @font-family-market-sans;
     font-weight: @typography-bold-text-font-weight;
 }
 

--- a/src/less/variables/base/typography-variables.less
+++ b/src/less/variables/base/typography-variables.less
@@ -1,14 +1,10 @@
-// typography common to ds4 & ds6
-
-@font-family-default: Arial, sans-serif;
-
 @marketsans-url: "https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/";
 @marketsans-fontname: "Market Sans";
 @marketsans-filename-regular: "MarketSans-Regular-WebS";
 @marketsans-filename-bold: "MarketSans-SemiBold-WebS";
 
-@font-size-12: 0.75rem;
-@font-size-16: 1rem;
+@font-family-default: Arial, sans-serif;
+@font-family-market-sans: @marketsans-fontname, @font-family-default;
 
 @font-size-12: 0.75rem;
 @font-size-13: 0.8125rem;
@@ -17,6 +13,7 @@
 @font-size-18: 1.125rem;
 @font-size-20: 1.25rem;
 @font-size-24: 1.5rem;
+@font-size-28: 1.75rem;
 @font-size-30: 1.875rem;
 @font-size-36: 2.25rem;
 

--- a/src/less/variables/ds4/badge-variables.less
+++ b/src/less/variables/ds4/badge-variables.less
@@ -1,3 +1,2 @@
-@badge-font-family: @font-family-base;
 @badge-background-color: @color-core-red;
 @badge-foreground-color: @color-core-white;

--- a/src/less/variables/ds4/filter-menu-variables.less
+++ b/src/less/variables/ds4/filter-menu-variables.less
@@ -1,4 +1,3 @@
-@filter-menu-font-family: @font-family-base;
 @filter-menu-border-color: @color-core-gray-silver;
 @filter-menu-checkbox-unchecked-color: @color-core-gray-dim;
 @filter-menu-checkbox-checked-color: @color-core-blue;

--- a/src/less/variables/ds4/pagination-variables.less
+++ b/src/less/variables/ds4/pagination-variables.less
@@ -5,6 +5,6 @@
 @pagination-item-current-background-color: @color-core-gray-light;
 @pagination-item-current-border-color: transparent;
 @pagination-item-current-foreground-color: @color-core-gray-jet;
-@pagination-item-current-font-weight: @font-weight-medium;
+@pagination-item-current-font-weight: @font-weight-bold;
 @pagination-paddle-disabled-foreground-color: @color-core-gray-silver;
 @pagination-paddle-hover-foreground-color: #a3a3a3;

--- a/src/less/variables/ds4/select-variables.less
+++ b/src/less/variables/ds4/select-variables.less
@@ -2,7 +2,6 @@
 @select-border-color: @color-core-gray-silver;
 @select-border-radius: 3px;
 @select-foreground-color: @color-core-gray-davys;
-@select-font-family: @font-family-base;
 @select-font-size: @font-size-14;
 @select-large-font-size: @font-size-16;
 @select-padding: 0 40px 0 16px;

--- a/src/less/variables/ds4/textbox-variables.less
+++ b/src/less/variables/ds4/textbox-variables.less
@@ -2,7 +2,6 @@
 @textbox-foreground-color: @color-core-gray-davys;
 @textbox-border-color: @color-core-gray-silver;
 @textbox-border-radius: 3px;
-@textbox-font-family: @font-family-base;
 @textbox-font-size: inherit;
 @textbox-height: @ds4-height-control-medium;
 @textbox-disabled-background-color: @color-core-gray-light;

--- a/src/less/variables/ds4/typography-variables.less
+++ b/src/less/variables/ds4/typography-variables.less
@@ -1,27 +1,10 @@
 @import "../base/typography-variables.less";
 @import "color-variables.less";
 
-@font-family-osx: "Helvetica Neue", Helvetica;
-@font-family-windows: Arial;
-@font-family-android: Roboto;
-@font-family-sans-serif: @font-family-osx, @font-family-windows, @font-family-android, sans-serif;
-@font-family-base: @font-family-sans-serif;
-@font-family-market-sans: @marketsans-fontname, @font-family-sans-serif;
-
-@font-size-15: 0.9375rem;
-@font-size-17: 1.062rem;
-@font-size-28: 1.75rem;
-@font-size-44: 2.75rem;
-@font-size-50: 3.125rem;
-@font-size-56: 3.5rem;
-
-@font-weight-thin: 100;
-@font-weight-light: 200;
 @font-weight-regular: 400;
-@font-weight-medium: 500;
-@font-weight-bold: @font-weight-medium;
+@font-weight-bold: 500;
 
-@typography-bold-text-font-weight: @font-weight-medium;
+@typography-bold-text-font-weight: @font-weight-bold;
 @typography-secondary-text-color: @color-core-gray-davys;
 @typography-emphasis-color: @color-core-red;
 @typography-negative-color: @color-core-red;

--- a/src/less/variables/ds6/badge-variables.less
+++ b/src/less/variables/ds6/badge-variables.less
@@ -1,3 +1,2 @@
-@badge-font-family: @font-family-custom;
 @badge-background-color: @color-badge-background;
 @badge-foreground-color: @color-badge-text;

--- a/src/less/variables/ds6/filter-menu-variables.less
+++ b/src/less/variables/ds6/filter-menu-variables.less
@@ -1,4 +1,3 @@
-@filter-menu-font-family: @font-family-custom;
 @filter-menu-border-color: #e1e1e1;
 @filter-menu-checkbox-unchecked-color: @color-grey5;
 @filter-menu-checkbox-checked-color: @color-b4;

--- a/src/less/variables/ds6/select-variables.less
+++ b/src/less/variables/ds6/select-variables.less
@@ -2,7 +2,6 @@
 @select-border-color: @color-grey4;
 @select-border-radius: initial;
 @select-foreground-color: @color-black;
-@select-font-family: @font-family-custom;
 @select-font-size: @font-size-14;
 @select-large-font-size: @font-size-18;
 @select-padding: 0 32px 0 16px;

--- a/src/less/variables/ds6/textbox-variables.less
+++ b/src/less/variables/ds6/textbox-variables.less
@@ -2,8 +2,7 @@
 @textbox-foreground-color: @color-black;
 @textbox-border-color: @color-grey4;
 @textbox-border-radius: 0;
-@textbox-font-family: inherit;
-@textbox-font-size: @font-size-14; // for Market Sans to align with buttons and select, it needs same font-size
+@textbox-font-size: @font-size-14; // to align with buttons and select, it needs same font-size
 @textbox-height: 40px;
 @textbox-disabled-background-color: @textbox-background-color;
 @textbox-disabled-foreground-color: @color-grey3;

--- a/src/less/variables/ds6/typography-variables.less
+++ b/src/less/variables/ds6/typography-variables.less
@@ -1,18 +1,8 @@
 @import "../base/typography-variables.less";
 @import "color-variables.less";
 
-// typography unique to ds6
-
-@font-family-custom: @marketsans-fontname, @font-family-default;
-
-@font-size-10: 0.6125rem;
-@font-size-22: 1.375rem;
-@font-size-26: 1.625rem;
-@font-size-28: 1.75rem;
-
-@font-weight-bold: 700;
-@font-weight-medium: @font-weight-bold;
 @font-weight-regular: 500;
+@font-weight-bold: 700;
 
 @typography-bold-text-font-weight: @font-weight-bold;
 @typography-secondary-text-color: @color-text-secondary;


### PR DESCRIPTION
Issue #1046

* Normalizes ds4 & ds6 typography
* Makes Arial the default font-family for ds4 & ds6.
* Market Sans is applied to titles only (ds4 & ds6)
* Removes some old unused font-sizes

The normalization cleanup is another effort to simplify the system as the starting point/baseline for Northstar and beyond.