### PR TITLE
Textbox: icon-btn svg color is taking precedence over textbox svg col…

### DIFF
--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -12,14 +12,14 @@
   position: relative;
 }
 .textbox button.icon-btn {
+  display: -webkit-inline-box;
+  display: inline-flex;
+  -webkit-box-pack: center;
+          justify-content: center;
   padding: 0;
   position: absolute;
   right: 0;
-}
-.textbox button.icon-btn svg.icon {
-  left: 0;
-  right: 0;
-  width: 1.274em;
+  top: 0;
 }
 span.textbox {
   display: inline-block;
@@ -170,7 +170,8 @@ input.textbox__control--underline:focus::-ms-input-placeholder {
 input.textbox__control--underline:focus::placeholder {
   color: #767676;
 }
-.textbox svg {
+.textbox > svg,
+.textbox .icon-btn > svg {
   color: #999;
   display: -webkit-inline-box;
   display: inline-flex;
@@ -181,18 +182,18 @@ input.textbox__control--underline:focus::placeholder {
   top: 0;
   width: 1em;
 }
-.textbox svg:first-child {
+.textbox > svg:first-child {
   left: 16px;
 }
-.textbox svg:first-child + input.textbox__control,
-.textbox svg:first-child + textarea.textbox__control {
+.textbox > svg:first-child + input.textbox__control,
+.textbox > svg:first-child + textarea.textbox__control {
   padding-left: 40px;
 }
 .textbox--icon-end input.textbox__control,
 .textbox--icon-end textarea.textbox__control {
   padding-right: 40px;
 }
-.textbox--icon-end svg:last-child {
+.textbox--icon-end > svg:last-child {
   right: 16px;
 }
 .textbox--large input.textbox__control,
@@ -203,11 +204,11 @@ input.textbox__control--underline:focus::placeholder {
 .textbox__control--fluid {
   width: 100%;
 }
-[dir="rtl"] .textbox svg:first-child {
+[dir="rtl"] .textbox > svg:first-child {
   right: 16px;
 }
-[dir="rtl"] .textbox svg:first-child + input.textbox__control,
-[dir="rtl"] .textbox svg:first-child + textarea.textbox__control {
+[dir="rtl"] .textbox > svg:first-child + input.textbox__control,
+[dir="rtl"] .textbox > svg:first-child + textarea.textbox__control {
   padding-right: 40px;
 }
 [dir="rtl"] .textbox--icon-end input.textbox__control,

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -20,14 +20,14 @@
   position: relative;
 }
 .textbox button.icon-btn {
+  display: -webkit-inline-box;
+  display: inline-flex;
+  -webkit-box-pack: center;
+          justify-content: center;
   padding: 0;
   position: absolute;
   right: 0;
-}
-.textbox button.icon-btn svg.icon {
-  left: 0;
-  right: 0;
-  width: 14px;
+  top: 0;
 }
 span.textbox {
   display: inline-block;
@@ -178,7 +178,8 @@ input.textbox__control--underline:focus::-ms-input-placeholder {
 input.textbox__control--underline:focus::placeholder {
   color: #767676;
 }
-.textbox svg {
+.textbox > svg,
+.textbox .icon-btn > svg {
   color: #c7c7c7;
   display: -webkit-inline-box;
   display: inline-flex;
@@ -189,18 +190,18 @@ input.textbox__control--underline:focus::placeholder {
   top: 0;
   width: 14px;
 }
-.textbox svg:first-child {
+.textbox > svg:first-child {
   left: 16px;
 }
-.textbox svg:first-child + input.textbox__control,
-.textbox svg:first-child + textarea.textbox__control {
+.textbox > svg:first-child + input.textbox__control,
+.textbox > svg:first-child + textarea.textbox__control {
   padding-left: 40px;
 }
 .textbox--icon-end input.textbox__control,
 .textbox--icon-end textarea.textbox__control {
   padding-right: 40px;
 }
-.textbox--icon-end svg:last-child {
+.textbox--icon-end > svg:last-child {
   right: 16px;
 }
 .textbox--large input.textbox__control,
@@ -211,11 +212,11 @@ input.textbox__control--underline:focus::placeholder {
 .textbox__control--fluid {
   width: 100%;
 }
-[dir="rtl"] .textbox svg:first-child {
+[dir="rtl"] .textbox > svg:first-child {
   right: 16px;
 }
-[dir="rtl"] .textbox svg:first-child + input.textbox__control,
-[dir="rtl"] .textbox svg:first-child + textarea.textbox__control {
+[dir="rtl"] .textbox > svg:first-child + input.textbox__control,
+[dir="rtl"] .textbox > svg:first-child + textarea.textbox__control {
   padding-right: 40px;
 }
 [dir="rtl"] .textbox--icon-end input.textbox__control,

--- a/docs/_includes/common/textbox.html
+++ b/docs/_includes/common/textbox.html
@@ -128,8 +128,8 @@
     {% highlight html %}
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
-    <svg class="icon icon--messages" focusable="false" width="16" height="16" aria-hidden="true">
-        <use xlink:href="#icon-messages"></use>
+    <svg class="icon icon--clear" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="#icon-clear"></use>
     </svg>
 </span>
     {% endhighlight %}
@@ -143,8 +143,8 @@
             <span class="textbox textbox--icon-end">
                 <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
                 <button class="icon-btn" type="button" aria-label="Choose Contact">
-                    <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
-                        <use xlink:href="#icon-messages"></use>
+                    <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
+                        <use xlink:href="#icon-clear"></use>
                     </svg>
                 </button>
             </span>
@@ -155,8 +155,8 @@
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
     <button class="icon-btn" type="button" aria-label="Choose Contact">
-        <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
-            <use xlink:href="#icon-messages"></use>
+        <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
+            <use xlink:href="#icon-clear"></use>
         </svg>
     </button>
 </span>
@@ -173,8 +173,8 @@
                 </svg>
                 <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
                 <button class="icon-btn" type="button" aria-label="Choose Contact">
-                    <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
-                        <use xlink:href="#icon-messages"></use>
+                    <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
+                        <use xlink:href="#icon-clear"></use>
                     </svg>
                 </button>
             </span>

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -9,15 +9,12 @@
     position: relative;
 
     button.icon-btn {
+        display: inline-flex;
+        justify-content: center;
         padding: 0;
         position: absolute;
         right: 0;
-
-        svg.icon {
-            left: 0;
-            right: 0;
-            width: @textbox-actionable-icon-width;
-        }
+        top: 0;
     }
 }
 
@@ -171,7 +168,8 @@ input.textbox__control--underline {
     }
 }
 
-.textbox svg {
+.textbox > svg,
+.textbox .icon-btn > svg {
     color: @textbox-icon-color;
     display: inline-flex;
     fill: @textbox-icon-fill;
@@ -182,7 +180,7 @@ input.textbox__control--underline {
     width: @textbox-icon-width;
 }
 
-.textbox svg:first-child {
+.textbox > svg:first-child {
     left: 16px;
 
     + input.textbox__control,
@@ -197,7 +195,7 @@ input.textbox__control--underline {
         padding-right: 40px;
     }
 
-    svg:last-child {
+    > svg:last-child {
         right: 16px;
     }
 }
@@ -215,7 +213,7 @@ input.textbox__control--underline {
 }
 
 [dir="rtl"] {
-    .textbox svg:first-child {
+    .textbox > svg:first-child {
         right: 16px;
 
         & + input.textbox__control,


### PR DESCRIPTION
Fixes #1190

Fixes actionable icon colour inside of textbox.

When I switched the icon from `messages` to `clear`, I also noticed some layout issues and kb focus outline issues. I have fixed those by applying flex layout. I added this layout directly in the textbox module, rather than actionable, to keep footprint of this PR minimal - but we might want to revisit that at some other time.

![Screen Shot 2020-07-28 at 1 01 13 PM](https://user-images.githubusercontent.com/38065/88714993-7140c080-d0d2-11ea-94be-3bcc786effbe.png)

![Screen Shot 2020-07-28 at 12 50 46 PM](https://user-images.githubusercontent.com/38065/88715014-7aca2880-d0d2-11ea-8097-70d5ba391105.png)


