### PR TITLE
Token normalization

### DIFF
--- a/dist/actionable/ds4/actionable.css
+++ b/dist/actionable/ds4/actionable.css
@@ -4,11 +4,10 @@ button.icon-btn {
   --actionable-icon-foreground-color: #555;
   --actionable-icon-active-foreground-color: #555;
   --actionable-icon-hover-foreground-color: #333;
-  --actionable-image-hover-border-color: #999;
+  --actionable-image-hover-border-color: #767676;
 }
 a.img-link,
 button.img-btn {
-  --actionable-image-visited-background-color: #ddd;
   --actionable-image-active-border-color: #767676;
   --actionable-image-hover-border-color: #767676;
 }
@@ -99,15 +98,11 @@ a.icon-link--badged .badge {
 }
 a.img-link[href]:hover,
 a.img-link[href]:focus {
-  border-color: #999;
-  border-color: var(--actionable-image-hover-border-color, #999);
+  border-color: #767676;
+  border-color: var(--actionable-image-hover-border-color, #767676);
 }
 a.img-link[href]:active {
   border-color: #767676;
-}
-a.img-link--visit:visited {
-  background-color: #eee;
-  background-color: var(--actionable-image-visited-background-color, #eee);
 }
 a.img-link,
 button.img-btn {
@@ -121,8 +116,8 @@ button.img-btn {
 }
 button.img-btn:not([disabled]):hover,
 button.img-btn:not([disabled]):focus {
-  border-color: #999;
-  border-color: var(--actionable-image-hover-border-color, #999);
+  border-color: #767676;
+  border-color: var(--actionable-image-hover-border-color, #767676);
 }
 button.img-btn:not([disabled]):active {
   border-color: #767676;

--- a/dist/actionable/ds6/actionable.css
+++ b/dist/actionable/ds6/actionable.css
@@ -8,7 +8,6 @@ button.icon-btn {
 }
 a.img-link,
 button.img-btn {
-  --actionable-image-visited-background-color: #e5e5e5;
   --actionable-image-active-border-color: #767676;
   --actionable-image-hover-border-color: #767676;
 }
@@ -119,10 +118,6 @@ a.img-link[href]:focus {
 }
 a.img-link[href]:active {
   border-color: #767676;
-}
-a.img-link--visit:visited {
-  background-color: #e5e5e5;
-  background-color: var(--actionable-image-visited-background-color, #e5e5e5);
 }
 a.img-link,
 button.img-btn {

--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -66,7 +66,7 @@ button.infotip__close {
 }
 button.infotip__close:focus svg,
 button.infotip__close:hover svg {
-  fill: rgba(153, 153, 153, 0.9);
+  fill: #333;
 }
 button.infotip__host.icon-btn:focus,
 button.infotip__host.icon-btn:hover,
@@ -76,7 +76,7 @@ button.infotip__host.icon-btn:active {
 button.infotip__host.icon-btn:focus svg,
 button.infotip__host.icon-btn:hover svg,
 button.infotip__host.icon-btn:active svg {
-  fill: rgba(153, 153, 153, 0.9);
+  fill: #333;
 }
 .infotip__pointer {
   background-color: #fff;

--- a/dist/link/ds4/link.css
+++ b/dist/link/ds4/link.css
@@ -1,5 +1,5 @@
 a.nav-link {
-  --nav-link-color: #000;
+  --nav-link-color: #333;
   --nav-link-hover-color: #0654ba;
 }
 button.fake-link {
@@ -7,13 +7,13 @@ button.fake-link {
   --fake-link-hover-color: #0654ba;
 }
 a.nav-link {
-  color: #000;
-  color: var(--nav-link-color, #000);
+  color: #333;
+  color: var(--nav-link-color, #333);
   text-decoration: none;
 }
 a.nav-link:visited {
-  color: #000;
-  color: var(--nav-link-color, #000);
+  color: #333;
+  color: var(--nav-link-color, #333);
 }
 a.nav-link:hover {
   color: #0654ba;

--- a/dist/variables/ds4/actionable-variables.less
+++ b/dist/variables/ds4/actionable-variables.less
@@ -1,8 +1,7 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
 @actionable-icon-foreground-color: @color-icon-actionable-default;
-@actionable-icon-active-foreground-color: @color-icon-actionable-default;
-@actionable-icon-hover-foreground-color: @color-text-default;
-@actionable-image-visited-background-color: @color-core-gray-light;
-@actionable-image-hover-border-color: @color-core-gray-spanish;
-@actionable-image-active-border-color: @color-core-gray-dim;
+@actionable-icon-active-foreground-color: @color-icon-actionable-active;
+@actionable-icon-hover-foreground-color: @color-icon-actionable-hover;
+@actionable-image-hover-border-color: @color-action-secondary;
+@actionable-image-active-border-color: @color-text-secondary;

--- a/dist/variables/ds4/badge-variables.less
+++ b/dist/variables/ds4/badge-variables.less
@@ -1,2 +1,2 @@
-@badge-background-color: @color-core-red;
-@badge-foreground-color: @color-core-white;
+@badge-background-color: @color-attention-icon;
+@badge-foreground-color: @color-background-default;

--- a/dist/variables/ds4/bubble-variables.less
+++ b/dist/variables/ds4/bubble-variables.less
@@ -1,3 +1,3 @@
 @import "color-variables.less";
 
-@bubble-box-shadow-color: @color-transparent-gray-gainsboro;
+@bubble-box-shadow-color: @color-interface-menu-shadow;

--- a/dist/variables/ds4/color-variables.less
+++ b/dist/variables/ds4/color-variables.less
@@ -1,15 +1,20 @@
-// Core Colours
+// Old DS4 aliases mapped to new DS6.5 palette
+// TODO: deprecate these aliases, replace throughout system with 6.5 aliases
 //-----------------------------
 
-@color-core-black: #000;
-@color-core-gray-jet: #333;
-@color-core-gray-davys: #555;
-@color-core-gray-dim: #767676;
-@color-core-gray-spanish: #999;
-@color-core-gray-silver: #ccc;
-@color-core-gray-gainsboro: #ddd;
-@color-core-gray-light: #eee;
-@color-core-white: #fff;
+@color-core-white: @color-white;
+@color-core-gray-light: @color-grey1;
+@color-core-gray-gainsboro: @color-grey2;
+@color-core-gray-silver: @color-grey3;
+@color-core-gray-spanish: @color-grey4;
+@color-core-gray-dim: @color-grey5;
+@color-core-gray-davys: #555; // todo: remove from system
+@color-core-gray-jet: @color-grey6;
+@color-core-black: @color-black;
+
+// Core DS4 Colours
+// TODO: deprecate these aliases, replace with 6.5 aliases
+//-----------------------------
 
 @color-core-orange: #f18e0c;
 @color-core-red: #dd1e31;
@@ -17,116 +22,104 @@
 @color-core-blue-dark: #00489f;
 @color-core-blue: #0654ba;
 @color-core-violet: #b1a9dc;
-@color-core-green: #5ba71b;
-
+@color-core-green: #5ba71b; // todo: does not pass a11y color contrast
 @color-core-beige: #f0eeec;
 @color-core-beige-light: #f5f5f5;
 
-// Transparent Shades
+// DS4 Transparent Shades (deprecated - vars unused in system)
 //-----------------------------
 
 @color-transparent-black: fade(#000, 100%);
 @color-transparent-gray-dim: fade(#000, 50%);
-@color-transparent-gray-spanish: fade(@color-core-gray-spanish, 90%);
+@color-transparent-gray-spanish: fade(@color-grey4, 90%);
 @color-transparent-gray-silver: fade(#000, 30%);
 @color-transparent-gray-gainsboro: fade(#000, 15%);
 @color-transparent-white: fade(@color-core-white, 90%);
 
-// Text Colours
+// DS4 Text Colours (deprecated - vars unused in system)
 //-----------------------------
 
-@color-text-subheader: @color-core-gray-dim;
-@color-text-footnote: @color-core-gray-spanish;
+@color-text-subheader: @color-grey5;
+@color-text-footnote: @color-grey4;
 @color-text-critical: @color-core-red;
 @color-text-positive: #447d14;
 
-// Interface Colours
+// DS4 Interface Colours
+// TODO: deprecate these aliases
 //-----------------------------
 
 @color-interface-hot: @color-core-red;
 @color-interface-cta-dark: @color-core-blue-dark;
 @color-interface-cta: @color-core-blue;
 @color-interface-cta-light: #81a9dc;
-@color-interface-positive: @color-core-green;
-
-@color-interface-line-separator: @color-core-gray-gainsboro;
+@color-interface-positive: @color-text-positive;
+@color-interface-line-separator: @color-grey2;
 @color-interface-view-background: @color-core-beige;
 @color-interface-base: @color-core-beige;
 @color-interface-base-light: @color-core-beige-light;
-@color-interface-card-visited: @color-core-beige-light;
-@color-interface-card-background: @color-core-white;
-
-@color-interface-modal-shadow: @color-transparent-gray-silver;
-@color-interface-menu-shadow: @color-transparent-gray-gainsboro;
-@color-interface-card-selection: @color-core-gray-gainsboro;
-@color-interface-card-highlight: @color-core-beige-light;
+@color-interface-modal-shadow: fade(#000, 30%);
+@color-interface-menu-shadow: fade(#000, 15%);
 @color-interface-inline-text-edit: #fdfbe8;
 
-// Infographic Colours
+// DS4 Infographic Colours
+// TODO: deprecate these aliases
 //-----------------------------
 
 @color-infographic-red-interaction: #ad1f3a;
 @color-infographic-red: @color-core-red;
 @color-infographic-red-light: fade(@color-infographic-red, 60%);
 @color-infographic-red-lightest: fade(@color-infographic-red, 20%);
-
 @color-infographic-green-interaction: #457016;
 @color-infographic-green: @color-core-green;
 @color-infographic-green-light: fade(@color-infographic-green, 60%);
 @color-infographic-green-lightest: fade(@color-infographic-green, 20%);
-
 @color-infographic-blue-interaction: #00407a;
 @color-infographic-blue: @color-core-blue;
 @color-infographic-blue-light: fade(@color-infographic-blue, 60%);
 @color-infographic-blue-lightest: fade(@color-infographic-blue, 20%);
-
 @color-infographic-orange-interaction: #d36c07;
 @color-infographic-orange: @color-core-orange;
 @color-infographic-orange-light: fade(@color-infographic-orange, 60%);
 @color-infographic-orange-lightest: fade(@color-infographic-orange, 20%);
-
 @color-infographic-purple-interaction: #3d1c7c;
 @color-infographic-purple: @color-core-purple;
 @color-infographic-purple-light: fade(@color-infographic-purple, 60%);
 @color-infographic-purple-lightest: fade(@color-infographic-purple, 20%);
-
-@color-infographic-gray-interaction: @color-core-gray-jet;
+@color-infographic-gray-interaction: @color-grey6;
 @color-infographic-gray: @color-core-gray-davys;
 @color-infographic-gray-light: fade(@color-infographic-gray, 60%);
 @color-infographic-gray-lightest: fade(@color-infographic-gray, 20%);
 
-// Icon Colours
+// DS6.5 greys
+
+@color-black: #000;
+@color-grey7: #111820;
+@color-grey6: #333;
+@color-grey5: #767676;
+@color-grey4: #999;
+@color-grey3: #ccc;
+@color-grey2: #ddd;
+@color-grey1: #eee;
+@color-white: #fff;
+
+// DS6.5 product aliases (enables us to normalize module-level variables)
 //-----------------------------
 
-@color-icon: @color-core-gray-dim;
-@color-icon-null: @color-core-gray-spanish;
-@color-icon-disabled: @color-core-gray-silver;
-
-@color-icon-actionable-default: @color-core-gray-davys;
-@color-icon-actionable-hover: fadeout(@color-core-gray-spanish, 10%);
-@color-icon-actionable-focus: @color-icon-actionable-hover;
-@color-icon-actionable-active: @color-core-gray-jet;
-@color-icon-actionable-disabled: @color-core-gray-silver;
-
-// DS6 Aliases (enables us to normalize the "Color" module)
-//-----------------------------
-
-@color-text-default: @color-core-gray-jet;
-@color-text-secondary: @color-text-subheader;
-@color-text-disabled: @color-core-gray-spanish;
-@color-image-border: @color-core-gray-light;
-@color-divider: @color-core-gray-light;
+@color-text-default: @color-grey6;
+@color-text-secondary: @color-grey5;
+@color-text-disabled: @color-grey4;
+@color-image-border: @color-grey1;
+@color-divider: @color-grey1;
 @color-background-default: @color-white;
-
-@color-action-secondary: @color-text-subheader;
+@color-disabled: @color-grey3;
+@color-action-secondary: @color-grey5;
 @color-action-primary: @color-core-blue;
 @color-action-hover: #0654ba;
 @color-action-visited: @color-core-purple;
-@color-action-destroy: @color-text-critical;
+@color-action-destroy: @color-core-red;
 @color-link-default: @color-action-primary;
 @color-link-hover: @color-action-hover;
 @color-link-visited: @color-action-visited;
-
 @color-information-background: @color-infographic-blue-lightest;
 @color-information-text: @color-core-blue;
 @color-information-icon: @color-core-blue;
@@ -135,18 +128,9 @@
 @color-confirmation-icon: @color-core-green;
 @color-confirmation-border: @color-core-green;
 @color-attention-background: @color-infographic-red-lightest;
-@color-attention-text: @color-text-critical;
-@color-attention-icon: @color-text-critical;
-
-// More DS6 Aliases
-//-----------------------------
-
-// Grey
-@color-white: @color-core-white;
-@color-grey1: @color-core-gray-light;
-@color-grey2: @color-core-gray-gainsboro;
-@color-grey3: @color-core-gray-silver;
-@color-grey4: @color-core-gray-spanish;
-@color-grey5: @color-core-gray-dim;
-@color-grey6: @color-core-gray-jet;
-@color-black: @color-core-black;
+@color-attention-text: @color-core-red;
+@color-attention-icon: @color-core-red;
+@color-icon-disabled: @color-disabled;
+@color-icon-actionable-default: @color-core-gray-davys;
+@color-icon-actionable-hover: @color-grey6;
+@color-icon-actionable-active: @color-core-gray-davys;

--- a/dist/variables/ds4/infotip-variables.less
+++ b/dist/variables/ds4/infotip-variables.less
@@ -1,3 +1,3 @@
-@infotip-background-color: #fff;
+@infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
 @infotip-close-hover-foreground-color: @color-icon-actionable-hover;

--- a/dist/variables/ds4/link-variables.less
+++ b/dist/variables/ds4/link-variables.less
@@ -1,4 +1,4 @@
-@nav-link-color: @color-core-black;
+@nav-link-color: @color-text-default;
 @nav-link-hover-color: @color-link-default;
 @fake-link-color: @color-link-default;
 @fake-link-hover-color: @color-link-hover;

--- a/dist/variables/ds4/switch-variables.less
+++ b/dist/variables/ds4/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-checked-background-color: @color-interface-cta;
-@switch-disabled-background-color: @color-core-gray-silver;
-@switch-unchecked-background-color: @color-core-gray-dim;
-@switch-foreground-color: @color-core-white;
-@switch-outline-color: @color-grey5;
+@switch-checked-background-color: @color-action-primary;
+@switch-disabled-background-color: @color-disabled;
+@switch-unchecked-background-color: @color-action-secondary;
+@switch-foreground-color: @color-background-default;
+@switch-custom-outline-color: @color-action-secondary;

--- a/dist/variables/ds6/actionable-variables.less
+++ b/dist/variables/ds6/actionable-variables.less
@@ -1,8 +1,7 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
-@actionable-icon-foreground-color: @color-text-default;
-@actionable-icon-active-foreground-color: @color-text-default;
-@actionable-icon-hover-foreground-color: @color-b4;
-@actionable-image-visited-background-color: @color-grey2;
+@actionable-icon-foreground-color: @color-icon-actionable-default;
+@actionable-icon-active-foreground-color: @color-icon-actionable-active;
+@actionable-icon-hover-foreground-color: @color-icon-actionable-hover;
+@actionable-image-hover-border-color: @color-action-secondary;
 @actionable-image-active-border-color: @color-text-secondary;
-@actionable-image-hover-border-color: @color-grey5;

--- a/dist/variables/ds6/badge-variables.less
+++ b/dist/variables/ds6/badge-variables.less
@@ -1,2 +1,2 @@
-@badge-background-color: @color-r4;
-@badge-foreground-color: @color-white;
+@badge-background-color: @color-attention-icon;
+@badge-foreground-color: @color-background-default;

--- a/dist/variables/ds6/color-variables.less
+++ b/dist/variables/ds6/color-variables.less
@@ -1,8 +1,3 @@
-// Colours
-//----------------------
-
-// BRAND COLORS
-
 // Yellow
 @color-y1: #fcf2bd;
 @color-y2: #f7e376;
@@ -11,6 +6,7 @@
 @color-y5: #e58c02;
 @color-y6: #aa5404;
 @color-y7: #592e13;
+
 // Orange
 @color-o1: #ffdec7;
 @color-o2: #feb786;
@@ -19,6 +15,7 @@
 @color-o5: #db3c07;
 @color-o6: #b03005;
 @color-o7: #5c1b05;
+
 // Red
 @color-r1: #ffd1dd;
 @color-r2: #ffa2b6;
@@ -27,6 +24,7 @@
 @color-r5: #c4003a;
 @color-r6: #a00739;
 @color-r7: #680226;
+
 // Magenta
 @color-m1: #fad8f0;
 @color-m2: #f5a0d9;
@@ -35,6 +33,7 @@
 @color-m5: #a60d8a;
 @color-m6: #82187c;
 @color-m7: #500750;
+
 // Blue
 @color-b1: #c5e5fb;
 @color-b2: #93c9ff;
@@ -43,6 +42,7 @@
 @color-b5: #382aef;
 @color-b6: #2b0eaf;
 @color-b7: #121258;
+
 // Teal
 @color-t1: #c2f2ef;
 @color-t2: #71e3e2;
@@ -51,6 +51,7 @@
 @color-t5: #01718f;
 @color-t6: #0e4a6c;
 @color-t7: #003147;
+
 // Green
 @color-g1: #ccfdce;
 @color-g2: #9ef4a6;
@@ -59,6 +60,7 @@
 @color-g5: #1bab49;
 @color-g6: #05823f;
 @color-g7: #07522c;
+
 // Lime
 @color-l1: #f4fabe;
 @color-l2: #e9f577;
@@ -67,6 +69,7 @@
 @color-l5: #86b300;
 @color-l6: #4b7d06;
 @color-l7: #364f03;
+
 // Grey
 @color-white: #fff;
 @color-grey1: #f5f5f5;
@@ -76,9 +79,9 @@
 @color-grey5: #767676;
 @color-grey6: #414141;
 @color-grey7: #111820;
-@color-black: @color-grey7;
+@color-black: @color-grey7; // todo: make this #000
 
-// Dark mode greys
+// Grey (dark mode)
 @color-black-dark-mode: #171717;
 @color-grey1-dark-mode: #212121;
 @color-grey2-dark-mode: #393939;
@@ -88,7 +91,8 @@
 @color-grey6-dark-mode: #ababab;
 @color-grey7-dark-mode: #dcdcdc;
 @color-white-dark-mode: @color-grey7-dark-mode;
-// Dark mode colors
+
+// Colors (dark mode)
 @color-b4-dark-mode: #5192ff;
 @color-b6-dark-mode: #94bcff;
 @color-m4-dark-mode: #d2a4cf;
@@ -96,13 +100,14 @@
 @color-g4-dark-mode: #24bc6b;
 @color-g6-dark-mode: #30c550;
 
-// PRODUCT COLORS
+// Product aliases
 @color-text-default: @color-grey7;
 @color-text-secondary: @color-grey5;
 @color-text-disabled: @color-grey3;
 @color-image-border: @color-grey2;
 @color-divider: @color-grey2;
 @color-background-default: @color-white;
+@color-disabled: @color-grey3;
 @color-action-secondary: @color-grey5;
 @color-action-primary: @color-b4;
 @color-action-hover: @color-b6;
@@ -121,9 +126,12 @@
 @color-attention-background: #fff5f8; // secret colour
 @color-attention-text: @color-r4;
 @color-attention-icon: @color-r4;
-@color-disabled: @color-grey3;
+@color-icon-disabled: @color-text-disabled;
+@color-icon-actionable-default: @color-text-default;
+@color-icon-actionable-active: @color-text-default;
+@color-icon-actionable-hover: @color-b4;
 
-// Dark mode product colors
+// Product aliases (dark mode)
 @color-background-default-dark-mode: @color-black-dark-mode;
 @color-text-default-dark-mode: @color-grey7-dark-mode;
 @color-text-secondary-dark-mode: @color-grey5-dark-mode;

--- a/dist/variables/ds6/icon-variables.less
+++ b/dist/variables/ds6/icon-variables.less
@@ -1,4 +1,4 @@
-@icon-color-disabled: @color-text-disabled;
+@icon-color-disabled: @color-icon-disabled;
 
 // Icon Dimensions
 //-------------------------

--- a/dist/variables/ds6/infotip-variables.less
+++ b/dist/variables/ds6/infotip-variables.less
@@ -1,3 +1,3 @@
-@infotip-background-color: @color-white;
+@infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
-@infotip-close-hover-foreground-color: @color-b4;
+@infotip-close-hover-foreground-color: @color-icon-actionable-hover;

--- a/dist/variables/ds6/link-variables.less
+++ b/dist/variables/ds6/link-variables.less
@@ -1,4 +1,4 @@
-@nav-link-color: @color-black;
+@nav-link-color: @color-text-default;
 @nav-link-hover-color: @color-link-default;
 @fake-link-color: @color-link-default;
 @fake-link-hover-color: @color-link-hover;

--- a/dist/variables/ds6/switch-variables.less
+++ b/dist/variables/ds6/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-checked-background-color: @color-b4;
-@switch-disabled-background-color: @color-grey3;
-@switch-unchecked-background-color: @color-grey5;
-@switch-foreground-color: @color-white;
-@switch-outline-color: @color-grey5;
+@switch-checked-background-color: @color-action-primary;
+@switch-disabled-background-color: @color-disabled;
+@switch-unchecked-background-color: @color-action-secondary;
+@switch-foreground-color: @color-background-default;
+@switch-custom-outline-color: @color-action-secondary;

--- a/docs/_includes/common/icon.html
+++ b/docs/_includes/common/icon.html
@@ -169,7 +169,7 @@
     <div class="demo">
         <div class="demo__inner">
             <svg aria-label="Disabled icon example" class="icon icon--chevron-right icon--disabled" focusable="false" height="24" width="24" role="img">
-                <use xlink:href="{{ page.svg_path }}#icon-chevron-right"></use>
+                {% include common/symbol.html name="chevron-right" %}
             </svg>
         </div>
     </div>

--- a/docs/_includes/common/less.html
+++ b/docs/_includes/common/less.html
@@ -50,6 +50,7 @@
                 <li class="demo-color-grey4">@color-grey4 <span class="demo-colors__info">(#{% if page.ds == 4 %}999{% else %}a2a2a2{% endif %})</span></li>
                 <li class="demo-color-grey5">@color-grey5 <span class="demo-colors__info">(#767676)</span></li>
                 <li class="demo-color-grey6">@color-grey6 <span class="demo-colors__info">(#{% if page.ds == 4 %}333{% else %}41413f{% endif %})</span></li>
+                <li class="demo-color-grey6">@color-grey7 <span class="demo-colors__info">(#111820)</span></li>
                 <li class="demo-color-black">@color-black <span class="demo-colors__info">(#{% if page.ds == 4 %}000{% else %}111820{% endif %})</span></li>
             </ul>
         </div>

--- a/docs/_includes/common/main.html
+++ b/docs/_includes/common/main.html
@@ -1,3 +1,7 @@
+{% comment %}
+{% include ds{{ page.ds }}/symbols.html %}
+{% endcomment %}
+
 {% include common/about.html %}
 <img class="skin-graphic" src="{{ page.static_dir }}/skin-graphic.png" alt="" />
 {% include common/install.html %}

--- a/src/less/actionable/base/actionable.less
+++ b/src/less/actionable/base/actionable.less
@@ -109,10 +109,6 @@ a.img-link {
     }
 }
 
-a.img-link--visit:visited {
-    .customBackgroundColorProperty(actionable-image-visited-background-color);
-}
-
 a.img-link,
 button.img-btn {
     border: 1px solid transparent;

--- a/src/less/properties/base/actionable-properties.less
+++ b/src/less/properties/base/actionable-properties.less
@@ -9,7 +9,6 @@ button.icon-btn {
 
 a.img-link,
 button.img-btn {
-    --actionable-image-visited-background-color: @color-grey2;
-    --actionable-image-active-border-color: @color-text-secondary;
-    --actionable-image-hover-border-color: @color-grey5;
+    --actionable-image-active-border-color: @actionable-image-active-border-color;
+    --actionable-image-hover-border-color: @actionable-image-hover-border-color;
 }

--- a/src/less/switch/base/switch.less
+++ b/src/less/switch/base/switch.less
@@ -60,7 +60,7 @@ input.switch__control {
     opacity: 0;
 
     &:focus + span.switch__button {
-        outline: 1px dotted @switch-outline-color;
+        outline: 1px dotted @switch-custom-outline-color;
     }
 }
 

--- a/src/less/variables/ds4/actionable-variables.less
+++ b/src/less/variables/ds4/actionable-variables.less
@@ -1,8 +1,7 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
 @actionable-icon-foreground-color: @color-icon-actionable-default;
-@actionable-icon-active-foreground-color: @color-icon-actionable-default;
-@actionable-icon-hover-foreground-color: @color-text-default;
-@actionable-image-visited-background-color: @color-core-gray-light;
-@actionable-image-hover-border-color: @color-core-gray-spanish;
-@actionable-image-active-border-color: @color-core-gray-dim;
+@actionable-icon-active-foreground-color: @color-icon-actionable-active;
+@actionable-icon-hover-foreground-color: @color-icon-actionable-hover;
+@actionable-image-hover-border-color: @color-action-secondary;
+@actionable-image-active-border-color: @color-text-secondary;

--- a/src/less/variables/ds4/badge-variables.less
+++ b/src/less/variables/ds4/badge-variables.less
@@ -1,2 +1,2 @@
-@badge-background-color: @color-core-red;
-@badge-foreground-color: @color-core-white;
+@badge-background-color: @color-attention-icon;
+@badge-foreground-color: @color-background-default;

--- a/src/less/variables/ds4/bubble-variables.less
+++ b/src/less/variables/ds4/bubble-variables.less
@@ -1,3 +1,3 @@
 @import "color-variables.less";
 
-@bubble-box-shadow-color: @color-transparent-gray-gainsboro;
+@bubble-box-shadow-color: @color-interface-menu-shadow;

--- a/src/less/variables/ds4/color-variables.less
+++ b/src/less/variables/ds4/color-variables.less
@@ -1,15 +1,20 @@
-// Core Colours
+// Old DS4 aliases mapped to new DS6.5 palette
+// TODO: deprecate these aliases, replace throughout system with 6.5 aliases
 //-----------------------------
 
-@color-core-black: #000;
-@color-core-gray-jet: #333;
-@color-core-gray-davys: #555;
-@color-core-gray-dim: #767676;
-@color-core-gray-spanish: #999;
-@color-core-gray-silver: #ccc;
-@color-core-gray-gainsboro: #ddd;
-@color-core-gray-light: #eee;
-@color-core-white: #fff;
+@color-core-white: @color-white;
+@color-core-gray-light: @color-grey1;
+@color-core-gray-gainsboro: @color-grey2;
+@color-core-gray-silver: @color-grey3;
+@color-core-gray-spanish: @color-grey4;
+@color-core-gray-dim: @color-grey5;
+@color-core-gray-davys: #555; // todo: remove from system
+@color-core-gray-jet: @color-grey6;
+@color-core-black: @color-black;
+
+// Core DS4 Colours
+// TODO: deprecate these aliases, replace with 6.5 aliases
+//-----------------------------
 
 @color-core-orange: #f18e0c;
 @color-core-red: #dd1e31;
@@ -17,116 +22,104 @@
 @color-core-blue-dark: #00489f;
 @color-core-blue: #0654ba;
 @color-core-violet: #b1a9dc;
-@color-core-green: #5ba71b;
-
+@color-core-green: #5ba71b; // todo: does not pass a11y color contrast
 @color-core-beige: #f0eeec;
 @color-core-beige-light: #f5f5f5;
 
-// Transparent Shades
+// DS4 Transparent Shades (deprecated - vars unused in system)
 //-----------------------------
 
 @color-transparent-black: fade(#000, 100%);
 @color-transparent-gray-dim: fade(#000, 50%);
-@color-transparent-gray-spanish: fade(@color-core-gray-spanish, 90%);
+@color-transparent-gray-spanish: fade(@color-grey4, 90%);
 @color-transparent-gray-silver: fade(#000, 30%);
 @color-transparent-gray-gainsboro: fade(#000, 15%);
 @color-transparent-white: fade(@color-core-white, 90%);
 
-// Text Colours
+// DS4 Text Colours (deprecated - vars unused in system)
 //-----------------------------
 
-@color-text-subheader: @color-core-gray-dim;
-@color-text-footnote: @color-core-gray-spanish;
+@color-text-subheader: @color-grey5;
+@color-text-footnote: @color-grey4;
 @color-text-critical: @color-core-red;
 @color-text-positive: #447d14;
 
-// Interface Colours
+// DS4 Interface Colours
+// TODO: deprecate these aliases
 //-----------------------------
 
 @color-interface-hot: @color-core-red;
 @color-interface-cta-dark: @color-core-blue-dark;
 @color-interface-cta: @color-core-blue;
 @color-interface-cta-light: #81a9dc;
-@color-interface-positive: @color-core-green;
-
-@color-interface-line-separator: @color-core-gray-gainsboro;
+@color-interface-positive: @color-text-positive;
+@color-interface-line-separator: @color-grey2;
 @color-interface-view-background: @color-core-beige;
 @color-interface-base: @color-core-beige;
 @color-interface-base-light: @color-core-beige-light;
-@color-interface-card-visited: @color-core-beige-light;
-@color-interface-card-background: @color-core-white;
-
-@color-interface-modal-shadow: @color-transparent-gray-silver;
-@color-interface-menu-shadow: @color-transparent-gray-gainsboro;
-@color-interface-card-selection: @color-core-gray-gainsboro;
-@color-interface-card-highlight: @color-core-beige-light;
+@color-interface-modal-shadow: fade(#000, 30%);
+@color-interface-menu-shadow: fade(#000, 15%);
 @color-interface-inline-text-edit: #fdfbe8;
 
-// Infographic Colours
+// DS4 Infographic Colours
+// TODO: deprecate these aliases
 //-----------------------------
 
 @color-infographic-red-interaction: #ad1f3a;
 @color-infographic-red: @color-core-red;
 @color-infographic-red-light: fade(@color-infographic-red, 60%);
 @color-infographic-red-lightest: fade(@color-infographic-red, 20%);
-
 @color-infographic-green-interaction: #457016;
 @color-infographic-green: @color-core-green;
 @color-infographic-green-light: fade(@color-infographic-green, 60%);
 @color-infographic-green-lightest: fade(@color-infographic-green, 20%);
-
 @color-infographic-blue-interaction: #00407a;
 @color-infographic-blue: @color-core-blue;
 @color-infographic-blue-light: fade(@color-infographic-blue, 60%);
 @color-infographic-blue-lightest: fade(@color-infographic-blue, 20%);
-
 @color-infographic-orange-interaction: #d36c07;
 @color-infographic-orange: @color-core-orange;
 @color-infographic-orange-light: fade(@color-infographic-orange, 60%);
 @color-infographic-orange-lightest: fade(@color-infographic-orange, 20%);
-
 @color-infographic-purple-interaction: #3d1c7c;
 @color-infographic-purple: @color-core-purple;
 @color-infographic-purple-light: fade(@color-infographic-purple, 60%);
 @color-infographic-purple-lightest: fade(@color-infographic-purple, 20%);
-
-@color-infographic-gray-interaction: @color-core-gray-jet;
+@color-infographic-gray-interaction: @color-grey6;
 @color-infographic-gray: @color-core-gray-davys;
 @color-infographic-gray-light: fade(@color-infographic-gray, 60%);
 @color-infographic-gray-lightest: fade(@color-infographic-gray, 20%);
 
-// Icon Colours
+// DS6.5 greys
+
+@color-black: #000;
+@color-grey7: #111820;
+@color-grey6: #333;
+@color-grey5: #767676;
+@color-grey4: #999;
+@color-grey3: #ccc;
+@color-grey2: #ddd;
+@color-grey1: #eee;
+@color-white: #fff;
+
+// DS6.5 product aliases (enables us to normalize module-level variables)
 //-----------------------------
 
-@color-icon: @color-core-gray-dim;
-@color-icon-null: @color-core-gray-spanish;
-@color-icon-disabled: @color-core-gray-silver;
-
-@color-icon-actionable-default: @color-core-gray-davys;
-@color-icon-actionable-hover: fadeout(@color-core-gray-spanish, 10%);
-@color-icon-actionable-focus: @color-icon-actionable-hover;
-@color-icon-actionable-active: @color-core-gray-jet;
-@color-icon-actionable-disabled: @color-core-gray-silver;
-
-// DS6 Aliases (enables us to normalize the "Color" module)
-//-----------------------------
-
-@color-text-default: @color-core-gray-jet;
-@color-text-secondary: @color-text-subheader;
-@color-text-disabled: @color-core-gray-spanish;
-@color-image-border: @color-core-gray-light;
-@color-divider: @color-core-gray-light;
+@color-text-default: @color-grey6;
+@color-text-secondary: @color-grey5;
+@color-text-disabled: @color-grey4;
+@color-image-border: @color-grey1;
+@color-divider: @color-grey1;
 @color-background-default: @color-white;
-
-@color-action-secondary: @color-text-subheader;
+@color-disabled: @color-grey3;
+@color-action-secondary: @color-grey5;
 @color-action-primary: @color-core-blue;
 @color-action-hover: #0654ba;
 @color-action-visited: @color-core-purple;
-@color-action-destroy: @color-text-critical;
+@color-action-destroy: @color-core-red;
 @color-link-default: @color-action-primary;
 @color-link-hover: @color-action-hover;
 @color-link-visited: @color-action-visited;
-
 @color-information-background: @color-infographic-blue-lightest;
 @color-information-text: @color-core-blue;
 @color-information-icon: @color-core-blue;
@@ -135,18 +128,9 @@
 @color-confirmation-icon: @color-core-green;
 @color-confirmation-border: @color-core-green;
 @color-attention-background: @color-infographic-red-lightest;
-@color-attention-text: @color-text-critical;
-@color-attention-icon: @color-text-critical;
-
-// More DS6 Aliases
-//-----------------------------
-
-// Grey
-@color-white: @color-core-white;
-@color-grey1: @color-core-gray-light;
-@color-grey2: @color-core-gray-gainsboro;
-@color-grey3: @color-core-gray-silver;
-@color-grey4: @color-core-gray-spanish;
-@color-grey5: @color-core-gray-dim;
-@color-grey6: @color-core-gray-jet;
-@color-black: @color-core-black;
+@color-attention-text: @color-core-red;
+@color-attention-icon: @color-core-red;
+@color-icon-disabled: @color-disabled;
+@color-icon-actionable-default: @color-core-gray-davys;
+@color-icon-actionable-hover: @color-grey6;
+@color-icon-actionable-active: @color-core-gray-davys;

--- a/src/less/variables/ds4/infotip-variables.less
+++ b/src/less/variables/ds4/infotip-variables.less
@@ -1,3 +1,3 @@
-@infotip-background-color: #fff;
+@infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
 @infotip-close-hover-foreground-color: @color-icon-actionable-hover;

--- a/src/less/variables/ds4/link-variables.less
+++ b/src/less/variables/ds4/link-variables.less
@@ -1,4 +1,4 @@
-@nav-link-color: @color-core-black;
+@nav-link-color: @color-text-default;
 @nav-link-hover-color: @color-link-default;
 @fake-link-color: @color-link-default;
 @fake-link-hover-color: @color-link-hover;

--- a/src/less/variables/ds4/switch-variables.less
+++ b/src/less/variables/ds4/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-checked-background-color: @color-interface-cta;
-@switch-disabled-background-color: @color-core-gray-silver;
-@switch-unchecked-background-color: @color-core-gray-dim;
-@switch-foreground-color: @color-core-white;
-@switch-outline-color: @color-grey5;
+@switch-checked-background-color: @color-action-primary;
+@switch-disabled-background-color: @color-disabled;
+@switch-unchecked-background-color: @color-action-secondary;
+@switch-foreground-color: @color-background-default;
+@switch-custom-outline-color: @color-action-secondary;

--- a/src/less/variables/ds6/actionable-variables.less
+++ b/src/less/variables/ds6/actionable-variables.less
@@ -1,8 +1,7 @@
 @actionable-badge-border-color: @color-background-default;
 @actionable-badge-font-size: @font-size-12;
-@actionable-icon-foreground-color: @color-text-default;
-@actionable-icon-active-foreground-color: @color-text-default;
-@actionable-icon-hover-foreground-color: @color-b4;
-@actionable-image-visited-background-color: @color-grey2;
+@actionable-icon-foreground-color: @color-icon-actionable-default;
+@actionable-icon-active-foreground-color: @color-icon-actionable-active;
+@actionable-icon-hover-foreground-color: @color-icon-actionable-hover;
+@actionable-image-hover-border-color: @color-action-secondary;
 @actionable-image-active-border-color: @color-text-secondary;
-@actionable-image-hover-border-color: @color-grey5;

--- a/src/less/variables/ds6/badge-variables.less
+++ b/src/less/variables/ds6/badge-variables.less
@@ -1,2 +1,2 @@
-@badge-background-color: @color-r4;
-@badge-foreground-color: @color-white;
+@badge-background-color: @color-attention-icon;
+@badge-foreground-color: @color-background-default;

--- a/src/less/variables/ds6/color-variables.less
+++ b/src/less/variables/ds6/color-variables.less
@@ -1,8 +1,3 @@
-// Colours
-//----------------------
-
-// BRAND COLORS
-
 // Yellow
 @color-y1: #fcf2bd;
 @color-y2: #f7e376;
@@ -11,6 +6,7 @@
 @color-y5: #e58c02;
 @color-y6: #aa5404;
 @color-y7: #592e13;
+
 // Orange
 @color-o1: #ffdec7;
 @color-o2: #feb786;
@@ -19,6 +15,7 @@
 @color-o5: #db3c07;
 @color-o6: #b03005;
 @color-o7: #5c1b05;
+
 // Red
 @color-r1: #ffd1dd;
 @color-r2: #ffa2b6;
@@ -27,6 +24,7 @@
 @color-r5: #c4003a;
 @color-r6: #a00739;
 @color-r7: #680226;
+
 // Magenta
 @color-m1: #fad8f0;
 @color-m2: #f5a0d9;
@@ -35,6 +33,7 @@
 @color-m5: #a60d8a;
 @color-m6: #82187c;
 @color-m7: #500750;
+
 // Blue
 @color-b1: #c5e5fb;
 @color-b2: #93c9ff;
@@ -43,6 +42,7 @@
 @color-b5: #382aef;
 @color-b6: #2b0eaf;
 @color-b7: #121258;
+
 // Teal
 @color-t1: #c2f2ef;
 @color-t2: #71e3e2;
@@ -51,6 +51,7 @@
 @color-t5: #01718f;
 @color-t6: #0e4a6c;
 @color-t7: #003147;
+
 // Green
 @color-g1: #ccfdce;
 @color-g2: #9ef4a6;
@@ -59,6 +60,7 @@
 @color-g5: #1bab49;
 @color-g6: #05823f;
 @color-g7: #07522c;
+
 // Lime
 @color-l1: #f4fabe;
 @color-l2: #e9f577;
@@ -67,6 +69,7 @@
 @color-l5: #86b300;
 @color-l6: #4b7d06;
 @color-l7: #364f03;
+
 // Grey
 @color-white: #fff;
 @color-grey1: #f5f5f5;
@@ -76,9 +79,9 @@
 @color-grey5: #767676;
 @color-grey6: #414141;
 @color-grey7: #111820;
-@color-black: @color-grey7;
+@color-black: @color-grey7; // todo: make this #000
 
-// Dark mode greys
+// Grey (dark mode)
 @color-black-dark-mode: #171717;
 @color-grey1-dark-mode: #212121;
 @color-grey2-dark-mode: #393939;
@@ -88,7 +91,8 @@
 @color-grey6-dark-mode: #ababab;
 @color-grey7-dark-mode: #dcdcdc;
 @color-white-dark-mode: @color-grey7-dark-mode;
-// Dark mode colors
+
+// Colors (dark mode)
 @color-b4-dark-mode: #5192ff;
 @color-b6-dark-mode: #94bcff;
 @color-m4-dark-mode: #d2a4cf;
@@ -96,13 +100,14 @@
 @color-g4-dark-mode: #24bc6b;
 @color-g6-dark-mode: #30c550;
 
-// PRODUCT COLORS
+// Product aliases
 @color-text-default: @color-grey7;
 @color-text-secondary: @color-grey5;
 @color-text-disabled: @color-grey3;
 @color-image-border: @color-grey2;
 @color-divider: @color-grey2;
 @color-background-default: @color-white;
+@color-disabled: @color-grey3;
 @color-action-secondary: @color-grey5;
 @color-action-primary: @color-b4;
 @color-action-hover: @color-b6;
@@ -121,9 +126,12 @@
 @color-attention-background: #fff5f8; // secret colour
 @color-attention-text: @color-r4;
 @color-attention-icon: @color-r4;
-@color-disabled: @color-grey3;
+@color-icon-disabled: @color-text-disabled;
+@color-icon-actionable-default: @color-text-default;
+@color-icon-actionable-active: @color-text-default;
+@color-icon-actionable-hover: @color-b4;
 
-// Dark mode product colors
+// Product aliases (dark mode)
 @color-background-default-dark-mode: @color-black-dark-mode;
 @color-text-default-dark-mode: @color-grey7-dark-mode;
 @color-text-secondary-dark-mode: @color-grey5-dark-mode;

--- a/src/less/variables/ds6/icon-variables.less
+++ b/src/less/variables/ds6/icon-variables.less
@@ -1,4 +1,4 @@
-@icon-color-disabled: @color-text-disabled;
+@icon-color-disabled: @color-icon-disabled;
 
 // Icon Dimensions
 //-------------------------

--- a/src/less/variables/ds6/infotip-variables.less
+++ b/src/less/variables/ds6/infotip-variables.less
@@ -1,3 +1,3 @@
-@infotip-background-color: @color-white;
+@infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
-@infotip-close-hover-foreground-color: @color-b4;
+@infotip-close-hover-foreground-color: @color-icon-actionable-hover;

--- a/src/less/variables/ds6/link-variables.less
+++ b/src/less/variables/ds6/link-variables.less
@@ -1,4 +1,4 @@
-@nav-link-color: @color-black;
+@nav-link-color: @color-text-default;
 @nav-link-hover-color: @color-link-default;
 @fake-link-color: @color-link-default;
 @fake-link-hover-color: @color-link-hover;

--- a/src/less/variables/ds6/switch-variables.less
+++ b/src/less/variables/ds6/switch-variables.less
@@ -1,5 +1,5 @@
-@switch-checked-background-color: @color-b4;
-@switch-disabled-background-color: @color-grey3;
-@switch-unchecked-background-color: @color-grey5;
-@switch-foreground-color: @color-white;
-@switch-outline-color: @color-grey5;
+@switch-checked-background-color: @color-action-primary;
+@switch-disabled-background-color: @color-disabled;
+@switch-unchecked-background-color: @color-action-secondary;
+@switch-foreground-color: @color-background-default;
+@switch-custom-outline-color: @color-action-secondary;


### PR DESCRIPTION
After a conversation with @mlrawlings he pointed out that more of the module variables files could be making use of product aliases, rather than arbitrary values, globals and primitives. I agree with him. This PR is tackles a few modules - actionable, badge, infotip & switch. If we are in agreement with this kind of direction we can follow up and do the rest of the modules. Ultimately, if we are to get onto a fully token based system, I do think we need to do this, and now is a good time.

Also, a few DS4 values change slightly as a result of this normalization:

* Nav link text colour (changes from black to default text colour)
* Actionable image border hover state (changes from arbitrary grey to a secondary text grey)
* Infotip close hover state (changes from arbitrary grey to a actionable icon hover grey)

I would expect more minor changes like this in DS4 as we go, but I think it's okay. 

I've also made a first step in starting to normalize the main color variables files themselves. I'm not sure we'll ever get the two fully in sync (as in, have all of the same token keys), or whether we need to, but I've given it a bit of a clean up and marked the deprecated parts of the DS4 naming convention.

