### PR TITLE
Removed extra margin for ds4 dialog

### DIFF
--- a/dist/dialog/ds4/dialog.css
+++ b/dist/dialog/ds4/dialog.css
@@ -401,6 +401,9 @@
   top: 0;
   white-space: nowrap;
 }
+.dialog__header > :last-child:not(:only-child) {
+  margin-left: 0;
+}
 .dialog__header > .dialog__close {
   position: absolute;
 }

--- a/src/less/dialog/ds4/dialog.less
+++ b/src/less/dialog/ds4/dialog.less
@@ -34,6 +34,11 @@
     white-space: nowrap;
 }
 
+// This can be removed in 11.0.0
+.dialog__header > :last-child:not(:only-child) {
+    margin-left: 0;
+}
+
 .dialog__header > .dialog__close {
     position: absolute;
 }


### PR DESCRIPTION
## Description
Removed a margin in DS4 dialog header which was causing some extra lines appearing. 

## References
https://github.com/eBay/ebayui-core/issues/1168

## Screenshots
<img width="924" alt="Screen Shot 2020-08-10 at 10 24 16 AM" src="https://user-images.githubusercontent.com/1755269/89811533-a813cf00-daf3-11ea-9502-b27f8455a770.png">
