### PR TITLE
add a top level less file to export all skin variables to be used in …

### DIFF
--- a/browser.json
+++ b/browser.json
@@ -101,6 +101,11 @@
       "if-flag": "ds-4"
     },
     {
+      "from": "./less.less",
+      "to": "./less[ds-4].less",
+      "if-flag": "ds-4"
+    },
+    {
       "from": "./link.js",
       "to": "./link[ds-4].js",
       "if-flag": "ds-4"

--- a/less.less
+++ b/less.less
@@ -1,0 +1,6 @@
+@import './dist/variables/ds6/color-variables.less';
+@import './dist/variables/ds6/icon-variables.less';
+@import './dist/variables/ds6/typography-variables.less';
+@import './dist/mixins/utility/utility-mixins.less';
+@import './dist/mixins/icon/ds6/icon-mixins.less';
+@import './dist/mixins/typography/ds6/typography-mixins.less';

--- a/less[ds-4].less
+++ b/less[ds-4].less
@@ -1,0 +1,6 @@
+@import './dist/variables/ds4/color-variables.less';
+@import './dist/variables/ds4/icon-variables.less';
+@import './dist/variables/ds4/typography-variables.less';
+@import './dist/mixins/utility/utility-mixins.less';
+@import './dist/mixins/icon/ds4/icon-mixins.less';
+@import './dist/mixins/typography/ds4/typography-mixins.less';


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
Add a top level `.less` file to be used in webpack/storybook. 

## Context
Not having a top level `.less` file is forcing apps to dig deep into skin structure to access the variables. 

## References
Fixes #1197 