### PR TITLE
Combobox: match DS4 color with textbox & select #1212

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -2,7 +2,7 @@
   --combobox-background-color: #fff;
   --combobox-border-color: #ccc;
   --combobox-border-radius: 3px;
-  --combobox-foreground-color: #333;
+  --combobox-foreground-color: #555;
   --combobox-focus-border-color: #0654ba;
   --dropdown-items-background-color: #fff;
   --dropdown-items-border-color: #ccc;
@@ -143,8 +143,8 @@ span.combobox {
   background-color: var(--combobox-background-color, #fff);
   border-color: #ccc;
   border-color: var(--combobox-border-color, #ccc);
-  color: #333;
-  color: var(--combobox-foreground-color, #333);
+  color: #555;
+  color: var(--combobox-foreground-color, #555);
   border-radius: 3px;
   border-radius: var(--combobox-border-radius, 3px);
   -webkit-appearance: none;
@@ -162,8 +162,8 @@ span.combobox {
   padding: 0 32px 0 16px;
 }
 .combobox__control > input[readonly] {
-  color: #333;
-  color: var(--combobox-foreground-color, #333);
+  color: #555;
+  color: var(--combobox-foreground-color, #555);
   cursor: default;
   text-shadow: 0 0 0 #555;
   -webkit-user-select: none;

--- a/dist/variables/ds4/combobox-variables.less
+++ b/dist/variables/ds4/combobox-variables.less
@@ -5,7 +5,7 @@
 @combobox-background-color: @color-core-white;
 @combobox-border-color: @color-core-gray-silver;
 @combobox-border-radius: 3px;
-@combobox-foreground-color: @color-text-default;
+@combobox-foreground-color: @color-core-gray-davys;
 @combobox-readonly-text-shadow-color: @color-core-gray-davys;
 @combobox-readonly-selection-background: @color-core-white;
 @combobox-disabled-background-color: @color-core-gray-light;

--- a/src/less/variables/ds4/combobox-variables.less
+++ b/src/less/variables/ds4/combobox-variables.less
@@ -5,7 +5,7 @@
 @combobox-background-color: @color-core-white;
 @combobox-border-color: @color-core-gray-silver;
 @combobox-border-radius: 3px;
-@combobox-foreground-color: @color-text-default;
+@combobox-foreground-color: @color-core-gray-davys;
 @combobox-readonly-text-shadow-color: @color-core-gray-davys;
 @combobox-readonly-selection-background: @color-core-white;
 @combobox-disabled-background-color: @color-core-gray-light;


### PR DESCRIPTION
Fixes #1212

Changes combobox text color from #333 to #555. This matches textbox and select.

in v11, DS4 is normalised to match DS6, and will use page default text colour (i.e. dark grey, almost black) for all 3 of those modules.