### PR TITLE
Dialog fixed fullscreen dialog animations

### DIFF
--- a/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
@@ -125,7 +125,8 @@
 .fullscreen-dialog--hide.fullscreen-dialog--show-init,
 .fullscreen-dialog--show-init.fullscreen-dialog--hide,
 .fullscreen-dialog--show-init.fullscreen-dialog--show-init {
-  display: block;
+  display: -webkit-box;
+  display: flex;
 }
 .fullscreen-dialog--hide.fullscreen-dialog--mask-fade,
 .fullscreen-dialog--show-init.fullscreen-dialog--mask-fade,

--- a/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
@@ -131,7 +131,8 @@
 .fullscreen-dialog--hide.fullscreen-dialog--show-init,
 .fullscreen-dialog--show-init.fullscreen-dialog--hide,
 .fullscreen-dialog--show-init.fullscreen-dialog--show-init {
-  display: block;
+  display: -webkit-box;
+  display: flex;
 }
 .fullscreen-dialog--hide.fullscreen-dialog--mask-fade,
 .fullscreen-dialog--show-init.fullscreen-dialog--mask-fade,

--- a/src/less/fullscreen-dialog/base/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/base/fullscreen-dialog.less
@@ -66,7 +66,7 @@
 .fullscreen-dialog--hide,
 .fullscreen-dialog--show-init {
     && {
-        display: block;
+        display: flex;
     }
 
     &.fullscreen-dialog--mask-fade,


### PR DESCRIPTION
There is a build failure on ebayui `6.0.0` branch. This PR should fix that. 
Animations were build displayed as block instead of flex for fullscreen dialog.