### PR TITLE
Website: sync dialog close button with playbook

### DIFF
--- a/docs/_includes/common/dialog.html
+++ b/docs/_includes/common/dialog.html
@@ -1,14 +1,11 @@
 <div id="dialog">
     {% include common/section-header.html name="dialog" version=page.versions.dialog %}
 
-    <p>A dialog is a child window spawned by the main web page or application. This window forms a new background layer in our design system topography.</p>
-    <p>A dialog must remain in a <span class="highlight">hidden</span> state for all users and devices until called upon.</p>
-    <p>The <span class="highlight">h2</span> tag inside the <span class="highlight">.dialog__header</span> will become the title. The close button will appear either on left or right depending if it comes before or after the heading</p>
+    <p>A dialog is a child window spawned by the main web page or application. It must remain in a <span class="highlight">hidden</span> state for all users and devices until called upon.</p>
     <p>All dialogs require a visible close button.</p>
 
-    <h3>Default Dialog</h3>
-    <p>The default dialog is a lightbox.</p>
-    <p>The lightbox will have a margin of 15vh and automatically scales vertically.</p>
+    <h3 id="dialog-lightbox">Lightbox Dialog</h3>
+    <p>The default dialog is a lightbox. It automatically scales vertically.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -16,12 +13,12 @@
             <div aria-labelledby="dialog-title-default" aria-modal="true" class="dialog" hidden id="dialog-default-0" role="dialog">
                 <div class="dialog__window">
                     <div class="dialog__header">
+                        <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
                             </svg>
                         </button>
-                        <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
                     </div>
                     <div class="dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -39,12 +36,12 @@
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
     <div class="dialog__window">
         <div class="dialog__header">
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
-            <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
         </div>
         <div class="dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -57,8 +54,7 @@
 </div>
     {% endhighlight %}
 
-    <h3>Fill Dialog</h3>
-    <p>Apply the <span class="highlight">dialog__window--fill</span> modifier to have the lightbox fill at least 70% of the screen (centered vertically).</p>
+    <p>Apply the <span class="highlight">dialog__window--fill</span> modifier to have the lightbox fill at least 70% of the screen.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -66,7 +62,7 @@
             <div aria-labelledby="dialog-title-fill" aria-modal="true" class="dialog" hidden id="dialog-fill-0" role="dialog">
                 <div class="dialog__window dialog__window--fill">
                     <div class="dialog__header">
-                        <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
+                        <h2 id="dialog-title-fill" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
@@ -89,7 +85,7 @@
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
     <div class="dialog__window dialog__window--fill">
         <div class="dialog__header">
-            <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
@@ -107,7 +103,7 @@
 </div>
     {% endhighlight %}
 
-    <h3>Left Panel Dialog</h3>
+    <h3 id="dialog-panel-left">Left Panel Dialog</h3>
     <p>Apply the <span class="highlight">dialog__window--left</span> modifier to have the dialog act as a left side panel (100vh height and aligned to the left side of the screen).</p>
 
     <div class="demo">
@@ -116,7 +112,7 @@
             <div aria-labelledby="dialog-title-left" aria-modal="true" class="dialog" hidden id="dialog-left-panel-0" role="dialog">
                 <div class="dialog__window dialog__window--left">
                     <div class="dialog__header">
-                        <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
+                        <h2 id="dialog-title-left" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
@@ -139,7 +135,7 @@
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
     <div class="dialog__window dialog__window--left">
         <div class="dialog__header">
-            <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
@@ -157,7 +153,7 @@
 </div>
     {% endhighlight %}
 
-    <h3>Right Panel Dialog</h3>
+    <h3 id="dialog-panel-right">Right Panel Dialog</h3>
     <p>Apply the <span class="highlight">dialog__window--right</span> modifier to have the dialog act as a right side panel (100vh height and aligned to the right side of the screen).</p>
 
     <div class="demo">
@@ -166,12 +162,12 @@
             <div aria-labelledby="dialog-title-right" aria-modal="true" class="dialog" hidden id="dialog-right-panel-0" role="dialog">
                 <div class="dialog__window dialog__window--right">
                     <div class="dialog__header">
-                        <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
                             </svg>
                         </button>
+                        <h2 id="dialog-title-right" class="large-text-1 bold-text">Heading</h2>
                     </div>
                     <div class="dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -189,12 +185,12 @@
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
     <div class="dialog__window dialog__window--right">
         <div class="dialog__header">
-            <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
         </div>
         <div class="dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -208,11 +204,13 @@
     {% endhighlight %}
 
     {% if page.ds == 6 %}
-    <h3>Right Panel Dialog with end button (DS6 only)</h3>
+
+    <p>A right panel also supports an alternate button layout - with close button on the left and a submit/done button on right.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-right-panel-1" type="button">Preview</button>
-            <div aria-labelledby="dialog-title-right" aria-modal="true" class="dialog" hidden id="dialog-right-panel-1" role="dialog">
+            <div aria-labelledby="dialog-title-right-end" aria-modal="true" class="dialog" hidden id="dialog-right-panel-1" role="dialog">
                 <div class="dialog__window dialog__window--right">
                     <div class="dialog__header">
                         <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -220,10 +218,8 @@
                                 <use xlink:href="#icon-close"></use>
                             </svg>
                         </button>
-                        <h2 id="dialog-title-default" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
-                        <button class="btn btn--secondary dialog__end-btn">
-                            Reset
-                        </button>
+                        <h2 id="dialog-title-right-end" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
+                        <button class="btn btn--secondary dialog__end-btn">Done</button>
                     </div>
                     <div class="dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -238,7 +234,7 @@
     </div>
 
     {% highlight html %}
-<div aria-labelledby="dialog-title-right" aria-modal="true" class="dialog" hidden id="dialog-right-panel-1" role="dialog">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden id="dialog-right-panel-1" role="dialog">
     <div class="dialog__window dialog__window--right">
         <div class="dialog__header">
             <button aria-label="Close dialog" class="dialog__close" type="button">
@@ -246,10 +242,8 @@
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
-            <h2 id="dialog-title-default" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
-            <button class="btn btn--secondary dialog__end-btn">
-                Reset
-            </button>
+            <h2 id="dialog-title" class="dialog__title dialog__title--center large-text-1 bold-text">Heading</h2>
+            <button class="btn btn--secondary dialog__end-btn">Done</button>
         </div>
         <div class="dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -264,28 +258,27 @@
 
     {% endif %}
 
-    <h3>Dialog with Footer</h3>
-    <p>Add a dialog footer in order to have a footer shown at bottom where you can add buttons</p>
+    <h3 id="dialog-footer">Dialog with Footer</h3>
+    <p>Use the optional <span class="highlight">dialog__footer</span> element for CTA button placement.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-with-footer-0" type="button">Preview</button>
-            <div aria-labelledby="dialog-title-fullscreen" aria-modal="true" class="dialog dialog--no-mask" hidden id="dialog-with-footer-0" role="dialog">
-                <div class="dialog__window dialog__window--full">
-                    <div id="dialog-title-fade-1" class="dialog__header">
+            <div aria-labelledby="dialog-title-footer" aria-modal="true" class="dialog" hidden id="dialog-with-footer-0" role="dialog">
+                <div class="dialog__window">
+                    <div class="dialog__header">
+                        <h2 id="dialog-title-footer" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
                             </svg>
                         </button>
-                        <h2 class="large-text-1 bold-text">Heading</h2>
                     </div>
                     <div class="dialog__main">
                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                             magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                             consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
                             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                        <p><a href="http://www.ebay.com">www.ebay.com</a></p>
                     </div>
                     <div class="dialog__footer">
                         <button class="btn">Cancel</button>
@@ -297,27 +290,27 @@
     </div>
 
     {% highlight html %}
-<div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
-    <div class="dialog__window dialog__window--full">
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" hidden role="dialog">
+    <div class="dialog__window">
+        <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
         <button aria-label="Close dialog" class="dialog__close" type="button">
             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-close"></use>
             </svg>
         </button>
         <div class="dialog__main">
-            <div id="dialog-title-fade-1" class="large-text-1 dialog__header">
+            <div class="large-text-1 dialog__header">
                 <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                         <use xlink:href="#icon-close"></use>
                     </svg>
                 </button>
-                <h2 class="large-text-1 bold-text">Heading</h2>
+                <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             </div>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                 magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
                 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
         </div>
         <div class="dialog__footer">
             <button class="btn">Cancel</button>
@@ -327,22 +320,22 @@
 </div>
     {% endhighlight %}
 
-    <h3>Fullscreen Panel Dialog</h3>
-    <p>Apply the <span class="highlight">dialog__window--full</span> modifier to have the dialog take up the entire viewport.</p>
-    <p>Having a mask on a fullscreen dialog doesn't typically make sense and can cause the animations to look a bit strange. You can disable the default background mask of the dialog by applying the <span class="highlight">dialog--no-mask</span> modifier on the <span class="highlight">dialog</span> element.</p>
+    <h3 id="dialog-fullscreen">Fullscreen Panel Dialog</h3>
+    <p>The <span class="highlight">dialog__window--full</span> modifier creates a fullscreen dialog that covers the entire viewport.</p>
+    <p>A fullscreen dialog used in conjunction with a background mask can cause the animations to look a bit strange. Remove the mask by applying the <span class="highlight">dialog--no-mask</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-fullscreen-panel-0" type="button">Preview</button>
             <div aria-labelledby="dialog-title-fullscreen" aria-modal="true" class="dialog dialog--no-mask" hidden id="dialog-fullscreen-panel-0" role="dialog">
                 <div class="dialog__window dialog__window--full">
-                    <div id="dialog-title-fade-1" class="dialog__header">
+                    <div class="dialog__header">
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
                             </svg>
                         </button>
-                        <h2 class="large-text-1 bold-text">Heading</h2>
+                        <h2 id="dialog-title-fullscreen" class="large-text-1 bold-text">Heading</h2>
                     </div>
                     <div class="dialog__main">
                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -365,13 +358,13 @@
             </svg>
         </button>
         <div class="dialog__main">
-            <div id="dialog-title-fade-1" class="large-text-1 dialog__header">
+            <div class="large-text-1 dialog__header">
                 <button aria-label="Close dialog" class="dialog__close" type="button">
                         <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                         <use xlink:href="#icon-close"></use>
                     </svg>
                 </button>
-                <h2 class="large-text-1 bold-text">Heading</h2>
+                <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             </div>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                 magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
@@ -383,8 +376,8 @@
 </div>
     {% endhighlight %}
 
-    <h3>Scrolling Panel Dialog</h3>
-    <p>When you have a lot of content, the <span class="highlight">dialog</span> will automatically handle scrolling for your.</p>
+    <h3 id="dialog-scrolling">Scrolling Panel Dialog</h3>
+    <p>With a lot of content, the <span class="highlight">dialog</span> will automatically handle scrolling.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -538,7 +531,7 @@ closeBtnEl.addEventListener("click", () => {
 
     {% endhighlight %}
 
-    <h3>Fade Transition</h3>
+    <h3 id="dialog-fade">Fade Transition</h3>
     <p>Any dialog window and mask can be faded in and out, using the <span class="highlight">dialog__window--fade</span> modifier on the <span class="highlight">dialog__window</span> and a <span class="highlight">dialog--mask-fade</span> modifier on the <span class="highlight">dialog</span>.</p>
     <p>The default fade duration is 16ms.<p>
 
@@ -571,12 +564,12 @@ closeBtnEl.addEventListener("click", () => {
             <div aria-labelledby="dialog-title-fade-2" aria-modal="true" class="dialog dialog--no-mask" data-makeup-dialog-has-transitions="true" hidden id="dialog-fade-fullscreen-0" role="dialog">
                 <div class="dialog__window dialog__window--full dialog__window--fade">
                     <div class="dialog__header">
-                        <h2 id="dialog-title-fade-2" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
                             </svg>
                         </button>
+                        <h2 id="dialog-title-fade-2" class="large-text-1 bold-text">Heading</h2>
                     </div>
                     <div class="dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -594,12 +587,12 @@ closeBtnEl.addEventListener("click", () => {
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--mask-fade" hidden role="dialog">
     <div class="dialog__window dialog__window--fade">
         <div class="dialog__header">
-            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
         </div>
         <div class="dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -634,16 +627,16 @@ closeBtnEl.addEventListener("click", () => {
 </div>
     {% endhighlight %}
 
-    <h3>Slide Transition</h3>
+    <h3 id="dialog-slide">Slide Transition</h3>
     <p>Any panel or fullscreen dialog can slide in and out, using the <span class="highlight">dialog__window--slide</span> modifier on the <span class="highlight">dialog__window</span>.</p>
     <p>The slide transition duration is 32ms. An accompanying <span class="highlight">dialog--mask-fade-slow</span> modifier on the <span class="highlight">dialog</span> should also be applied. This slower fade matches the 32ms of the slide transition.<p>
 
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-slide-left-panel-0" type="button">Full Panel</button>
-            <div aria-labelledby="dialog-title-slide-0" aria-modal="true" class="dialog dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-left-panel-0" role="dialog">
+            <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-slide-full-0" type="button">Full Panel</button>
+            <div aria-labelledby="dialog-title-slide-1" aria-modal="true" class="dialog dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-full-0" role="dialog">
                 <div class="dialog__window dialog__window--full dialog__window--slide">
-                    <div id="dialog-title-fade-1" class="dialog__header">
+                    <div id="dialog-title-slide-1" class="dialog__header">
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
@@ -662,10 +655,10 @@ closeBtnEl.addEventListener("click", () => {
             </div>
 
             <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-slide-left-panel-0" type="button">Left Panel</button>
-            <div aria-labelledby="dialog-title-slide-1" aria-modal="true" class="dialog dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-left-panel-0" role="dialog">
+            <div aria-labelledby="dialog-title-slide-2" aria-modal="true" class="dialog dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-left-panel-0" role="dialog">
                 <div class="dialog__window dialog__window--left dialog__window--slide">
                     <div class="dialog__header">
-                        <h2 id="dialog-title-slide-1" class="large-text-1 bold-text">Heading</h2>
+                        <h2 id="dialog-title-slide-2" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
@@ -683,17 +676,17 @@ closeBtnEl.addEventListener("click", () => {
             </div>
 
             <button class="btn btn--primary dialog-button" data-makeup-dialog-button-for="dialog-slide-right-panel-0" type="button">Right Panel</button>
-            <div aria-labelledby="dialog-title-slide-2" aria-modal="true" class="dialog dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-right-panel-0" role="dialog">
+            <div aria-labelledby="dialog-title-slide-3" aria-modal="true" class="dialog dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-right-panel-0" role="dialog">
                 <div class="dialog__window dialog__window--right dialog__window--slide">
                     <div class="dialog__header">
-                        <h2 id="dialog-title-slide-2" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
                             </svg>
                         </button>
-                        </div>
-                        <div class="dialog__main">
+                        <h2 id="dialog-title-slide-3" class="large-text-1 bold-text">Heading</h2>
+                    </div>
+                    <div class="dialog__main">
                             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
                             magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
                             consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.


### PR DESCRIPTION
This PR syncronizes the website examples with playbook.

Moved lightbox close button from left to right.
Moved right panel close button from right to left.

Plus some other misc fixes and updates.

I notice the storybook for dialog needs updating too. It's quite a bit out of date. Once these changes are approved, one of us can take care of that.