### PR TITLE
Button: component-level updates #1157

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -136,7 +136,9 @@ a.fake-btn--primary:hover,
 button.btn--primary:active,
 a.fake-btn--primary:active {
   background-color: #00489f;
+  background-color: var(--button-primary-hover-background-color, #00489f);
   border-color: #0654ba;
+  border-color: var(--button-primary-hover-foreground-color, #0654ba);
 }
 button.btn--primary:visited,
 a.fake-btn--primary:visited {
@@ -233,8 +235,11 @@ a.fake-btn--secondary:focus,
 button.btn--secondary:active,
 a.fake-btn--secondary:active {
   background-color: rgba(221, 221, 221, 0.5);
-  border-color: #767676;
+  background-color: var(--button-secondary-hover-background-color, rgba(221, 221, 221, 0.5));
+  border-color: #555;
+  border-color: var(--button-secondary-hover-foreground-color, #555);
   color: #555;
+  color: var(--button-secondary-hover-foreground-color, #555);
 }
 /* stylelint-enable no-descending-specificity */
 button.btn--delete,

--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -210,8 +210,11 @@ a.fake-btn--primary[aria-disabled="true"]:hover,
 a.fake-btn--primary:not([href]):active,
 a.fake-btn--primary[aria-disabled="true"]:active {
   background-color: #0654ba;
+  background-color: var(--button-primary-disabled-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-disabled-border-color, #0654ba);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
   opacity: 0.5;
 }
 /* stylelint-disable no-descending-specificity */

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -232,8 +232,11 @@ a.fake-btn--primary[aria-disabled="true"]:hover,
 a.fake-btn--primary:not([href]):active,
 a.fake-btn--primary[aria-disabled="true"]:active {
   background-color: #c7c7c7;
+  background-color: var(--button-primary-disabled-background-color, #c7c7c7);
   border-color: #c7c7c7;
+  border-color: var(--button-primary-disabled-border-color, #c7c7c7);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
   opacity: 1;
 }
 /* stylelint-disable no-descending-specificity */

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -22,18 +22,21 @@ a.fake-btn {
   .skin-experiment-1 a.fake-btn {
     --button-primary-background-color: #5192ff;
     --button-primary-foreground-color: #171717;
+    --button-primary-hover-background-color: #94bcff;
     --button-secondary-background-color: #171717;
     --button-secondary-border-color: #5192ff;
     --button-secondary-foreground-color: #5192ff;
+    --button-secondary-hover-background-color: #171717;
+    --button-secondary-hover-foreground-color: #94bcff;
     --button-delete-background-color: #171717;
     --button-delete-border-color: #e75064;
     --button-delete-foreground-color: #e75064;
-    --button-primary-disabled-background-color: #171717;
+    --button-primary-disabled-background-color: #4d4d4d;
     --button-primary-disabled-foreground-color: #767676;
     --button-primary-disabled-border-color: #767676;
     --button-secondary-disabled-background-color: #171717;
-    --button-secondary-disabled-foreground-color: #767676;
-    --button-secondary-disabled-border-color: #767676;
+    --button-secondary-disabled-foreground-color: #4d4d4d;
+    --button-secondary-disabled-border-color: #4d4d4d;
   }
 }
 button.btn,
@@ -155,7 +158,9 @@ a.fake-btn--primary:hover,
 button.btn--primary:active,
 a.fake-btn--primary:active {
   background-color: #2b0eaf;
+  background-color: var(--button-primary-hover-background-color, #2b0eaf);
   border-color: #3665f3;
+  border-color: var(--button-primary-hover-foreground-color, #3665f3);
 }
 button.btn--primary:visited,
 a.fake-btn--primary:visited {
@@ -252,8 +257,11 @@ a.fake-btn--secondary:focus,
 button.btn--secondary:active,
 a.fake-btn--secondary:active {
   background-color: #fff;
+  background-color: var(--button-secondary-hover-background-color, #fff);
   border-color: #2b0eaf;
+  border-color: var(--button-secondary-hover-foreground-color, #2b0eaf);
   color: #2b0eaf;
+  color: var(--button-secondary-hover-foreground-color, #2b0eaf);
 }
 /* stylelint-enable no-descending-specificity */
 button.btn--delete,

--- a/dist/cta-button/ds6/cta-button.css
+++ b/dist/cta-button/ds6/cta-button.css
@@ -12,11 +12,11 @@ a.cta-btn {
 @media (prefers-color-scheme: dark) {
   .skin-experiment-1 a.cta-btn {
     --cta-button-background-color: #171717;
-    --cta-button-foreground-color: #5192ff;
-    --cta-button-visited-foreground-color: #5192ff;
-    --cta-button-hover-background-color: #171717;
-    --cta-button-hover-foreground-color: #fff;
-    --cta-button-hover-border-color: #fff;
+    --cta-button-foreground-color: #dcdcdc;
+    --cta-button-visited-foreground-color: #dcdcdc;
+    --cta-button-hover-background-color: #dcdcdc;
+    --cta-button-hover-foreground-color: #171717;
+    --cta-button-hover-border-color: #dcdcdc;
   }
 }
 a.cta-btn {

--- a/dist/expand-button/ds4/expand-button.css
+++ b/dist/expand-button/ds4/expand-button.css
@@ -1,4 +1,19 @@
 button.expand-btn {
+  --button-border-radius: 3px;
+  --button-primary-background-color: #0654ba;
+  --button-primary-border-color: #0654ba;
+  --button-primary-foreground-color: #fff;
+  --button-primary-disabled-background-color: #0654ba;
+  --button-primary-disabled-border-color: #0654ba;
+  --button-primary-disabled-foreground-color: #fff;
+  --button-secondary-background-color: rgba(238, 238, 238, 0.5);
+  --button-secondary-border-color: #999;
+  --button-secondary-foreground-color: #555;
+  --button-secondary-disabled-background-color: #ccc;
+  --button-secondary-disabled-border-color: #999;
+  --button-secondary-disabled-foreground-color: #555;
+}
+button.expand-btn {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   font-family: inherit;
@@ -69,8 +84,19 @@ span.expand-btn__cell--truncated > svg {
 }
 button.expand-btn--primary {
   background-color: #0654ba;
+  background-color: var(--button-primary-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-border-color, #0654ba);
   color: #fff;
+  color: var(--button-primary-foreground-color, #fff);
+}
+button.expand-btn--primary:focus,
+button.expand-btn--primary:hover,
+button.expand-btn--primary:active {
+  background-color: #00489f;
+  background-color: var(--button-primary-hover-background-color, #00489f);
+  border-color: #0654ba;
+  border-color: var(--button-primary-hover-foreground-color, #0654ba);
 }
 span.expand-btn__cell--fixed-height svg.icon {
   align-self: center;
@@ -98,26 +124,47 @@ button.expand-btn[aria-disabled="true"] {
 button.expand-btn--primary[disabled],
 button.expand-btn--primary[aria-disabled="true"] {
   background-color: #0654ba;
+  background-color: var(--button-primary-disabled-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-disabled-border-color, #0654ba);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.expand-btn--primary[disabled]:hover,
 button.expand-btn--primary[aria-disabled="true"]:hover,
 button.expand-btn--primary[disabled]:focus,
 button.expand-btn--primary[aria-disabled="true"]:focus {
   background-color: #0654ba;
+  background-color: var(--button-primary-disabled-background-color, #0654ba);
   border-color: #0654ba;
+  border-color: var(--button-primary-disabled-border-color, #0654ba);
 }
 button.expand-btn--secondary {
   background-color: rgba(238, 238, 238, 0.5);
+  background-color: var(--button-secondary-background-color, rgba(238, 238, 238, 0.5));
   border-color: #999;
+  border-color: var(--button-secondary-border-color, #999);
   color: #555;
+  color: var(--button-secondary-foreground-color, #555);
+}
+button.expand-btn--secondary:focus,
+button.expand-btn--secondary:hover,
+button.expand-btn--secondary:active {
+  background-color: rgba(221, 221, 221, 0.5);
+  background-color: var(--button-secondary-hover-background-color, rgba(221, 221, 221, 0.5));
+  border-color: #555;
+  border-color: var(--button-secondary-hover-foreground-color, #555);
+  color: #555;
+  color: var(--button-secondary-hover-foreground-color, #555);
 }
 button.expand-btn--secondary[disabled],
 button.expand-btn--secondary[aria-disabled="true"] {
   background-color: #ccc;
+  background-color: var(--button-secondary-disabled-background-color, #ccc);
   border-color: #999;
+  border-color: var(--button-secondary-disabled-border-color, #999);
   color: #555;
+  color: var(--button-secondary-disabled-foreground-color, #555);
 }
 button.expand-btn--secondary[disabled]:hover,
 button.expand-btn--secondary[aria-disabled="true"]:hover,
@@ -126,7 +173,9 @@ button.expand-btn--secondary[aria-disabled="true"]:focus,
 button.expand-btn--secondary[disabled]:active,
 button.expand-btn--secondary[aria-disabled="true"]:active {
   background-color: #ccc;
+  background-color: var(--button-secondary-disabled-background-color, #ccc);
   border-color: #999;
+  border-color: var(--button-secondary-disabled-border-color, #999);
 }
 button.expand-btn svg.icon:only-child {
   display: -webkit-box;

--- a/dist/expand-button/ds6/expand-button.css
+++ b/dist/expand-button/ds6/expand-button.css
@@ -1,4 +1,37 @@
 button.expand-btn {
+  --button-border-radius: 0;
+  --button-primary-background-color: #3665f3;
+  --button-primary-border-color: #3665f3;
+  --button-primary-foreground-color: #fff;
+  --button-primary-disabled-background-color: #c7c7c7;
+  --button-primary-disabled-border-color: #c7c7c7;
+  --button-primary-disabled-foreground-color: #fff;
+  --button-secondary-background-color: #fff;
+  --button-secondary-border-color: #3665f3;
+  --button-secondary-foreground-color: #3665f3;
+  --button-secondary-disabled-background-color: #fff;
+  --button-secondary-disabled-border-color: #c7c7c7;
+  --button-secondary-disabled-foreground-color: #c7c7c7;
+}
+@media (prefers-color-scheme: dark) {
+  .skin-experiment-1 button.expand-btn {
+    --button-primary-background-color: #5192ff;
+    --button-primary-foreground-color: #171717;
+    --button-primary-hover-background-color: #94bcff;
+    --button-secondary-background-color: #171717;
+    --button-secondary-border-color: #5192ff;
+    --button-secondary-foreground-color: #5192ff;
+    --button-secondary-hover-background-color: #171717;
+    --button-secondary-hover-foreground-color: #94bcff;
+    --button-primary-disabled-background-color: #4d4d4d;
+    --button-primary-disabled-foreground-color: #767676;
+    --button-primary-disabled-border-color: #767676;
+    --button-secondary-disabled-background-color: #171717;
+    --button-secondary-disabled-foreground-color: #4d4d4d;
+    --button-secondary-disabled-border-color: #4d4d4d;
+  }
+}
+button.expand-btn {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   font-family: inherit;
@@ -69,8 +102,19 @@ span.expand-btn__cell--truncated > svg {
 }
 button.expand-btn--primary {
   background-color: #3665f3;
+  background-color: var(--button-primary-background-color, #3665f3);
   border-color: #3665f3;
+  border-color: var(--button-primary-border-color, #3665f3);
   color: #fff;
+  color: var(--button-primary-foreground-color, #fff);
+}
+button.expand-btn--primary:focus,
+button.expand-btn--primary:hover,
+button.expand-btn--primary:active {
+  background-color: #2b0eaf;
+  background-color: var(--button-primary-hover-background-color, #2b0eaf);
+  border-color: #3665f3;
+  border-color: var(--button-primary-hover-foreground-color, #3665f3);
 }
 span.expand-btn__cell--fixed-height svg.icon {
   align-self: center;
@@ -98,26 +142,47 @@ button.expand-btn[aria-disabled="true"] {
 button.expand-btn--primary[disabled],
 button.expand-btn--primary[aria-disabled="true"] {
   background-color: #c7c7c7;
+  background-color: var(--button-primary-disabled-background-color, #c7c7c7);
   border-color: #c7c7c7;
+  border-color: var(--button-primary-disabled-border-color, #c7c7c7);
   color: #fff;
+  color: var(--button-primary-disabled-foreground-color, #fff);
 }
 button.expand-btn--primary[disabled]:hover,
 button.expand-btn--primary[aria-disabled="true"]:hover,
 button.expand-btn--primary[disabled]:focus,
 button.expand-btn--primary[aria-disabled="true"]:focus {
   background-color: #c7c7c7;
+  background-color: var(--button-primary-disabled-background-color, #c7c7c7);
   border-color: #c7c7c7;
+  border-color: var(--button-primary-disabled-border-color, #c7c7c7);
 }
 button.expand-btn--secondary {
   background-color: #fff;
+  background-color: var(--button-secondary-background-color, #fff);
   border-color: #3665f3;
+  border-color: var(--button-secondary-border-color, #3665f3);
   color: #3665f3;
+  color: var(--button-secondary-foreground-color, #3665f3);
+}
+button.expand-btn--secondary:focus,
+button.expand-btn--secondary:hover,
+button.expand-btn--secondary:active {
+  background-color: #fff;
+  background-color: var(--button-secondary-hover-background-color, #fff);
+  border-color: #2b0eaf;
+  border-color: var(--button-secondary-hover-foreground-color, #2b0eaf);
+  color: #2b0eaf;
+  color: var(--button-secondary-hover-foreground-color, #2b0eaf);
 }
 button.expand-btn--secondary[disabled],
 button.expand-btn--secondary[aria-disabled="true"] {
   background-color: #fff;
+  background-color: var(--button-secondary-disabled-background-color, #fff);
   border-color: #c7c7c7;
+  border-color: var(--button-secondary-disabled-border-color, #c7c7c7);
   color: #c7c7c7;
+  color: var(--button-secondary-disabled-foreground-color, #c7c7c7);
 }
 button.expand-btn--secondary[disabled]:hover,
 button.expand-btn--secondary[aria-disabled="true"]:hover,
@@ -126,7 +191,9 @@ button.expand-btn--secondary[aria-disabled="true"]:focus,
 button.expand-btn--secondary[disabled]:active,
 button.expand-btn--secondary[aria-disabled="true"]:active {
   background-color: #fff;
+  background-color: var(--button-secondary-disabled-background-color, #fff);
   border-color: #c7c7c7;
+  border-color: var(--button-secondary-disabled-border-color, #c7c7c7);
 }
 button.expand-btn svg.icon:only-child {
   display: -webkit-box;

--- a/dist/variables/ds4/button-variables.less
+++ b/dist/variables/ds4/button-variables.less
@@ -12,7 +12,7 @@
 @button-primary-border-color: @color-action-primary;
 @button-primary-foreground-color: @color-background-default;
 @button-primary-hover-background-color: @color-action-hover;
-@button-primary-hover-border-color: @color-action-primary;
+@button-primary-hover-foreground-color: @color-action-primary;
 @button-primary-disabled-background-color: @color-action-primary-disabled;
 @button-primary-disabled-border-color: @color-action-primary-disabled;
 @button-primary-disabled-foreground-color: @color-background-default;

--- a/dist/variables/ds6/button-variables.less
+++ b/dist/variables/ds6/button-variables.less
@@ -12,7 +12,7 @@
 @button-primary-border-color: @color-action-primary;
 @button-primary-foreground-color: @color-background-default;
 @button-primary-hover-background-color: @color-action-hover;
-@button-primary-hover-border-color: @color-action-primary;
+@button-primary-hover-foreground-color: @color-action-primary;
 @button-primary-disabled-background-color: @color-action-primary-disabled;
 @button-primary-disabled-border-color: @color-action-primary-disabled;
 @button-primary-disabled-foreground-color: @color-background-default;
@@ -20,7 +20,7 @@
 @button-secondary-background-color: @color-white;
 @button-secondary-border-color: @color-b4;
 @button-secondary-foreground-color: @color-b4;
-@button-secondary-hover-background-color: @button-secondary-background-color;
+@button-secondary-hover-background-color: @color-white;
 @button-secondary-hover-border-color: @color-b6;
 @button-secondary-hover-foreground-color: @color-b6;
 @button-secondary-disabled-background-color: @color-white;

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -132,9 +132,10 @@ a.fake-btn--primary[aria-disabled="true"] {
     &:focus,
     &:hover,
     &:active {
-        background-color: @button-primary-disabled-background-color;
-        border-color: @button-primary-disabled-border-color;
-        color: @button-primary-disabled-foreground-color;
+        .customBackgroundColorProperty(button-primary-disabled-background-color);
+        .customBorderColorProperty(button-primary-disabled-border-color);
+        .customColorProperty(button-primary-disabled-foreground-color);
+
         opacity: @button-disabled-opacity;
     }
 }

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -65,8 +65,8 @@ a.fake-btn--primary {
     &:focus,
     &:hover,
     &:active {
-        background-color: @button-primary-hover-background-color;
-        border-color: @button-primary-hover-border-color;
+        .customBackgroundColorProperty(button-primary-hover-background-color);
+        .customBorderColorProperty(button-primary-hover-foreground-color);
     }
 
     &:visited {
@@ -153,9 +153,9 @@ a.fake-btn--secondary {
     &:hover,
     &:focus,
     &:active {
-        background-color: @button-secondary-hover-background-color;
-        border-color: @button-secondary-hover-border-color;
-        color: @button-secondary-hover-foreground-color;
+        .customBackgroundColorProperty(button-secondary-hover-background-color);
+        .customBorderColorProperty(button-secondary-hover-foreground-color);
+        .customColorProperty(button-secondary-hover-foreground-color);
     }
 }
 /* stylelint-enable no-descending-specificity */

--- a/src/less/expand-button/base/expand-button.less
+++ b/src/less/expand-button/base/expand-button.less
@@ -1,3 +1,5 @@
+@import "../../mixins/utility/utility-mixins.less";
+
 button.expand-btn {
     .btn-base();
 
@@ -29,9 +31,16 @@ span.expand-btn__cell {
 }
 
 button.expand-btn--primary {
-    background-color: @button-primary-background-color;
-    border-color: @button-primary-border-color;
-    color: @button-primary-foreground-color;
+    .customBackgroundColorProperty(button-primary-background-color);
+    .customBorderColorProperty(button-primary-border-color);
+    .customColorProperty(button-primary-foreground-color);
+
+    &:focus,
+    &:hover,
+    &:active {
+        .customBackgroundColorProperty(button-primary-hover-background-color);
+        .customBorderColorProperty(button-primary-hover-foreground-color);
+    }
 }
 
 span.expand-btn__cell--fixed-height svg.icon {
@@ -60,34 +69,42 @@ button.expand-btn[aria-disabled="true"] {
 
 button.expand-btn--primary[disabled],
 button.expand-btn--primary[aria-disabled="true"] {
-    background-color: @button-primary-disabled-background-color;
-    border-color: @button-primary-disabled-border-color;
-    color: @button-primary-disabled-foreground-color;
+    .customBackgroundColorProperty(button-primary-disabled-background-color);
+    .customBorderColorProperty(button-primary-disabled-border-color);
+    .customColorProperty(button-primary-disabled-foreground-color);
 
     &:hover,
     &:focus {
-        background-color: @button-primary-disabled-background-color;
-        border-color: @button-primary-disabled-border-color;
+        .customBackgroundColorProperty(button-primary-disabled-background-color);
+        .customBorderColorProperty(button-primary-disabled-border-color);
     }
 }
 
 button.expand-btn--secondary {
-    background-color: @button-secondary-background-color;
-    border-color: @button-secondary-border-color;
-    color: @button-secondary-foreground-color;
+    .customBackgroundColorProperty(button-secondary-background-color);
+    .customBorderColorProperty(button-secondary-border-color);
+    .customColorProperty(button-secondary-foreground-color);
+
+    &:focus,
+    &:hover,
+    &:active {
+        .customBackgroundColorProperty(button-secondary-hover-background-color);
+        .customBorderColorProperty(button-secondary-hover-foreground-color);
+        .customColorProperty(button-secondary-hover-foreground-color);
+    }
 }
 
 button.expand-btn--secondary[disabled],
 button.expand-btn--secondary[aria-disabled="true"] {
-    background-color: @button-secondary-disabled-background-color;
-    border-color: @button-secondary-disabled-border-color;
-    color: @button-secondary-disabled-foreground-color;
+    .customBackgroundColorProperty(button-secondary-disabled-background-color);
+    .customBorderColorProperty(button-secondary-disabled-border-color);
+    .customColorProperty(button-secondary-disabled-foreground-color);
 
     &:hover,
     &:focus,
     &:active {
-        background-color: @button-secondary-disabled-background-color;
-        border-color: @button-secondary-disabled-border-color;
+        .customBackgroundColorProperty(button-secondary-disabled-background-color);
+        .customBorderColorProperty(button-secondary-disabled-border-color);
     }
 }
 

--- a/src/less/expand-button/ds4/expand-button.less
+++ b/src/less/expand-button/ds4/expand-button.less
@@ -1,7 +1,3 @@
-@import "../../variables/ds4/color-variables.less";
-@import "../../variables/ds4/typography-variables.less";
-@import "../../variables/ds4/expand-button-variables.less";
-@import "../../variables/ds4/button-variables.less";
+@import "../../properties/ds4/expand-button-properties.less";
 @import "../../mixins/button/ds4/button-mixins.less";
-@import "../../mixins/icon/ds4/icon-mixins.less";
 @import "../base/expand-button.less";

--- a/src/less/expand-button/ds6/expand-button.less
+++ b/src/less/expand-button/ds6/expand-button.less
@@ -1,7 +1,3 @@
-@import "../../variables/ds6/color-variables.less";
-@import "../../variables/ds6/typography-variables.less";
-@import "../../variables/ds6/expand-button-variables.less";
-@import "../../variables/ds6/button-variables.less";
+@import "../../properties/ds6/expand-button-properties.less";
 @import "../../mixins/button/ds6/button-mixins.less";
-@import "../../mixins/icon/ds6/icon-mixins.less";
 @import "../base/expand-button.less";

--- a/src/less/properties/base/expand-button-properties.less
+++ b/src/less/properties/base/expand-button-properties.less
@@ -1,0 +1,15 @@
+button.expand-btn {
+    --button-border-radius: @button-border-radius;
+    --button-primary-background-color: @button-primary-background-color;
+    --button-primary-border-color: @button-primary-border-color;
+    --button-primary-foreground-color: @button-primary-foreground-color;
+    --button-primary-disabled-background-color: @button-primary-disabled-background-color;
+    --button-primary-disabled-border-color: @button-primary-disabled-border-color;
+    --button-primary-disabled-foreground-color: @button-primary-disabled-foreground-color;
+    --button-secondary-background-color: @button-secondary-background-color;
+    --button-secondary-border-color: @button-secondary-border-color;
+    --button-secondary-foreground-color: @button-secondary-foreground-color;
+    --button-secondary-disabled-background-color: @button-secondary-disabled-background-color;
+    --button-secondary-disabled-border-color: @button-secondary-disabled-border-color;
+    --button-secondary-disabled-foreground-color: @button-secondary-disabled-foreground-color;
+}

--- a/src/less/properties/ds4/expand-button-properties.less
+++ b/src/less/properties/ds4/expand-button-properties.less
@@ -1,0 +1,5 @@
+@import "../../variables/ds4/color-variables.less";
+@import "../../variables/ds4/typography-variables.less";
+@import "../../variables/ds4/button-variables.less";
+@import "../../variables/ds4/expand-button-variables.less";
+@import "../base/expand-button-properties.less";

--- a/src/less/properties/ds6/cta-button-properties.less
+++ b/src/less/properties/ds6/cta-button-properties.less
@@ -9,11 +9,11 @@
     .skin-experiment-1 {
         a.cta-btn {
             --cta-button-background-color: @color-black-dark-mode;
-            --cta-button-foreground-color: @color-b4-dark-mode;
-            --cta-button-visited-foreground-color: @color-b4-dark-mode;
-            --cta-button-hover-background-color: @color-black-dark-mode;
-            --cta-button-hover-foreground-color: #fff;
-            --cta-button-hover-border-color: #fff;
+            --cta-button-foreground-color: @color-white-dark-mode;
+            --cta-button-visited-foreground-color: @color-white-dark-mode;
+            --cta-button-hover-background-color: @color-white-dark-mode;
+            --cta-button-hover-foreground-color: @color-black-dark-mode;
+            --cta-button-hover-border-color: @color-white-dark-mode;
         }
     }
 }

--- a/src/less/properties/ds6/expand-button-properties.less
+++ b/src/less/properties/ds6/expand-button-properties.less
@@ -1,13 +1,13 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/button-variables.less";
-@import "../base/button-properties.less";
+@import "../../variables/ds6/expand-button-variables.less";
+@import "../base/expand-button-properties.less";
 
 // Dark-mode (ds6 only)
 @media (prefers-color-scheme: dark) {
     .skin-experiment-1 {
-        button.btn,
-        a.fake-btn {
+        button.expand-btn {
             --button-primary-background-color: @color-b4-dark-mode;
             --button-primary-foreground-color: @color-black-dark-mode;
             --button-primary-hover-background-color: @color-b6-dark-mode;
@@ -16,9 +16,6 @@
             --button-secondary-foreground-color: @color-b4-dark-mode;
             --button-secondary-hover-background-color: @color-black-dark-mode;
             --button-secondary-hover-foreground-color: @color-b6-dark-mode;
-            --button-delete-background-color: @color-black-dark-mode;
-            --button-delete-border-color: @color-r4-dark-mode;
-            --button-delete-foreground-color: @color-r4-dark-mode;
             --button-primary-disabled-background-color: @color-grey3-dark-mode;
             --button-primary-disabled-foreground-color: @color-grey5;
             --button-primary-disabled-border-color: @color-grey5;

--- a/src/less/variables/ds4/button-variables.less
+++ b/src/less/variables/ds4/button-variables.less
@@ -12,7 +12,7 @@
 @button-primary-border-color: @color-action-primary;
 @button-primary-foreground-color: @color-background-default;
 @button-primary-hover-background-color: @color-action-hover;
-@button-primary-hover-border-color: @color-action-primary;
+@button-primary-hover-foreground-color: @color-action-primary;
 @button-primary-disabled-background-color: @color-action-primary-disabled;
 @button-primary-disabled-border-color: @color-action-primary-disabled;
 @button-primary-disabled-foreground-color: @color-background-default;

--- a/src/less/variables/ds6/button-variables.less
+++ b/src/less/variables/ds6/button-variables.less
@@ -12,7 +12,7 @@
 @button-primary-border-color: @color-action-primary;
 @button-primary-foreground-color: @color-background-default;
 @button-primary-hover-background-color: @color-action-hover;
-@button-primary-hover-border-color: @color-action-primary;
+@button-primary-hover-foreground-color: @color-action-primary;
 @button-primary-disabled-background-color: @color-action-primary-disabled;
 @button-primary-disabled-border-color: @color-action-primary-disabled;
 @button-primary-disabled-foreground-color: @color-background-default;
@@ -20,7 +20,7 @@
 @button-secondary-background-color: @color-white;
 @button-secondary-border-color: @color-b4;
 @button-secondary-foreground-color: @color-b4;
-@button-secondary-hover-background-color: @button-secondary-background-color;
+@button-secondary-hover-background-color: @color-white;
 @button-secondary-hover-border-color: @color-b6;
 @button-secondary-hover-foreground-color: @color-b6;
 @button-secondary-disabled-background-color: @color-white;


### PR DESCRIPTION
PLEASE SQUASH

Updates button, cta-button and expand buttons with latest dark mode colours.

I started working on expand-button, but didn't fully finish all of its disabled states because I started to see this code smell: #1233 So, even though I'm most likely to do some refactoring, I'd like to get this PR in before I do so.

Note also that I haven't added the "inverted" button variant. That too can be part of the thinking for #1233.

![Screen Shot 2020-09-08 at 5 05 32 PM](https://user-images.githubusercontent.com/38065/92548082-f8717000-f20a-11ea-8147-e1182d7aa8b8.png)

![Screen Shot 2020-09-08 at 5 33 03 PM](https://user-images.githubusercontent.com/38065/92548078-f7404300-f20a-11ea-864d-61cee1ad9b1b.png)

![Screen Shot 2020-09-08 at 7 31 06 PM](https://user-images.githubusercontent.com/38065/92548073-f3acbc00-f20a-11ea-9e4c-1ad6d75af7b0.png)

![Screen Shot 2020-09-08 at 6 05 23 PM](https://user-images.githubusercontent.com/38065/92548074-f4dde900-f20a-11ea-8042-8b3bf8cf0964.png)

