### PR TITLE
Dialogs: require icon-btn class in close button

### DIFF
--- a/dist/drawer-dialog/ds4/drawer-dialog.css
+++ b/dist/drawer-dialog/ds4/drawer-dialog.css
@@ -1,6 +1,5 @@
 .drawer-dialog {
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #333;
 }
 /* large screens */
 .drawer-dialog[role="dialog"] {
@@ -88,19 +87,13 @@
 .drawer-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-.drawer-dialog__back,
-.drawer-dialog__close {
-  color: #333;
-  color: var(--dialog-back-close-foreground-color, #333);
+button.drawer-dialog__close {
   background-color: transparent;
   border: 0;
+  height: auto;
+  outline-offset: 4px;
+  width: auto;
   z-index: 1;
-}
-.drawer-dialog__back:hover,
-.drawer-dialog__close:hover,
-.drawer-dialog__back:focus,
-.drawer-dialog__close:focus {
-  color: #0654ba;
 }
 .drawer-dialog__window {
   background-color: #fff;

--- a/dist/drawer-dialog/ds6/drawer-dialog.css
+++ b/dist/drawer-dialog/ds6/drawer-dialog.css
@@ -1,11 +1,9 @@
 .drawer-dialog {
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #111820;
 }
 @media (prefers-color-scheme: dark) {
   .skin-experiment-1 .drawer-dialog {
     --dialog-window-background-color: #212121;
-    --dialog-back-close-foreground-color: #dcdcdc;
   }
 }
 /* large screens */
@@ -94,19 +92,13 @@
 .drawer-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-.drawer-dialog__back,
-.drawer-dialog__close {
-  color: #111820;
-  color: var(--dialog-back-close-foreground-color, #111820);
+button.drawer-dialog__close {
   background-color: transparent;
   border: 0;
+  height: auto;
+  outline-offset: 4px;
+  width: auto;
   z-index: 1;
-}
-.drawer-dialog__back:hover,
-.drawer-dialog__close:hover,
-.drawer-dialog__back:focus,
-.drawer-dialog__close:focus {
-  color: #3665f3;
 }
 .drawer-dialog__window {
   background-color: #fff;

--- a/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
@@ -53,6 +53,10 @@
 .fullscreen-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
 }
+.fullscreen-dialog__header .fake-link {
+  outline-offset: 4px;
+  text-decoration: none;
+}
 .fullscreen-dialog__main {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
@@ -86,7 +90,6 @@ button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
   align-self: center;
   border: 0;
-  height: auto;
   outline-offset: 4px;
   padding: 0;
   position: relative;

--- a/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
@@ -82,7 +82,8 @@
 .fullscreen-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-button.fullscreen-dialog__close {
+button.fullscreen-dialog__close,
+button.fullscreen-dialog__back {
   align-self: center;
   border: 0;
   height: auto;

--- a/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
@@ -2,7 +2,6 @@
 .fullscreen-dialog {
   --dialog-mask-background-color: #333;
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #333;
 }
 .fullscreen-dialog[role="dialog"] {
   background-color: rgba(51, 51, 51, 0.7);
@@ -83,22 +82,15 @@
 .fullscreen-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-.fullscreen-dialog__back,
-.fullscreen-dialog__close {
-  color: #333;
-  color: var(--dialog-back-close-foreground-color, #333);
+button.fullscreen-dialog__close {
   align-self: center;
-  background-color: transparent;
   border: 0;
+  height: auto;
+  outline-offset: 4px;
   padding: 0;
   position: relative;
+  width: auto;
   z-index: 1;
-}
-.fullscreen-dialog__back:hover,
-.fullscreen-dialog__close:hover,
-.fullscreen-dialog__back:focus,
-.fullscreen-dialog__close:focus {
-  color: #0654ba;
 }
 .fullscreen-dialog--show.fullscreen-dialog--mask-fade,
 .fullscreen-dialog--hide.fullscreen-dialog--mask-fade {

--- a/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
@@ -58,6 +58,10 @@
 .fullscreen-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
 }
+.fullscreen-dialog__header .fake-link {
+  outline-offset: 4px;
+  text-decoration: none;
+}
 .fullscreen-dialog__main {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
@@ -91,7 +95,6 @@ button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
   align-self: center;
   border: 0;
-  height: auto;
   outline-offset: 4px;
   padding: 0;
   position: relative;

--- a/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
@@ -2,12 +2,10 @@
 .fullscreen-dialog {
   --dialog-mask-background-color: #111820;
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #111820;
 }
 @media (prefers-color-scheme: dark) {
   .skin-experiment-1 .fullscreen-dialog {
     --dialog-window-background-color: #212121;
-    --dialog-back-close-foreground-color: #dcdcdc;
   }
 }
 .fullscreen-dialog[role="dialog"] {
@@ -89,22 +87,15 @@
 .fullscreen-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-.fullscreen-dialog__back,
-.fullscreen-dialog__close {
-  color: #111820;
-  color: var(--dialog-back-close-foreground-color, #111820);
+button.fullscreen-dialog__close {
   align-self: center;
-  background-color: transparent;
   border: 0;
+  height: auto;
+  outline-offset: 4px;
   padding: 0;
   position: relative;
+  width: auto;
   z-index: 1;
-}
-.fullscreen-dialog__back:hover,
-.fullscreen-dialog__close:hover,
-.fullscreen-dialog__back:focus,
-.fullscreen-dialog__close:focus {
-  color: #3665f3;
 }
 .fullscreen-dialog--show.fullscreen-dialog--mask-fade,
 .fullscreen-dialog--hide.fullscreen-dialog--mask-fade {

--- a/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
@@ -87,7 +87,8 @@
 .fullscreen-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-button.fullscreen-dialog__close {
+button.fullscreen-dialog__close,
+button.fullscreen-dialog__back {
   align-self: center;
   border: 0;
   height: auto;

--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -2,7 +2,6 @@
 .lightbox-dialog {
   --dialog-mask-background-color: #333;
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #333;
 }
 .lightbox-dialog[role="dialog"],
 .lightbox-dialog[role="alertdialog"] {
@@ -114,22 +113,14 @@
   margin-right: 5px;
   margin-top: 0;
 }
-.lightbox-dialog__back,
-.lightbox-dialog__close {
-  color: #333;
-  color: var(--dialog-back-close-foreground-color, #333);
+button.lightbox-dialog__close {
   align-self: center;
-  background-color: transparent;
   border: 0;
-  padding: 0;
+  height: auto;
+  outline-offset: 4px;
   position: relative;
+  width: auto;
   z-index: 1;
-}
-.lightbox-dialog__back:hover,
-.lightbox-dialog__close:hover,
-.lightbox-dialog__back:focus,
-.lightbox-dialog__close:focus {
-  color: #0654ba;
 }
 .lightbox-dialog__title:not(:first-child) {
   margin-left: 16px;

--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -116,7 +116,6 @@
 button.lightbox-dialog__close {
   align-self: center;
   border: 0;
-  height: auto;
   outline-offset: 4px;
   position: relative;
   width: auto;

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -2,12 +2,10 @@
 .lightbox-dialog {
   --dialog-mask-background-color: #111820;
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #111820;
 }
 @media (prefers-color-scheme: dark) {
   .skin-experiment-1 .lightbox-dialog {
     --dialog-window-background-color: #212121;
-    --dialog-back-close-foreground-color: #dcdcdc;
   }
 }
 .lightbox-dialog[role="dialog"],
@@ -120,22 +118,14 @@
   margin-right: 5px;
   margin-top: 0;
 }
-.lightbox-dialog__back,
-.lightbox-dialog__close {
-  color: #111820;
-  color: var(--dialog-back-close-foreground-color, #111820);
+button.lightbox-dialog__close {
   align-self: center;
-  background-color: transparent;
   border: 0;
-  padding: 0;
+  height: auto;
+  outline-offset: 4px;
   position: relative;
+  width: auto;
   z-index: 1;
-}
-.lightbox-dialog__back:hover,
-.lightbox-dialog__close:hover,
-.lightbox-dialog__back:focus,
-.lightbox-dialog__close:focus {
-  color: #3665f3;
 }
 .lightbox-dialog__title:not(:first-child) {
   margin-left: 16px;

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -121,7 +121,6 @@
 button.lightbox-dialog__close {
   align-self: center;
   border: 0;
-  height: auto;
   outline-offset: 4px;
   position: relative;
   width: auto;

--- a/dist/mixins/filter-button/base/filter-button-mixins.less
+++ b/dist/mixins/filter-button/base/filter-button-mixins.less
@@ -1,10 +1,4 @@
-.filter-group() {
-    display: flex;
-    flex-wrap: wrap;
-}
-
 .filter-button-base() {
-    .filter-button-sibling-spacing();
     .customColorProperty(filter-button-foreground-color);
 
     align-items: center;
@@ -26,18 +20,8 @@
     text-align: center;
     text-decoration: none;
     vertical-align: bottom;
-}
 
-.filter-button-sibling-spacing() {
     & + & {
         margin-left: 8px;
     }
-}
-
-.filter-button-selected() {
-    font-weight: bold;
-}
-
-.filter-button-disabled() {
-    font-weight: normal;
 }

--- a/dist/panel-dialog/ds4/panel-dialog.css
+++ b/dist/panel-dialog/ds4/panel-dialog.css
@@ -2,7 +2,6 @@
 .panel-dialog {
   --dialog-mask-background-color: #333;
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #333;
 }
 .panel-dialog[role="dialog"] {
   background-color: rgba(51, 51, 51, 0.7);
@@ -61,6 +60,7 @@
   margin-left: 16px;
 }
 .panel-dialog__header .fake-link {
+  outline-offset: 4px;
   text-decoration: none;
 }
 .panel-dialog__main {
@@ -91,22 +91,15 @@
 .panel-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-.panel-dialog__back,
-.panel-dialog__close {
-  color: #333;
-  color: var(--dialog-back-close-foreground-color, #333);
+button.panel-dialog__close {
   align-self: center;
-  background-color: transparent;
   border: 0;
+  height: auto;
+  outline-offset: 4px;
   padding: 0;
   position: relative;
+  width: auto;
   z-index: 1;
-}
-.panel-dialog__back:hover,
-.panel-dialog__close:hover,
-.panel-dialog__back:focus,
-.panel-dialog__close:focus {
-  color: #0654ba;
 }
 .panel-dialog__title:not(:first-child) {
   margin-left: 16px;

--- a/dist/panel-dialog/ds4/panel-dialog.css
+++ b/dist/panel-dialog/ds4/panel-dialog.css
@@ -94,7 +94,6 @@
 button.panel-dialog__close {
   align-self: center;
   border: 0;
-  height: auto;
   outline-offset: 4px;
   padding: 0;
   position: relative;

--- a/dist/panel-dialog/ds6/panel-dialog.css
+++ b/dist/panel-dialog/ds6/panel-dialog.css
@@ -99,7 +99,6 @@
 button.panel-dialog__close {
   align-self: center;
   border: 0;
-  height: auto;
   outline-offset: 4px;
   padding: 0;
   position: relative;

--- a/dist/panel-dialog/ds6/panel-dialog.css
+++ b/dist/panel-dialog/ds6/panel-dialog.css
@@ -2,12 +2,10 @@
 .panel-dialog {
   --dialog-mask-background-color: #111820;
   --dialog-window-background-color: #fff;
-  --dialog-back-close-foreground-color: #111820;
 }
 @media (prefers-color-scheme: dark) {
   .skin-experiment-1 .panel-dialog {
     --dialog-window-background-color: #212121;
-    --dialog-back-close-foreground-color: #dcdcdc;
   }
 }
 .panel-dialog[role="dialog"] {
@@ -67,6 +65,7 @@
   margin-left: 16px;
 }
 .panel-dialog__header .fake-link {
+  outline-offset: 4px;
   text-decoration: none;
 }
 .panel-dialog__main {
@@ -97,22 +96,15 @@
 .panel-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-.panel-dialog__back,
-.panel-dialog__close {
-  color: #111820;
-  color: var(--dialog-back-close-foreground-color, #111820);
+button.panel-dialog__close {
   align-self: center;
-  background-color: transparent;
   border: 0;
+  height: auto;
+  outline-offset: 4px;
   padding: 0;
   position: relative;
+  width: auto;
   z-index: 1;
-}
-.panel-dialog__back:hover,
-.panel-dialog__close:hover,
-.panel-dialog__back:focus,
-.panel-dialog__close:focus {
-  color: #3665f3;
 }
 .panel-dialog__title:not(:first-child) {
   margin-left: 16px;

--- a/dist/toast-dialog/ds4/toast-dialog.css
+++ b/dist/toast-dialog/ds4/toast-dialog.css
@@ -60,17 +60,21 @@
 .toast-dialog__title {
   margin: 0;
 }
-.toast-dialog__close {
-  background-color: #0654ba;
-  background-color: var(--toast-dialog-background-color, #0654ba);
-  color: #fff;
-  color: var(--toast-dialog-foreground-color, #fff);
+button.toast-dialog__close {
   align-self: center;
   border: 0;
+  height: auto;
   margin: 0 0 0 auto;
   padding: 0;
+  width: auto;
 }
-.toast-dialog__close:focus {
+button.toast-dialog__close > svg,
+button.toast-dialog__close:hover > svg,
+button.toast-dialog__close:focus > svg {
+  fill: #fff;
+  fill: var(--toast-dialog-foreground-color, #fff);
+}
+button.toast-dialog__close:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
   outline-offset: 4px;

--- a/dist/toast-dialog/ds6/toast-dialog.css
+++ b/dist/toast-dialog/ds6/toast-dialog.css
@@ -60,17 +60,21 @@
 .toast-dialog__title {
   margin: 0;
 }
-.toast-dialog__close {
-  background-color: #3665f3;
-  background-color: var(--toast-dialog-background-color, #3665f3);
-  color: #fff;
-  color: var(--toast-dialog-foreground-color, #fff);
+button.toast-dialog__close {
   align-self: center;
   border: 0;
+  height: auto;
   margin: 0 0 0 auto;
   padding: 0;
+  width: auto;
 }
-.toast-dialog__close:focus {
+button.toast-dialog__close > svg,
+button.toast-dialog__close:hover > svg,
+button.toast-dialog__close:focus > svg {
+  fill: #fff;
+  fill: var(--toast-dialog-foreground-color, #fff);
+}
+button.toast-dialog__close:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
   outline-offset: 4px;

--- a/dist/variables/ds4/dialog-variables.less
+++ b/dist/variables/ds4/dialog-variables.less
@@ -3,11 +3,6 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
-@dialog-back-close-foreground-color: @color-text-default;
-@dialog-back-close-hover-foreground-color: @color-action-primary;
-@dialog-transitions-hide-mask-fade-background-color: @color-text-default;
-@dialog-transitions-show-mask-fade-background-color: @color-text-default;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
-@dialog-handle-color: @color-grey4;
 @dialog-max-width: 616px;

--- a/dist/variables/ds4/drawer-dialog-variables.less
+++ b/dist/variables/ds4/drawer-dialog-variables.less
@@ -2,3 +2,4 @@
 @import "./typography-variables.less";
 
 @dialog-window-background-color: @color-background-default;
+@dialog-handle-color: @color-grey4;

--- a/dist/variables/ds6/dialog-variables.less
+++ b/dist/variables/ds6/dialog-variables.less
@@ -3,11 +3,6 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
-@dialog-back-close-foreground-color: @color-text-default;
-@dialog-back-close-hover-foreground-color: @color-action-primary;
-@dialog-transitions-hide-mask-fade-background-color: @color-text-default;
-@dialog-transitions-show-mask-fade-background-color: @color-text-default;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
-@dialog-handle-color: @color-grey4;
 @dialog-max-width: 616px;

--- a/dist/variables/ds6/drawer-dialog-variables.less
+++ b/dist/variables/ds6/drawer-dialog-variables.less
@@ -2,3 +2,4 @@
 @import "./typography-variables.less";
 
 @dialog-window-background-color: @color-background-default;
+@dialog-handle-color: @color-grey4;

--- a/docs/_includes/common/drawer-dialog.html
+++ b/docs/_includes/common/drawer-dialog.html
@@ -13,7 +13,7 @@
                     <button class="drawer-dialog__handle" type="button"></button>
                     <div class="drawer-dialog__header">
                         <h2 id="dialog-title-1" class="large-text-1 bold-text">Heading</h2>
-                        <button aria-label="Close dialog" class="drawer-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -58,7 +58,7 @@
             <button aria-label="Expand Dialog" class="drawer-dialog__handle" type="button"></button>
             <div class="drawer-dialog__header">
                 <h2 id="drawer-dialog-title" class="large-text-1 bold-text">Heading</h2>
-                <button aria-label="Close dialog" class="drawer-dialog__close" type="button">
+                <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                     <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                         <use xlink:href="#icon-close"></use>
                     </svg>

--- a/docs/_includes/common/fullscreen-dialog.html
+++ b/docs/_includes/common/fullscreen-dialog.html
@@ -10,7 +10,7 @@
             <div aria-labelledby="dialog-title-fullscreen" aria-modal="true" class="fullscreen-dialog" hidden id="dialog-fullscreen-panel-0" role="dialog">
                 <div class="fullscreen-dialog__window">
                     <div id="dialog-title-fade-1" class="fullscreen-dialog__header">
-                        <button aria-label="Close dialog" class="fullscreen-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -33,7 +33,7 @@
 <div aria-labelledby="dialog-title" aria-modal="true" class="fullscreen-dialog" hidden role="dialog">
     <div class="fullscreen-dialog__window">
         <div id="dialog-title-fade-1" class="fullscreen-dialog__header">
-            <button aria-label="Close dialog" class="fullscreen-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -61,7 +61,7 @@
             <div aria-labelledby="dialog-title-fade-2" aria-modal="true" class="fullscreen-dialog fullscreen-dialog--no-mask" data-makeup-dialog-has-transitions="true" hidden id="dialog-fade-fullscreen-0" role="dialog">
                 <div class="fullscreen-dialog__window fullscreen-dialog__window--fade">
                     <div class="fullscreen-dialog__header">
-                        <button aria-label="Close dialog" class="fullscreen-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 <use xlink:href="#icon-close"></use>
                             </svg>
@@ -84,7 +84,7 @@
 <div aria-labelledby="dialog-title" aria-modal="true" class="fullscreen-dialog fullscreen-dialog--no-mask" hidden role="dialog">
     <div class="fullscreen-dialog__window fullscreen-dialog__window--fade">
         <div class="fullscreen-dialog__header">
-            <button aria-label="Close dialog" class="fullscreen-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -112,7 +112,7 @@
             <div aria-labelledby="dialog-title-slide-0" aria-modal="true" class="fullscreen-dialog fullscreen-dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-full-panel-0" role="dialog">
                 <div class="fullscreen-dialog__window fullscreen-dialog__window--slide">
                     <div id="dialog-title-fade-1" class="fullscreen-dialog__header">
-                        <button aria-label="Close dialog" class="fullscreen-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -136,7 +136,7 @@
     <div class="fullscreen-dialog__window dialog__window--slide">
         <div class="dfullscreen-ialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="fullscreen-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>

--- a/docs/_includes/common/lightbox-dialog.html
+++ b/docs/_includes/common/lightbox-dialog.html
@@ -10,7 +10,7 @@
                 <div class="lightbox-dialog__window">
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
-                        <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -33,7 +33,7 @@
     <div class="lightbox-dialog__window">
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -60,7 +60,7 @@
                 <div class="lightbox-dialog__window">
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-scrolling">Heading</h2>
-                        <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -83,7 +83,7 @@
     <div class="lightbox-dialog__window lightbox-dialog__window--full">
         <div class="lightbox-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     {% include common/symbol.html name="close" %}
                 </svg>
@@ -115,7 +115,7 @@
                 <div class="lightbox-dialog__window lightbox-dialog__window--fade">
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-fade-title" class="large-text-1 bold-text">Heading</h2>
-                        <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -140,7 +140,7 @@
     <div class="lightbox-dialog__window lightbox-dialog__window--fade">
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -171,7 +171,7 @@
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                     </div>
                     <div class="lightbox-dialog__footer">
-                        <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -189,7 +189,7 @@
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
         <div class="lightbox-dialog__footer">
-            <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -209,7 +209,7 @@
                 <div class="lightbox-dialog__window">
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-footer-title" class="large-text-1 bold-text">Heading</h2>
-                        <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -236,7 +236,7 @@
     <div class="lightbox-dialog__window">
         <div class="large-text-1 lightbox-dialog__header">
             <h2 class="large-text-1 bold-text" id="lightbox-dialog-title">Heading</h2>
-            <button aria-label="Close dialog" class="lightbox-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>

--- a/docs/_includes/common/panel-dialog.html
+++ b/docs/_includes/common/panel-dialog.html
@@ -11,7 +11,7 @@
                 <div class="panel-dialog__window">
                     <div class="panel-dialog__header">
                         <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
-                        <button aria-label="Close dialog" class="panel-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -34,7 +34,7 @@
     <div class="panel-dialog__window">
         <div class="panel-dialog__header">
             <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="panel-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -61,7 +61,7 @@
             <div aria-labelledby="dialog-title-right" aria-modal="true" class="panel-dialog" hidden id="dialog-right-panel-1" role="dialog">
                 <div class="panel-dialog__window panel-dialog__window--end">
                     <div class="panel-dialog__header">
-                        <button aria-label="Close dialog" class="panel-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -85,7 +85,7 @@
 <div aria-labelledby="dialog-title-right" aria-modal="true" class="panel-dialog" hidden id="dialog-right-panel-1" role="dialog">
     <div class="panel-dialog__window panel-dialog__window--end">
         <div class="panel-dialog__header">
-            <button aria-label="Close dialog" class="panel-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -115,7 +115,7 @@
                 <div class="panel-dialog__window panel-dialog__window--slide">
                     <div class="panel-dialog__header">
                         <h2 id="dialog-title-slide-1" class="panel-dialog__title large-text-1 bold-text">Heading</h2>
-                        <button aria-label="Close dialog" class="panel-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -135,7 +135,7 @@
             <div aria-labelledby="dialog-title-slide-2" aria-modal="true" class="panel-dialog panel-dialog--mask-fade-slow" data-makeup-dialog-has-transitions="true" hidden id="dialog-slide-right-panel-0" role="dialog">
                 <div class="panel-dialog__window panel-dialog__window--end panel-dialog__window--slide">
                     <div class="panel-dialog__header">
-                        <button aria-label="Close dialog" class="panel-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -159,7 +159,7 @@
     <div class="panel-dialog__window panel-dialog__window--slide">
         <div class="panel-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="panel-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>

--- a/docs/_includes/common/toast-dialog.html
+++ b/docs/_includes/common/toast-dialog.html
@@ -12,7 +12,7 @@
                 <div class="toast-dialog__window">
                     <div class="toast-dialog__header">
                         <h3 class="toast-dialog__title">User Privacy Preferences</h3>
-                        <button class="toast-dialog__close" type="button" aria-label="Close notification dialog">
+                        <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
                             <svg class="icon icon--close" focusable="false" height="24" width="24">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -33,7 +33,7 @@
     <div class="toast-dialog__window">
         <div class="toast-dialog__header">
             <h2 class="toast-dialog__title">User Privacy Preferences</h2>
-            <button class="toast-dialog__close" type="button" aria-label="Close notification dialog">
+            <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
                 <svg class="icon icon--close" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-close"></use>
                 </svg>

--- a/drawer-dialog.browser.json
+++ b/drawer-dialog.browser.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-         "require: ./drawer-dialog"
+        "require: ./actionable",
+        "require: ./drawer-dialog"
     ]
 }

--- a/drawer-dialog.js
+++ b/drawer-dialog.js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/drawer-dialog/ds6/drawer-dialog.css');

--- a/drawer-dialog[ds-4].js
+++ b/drawer-dialog[ds-4].js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/drawer-dialog/ds4/drawer-dialog.css');

--- a/fullscreen-dialog.browser.json
+++ b/fullscreen-dialog.browser.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-         "require: ./fullscreen-dialog"
+        "require: ./actionable",
+        "require: ./fullscreen-dialog"
     ]
 }

--- a/fullscreen-dialog.js
+++ b/fullscreen-dialog.js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/fullscreen-dialog/ds6/fullscreen-dialog.css');

--- a/fullscreen-dialog[ds-4].js
+++ b/fullscreen-dialog[ds-4].js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/fullscreen-dialog/ds4/fullscreen-dialog.css');

--- a/lightbox-dialog.browser.json
+++ b/lightbox-dialog.browser.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-         "require: ./lightbox-dialog"
+        "require: ./actionable",
+        "require: ./lightbox-dialog"
     ]
 }

--- a/lightbox-dialog.js
+++ b/lightbox-dialog.js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/lightbox-dialog/ds6/lightbox-dialog.css');

--- a/lightbox-dialog[ds-4].js
+++ b/lightbox-dialog[ds-4].js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/lightbox-dialog/ds4/lightbox-dialog.css');

--- a/panel-dialog.browser.json
+++ b/panel-dialog.browser.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-         "require: ./panel-dialog"
+        "require: ./actionable",
+        "require: ./panel-dialog"
     ]
 }

--- a/panel-dialog.js
+++ b/panel-dialog.js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/panel-dialog/ds6/panel-dialog.css');

--- a/panel-dialog[ds-4].js
+++ b/panel-dialog[ds-4].js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/panel-dialog/ds4/panel-dialog.css');

--- a/src/less/drawer-dialog/base/drawer-dialog.less
+++ b/src/less/drawer-dialog/base/drawer-dialog.less
@@ -47,18 +47,14 @@
     .dialog-footer-content();
 }
 
-.drawer-dialog__back,
-.drawer-dialog__close {
-    .customColorProperty(dialog-back-close-foreground-color);
-
+// inherits from .icon-btn
+button.drawer-dialog__close {
     background-color: transparent;
     border: 0;
+    height: auto;
+    outline-offset: 4px;
+    width: auto;
     z-index: 1;
-
-    &:hover,
-    &:focus {
-        color: @dialog-back-close-hover-foreground-color;
-    }
 }
 
 .drawer-dialog__window {
@@ -111,7 +107,7 @@
     // Root animations.
     &.drawer-dialog--mask-fade,
     &.drawer-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-hide-mask-fade-background-color, 0%);
+        background-color: fade(@dialog-mask-background-color, 0%);
     }
 
     // code smell, chained modifier
@@ -130,7 +126,7 @@
     // Root animations.
     &.drawer-dialog--mask-fade,
     &.drawer-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-show-mask-fade-background-color, 70%);
+        background-color: fade(@dialog-mask-background-color, 70%);
     }
 
     // Child animations.

--- a/src/less/drawer-dialog/stories/drawer-dialog.stories.js
+++ b/src/less/drawer-dialog/stories/drawer-dialog.stories.js
@@ -6,7 +6,7 @@ export const empty = () => `
         <button class="drawer-dialog__handle"></button>
         <div class="drawer-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="drawer-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -24,7 +24,7 @@ export const partial = () => `
         <button class="drawer-dialog__handle"></button>
         <div class="drawer-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="drawer-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -47,7 +47,7 @@ export const half = () => `
         <button class="drawer-dialog__handle"></button>
         <div class="drawer-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="drawer-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -106,7 +106,7 @@ export const full = () => `
         <button class="drawer-dialog__handle"></button>
         <div class="drawer-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="drawer-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>

--- a/src/less/floating-label/stories/floating-label.stories.js
+++ b/src/less/floating-label/stories/floating-label.stories.js
@@ -1,4 +1,4 @@
-export default { title: 'Floatin Label' };
+export default { title: 'Floating Label' };
 
 export const base = () => `
 <span class="floating-label">

--- a/src/less/fullscreen-dialog/base/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/base/fullscreen-dialog.less
@@ -29,7 +29,8 @@
 }
 
 // inherits from .icon-btn
-button.fullscreen-dialog__close {
+button.fullscreen-dialog__close,
+button.fullscreen-dialog__back {
     align-self: center;
     border: 0;
     height: auto;

--- a/src/less/fullscreen-dialog/base/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/base/fullscreen-dialog.less
@@ -28,21 +28,16 @@
     .dialog-footer-content();
 }
 
-.fullscreen-dialog__back,
-.fullscreen-dialog__close {
-    .customColorProperty(dialog-back-close-foreground-color);
-
+// inherits from .icon-btn
+button.fullscreen-dialog__close {
     align-self: center;
-    background-color: transparent;
     border: 0;
+    height: auto;
+    outline-offset: 4px;
     padding: 0;
     position: relative;
+    width: auto;
     z-index: 1;
-
-    &:hover,
-    &:focus {
-        color: @dialog-back-close-hover-foreground-color;
-    }
 }
 
 .fullscreen-dialog--show,
@@ -72,7 +67,7 @@
 
     &.fullscreen-dialog--mask-fade,
     &.fullscreen-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-hide-mask-fade-background-color, 0%);
+        background-color: fade(@dialog-mask-background-color, 0%);
     }
 
     .fullscreen-dialog__window--fade {
@@ -92,7 +87,7 @@
 
     &.fullscreen-dialog--mask-fade,
     &.fullscreen-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-show-mask-fade-background-color, 70%);
+        background-color: fade(@dialog-mask-background-color, 70%);
     }
 
     .fullscreen-dialog__window--fade {

--- a/src/less/fullscreen-dialog/base/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/base/fullscreen-dialog.less
@@ -18,6 +18,11 @@
     .dialog-header-content();
 }
 
+.fullscreen-dialog__header .fake-link {
+    outline-offset: 4px;
+    text-decoration: none;
+}
+
 .fullscreen-dialog__main {
     .dialog-body-content();
 
@@ -33,7 +38,6 @@ button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
     align-self: center;
     border: 0;
-    height: auto;
     outline-offset: 4px;
     padding: 0;
     position: relative;

--- a/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
+++ b/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
@@ -1,17 +1,17 @@
 export default { title: 'Dialog' };
 
 export const full = () => `
-<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
-    <div class="dialog__window dialog__window--full">
-        <div class="dialog__header">
-            <button class="dialog__close" type="button" aria-label="Close Dialog">
+<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
+    <div class="fullscreen-dialog__window fullscreen-dialog__window--full">
+        <div class="fullscreen-dialog__header">
+            <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
-            <h2 id="dialog-title">Dialog Full</h2>
+            <h2 id="fullscreen-dialog-title">Dialog Full</h2>
         </div>
-        <div class="dialog__main">
+        <div class="fullscreen-dialog__main">
             <h3>Heading</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>
@@ -24,17 +24,17 @@ export const full = () => `
 `;
 
 export const fullWithFooter = () => `
-<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
-    <div class="dialog__window dialog__window--full">
-        <div class="dialog__header">
-            <h2 id="dialog-title">Dialog Full (With footer)</h2>
-            <button class="dialog__close" type="button" aria-label="Close Dialog">
+<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
+    <div class="fullscreen-dialog__window fullscreen-dialog__window--full">
+        <div class="fullscreen-dialog__header">
+            <h2 id="fullscreen-dialog-title">Dialog Full (With footer)</h2>
+            <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
         </div>
-        <div class="dialog__main">
+        <div class="fullscreen-dialog__main">
             <h3>Heading</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>
@@ -42,7 +42,7 @@ export const fullWithFooter = () => `
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>
         </div>
-        <div class="dialog__footer">
+        <div class="fullscreen-dialog__footer">
             <button class="btn">Cancel</button>
             <button class="btn btn--primary">Submit</button>
         </div>
@@ -51,18 +51,18 @@ export const fullWithFooter = () => `
 `;
 
 export const multistep = () => `
-<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
-    <div class="dialog__window dialog__window--full" role="document">
-        <div class="dialog__header">
-        <button class="dialog__back" type="button" aria-label="Back">
+<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" id="dialog" role="dialog">
+    <div class="fullscreen-dialog__window fullscreen-dialog__window--full" role="document">
+        <div class="fullscreen-dialog__header">
+        <button class="icon-btn fullscreen-dialog__back" type="button" aria-label="Back">
             <svg class="icon icon--back" aria-hidden="true">
                 <use xlink:href="#icon-back"></use>
             </svg>
         </button>
-            <h2 id="dialog-title">Multi-Step</h2>
-        <button class="dialog__close" type="button">Done</button>
+            <h2 id="fullscreen-dialog-title">Multi-Step</h2>
+        <button class="fullscreen-dialog__close" type="button">Done</button>
         </div>
-        <div class="dialog__main">
+        <div class="fullscreen-dialog__main">
             <h3>Heading</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>
@@ -79,17 +79,17 @@ multistep.story = {
 }
 
 export const subpage = () => `
-<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
-    <div class="dialog__window dialog__window--full" role="document">
-        <div class="dialog__header">
-            <button class="dialog__back" type="button" aria-label="Back">
+<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" id="dialog" role="dialog">
+    <div class="fullscreen-dialog__window dialog__window--full" role="document">
+        <div class="fullscreen-dialog__header">
+            <button class="icon-btn fullscreen-dialog__back" type="button" aria-label="Back">
                 <svg class="icon icon--back" aria-hidden="true">
                     <use xlink:href="#icon-back"></use>
                 </svg>
             </button>
-            <h2 id="dialog-title">Sub Page</h2>
+            <h2 id="fullscreen-dialog-title">Sub Page</h2>
         </div>
-        <div class="dialog__main">
+        <div class="fullscreen-dialog__main">
             <h3>Heading</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>

--- a/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
+++ b/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
@@ -1,8 +1,8 @@
-export default { title: 'Dialog' };
+export default { title: 'Fullscreen Dialog' };
 
-export const full = () => `
+export const closeButton = () => `
 <div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
-    <div class="fullscreen-dialog__window fullscreen-dialog__window--full">
+    <div class="fullscreen-dialog__window">
         <div class="fullscreen-dialog__header">
             <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
@@ -23,71 +23,16 @@ export const full = () => `
 </div>
 `;
 
-export const fullWithFooter = () => `
+export const backButton = () => `
 <div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
-    <div class="fullscreen-dialog__window fullscreen-dialog__window--full">
-        <div class="fullscreen-dialog__header">
-            <h2 id="fullscreen-dialog-title">Dialog Full (With footer)</h2>
-            <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
-                <svg class="icon icon--close" aria-hidden="true">
-                    <use xlink:href="#icon-close"></use>
-                </svg>
-            </button>
-        </div>
-        <div class="fullscreen-dialog__main">
-            <h3>Heading</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-            <h3>Heading</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-        </div>
-        <div class="fullscreen-dialog__footer">
-            <button class="btn">Cancel</button>
-            <button class="btn btn--primary">Submit</button>
-        </div>
-    </div>
-</div>
-`;
-
-export const multistep = () => `
-<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" id="dialog" role="dialog">
-    <div class="fullscreen-dialog__window fullscreen-dialog__window--full" role="document">
-        <div class="fullscreen-dialog__header">
-        <button class="icon-btn fullscreen-dialog__back" type="button" aria-label="Back">
-            <svg class="icon icon--back" aria-hidden="true">
-                <use xlink:href="#icon-back"></use>
-            </svg>
-        </button>
-            <h2 id="fullscreen-dialog-title">Multi-Step</h2>
-        <button class="fullscreen-dialog__close" type="button">Done</button>
-        </div>
-        <div class="fullscreen-dialog__main">
-            <h3>Heading</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-            <h3>Heading</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-        </div>
-    </div>
-</div>
-`;
-
-multistep.story = {
-    name: 'Multistep (DS4 only)'
-}
-
-export const subpage = () => `
-<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" id="dialog" role="dialog">
-    <div class="fullscreen-dialog__window dialog__window--full" role="document">
+    <div class="fullscreen-dialog__window">
         <div class="fullscreen-dialog__header">
             <button class="icon-btn fullscreen-dialog__back" type="button" aria-label="Back">
                 <svg class="icon icon--back" aria-hidden="true">
                     <use xlink:href="#icon-back"></use>
                 </svg>
             </button>
-            <h2 id="fullscreen-dialog-title">Sub Page</h2>
+            <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>
         </div>
         <div class="fullscreen-dialog__main">
             <h3>Heading</h3>
@@ -101,6 +46,26 @@ export const subpage = () => `
 </div>
 `;
 
-subpage.story = {
-    name: 'Subpage (DS4 only)'
-}
+export const secondaryButton = () => `
+<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
+    <div class="fullscreen-dialog__window">
+        <div class="fullscreen-dialog__header">
+            <button class="icon-btn fullscreen-dialog__back" type="button" aria-label="Back">
+                <svg class="icon icon--back" aria-hidden="true">
+                    <use xlink:href="#icon-back"></use>
+                </svg>
+            </button>
+            <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>
+            <button class="fake-link fullscreen-dialog__close" type="button">Reset</button>
+        </div>
+        <div class="fullscreen-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/lightbox-dialog/base/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/base/lightbox-dialog.less
@@ -58,21 +58,15 @@
     }
 }
 
-.lightbox-dialog__back,
-.lightbox-dialog__close {
-    .customColorProperty(dialog-back-close-foreground-color);
-
+// inherits from .icon-btn
+button.lightbox-dialog__close {
     align-self: center;
-    background-color: transparent;
     border: 0;
-    padding: 0;
+    height: auto;
+    outline-offset: 4px;
     position: relative;
+    width: auto;
     z-index: 1;
-
-    &:hover,
-    &:focus {
-        color: @dialog-back-close-hover-foreground-color;
-    }
 }
 
 .lightbox-dialog__title {
@@ -109,7 +103,7 @@
 
     &.lightbox-dialog--mask-fade,
     &.lightbox-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-hide-mask-fade-background-color, 0%);
+        background-color: fade(@dialog-mask-background-color, 0%);
     }
 
     .lightbox-dialog__compact-window--fade,
@@ -126,7 +120,7 @@
 
     &.lightbox-dialog--mask-fade,
     &.lightbox-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-show-mask-fade-background-color, 70%);
+        background-color: fade(@dialog-mask-background-color, 70%);
     }
 
     .lightbox-dialog__compact-window--fade,

--- a/src/less/lightbox-dialog/base/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/base/lightbox-dialog.less
@@ -62,7 +62,6 @@
 button.lightbox-dialog__close {
     align-self: center;
     border: 0;
-    height: auto;
     outline-offset: 4px;
     position: relative;
     width: auto;

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -1,17 +1,17 @@
 export default { title: 'Lightbox Dialog' };
 
 export const lightbox = () => `
-<div aria-labelledby="dialog-title" aria-modal="true" class="dialog" id="dialog_window" role="dialog">
-    <div class="dialog__window" role="document">
-        <div class="dialog__header">
-            <h2 id="dialog-title">Dialog Lightbox</h2>
-            <button class="dialog__close" type="button" aria-label="Close Dialog">
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window">
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
         </div>
-        <div class="dialog__main">
+        <div class="lightbox-dialog__main">
             <h3>Heading</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>

--- a/src/less/link/base/link.less
+++ b/src/less/link/base/link.less
@@ -1,43 +1,36 @@
 @import "../../mixins/utility/utility-mixins.less";
 
-a {
-    &.nav-link {
+a.nav-link {
+    .customColorProperty(nav-link-color);
+
+    text-decoration: none;
+
+    &:visited {
         .customColorProperty(nav-link-color);
+    }
 
-        text-decoration: none;
+    &:hover {
+        .customColorProperty(nav-link-hover-color);
 
-        &:visited {
-            .customColorProperty(nav-link-color);
-        }
-
-        &:hover {
-            .customColorProperty(nav-link-hover-color);
-
-            text-decoration: underline;
-        }
+        text-decoration: underline;
     }
 }
 
-// FAKE-LINK
-//-----------------------------
+button.fake-link {
+    .customColorProperty(fake-link-color);
 
-button {
-    &.fake-link {
-        .customColorProperty(fake-link-color);
+    background-color: transparent;
+    border: 0;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0;
+    text-decoration: underline;
 
-        background-color: transparent;
-        border: 0;
-        font-family: inherit;
-        font-size: inherit;
-        padding: 0;
-        text-decoration: underline;
+    &[disabled] {
+        opacity: 0.5;
+    }
 
-        &[disabled] {
-            opacity: 0.5;
-        }
-
-        &:hover {
-            .customColorProperty(fake-link-hover-color);
-        }
+    &:hover {
+        .customColorProperty(fake-link-hover-color);
     }
 }

--- a/src/less/panel-dialog/base/panel-dialog.less
+++ b/src/less/panel-dialog/base/panel-dialog.less
@@ -26,6 +26,7 @@
 }
 
 .panel-dialog__header .fake-link {
+    outline-offset: 4px;
     text-decoration: none;
 }
 
@@ -37,21 +38,16 @@
     .dialog-footer-content();
 }
 
-.panel-dialog__back,
-.panel-dialog__close {
-    .customColorProperty(dialog-back-close-foreground-color);
-
+// inherits from .icon-btn
+button.panel-dialog__close {
     align-self: center;
-    background-color: transparent;
     border: 0;
+    height: auto;
+    outline-offset: 4px;
     padding: 0;
     position: relative;
+    width: auto;
     z-index: 1;
-
-    &:hover,
-    &:focus {
-        color: @dialog-back-close-hover-foreground-color;
-    }
 }
 
 .panel-dialog__title {
@@ -87,7 +83,7 @@
 
     &.panel-dialog--mask-fade,
     &.panel-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-hide-mask-fade-background-color, 0%);
+        background-color: fade(@dialog-mask-background-color, 0%);
     }
 
     .panel-dialog__window--slide-left {
@@ -117,7 +113,7 @@
 
     &.panel-dialog--mask-fade,
     &.panel-dialog--mask-fade-slow {
-        background-color: fade(@dialog-transitions-show-mask-fade-background-color, 70%);
+        background-color: fade(@dialog-mask-background-color, 70%);
     }
 
     .panel-dialog__window--slide {

--- a/src/less/panel-dialog/base/panel-dialog.less
+++ b/src/less/panel-dialog/base/panel-dialog.less
@@ -42,7 +42,6 @@
 button.panel-dialog__close {
     align-self: center;
     border: 0;
-    height: auto;
     outline-offset: 4px;
     padding: 0;
     position: relative;

--- a/src/less/panel-dialog/stories/panel-dialog.stories.js
+++ b/src/less/panel-dialog/stories/panel-dialog.stories.js
@@ -27,12 +27,36 @@ export const panelEnd = () => `
 <div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
     <div class="panel-dialog__window panel-dialog__window--end">
         <div class="panel-dialog__header">
-            <h2 id="panel-title">Right Panel</h2>
             <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
+            <h2 id="panel-title">Right Panel</h2>
+        </div>
+        <div class="panel-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;
+
+export const panelEndSecondaryButton = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window panel-dialog__window--end">
+        <div class="panel-dialog__header">
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close" aria-hidden="true">
+                    <use xlink:href="#icon-close"></use>
+                </svg>
+            </button>
+            <h2 id="panel-title">Right Panel</h2>
+            <button class="fake-link panel-dialog__close" type="button">Reset</button>
         </div>
         <div class="panel-dialog__main">
             <h3>Heading</h3>

--- a/src/less/panel-dialog/stories/panel-dialog.stories.js
+++ b/src/less/panel-dialog/stories/panel-dialog.stories.js
@@ -1,17 +1,17 @@
 export default { title: 'Panel Dialog' };
 
-export const panelLeft = () => `
-<div aria-labelledby="panel-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
-    <div class="dialog__window dialog__window--left" role="document">
-        <div class="dialog__header">
+export const panelStart = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window">
+        <div class="panel-dialog__header">
             <h2 id="panel-title">Left Panel</h2>
-            <button class="dialog__close" type="button" aria-label="Close Dialog">
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
         </div>
-        <div class="dialog__main">
+        <div class="panel-dialog__main">
             <h3>Heading</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>
@@ -23,18 +23,18 @@ export const panelLeft = () => `
 </div>
 `;
 
-export const panelRight = () => `
-<div aria-labelledby="panel-title" aria-modal="true" class="dialog" id="dialog" role="dialog">
-    <div class="dialog__window dialog__window--right" role="document">
-        <div class="dialog__header">
+export const panelEnd = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window panel-dialog__window--end">
+        <div class="panel-dialog__header">
             <h2 id="panel-title">Right Panel</h2>
-            <button class="dialog__close" type="button" aria-label="Close Dialog">
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close" aria-hidden="true">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
         </div>
-        <div class="dialog__main">
+        <div class="panel-dialog__main">
             <h3>Heading</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>

--- a/src/less/properties/base/drawer-dialog-properties.less
+++ b/src/less/properties/base/drawer-dialog-properties.less
@@ -1,4 +1,3 @@
 .drawer-dialog {
     --dialog-window-background-color: @dialog-window-background-color;
-    --dialog-back-close-foreground-color: @dialog-back-close-foreground-color;
 }

--- a/src/less/properties/base/fullscreen-dialog-properties.less
+++ b/src/less/properties/base/fullscreen-dialog-properties.less
@@ -1,5 +1,4 @@
 .fullscreen-dialog {
     --dialog-mask-background-color: @dialog-mask-background-color;
     --dialog-window-background-color: @dialog-window-background-color;
-    --dialog-back-close-foreground-color: @dialog-back-close-foreground-color;
 }

--- a/src/less/properties/base/lightbox-dialog-properties.less
+++ b/src/less/properties/base/lightbox-dialog-properties.less
@@ -1,5 +1,4 @@
 .lightbox-dialog {
     --dialog-mask-background-color: @dialog-mask-background-color;
     --dialog-window-background-color: @dialog-window-background-color;
-    --dialog-back-close-foreground-color: @dialog-back-close-foreground-color;
 }

--- a/src/less/properties/base/panel-dialog-properties.less
+++ b/src/less/properties/base/panel-dialog-properties.less
@@ -1,5 +1,4 @@
 .panel-dialog {
     --dialog-mask-background-color: @dialog-mask-background-color;
     --dialog-window-background-color: @dialog-window-background-color;
-    --dialog-back-close-foreground-color: @dialog-back-close-foreground-color;
 }

--- a/src/less/properties/ds6/drawer-dialog-properties.less
+++ b/src/less/properties/ds6/drawer-dialog-properties.less
@@ -8,7 +8,6 @@
     .skin-experiment-1 {
         .drawer-dialog {
             --dialog-window-background-color: @color-grey1-dark-mode;
-            --dialog-back-close-foreground-color: @color-text-default-dark-mode;
         }
     }
 }

--- a/src/less/properties/ds6/fullscreen-dialog-properties.less
+++ b/src/less/properties/ds6/fullscreen-dialog-properties.less
@@ -8,7 +8,6 @@
     .skin-experiment-1 {
         .fullscreen-dialog {
             --dialog-window-background-color: @color-grey1-dark-mode;
-            --dialog-back-close-foreground-color: @color-text-default-dark-mode;
         }
     }
 }

--- a/src/less/properties/ds6/lightbox-dialog-properties.less
+++ b/src/less/properties/ds6/lightbox-dialog-properties.less
@@ -8,7 +8,6 @@
     .skin-experiment-1 {
         .lightbox-dialog {
             --dialog-window-background-color: @color-grey1-dark-mode;
-            --dialog-back-close-foreground-color: @color-text-default-dark-mode;
         }
     }
 }

--- a/src/less/properties/ds6/panel-dialog-properties.less
+++ b/src/less/properties/ds6/panel-dialog-properties.less
@@ -8,7 +8,6 @@
     .skin-experiment-1 {
         .panel-dialog {
             --dialog-window-background-color: @color-grey1-dark-mode;
-            --dialog-back-close-foreground-color: @color-text-default-dark-mode;
         }
     }
 }

--- a/src/less/toast-dialog/base/toast-dialog.less
+++ b/src/less/toast-dialog/base/toast-dialog.less
@@ -66,14 +66,20 @@
     margin: 0;
 }
 
-.toast-dialog__close {
-    .customBackgroundColorProperty(toast-dialog-background-color);
-    .customColorProperty(toast-dialog-foreground-color);
-
+// inherits from .icon-btn
+button.toast-dialog__close {
     align-self: center;
     border: 0;
+    height: auto;
     margin: 0 0 0 auto;
     padding: 0;
+    width: auto;
+
+    > svg,
+    &:hover > svg,
+    &:focus > svg {
+        .customFillProperty(toast-dialog-foreground-color);
+    }
 
     &:focus {
         .toast-dialog-outline();

--- a/src/less/toast-dialog/stories/toast-dialog.stories.js
+++ b/src/less/toast-dialog/stories/toast-dialog.stories.js
@@ -5,7 +5,7 @@ export const primaryAction = () => `
     <div class="toast-dialog__window">
         <div class="toast-dialog__header">
             <h2>User Privacy Preferences</h2>
-            <button class="icon-btn" type="button" aria-label="Close notification dialog">
+            <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
                 <svg class="icon icon--close" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -27,7 +27,7 @@ export const secondaryAction = () => `
     <div class="toast-dialog__window">
         <div class="toast-dialog__header">
             <h2>User Privacy Preferences</h2>
-            <button class="icon-btn" type="button" aria-label="Close notification dialog">
+            <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
                 <svg class="icon icon--close" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-close"></use>
                 </svg>

--- a/src/less/variables/ds4/dialog-variables.less
+++ b/src/less/variables/ds4/dialog-variables.less
@@ -3,11 +3,6 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
-@dialog-back-close-foreground-color: @color-text-default;
-@dialog-back-close-hover-foreground-color: @color-action-primary;
-@dialog-transitions-hide-mask-fade-background-color: @color-text-default;
-@dialog-transitions-show-mask-fade-background-color: @color-text-default;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
-@dialog-handle-color: @color-grey4;
 @dialog-max-width: 616px;

--- a/src/less/variables/ds4/drawer-dialog-variables.less
+++ b/src/less/variables/ds4/drawer-dialog-variables.less
@@ -2,3 +2,4 @@
 @import "./typography-variables.less";
 
 @dialog-window-background-color: @color-background-default;
+@dialog-handle-color: @color-grey4;

--- a/src/less/variables/ds6/dialog-variables.less
+++ b/src/less/variables/ds6/dialog-variables.less
@@ -3,11 +3,6 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
-@dialog-back-close-foreground-color: @color-text-default;
-@dialog-back-close-hover-foreground-color: @color-action-primary;
-@dialog-transitions-hide-mask-fade-background-color: @color-text-default;
-@dialog-transitions-show-mask-fade-background-color: @color-text-default;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
-@dialog-handle-color: @color-grey4;
 @dialog-max-width: 616px;

--- a/src/less/variables/ds6/drawer-dialog-variables.less
+++ b/src/less/variables/ds6/drawer-dialog-variables.less
@@ -2,3 +2,4 @@
 @import "./typography-variables.less";
 
 @dialog-window-background-color: @color-background-default;
+@dialog-handle-color: @color-grey4;

--- a/toast-dialog.browser.json
+++ b/toast-dialog.browser.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-         "require: ./toast-dialog"
+        "require: ./actionable",
+        "require: ./toast-dialog"
     ]
 }

--- a/toast-dialog.js
+++ b/toast-dialog.js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/toast-dialog/ds6/toast-dialog.css');

--- a/toast-dialog[ds-4].js
+++ b/toast-dialog[ds-4].js
@@ -1,1 +1,2 @@
+require('./actionable');
 require('./dist/toast-dialog/ds4/toast-dialog.css');


### PR DESCRIPTION
PLEASE SQUASH

Cleaning up some code smells whilst doing the custom property and dark mode. For the dialog close button, I noticed that we were declaring essentially the same property names and values multiple time across dialogs. Really, these names & values are already defined in the actionable module (`icon-btn`) class. By specifying the `icon-btn` class name in the HTML we can get all of the properties benefits for free in the cascade.

I know we have gone back and forth on the pattern of explicit classnames in the HTML vs mixins in LESS, but with the advent of custom properties and the nuances of dark mode, I'm definitely starting to lean more towards actual classnames in the HTML, as this results in less CSS delivered to the client.

Oops, also need to update stories...will do that now.