### PR TITLE
Added negative offset and fixed toast dialog button

### DIFF
--- a/dist/drawer-dialog/ds4/drawer-dialog.css
+++ b/dist/drawer-dialog/ds4/drawer-dialog.css
@@ -97,7 +97,7 @@ button.drawer-dialog__close {
   background-color: transparent;
   border: 0;
   height: auto;
-  outline-offset: 4px;
+  outline-offset: -8px;
   z-index: 1;
 }
 .drawer-dialog__window {

--- a/dist/drawer-dialog/ds6/drawer-dialog.css
+++ b/dist/drawer-dialog/ds6/drawer-dialog.css
@@ -102,7 +102,7 @@ button.drawer-dialog__close {
   background-color: transparent;
   border: 0;
   height: auto;
-  outline-offset: 4px;
+  outline-offset: -8px;
   z-index: 1;
 }
 .drawer-dialog__window {

--- a/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
@@ -96,7 +96,7 @@ button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
   align-self: center;
   border: 0;
-  outline-offset: 4px;
+  outline-offset: -8px;
   padding: 0;
   position: relative;
   z-index: 1;

--- a/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
@@ -101,7 +101,7 @@ button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
   align-self: center;
   border: 0;
-  outline-offset: 4px;
+  outline-offset: -8px;
   padding: 0;
   position: relative;
   z-index: 1;

--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -122,7 +122,7 @@
 button.lightbox-dialog__close {
   align-self: center;
   border: 0;
-  outline-offset: 4px;
+  outline-offset: -8px;
   position: relative;
   z-index: 1;
 }

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -127,7 +127,7 @@
 button.lightbox-dialog__close {
   align-self: center;
   border: 0;
-  outline-offset: 4px;
+  outline-offset: -8px;
   position: relative;
   z-index: 1;
 }

--- a/dist/panel-dialog/ds4/panel-dialog.css
+++ b/dist/panel-dialog/ds4/panel-dialog.css
@@ -100,7 +100,7 @@
 button.panel-dialog__close {
   align-self: center;
   border: 0;
-  outline-offset: 4px;
+  outline-offset: -8px;
   padding: 0;
   position: relative;
   z-index: 1;

--- a/dist/panel-dialog/ds6/panel-dialog.css
+++ b/dist/panel-dialog/ds6/panel-dialog.css
@@ -105,7 +105,7 @@
 button.panel-dialog__close {
   align-self: center;
   border: 0;
-  outline-offset: 4px;
+  outline-offset: -8px;
   padding: 0;
   position: relative;
   z-index: 1;

--- a/dist/toast-dialog/ds4/toast-dialog.css
+++ b/dist/toast-dialog/ds4/toast-dialog.css
@@ -25,7 +25,7 @@
 .toast-dialog a:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
-  outline-offset: 4px;
+  outline-offset: -8px;
   outline-style: dotted;
   outline-width: 1px;
 }
@@ -50,9 +50,11 @@
           transform: translateY(110%);
 }
 .toast-dialog__window {
-  margin: 16px;
+  margin: 8px 16px 16px;
 }
 .toast-dialog__header {
+  -webkit-box-align: center;
+          align-items: center;
   display: -webkit-box;
   display: flex;
 }
@@ -63,7 +65,6 @@
 button.toast-dialog__close {
   align-self: center;
   border: 0;
-  height: auto;
   margin: 0 0 0 auto;
   padding: 0;
 }
@@ -76,7 +77,7 @@ button.toast-dialog__close:focus > svg {
 button.toast-dialog__close:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
-  outline-offset: 4px;
+  outline-offset: -8px;
   outline-style: dotted;
   outline-width: 1px;
 }
@@ -107,7 +108,7 @@ button.toast-dialog__close:focus {
 .toast-dialog__footer .btn--secondary:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
-  outline-offset: 4px;
+  outline-offset: -8px;
   outline-style: dotted;
   outline-width: 1px;
 }
@@ -129,6 +130,6 @@ button.toast-dialog__close:focus {
     width: auto;
   }
   .toast-dialog__window {
-    margin: 24px;
+    margin: 16px 24px 24px;
   }
 }

--- a/dist/toast-dialog/ds6/toast-dialog.css
+++ b/dist/toast-dialog/ds6/toast-dialog.css
@@ -25,7 +25,7 @@
 .toast-dialog a:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
-  outline-offset: 4px;
+  outline-offset: -8px;
   outline-style: dotted;
   outline-width: 1px;
 }
@@ -50,9 +50,11 @@
           transform: translateY(110%);
 }
 .toast-dialog__window {
-  margin: 16px;
+  margin: 8px 16px 16px;
 }
 .toast-dialog__header {
+  -webkit-box-align: center;
+          align-items: center;
   display: -webkit-box;
   display: flex;
 }
@@ -63,7 +65,6 @@
 button.toast-dialog__close {
   align-self: center;
   border: 0;
-  height: auto;
   margin: 0 0 0 auto;
   padding: 0;
 }
@@ -76,7 +77,7 @@ button.toast-dialog__close:focus > svg {
 button.toast-dialog__close:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
-  outline-offset: 4px;
+  outline-offset: -8px;
   outline-style: dotted;
   outline-width: 1px;
 }
@@ -107,7 +108,7 @@ button.toast-dialog__close:focus {
 .toast-dialog__footer .btn--secondary:focus {
   outline-color: #fff;
   outline-color: var(--toast-dialog-foreground-color, #fff);
-  outline-offset: 4px;
+  outline-offset: -8px;
   outline-style: dotted;
   outline-width: 1px;
 }
@@ -129,6 +130,6 @@ button.toast-dialog__close:focus {
     width: auto;
   }
   .toast-dialog__window {
-    margin: 24px;
+    margin: 16px 24px 24px;
   }
 }

--- a/src/less/drawer-dialog/base/drawer-dialog.less
+++ b/src/less/drawer-dialog/base/drawer-dialog.less
@@ -52,7 +52,7 @@ button.drawer-dialog__close {
     background-color: transparent;
     border: 0;
     height: auto;
-    outline-offset: 4px;
+    outline-offset: -8px;
     z-index: 1;
 }
 

--- a/src/less/fullscreen-dialog/base/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/base/fullscreen-dialog.less
@@ -38,7 +38,7 @@ button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
     align-self: center;
     border: 0;
-    outline-offset: 4px;
+    outline-offset: -8px;
     padding: 0;
     position: relative;
     z-index: 1;

--- a/src/less/lightbox-dialog/base/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/base/lightbox-dialog.less
@@ -62,7 +62,7 @@
 button.lightbox-dialog__close {
     align-self: center;
     border: 0;
-    outline-offset: 4px;
+    outline-offset: -8px;
     position: relative;
     z-index: 1;
 }

--- a/src/less/panel-dialog/base/panel-dialog.less
+++ b/src/less/panel-dialog/base/panel-dialog.less
@@ -42,7 +42,7 @@
 button.panel-dialog__close {
     align-self: center;
     border: 0;
-    outline-offset: 4px;
+    outline-offset: -8px;
     padding: 0;
     position: relative;
     z-index: 1;

--- a/src/less/toast-dialog/base/toast-dialog.less
+++ b/src/less/toast-dialog/base/toast-dialog.less
@@ -3,7 +3,7 @@
 .toast-dialog-outline() {
     .customOutlineColorProperty(toast-dialog-foreground-color);
 
-    outline-offset: 4px;
+    outline-offset: -8px;
     outline-style: dotted;
     outline-width: 1px;
 }
@@ -53,10 +53,11 @@
 }
 
 .toast-dialog__window {
-    margin: 16px;
+    margin: 8px 16px 16px;
 }
 
 .toast-dialog__header {
+    align-items: center;
     display: flex;
 }
 
@@ -70,7 +71,6 @@
 button.toast-dialog__close {
     align-self: center;
     border: 0;
-    height: auto;
     margin: 0 0 0 auto;
     padding: 0;
 
@@ -137,6 +137,6 @@ button.toast-dialog__close {
     }
 
     .toast-dialog__window {
-        margin: 24px;
+        margin: 16px 24px 24px;
     }
 }


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
Changed offset to be negative 8px. This way icons are `40px` and the selector box is now small
Also updated toast button
(I looked at mini dialog button and it looks fine imo, but let me know if I missed something)

## Screenshots
For these I was on another browser which made them render differently than chome does. 
![pic-selected-200913-1456-54](https://user-images.githubusercontent.com/1755269/93029663-882f6980-f5d1-11ea-956e-a41d77d87b66.png)
![pic-selected-200913-1457-11](https://user-images.githubusercontent.com/1755269/93029665-88c80000-f5d1-11ea-8017-75691bb682a1.png)
![pic-selected-200913-1457-33](https://user-images.githubusercontent.com/1755269/93029667-88c80000-f5d1-11ea-8999-9197ae3fd2fa.png)
