### PR TITLE
Pagination: use icon-button classes on paddles

### DIFF
--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -31,7 +31,6 @@ button.icon-btn > svg,
 a.icon-link > svg {
   fill: #555;
   fill: var(--icon-button-icon-foreground-color, #555);
-  height: 100%;
   max-width: 100%;
   position: relative;
 }
@@ -47,21 +46,26 @@ a.icon-link:hover > svg {
   fill: #333;
   fill: var(--icon-button-icon-hover-foreground-color, #333);
 }
-button[disabled].icon-btn,
-button[aria-disabled="true"].icon-btn,
-a:not([href]).icon-link,
-a[aria-disabled="true"].icon-link {
-  opacity: 0.5;
+a.icon-link:visited > svg {
+  fill: #555;
+  fill: var(--icon-button-icon-foreground-color, #555);
 }
 button[disabled].icon-btn > svg,
 button[aria-disabled="true"].icon-btn > svg,
 a:not([href]).icon-link > svg,
 a[aria-disabled="true"].icon-link > svg {
   background-color: transparent;
+  fill: #ccc;
 }
-a.icon-link:visited > svg {
-  fill: #555;
-  fill: var(--icon-button-icon-foreground-color, #555);
+button[disabled].icon-btn:focus > svg,
+button[aria-disabled="true"].icon-btn:focus > svg,
+a:not([href]).icon-link:focus > svg,
+a[aria-disabled="true"].icon-link:focus > svg,
+button[disabled].icon-btn:hover > svg,
+button[aria-disabled="true"].icon-btn:hover > svg,
+a:not([href]).icon-link:hover > svg,
+a[aria-disabled="true"].icon-link:hover > svg {
+  fill: #ccc;
 }
 a.icon-link:visited:hover > svg,
 a.icon-link:visited:focus > svg {

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -40,7 +40,6 @@ button.icon-btn > svg,
 a.icon-link > svg {
   fill: #111820;
   fill: var(--icon-button-icon-foreground-color, #111820);
-  height: 100%;
   max-width: 100%;
   position: relative;
 }
@@ -56,21 +55,26 @@ a.icon-link:hover > svg {
   fill: #3665f3;
   fill: var(--icon-button-icon-hover-foreground-color, #3665f3);
 }
-button[disabled].icon-btn,
-button[aria-disabled="true"].icon-btn,
-a:not([href]).icon-link,
-a[aria-disabled="true"].icon-link {
-  opacity: 0.5;
+a.icon-link:visited > svg {
+  fill: #111820;
+  fill: var(--icon-button-icon-foreground-color, #111820);
 }
 button[disabled].icon-btn > svg,
 button[aria-disabled="true"].icon-btn > svg,
 a:not([href]).icon-link > svg,
 a[aria-disabled="true"].icon-link > svg {
   background-color: transparent;
+  fill: #c7c7c7;
 }
-a.icon-link:visited > svg {
-  fill: #111820;
-  fill: var(--icon-button-icon-foreground-color, #111820);
+button[disabled].icon-btn:focus > svg,
+button[aria-disabled="true"].icon-btn:focus > svg,
+a:not([href]).icon-link:focus > svg,
+a[aria-disabled="true"].icon-link:focus > svg,
+button[disabled].icon-btn:hover > svg,
+button[aria-disabled="true"].icon-btn:hover > svg,
+a:not([href]).icon-link:hover > svg,
+a[aria-disabled="true"].icon-link:hover > svg {
+  fill: #c7c7c7;
 }
 a.icon-link:visited:hover > svg,
 a.icon-link:visited:focus > svg {

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -5,7 +5,6 @@
   --pagination-item-current-background-color: #eee;
   --pagination-item-current-border-color: transparent;
   --pagination-item-current-foreground-color: #333;
-  --pagination-paddle-hover-foreground-color: #a3a3a3;
 }
 nav.pagination {
   -webkit-box-align: center;
@@ -50,33 +49,17 @@ ol.pagination__items li:not([hidden]) {
   -webkit-box-pack: center;
           justify-content: center;
 }
-.pagination__next,
-.pagination__previous {
+a.pagination__next,
+a.pagination__previous,
+button.pagination__next,
+button.pagination__previous {
   -webkit-box-align: center;
           align-items: center;
   display: -webkit-inline-box;
   display: inline-flex;
   -webkit-box-pack: center;
           justify-content: center;
-  height: 48px;
   outline-offset: -4px;
-  width: 48px;
-}
-.pagination__next:focus svg,
-.pagination__previous:focus svg,
-.pagination__next:hover svg,
-.pagination__previous:hover svg {
-  fill: #a3a3a3;
-  fill: var(--pagination-paddle-hover-foreground-color, #a3a3a3);
-}
-.pagination__next[aria-disabled="true"] svg,
-.pagination__previous[aria-disabled="true"] svg {
-  fill: #ccc;
-}
-button.pagination__next,
-button.pagination__previous {
-  background: none;
-  border: none;
 }
 .pagination__item {
   -webkit-box-align: center;

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -5,13 +5,11 @@
   --pagination-item-current-background-color: transparent;
   --pagination-item-current-border-color: #3665f3;
   --pagination-item-current-foreground-color: #3665f3;
-  --pagination-paddle-hover-foreground-color: #2b0eaf;
 }
 @media (prefers-color-scheme: dark) {
   .skin-experiment-1 .pagination {
     --pagination-item-foreground-color: #dcdcdc;
     --pagination-item-hover-foreground-color: #5192ff;
-    --pagination-paddle-hover-foreground-color: #5192ff;
   }
 }
 nav.pagination {
@@ -57,33 +55,17 @@ ol.pagination__items li:not([hidden]) {
   -webkit-box-pack: center;
           justify-content: center;
 }
-.pagination__next,
-.pagination__previous {
+a.pagination__next,
+a.pagination__previous,
+button.pagination__next,
+button.pagination__previous {
   -webkit-box-align: center;
           align-items: center;
   display: -webkit-inline-box;
   display: inline-flex;
   -webkit-box-pack: center;
           justify-content: center;
-  height: 48px;
   outline-offset: -4px;
-  width: 48px;
-}
-.pagination__next:focus svg,
-.pagination__previous:focus svg,
-.pagination__next:hover svg,
-.pagination__previous:hover svg {
-  fill: #2b0eaf;
-  fill: var(--pagination-paddle-hover-foreground-color, #2b0eaf);
-}
-.pagination__next[aria-disabled="true"] svg,
-.pagination__previous[aria-disabled="true"] svg {
-  fill: #c7c7c7;
-}
-button.pagination__next,
-button.pagination__previous {
-  background: none;
-  border: none;
 }
 .pagination__item {
   -webkit-box-align: center;

--- a/docs/_includes/common/pagination.html
+++ b/docs/_includes/common/pagination.html
@@ -13,7 +13,7 @@
                 <span aria-live="off" role="status">
                     <h2 class="clipped" id="pagination-heading-1">Results Pagination - Page 1</h2>
                 </span>
-                <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+                <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
                     <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include common/symbol.html name="pagination-prev" %}
                     </svg>
@@ -35,7 +35,7 @@
                         <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
                     </li>
                 </ol>
-                <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+                <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
                     <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include common/symbol.html name="pagination-next" %}
                     </svg>
@@ -48,7 +48,7 @@
     <span aria-live="off" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -65,7 +65,7 @@
         </li>
         ...
     </ol>
-    <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -82,7 +82,7 @@
                 <span aria-live="polite" role="status">
                     <h2 class="clipped" id="pagination-heading-2">Results Pagination - Page 1</h2>
                 </span>
-                <button aria-disabled="true" aria-label="Previous Page" class="pagination__previous">
+                <button aria-disabled="true" aria-label="Previous Page" class="icon-btn pagination__previous">
                     <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include common/symbol.html name="pagination-prev" %}
                     </svg>
@@ -104,7 +104,7 @@
                         <button class="pagination__item">5</button>
                     </li>
                 </ol>
-                <button aria-label="Next Page" class="pagination__next">
+                <button aria-label="Next Page" class="icon-btn pagination__next">
                     <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include common/symbol.html name="pagination-next" %}
                     </svg>
@@ -117,7 +117,7 @@
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <button aria-disabled="true" aria-label="Previous Page" class="pagination__previous">
+    <button aria-disabled="true" aria-label="Previous Page" class="icon-btn pagination__previous">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -134,7 +134,7 @@
         </li>
         ...
     </ol>
-    <button aria-label="Next Page" class="pagination__next">
+    <button aria-label="Next Page" class="icon-btn pagination__next">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -151,7 +151,7 @@
                 <span aria-live="polite" role="status">
                     <h2 class="clipped" id="pagination-heading-3">Results Pagination - Page 1</h2>
                 </span>
-                <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+                <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
                     <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include common/symbol.html name="pagination-prev" %}
                     </svg>
@@ -185,7 +185,7 @@
                         <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
                     </li>
                 </ol>
-                <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+                <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
                     <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include common/symbol.html name="pagination-next" %}
                     </svg>
@@ -198,7 +198,7 @@
     <span aria-live="off" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -215,7 +215,7 @@
         </li>
         ...
     </ol>
-    <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>

--- a/pagination.browser.json
+++ b/pagination.browser.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-         "require: ./pagination"
+        "require: ./icon-button",
+        "require: ./pagination"
     ]
 }

--- a/pagination.js
+++ b/pagination.js
@@ -1,1 +1,2 @@
+require('./icon-button');
 require('./dist/pagination/ds6/pagination.css');

--- a/pagination[ds-4].js
+++ b/pagination[ds-4].js
@@ -1,1 +1,2 @@
+require('./icon-button');
 require('./dist/pagination/ds4/pagination.css');

--- a/src/less/icon-button/base/icon-button.less
+++ b/src/less/icon-button/base/icon-button.less
@@ -27,7 +27,6 @@ a.icon-link {
     > svg {
         .customFillProperty(icon-button-icon-foreground-color);
 
-        height: 100%; // vertical centering
         max-width: 100%; // helps when width & height HTML attrs not set
         position: relative; // Safari centering
     }
@@ -42,25 +41,29 @@ a.icon-link {
     }
 }
 
+// visited link state
+a.icon-link:visited > svg {
+    .customFillProperty(icon-button-icon-foreground-color);
+}
+
 // disabled & partially disabled states
-// todo: change opacity to a color
 button[disabled].icon-btn,
 button[aria-disabled="true"].icon-btn,
 a:not([href]).icon-link,
 a[aria-disabled="true"].icon-link {
-    opacity: 0.5;
-
     > svg {
         background-color: transparent;
+        fill: @color-action-disabled;
+    }
+
+    &:focus > svg,
+    &:hover > svg {
+        fill: @color-action-disabled;
     }
 }
 
-// visited link state
+// visited link hover/focus states
 a.icon-link:visited {
-    & > svg {
-        .customFillProperty(icon-button-icon-foreground-color);
-    }
-
     &:hover > svg,
     &:focus > svg {
         .customFillProperty(icon-button-icon-hover-foreground-color);

--- a/src/less/pagination/base/pagination.less
+++ b/src/less/pagination/base/pagination.less
@@ -32,30 +32,13 @@ ol.pagination__items {
     }
 }
 
-.pagination__next,
-.pagination__previous {
-    .flex-items-centered(inline-flex);
-
-    height: 48px;
-    outline-offset: -4px; // match items, needed because of hidden overflow
-    width: 48px;
-
-    &:focus,
-    &:hover {
-        svg {
-            .customFillProperty(pagination-paddle-hover-foreground-color);
-        }
-    }
-
-    &[aria-disabled="true"] svg {
-        fill: @pagination-paddle-disabled-foreground-color;
-    }
-}
-
+a.pagination__next,
+a.pagination__previous,
 button.pagination__next,
 button.pagination__previous {
-    background: none;
-    border: none;
+    .flex-items-centered(inline-flex);
+
+    outline-offset: -4px; // match items, needed because of hidden overflow
 }
 
 .pagination__item {

--- a/src/less/pagination/stories/button-cascade.stories.js
+++ b/src/less/pagination/stories/button-cascade.stories.js
@@ -5,7 +5,7 @@ export const fontSize = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <button aria-disabled="true" aria-label="Previous Page" class="pagination__previous">
+    <button aria-disabled="true" aria-label="Previous Page" class="icon-btn pagination__previous">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -27,7 +27,7 @@ export const fontSize = () => `
             <button class="pagination__item">5</button>
         </li>
     </ol>
-    <button aria-label="Next Page" class="pagination__next">
+    <button aria-label="Next Page" class="icon-btn pagination__next">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -40,7 +40,7 @@ export const color = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <button aria-disabled="true" aria-label="Previous Page" class="pagination__previous">
+    <button aria-disabled="true" aria-label="Previous Page" class="icon-btn pagination__previous">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -62,7 +62,7 @@ export const color = () => `
             <button class="pagination__item">5</button>
         </li>
     </ol>
-    <button aria-label="Next Page" class="pagination__next">
+    <button aria-label="Next Page" class="icon-btn pagination__next">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -76,7 +76,7 @@ export const RTL = () => `
         <span aria-live="polite" role="status">
             <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
         </span>
-        <button aria-disabled="true" aria-label="Previous Page" class="pagination__previous">
+        <button aria-disabled="true" aria-label="Previous Page" class="icon-btn pagination__previous">
             <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
                 <use xlink:href="#icon-pagination-prev"></use>
             </svg>
@@ -98,7 +98,7 @@ export const RTL = () => `
                 <button class="pagination__item">5</button>
             </li>
         </ol>
-        <button aria-label="Next Page" class="pagination__next">
+        <button aria-label="Next Page" class="icon-btn pagination__next">
             <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
                 <use xlink:href="#icon-pagination-next"></use>
             </svg>

--- a/src/less/pagination/stories/buttons.stories.js
+++ b/src/less/pagination/stories/buttons.stories.js
@@ -5,7 +5,7 @@ export const base = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <button aria-disabled="true" aria-label="Previous Page" class="pagination__previous">
+    <button aria-disabled="true" aria-label="Previous Page" class="icon-btn pagination__previous">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -27,7 +27,7 @@ export const base = () => `
             <button class="pagination__item">5</button>
         </li>
     </ol>
-    <button aria-label="Next Page" class="pagination__next">
+    <button aria-label="Next Page" class="icon-btn pagination__next">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -40,7 +40,7 @@ export const fluid = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <button aria-disabled="true" aria-label="Previous Page" class="pagination__previous">
+    <button aria-disabled="true" aria-label="Previous Page" class="icon-btn pagination__previous">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -62,7 +62,7 @@ export const fluid = () => `
             <button class="pagination__item">5</button>
         </li>
     </ol>
-    <button aria-label="Next Page" class="pagination__next">
+    <button aria-label="Next Page" class="icon-btn pagination__next">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>

--- a/src/less/pagination/stories/link-cascade.stories.js
+++ b/src/less/pagination/stories/link-cascade.stories.js
@@ -5,7 +5,7 @@ export const fontSize = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -27,7 +27,7 @@ export const fontSize = () => `
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
         </li>
     </ol>
-    <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -40,7 +40,7 @@ export const color = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -62,7 +62,7 @@ export const color = () => `
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
         </li>
     </ol>
-    <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -76,7 +76,7 @@ export const RTL = () => `
         <span aria-live="polite" role="status">
             <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
         </span>
-        <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+        <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
             <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
                 <use xlink:href="#icon-pagination-prev"></use>
             </svg>
@@ -98,7 +98,7 @@ export const RTL = () => `
                 <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
             </li>
         </ol>
-        <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+        <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
             <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
                 <use xlink:href="#icon-pagination-next"></use>
             </svg>

--- a/src/less/pagination/stories/links.stories.js
+++ b/src/less/pagination/stories/links.stories.js
@@ -5,7 +5,7 @@ export const base = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -27,7 +27,7 @@ export const base = () => `
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
         </li>
     </ol>
-    <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>
@@ -40,7 +40,7 @@ export const fluid = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
-    <a aria-disabled="true" aria-label="Previous Page" class="pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>
@@ -74,7 +74,7 @@ export const fluid = () => `
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
     </ol>
-    <a aria-label="Next Page" class="pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
         <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-next"></use>
         </svg>

--- a/src/less/properties/base/pagination-properties.less
+++ b/src/less/properties/base/pagination-properties.less
@@ -5,5 +5,4 @@
     --pagination-item-current-background-color: @pagination-item-current-background-color;
     --pagination-item-current-border-color: @pagination-item-current-border-color;
     --pagination-item-current-foreground-color: @pagination-item-current-foreground-color;
-    --pagination-paddle-hover-foreground-color: @pagination-paddle-hover-foreground-color;
 }

--- a/src/less/properties/ds6/pagination-properties.less
+++ b/src/less/properties/ds6/pagination-properties.less
@@ -9,7 +9,6 @@
         .pagination {
             --pagination-item-foreground-color: @color-text-default-dark-mode;
             --pagination-item-hover-foreground-color: @color-b4-dark-mode;
-            --pagination-paddle-hover-foreground-color: @color-b4-dark-mode;
         }
     }
 }

--- a/src/less/variables/ds4/pagination-variables.less
+++ b/src/less/variables/ds4/pagination-variables.less
@@ -6,5 +6,3 @@
 @pagination-item-current-border-color: transparent;
 @pagination-item-current-foreground-color: @color-text-default;
 @pagination-item-current-font-weight: @font-weight-bold;
-@pagination-paddle-disabled-foreground-color: @color-disabled;
-@pagination-paddle-hover-foreground-color: #a3a3a3;

--- a/src/less/variables/ds6/pagination-variables.less
+++ b/src/less/variables/ds6/pagination-variables.less
@@ -6,5 +6,3 @@
 @pagination-item-current-border-color: @color-link-default;
 @pagination-item-current-foreground-color: @color-link-default;
 @pagination-item-current-font-weight: @font-weight-bold;
-@pagination-paddle-disabled-foreground-color: @color-disabled;
-@pagination-paddle-hover-foreground-color: @color-b6;


### PR DESCRIPTION
Similar to the changes in dialog close button, I have updated pagination paddle buttons to directly use the icon button classes. This means they inherit all of the light & dark mode properties of icon button, and we get a reduction in duplicated css and properties sent to the client.

CoreUI will need its markup updating accordingly.

![Screen Shot 2020-09-14 at 2 58 57 PM](https://user-images.githubusercontent.com/38065/93142896-b5e0e500-f69b-11ea-8311-ca3193b4eea8.png)

![Screen Shot 2020-09-14 at 2 59 01 PM](https://user-images.githubusercontent.com/38065/93142892-b5484e80-f69b-11ea-8ca0-b0ae261eae93.png)


![Screen Shot 2020-09-14 at 2 58 44 PM](https://user-images.githubusercontent.com/38065/93142899-b7121200-f69b-11ea-960d-73fb9aebe2c5.png)

![Screen Shot 2020-09-14 at 2 58 48 PM](https://user-images.githubusercontent.com/38065/93142897-b6797b80-f69b-11ea-8bc6-aa777d1d8661.png)




