### PR TITLE
Added autoprefixer for storybook (fixes select on safari)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -10,6 +10,21 @@ module.exports = {
 			use: [
 				'style-loader',
 				'css-loader',
+				{
+					loader: 'postcss-loader',
+					options: {
+					  postcssOptions: {
+						plugins: [
+						  [
+							'autoprefixer',
+							{
+							  // Options
+							},
+						  ],
+						],
+					  },
+					}
+				},
 				'less-loader'
 			]
 		});

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "nodelist-foreach-polyfill": "^1",
     "npm-run-all": "^4",
     "percy": "~0.28.1",
+    "postcss-loader": "^4.0.3",
     "rimraf": "^3",
     "stylelint": "^13",
     "stylelint-config-standard": "^20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8360,7 +8360,7 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-klona@^2.0.3:
+klona@^2.0.3, klona@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
@@ -10739,6 +10739,17 @@ postcss-loader@^3.0.0:
     postcss "^7.0.0"
     postcss-load-config "^2.0.0"
     schema-utils "^1.0.0"
+
+postcss-loader@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.0.3.tgz#337f51bbdfb02269fb42f7db9fc7f0a93c1b2e3f"
+  integrity sha512-jHboC/AOnJLPu8/974hODCJ/rNAa2YhhJOclUeuRlAmFpKmEcBY6az8y1ejHyYc2LThzPl8qPRekh2Yz3CiRKA==
+  dependencies:
+    cosmiconfig "^7.0.0"
+    klona "^2.0.4"
+    loader-utils "^2.0.0"
+    schema-utils "^2.7.1"
+    semver "^7.3.2"
 
 postcss-media-query-parser@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
## Description
So in the storybook config we are not running autoprefixer on our less files. This makes it so some browser specific styles are not being generated. One of these is `--webkit-appearance` which safari uses for select. 
This is actually an existing issue and is present in production for safari. 
The good news is this only affects the storybook since the other bundles have the autoprefixer properly run.

This changes changes webpack loader to also run autoprefixer on all `less` files, so storybook should work properly now.

## References
#1259