### PR TITLE
Added header class with flex direction of row-reverse for dialog-mini

### DIFF
--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -48,8 +48,8 @@
   align-self: center;
   border-radius: 7px;
   -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-          flex-direction: row;
+  -webkit-box-direction: reverse;
+          flex-direction: row-reverse;
   margin-top: 0;
   max-width: 400px;
   min-height: 55px;
@@ -78,6 +78,9 @@
 }
 .lightbox-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
+}
+.lightbox-dialog__window--mini .lightbox-dialog__header {
+  margin-top: 8px;
 }
 .lightbox-dialog__main {
   -webkit-box-sizing: border-box;

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -53,8 +53,8 @@
   align-self: center;
   border-radius: 7px;
   -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-          flex-direction: row;
+  -webkit-box-direction: reverse;
+          flex-direction: row-reverse;
   margin-top: 0;
   max-width: 400px;
   min-height: 55px;
@@ -83,6 +83,9 @@
 }
 .lightbox-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
+}
+.lightbox-dialog__window--mini .lightbox-dialog__header {
+  margin-top: 8px;
 }
 .lightbox-dialog__main {
   -webkit-box-sizing: border-box;

--- a/docs/_includes/common/lightbox-dialog.html
+++ b/docs/_includes/common/lightbox-dialog.html
@@ -167,15 +167,15 @@
             <button class="btn btn--primary dialog-lightbox-button" data-makeup-dialog-button-for="lightbox-dialog-mini-0" type="button">Open Mini Lightbox Dialog</button>
             <div aria-label="Infotip" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-mini-0" role="dialog">
                 <div class="lightbox-dialog__window lightbox-dialog__window--mini lightbox-dialog__window--fade">
-                    <div class="lightbox-dialog__main">
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-                    </div>
-                    <div class="lightbox-dialog__footer">
+                    <div class="lightbox-dialog__header">
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                                 {% include common/symbol.html name="close" %}
                             </svg>
                         </button>
+                    </div>
+                    <div class="lightbox-dialog__main">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                     </div>
                 </div>
             </div>
@@ -185,15 +185,15 @@
     {% highlight html %}
 <div aria-label="Infotip" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden role="dialog">
     <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
-        <div class="lightbox-dialog__main">
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-        </div>
-        <div class="lightbox-dialog__footer">
+        <div class="lightbox-dialog__header">
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
                     <use xlink:href="#icon-close"></use>
                 </svg>
             </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </div>
 </div>

--- a/src/less/lightbox-dialog/base/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/base/lightbox-dialog.less
@@ -22,7 +22,7 @@
     align-items: flex-start;
     align-self: center;
     border-radius: 7px;
-    flex-direction: row;
+    flex-direction: row-reverse;
     margin-top: 0;
     max-width: 400px;
     min-height: 55px;
@@ -35,6 +35,10 @@
 
 .lightbox-dialog__header {
     .dialog-header-content();
+}
+
+.lightbox-dialog__window--mini .lightbox-dialog__header {
+    margin-top: 8px;
 }
 
 .lightbox-dialog__main {


### PR DESCRIPTION
## Description
Added header class again but changed dialog-mini flex to be `row-reverse`. This is so header comes first in dom (as well as close button), and then content even though it's on the right side of the dialog.
Also added padding-top: 8px to align the close button to the top. This will be picked up in mweb (but not dweb).

## Screenshots
<img width="467" alt="Screen Shot 2020-10-09 at 3 59 25 PM" src="https://user-images.githubusercontent.com/1755269/95638404-57fcae80-0a49-11eb-95f5-8c25bcae9920.png">
