### PR TITLE
Changed ds4 carousel icons to use DS4 dimensions

### DIFF
--- a/dist/icon/ds4/icon.css
+++ b/dist/icon/ds4/icon.css
@@ -35,12 +35,12 @@ svg.icon--camera {
   width: 22px;
 }
 svg.icon--carousel-next {
-  height: 23px;
-  width: 14px;
+  height: 14px;
+  width: 8px;
 }
 svg.icon--carousel-prev {
-  height: 24px;
-  width: 14px;
+  height: 14px;
+  width: 8px;
 }
 svg.icon--cart {
   height: 24px;

--- a/dist/variables/ds4/icon-variables.less
+++ b/dist/variables/ds4/icon-variables.less
@@ -229,10 +229,11 @@
 @icon-watching-null-height: 9px;
 @icon-window-width: 28px;
 @icon-window-height: 25px;
-@icon-carousel-prev-width: @icon-chevron-left-width;
-@icon-carousel-prev-height: @icon-chevron-left-height;
-@icon-carousel-next-width: @icon-chevron-right-width;
-@icon-carousel-next-height: @icon-chevron-right-height;
+// Use ds6 small chevron icons
+@icon-carousel-prev-width: 8px;
+@icon-carousel-prev-height: 14px;
+@icon-carousel-next-width: 8px;
+@icon-carousel-next-height: 14px;
 @icon-arrow-right-bold-width: 22px;
 @icon-arrow-right-bold-height: 21px;
 @icon-breadcrumb-width: 8px;

--- a/src/less/variables/ds4/icon-variables.less
+++ b/src/less/variables/ds4/icon-variables.less
@@ -229,10 +229,11 @@
 @icon-watching-null-height: 9px;
 @icon-window-width: 28px;
 @icon-window-height: 25px;
-@icon-carousel-prev-width: @icon-chevron-left-width;
-@icon-carousel-prev-height: @icon-chevron-left-height;
-@icon-carousel-next-width: @icon-chevron-right-width;
-@icon-carousel-next-height: @icon-chevron-right-height;
+// Use ds6 small chevron icons
+@icon-carousel-prev-width: 8px;
+@icon-carousel-prev-height: 14px;
+@icon-carousel-next-width: 8px;
+@icon-carousel-next-height: 14px;
 @icon-arrow-right-bold-width: 22px;
 @icon-arrow-right-bold-height: 21px;
 @icon-breadcrumb-width: 8px;


### PR DESCRIPTION
##  Description
Changed the carousel next/prev icons to have the same dimensions as the small chevrons. This fits them nicer in the field.
We could also change the icon, but this icon still is the DS4 chevron.

## Screenshots
<img width="1792" alt="Screen Shot 2020-10-12 at 2 10 58 PM" src="https://user-images.githubusercontent.com/1755269/95790707-c41f2280-0c94-11eb-8e3d-c990d6fed520.png">

