### PR TITLE
Added dialog, menu/listbox dropdowns, and toast rounded corners

### DIFF
--- a/.stylelintrc-css
+++ b/.stylelintrc-css
@@ -7,6 +7,7 @@
     "indentation": null,
     "no-descending-specificity": null,
     "no-duplicate-selectors": null,
+    "declaration-block-no-duplicate-properties": null,
     "rule-empty-line-before": null,
     "function-calc-no-invalid": null
   }

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -43,11 +43,11 @@ a.fake-btn {
 }
 .skin-experiment-rounded button.btn,
 .skin-experiment-rounded a.fake-btn {
-  --button-border-radius: 20px;
+  --button-border-radius: 48px;
 }
 .skin-experiment-rounded button.btn--large,
 .skin-experiment-rounded a.fake-btn--large {
-  --button-border-radius: 24px;
+  --button-border-radius: 48px;
 }
 .skin-experiment-rounded a.fake-btn--icon-only,
 .skin-experiment-rounded button.btn--icon-only {

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -37,6 +37,12 @@ span.combobox {
   background-color: var(--dropdown-items-background-color, #fff);
   border-color: #ccc;
   border-color: var(--dropdown-items-border-color, #ccc);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+          box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   -webkit-box-sizing: border-box;
@@ -46,8 +52,6 @@ span.combobox {
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
-  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   display: none;
   position: absolute;
   top: calc(100% - 1px);

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -49,6 +49,12 @@ span.combobox {
   background-color: var(--dropdown-items-background-color, #fff);
   border-color: #c7c7c7;
   border-color: var(--dropdown-items-border-color, #c7c7c7);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+          box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   -webkit-box-sizing: border-box;
@@ -58,8 +64,6 @@ span.combobox {
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
-  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   display: none;
   position: absolute;
   top: calc(100% - 1px);
@@ -264,4 +268,9 @@ span.combobox {
 }
 [dir="rtl"] .combobox__control > button {
   left: 0;
+}
+.skin-experiment-rounded .combobox__listbox {
+  --dropdown-items-border-radius: 8px;
+  --dropdown-items-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
+  --dropdown-items-border-color: #f5f5f5;
 }

--- a/dist/cta-button/ds6/cta-button.css
+++ b/dist/cta-button/ds6/cta-button.css
@@ -20,10 +20,10 @@ a.cta-btn {
   }
 }
 .skin-experiment-rounded a.cta-btn {
-  --button-border-radius: 20px;
+  --button-border-radius: 48px;
 }
 .skin-experiment-rounded a.cta-button--large {
-  --button-border-radius: 24px;
+  --button-border-radius: 48px;
 }
 a.cta-btn {
   border: 1px solid;

--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -9,8 +9,12 @@ span.infotip {
   display: inline-block;
 }
 .infotip__overlay {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   -webkit-box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15);
           box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -19,22 +23,20 @@ span.infotip {
   background-color: var(--infotip-background-color, #fff);
   color: #333;
   color: var(--infotip-foreground-color, #333);
-  border-radius: 0;
-  border-radius: var(--infotip-border-radius, 0);
   display: none;
   left: -10px;
   margin-top: 16px;
   position: absolute;
 }
 .infotip__mask {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   position: relative;
   z-index: 1;
   background-color: #fff;
   background-color: var(--infotip-background-color, #fff);
   color: #333;
   color: var(--infotip-foreground-color, #333);
-  border-radius: 0;
-  border-radius: var(--infotip-border-radius, 0);
 }
 span.infotip__mask {
   display: block;
@@ -66,46 +68,60 @@ span.infotip__mask {
   z-index: 0;
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: calc(50% - 8px);
 }
 .infotip__pointer--top-left {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: 12px;
 }
 .infotip__pointer--top {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: calc(50% - 8px);
 }
 .infotip__pointer--top-right {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: auto;
   right: 12px;
 }
 .infotip__pointer--bottom-left {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: 12px;
 }
 .infotip__pointer--bottom {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: calc(50% - 8px);
 }
 .infotip__pointer--bottom-right {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: auto;
   right: 12px;
@@ -115,15 +131,19 @@ span.infotip__mask {
   left: -7px;
 }
 .infotip__pointer--left-bottom {
-  bottom: 12px;
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: 12px;
   left: -7px;
   top: auto;
 }
 .infotip__pointer--left-top {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
   left: -7px;
   top: 12px;
 }
@@ -131,13 +151,17 @@ span.infotip__mask {
   top: calc(50% - 8px);
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
   left: auto;
   right: -7px;
 }
 .infotip__pointer--right-bottom {
-  bottom: 12px;
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+  bottom: 12px;
   left: auto;
   right: -7px;
   top: auto;
@@ -145,6 +169,8 @@ span.infotip__mask {
 .infotip__pointer--right-top {
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
   left: auto;
   right: -7px;
   top: 12px;

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -10,7 +10,7 @@
 }
 .skin-experiment-rounded .infotip__overlay,
 .skin-experiment-rounded .infotip__mask {
-  --infotip-border-radius: 8px;
+  --infotip-border-radius: 4px;
 }
 .infotip {
   position: relative;

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -8,9 +8,13 @@
     --infotip-foreground-color: #dcdcdc;
   }
 }
-.skin-experiment-rounded .infotip__overlay,
-.skin-experiment-rounded .infotip__mask {
-  --infotip-border-radius: 4px;
+.skin-experiment-rounded .infotip {
+  --bubble-border-radius: 4px;
+  --bubble-base-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-left-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-right-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-bottom-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-top-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
 }
 .infotip {
   position: relative;
@@ -19,8 +23,12 @@ span.infotip {
   display: inline-block;
 }
 .infotip__overlay {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   -webkit-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
           box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5));
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
@@ -29,22 +37,20 @@ span.infotip {
   background-color: var(--infotip-background-color, #fff);
   color: #111820;
   color: var(--infotip-foreground-color, #111820);
-  border-radius: 0;
-  border-radius: var(--infotip-border-radius, 0);
   display: none;
   left: -10px;
   margin-top: 16px;
   position: absolute;
 }
 .infotip__mask {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   position: relative;
   z-index: 1;
   background-color: #fff;
   background-color: var(--infotip-background-color, #fff);
   color: #111820;
   color: var(--infotip-foreground-color, #111820);
-  border-radius: 0;
-  border-radius: var(--infotip-border-radius, 0);
 }
 span.infotip__mask {
   display: block;
@@ -76,46 +82,60 @@ span.infotip__mask {
   z-index: 0;
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: calc(50% - 8px);
 }
 .infotip__pointer--top-left {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: 12px;
 }
 .infotip__pointer--top {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: calc(50% - 8px);
 }
 .infotip__pointer--top-right {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: auto;
   right: 12px;
 }
 .infotip__pointer--bottom-left {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: 12px;
 }
 .infotip__pointer--bottom {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: calc(50% - 8px);
 }
 .infotip__pointer--bottom-right {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: auto;
   right: 12px;
@@ -125,15 +145,19 @@ span.infotip__mask {
   left: -7px;
 }
 .infotip__pointer--left-bottom {
-  bottom: 12px;
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: 12px;
   left: -7px;
   top: auto;
 }
 .infotip__pointer--left-top {
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
   left: -7px;
   top: 12px;
 }
@@ -141,13 +165,17 @@ span.infotip__mask {
   top: calc(50% - 8px);
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
   left: auto;
   right: -7px;
 }
 .infotip__pointer--right-bottom {
-  bottom: 12px;
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+  bottom: 12px;
   left: auto;
   right: -7px;
   top: auto;
@@ -155,6 +183,8 @@ span.infotip__mask {
 .infotip__pointer--right-top {
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
   left: auto;
   right: -7px;
   top: 12px;

--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -38,6 +38,8 @@
           flex-direction: column;
   min-height: 55px;
   will-change: opacity, transform;
+  border-radius: 0;
+  border-radius: var(--dialog-border-radius, 0);
   flex-basis: 616px;
   margin-top: 15vh;
   max-width: calc(100% - 32px);

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -8,6 +8,10 @@
     --dialog-window-background-color: #212121;
   }
 }
+.skin-experiment-rounded .lightbox-dialog__compact-window,
+.skin-experiment-rounded .lightbox-dialog__window {
+  --dialog-border-radius: 16px;
+}
 .lightbox-dialog[role="dialog"],
 .lightbox-dialog[role="alertdialog"] {
   background-color: rgba(17, 24, 32, 0.7);
@@ -43,6 +47,8 @@
           flex-direction: column;
   min-height: 55px;
   will-change: opacity, transform;
+  border-radius: 0;
+  border-radius: var(--dialog-border-radius, 0);
   flex-basis: 616px;
   margin-top: 15vh;
   max-width: calc(100% - 32px);

--- a/dist/listbox-button/ds4/listbox-button.css
+++ b/dist/listbox-button/ds4/listbox-button.css
@@ -37,6 +37,8 @@ div.listbox-button__listbox {
   display: none;
   position: absolute;
   top: calc(100% - 1px);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
   border-bottom-color: transparent;
 }
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {

--- a/dist/listbox-button/ds4/listbox-button.css
+++ b/dist/listbox-button/ds4/listbox-button.css
@@ -23,6 +23,12 @@ div.listbox-button__listbox {
   background-color: var(--dropdown-items-background-color, #fff);
   border-color: #ccc;
   border-color: var(--dropdown-items-border-color, #ccc);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+          box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   -webkit-box-sizing: border-box;
@@ -32,13 +38,9 @@ div.listbox-button__listbox {
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
-  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   display: none;
   position: absolute;
   top: calc(100% - 1px);
-  border-radius: 0;
-  border-radius: var(--dropdown-items-border-radius, 0);
   border-bottom-color: transparent;
 }
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {

--- a/dist/listbox-button/ds6/listbox-button.css
+++ b/dist/listbox-button/ds6/listbox-button.css
@@ -18,6 +18,8 @@
 }
 .skin-experiment-rounded .listbox-button__listbox {
   --dropdown-items-border-radius: 8px;
+  --dropdown-items-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
+  --dropdown-items-border-color: #f5f5f5;
 }
 .listbox-button {
   line-height: normal;
@@ -36,6 +38,12 @@ div.listbox-button__listbox {
   background-color: var(--dropdown-items-background-color, #fff);
   border-color: #c7c7c7;
   border-color: var(--dropdown-items-border-color, #c7c7c7);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+          box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   -webkit-box-sizing: border-box;
@@ -45,13 +53,9 @@ div.listbox-button__listbox {
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
-  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   display: none;
   position: absolute;
   top: calc(100% - 1px);
-  border-radius: 0;
-  border-radius: var(--dropdown-items-border-radius, 0);
   border-bottom-color: transparent;
 }
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {

--- a/dist/listbox-button/ds6/listbox-button.css
+++ b/dist/listbox-button/ds6/listbox-button.css
@@ -16,6 +16,9 @@
     --dropdown-item-hover-foreground-color: #111820;
   }
 }
+.skin-experiment-rounded .listbox-button__listbox {
+  --dropdown-items-border-radius: 8px;
+}
 .listbox-button {
   line-height: normal;
   position: relative;
@@ -47,6 +50,8 @@ div.listbox-button__listbox {
   display: none;
   position: absolute;
   top: calc(100% - 1px);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
   border-bottom-color: transparent;
 }
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {

--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -18,22 +18,24 @@
   background-color: var(--dropdown-items-background-color, #fff);
   border-color: #ccc;
   border-color: var(--dropdown-items-border-color, #ccc);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+          box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   min-width: 100%;
   width: auto;
-  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   display: none;
   position: absolute;
   top: calc(100% - 1px);
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
-  border-radius: 0;
-  border-radius: var(--dropdown-items-border-radius, 0);
   outline: 0;
 }
 span.menu-button__button,

--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -32,6 +32,8 @@
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
   outline: 0;
 }
 span.menu-button__button,

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -16,6 +16,10 @@
     --dropdown-item-hover-foreground-color: #111820;
   }
 }
+.skin-experiment-rounded .menu-button__menu,
+.skin-experiment-rounded .menu-button__fake-menu {
+  --dropdown-items-border-radius: 8px;
+}
 .menu-button,
 .fake-menu-button {
   line-height: normal;
@@ -41,6 +45,8 @@
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
   outline: 0;
 }
 span.menu-button__button,

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -19,6 +19,8 @@
 .skin-experiment-rounded .menu-button__menu,
 .skin-experiment-rounded .menu-button__fake-menu {
   --dropdown-items-border-radius: 8px;
+  --dropdown-items-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
+  --dropdown-items-border-color: #f5f5f5;
 }
 .menu-button,
 .fake-menu-button {
@@ -31,22 +33,24 @@
   background-color: var(--dropdown-items-background-color, #fff);
   border-color: #c7c7c7;
   border-color: var(--dropdown-items-border-color, #c7c7c7);
+  border-radius: 0;
+  border-radius: var(--dropdown-items-border-radius, 0);
+  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+          box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   min-width: 100%;
   width: auto;
-  -webkit-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-          box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
   display: none;
   position: absolute;
   top: calc(100% - 1px);
   max-height: 400px;
   overflow-y: auto;
   z-index: 2;
-  border-radius: 0;
-  border-radius: var(--dropdown-items-border-radius, 0);
   outline: 0;
 }
 span.menu-button__button,

--- a/dist/mixins/bubble/base/bubble-mixins.less
+++ b/dist/mixins/bubble/base/bubble-mixins.less
@@ -1,11 +1,10 @@
 // this mixin is used by infotip, tooltip, infotip
 // this mixin is internal only for now
 
-@left-box-shadow: -2px 2px 2px @bubble-box-shadow-color;
-@right-box-shadow: 2px -2px 2px @bubble-box-shadow-color;
-
 .bubble() {
-    box-shadow: 0 -2px 2px @bubble-box-shadow-color, 2px 0 2px @bubble-box-shadow-color, 0 2px 2px @bubble-box-shadow-color, -2px 0 2px @bubble-box-shadow-color,;
+    .customBorderRadiusProperty(bubble-border-radius);
+    .customBoxShadowProperty(bubble-base-box-shadow);
+
     font-size: 14px;
     max-width: 344px;
     min-width: 320px;
@@ -13,6 +12,8 @@
 }
 
 .bubble-mask() {
+    .customBorderRadiusProperty(bubble-border-radius);
+
     position: relative;
     z-index: 1;
 }
@@ -62,8 +63,9 @@
 }
 
 .pointer-bottom() {
+    .customBoxShadowProperty(bubble-bottom-box-shadow);
+
     bottom: -7px;
-    box-shadow: 2px 2px 2px @bubble-box-shadow-color;
     top: auto;
 }
 
@@ -72,7 +74,8 @@
 }
 
 .pointer-top() {
-    box-shadow: -2px -2px 2px @bubble-box-shadow-color;
+    .customBoxShadowProperty(bubble-top-box-shadow);
+
     top: -7px;
 }
 
@@ -123,36 +126,40 @@
 }
 
 .pointer-left-top() {
-    box-shadow: @left-box-shadow;
+    .customBoxShadowProperty(bubble-left-box-shadow);
+
     left: -7px;
     top: 12px;
 }
 
 .pointer-left-bottom() {
+    .customBoxShadowProperty(bubble-left-box-shadow);
+
     bottom: 12px;
-    box-shadow: @left-box-shadow;
     left: -7px;
     top: auto;
 }
 
 .pointer-right() {
     .pointer-side-middle();
+    .customBoxShadowProperty(bubble-right-box-shadow);
 
-    box-shadow: @right-box-shadow;
     left: auto;
     right: -7px;
 }
 
 .pointer-right-top() {
-    box-shadow: @right-box-shadow;
+    .customBoxShadowProperty(bubble-right-box-shadow);
+
     left: auto;
     right: -7px;
     top: 12px;
 }
 
 .pointer-right-bottom() {
+    .customBoxShadowProperty(bubble-right-box-shadow);
+
     bottom: 12px;
-    box-shadow: @right-box-shadow;
     left: auto;
     right: -7px;
     top: auto;

--- a/dist/mixins/dropdown/base/dropdown-mixins.less
+++ b/dist/mixins/dropdown/base/dropdown-mixins.less
@@ -1,6 +1,8 @@
 .dropdown-base() {
     .customBackgroundColorProperty(dropdown-items-background-color);
     .customBorderColorProperty(dropdown-items-border-color);
+    .customBorderRadiusProperty(dropdown-items-border-radius);
+    .customBoxShadowProperty(dropdown-items-box-shadow);
 
     border-style: solid;
     border-width: 1px;
@@ -18,7 +20,6 @@
 .dropdown-overlay() {
     .dropdown-overlay-constraints();
 
-    box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
     display: none;
     position: absolute;
     top: calc(100% - 1px);

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -52,6 +52,10 @@
     .customProperty(border-radius, @token);
 }
 
+.customBoxShadowProperty(@token) {
+    .customProperty(box-shadow, @token);
+}
+
 .customFillProperty(@token) {
     .customProperty(fill, @token);
 }

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -4,6 +4,7 @@
   --pagination-item-hover-foreground-color: #333;
   --pagination-item-current-background-color: #eee;
   --pagination-item-current-border-color: transparent;
+  --pagination-item-current-border-radius: 0;
   --pagination-item-current-foreground-color: #333;
 }
 nav.pagination {
@@ -93,6 +94,8 @@ button.pagination__previous {
   border-color: var(--pagination-item-current-border-color, transparent);
   color: #333;
   color: var(--pagination-item-current-foreground-color, #333);
+  border-radius: 0;
+  border-radius: var(--pagination-item-current-border-radius, 0);
   border-style: solid;
   border-width: 2px;
   font-weight: 500;

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -4,6 +4,7 @@
   --pagination-item-hover-foreground-color: #2b0eaf;
   --pagination-item-current-background-color: transparent;
   --pagination-item-current-border-color: #3665f3;
+  --pagination-item-current-border-radius: 0;
   --pagination-item-current-foreground-color: #3665f3;
 }
 @media (prefers-color-scheme: dark) {
@@ -11,6 +12,9 @@
     --pagination-item-foreground-color: #dcdcdc;
     --pagination-item-hover-foreground-color: #5192ff;
   }
+}
+.skin-experiment-rounded .pagination__item[aria-current="page"] {
+  --pagination-item-current-border-radius: 8px;
 }
 nav.pagination {
   -webkit-box-align: center;
@@ -99,6 +103,8 @@ button.pagination__previous {
   border-color: var(--pagination-item-current-border-color, #3665f3);
   color: #3665f3;
   color: var(--pagination-item-current-foreground-color, #3665f3);
+  border-radius: 0;
+  border-radius: var(--pagination-item-current-border-radius, 0);
   border-style: solid;
   border-width: 2px;
   font-weight: 700;

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -15,6 +15,9 @@
 .skin-experiment-rounded .select select {
   --select-border-radius: 8px;
 }
+.skin-experiment-rounded .select--underline select {
+  --select-border-radius: 0;
+}
 .select {
   color: #111820;
   color: var(--select-foreground-color, #111820);

--- a/dist/toast-dialog/ds4/toast-dialog.css
+++ b/dist/toast-dialog/ds4/toast-dialog.css
@@ -10,8 +10,8 @@
   border-radius: 0;
   border-radius: var(--toast-dialog-border-radius, 0);
   bottom: 0;
-  -webkit-box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
-          box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
+  -webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
+          box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
   left: 0;
   max-height: 40vh;
   min-width: 320px;

--- a/dist/toast-dialog/ds4/toast-dialog.css
+++ b/dist/toast-dialog/ds4/toast-dialog.css
@@ -10,6 +10,8 @@
   border-radius: 0;
   border-radius: var(--toast-dialog-border-radius, 0);
   bottom: 0;
+  -webkit-box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
+          box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
   left: 0;
   max-height: 40vh;
   min-width: 320px;

--- a/dist/toast-dialog/ds4/toast-dialog.css
+++ b/dist/toast-dialog/ds4/toast-dialog.css
@@ -7,6 +7,8 @@
   background-color: var(--toast-dialog-background-color, #0654ba);
   color: #fff;
   color: var(--toast-dialog-foreground-color, #fff);
+  border-radius: 0;
+  border-radius: var(--toast-dialog-border-radius, 0);
   bottom: 0;
   left: 0;
   max-height: 40vh;

--- a/dist/toast-dialog/ds6/toast-dialog.css
+++ b/dist/toast-dialog/ds6/toast-dialog.css
@@ -13,8 +13,8 @@
   border-radius: 0;
   border-radius: var(--toast-dialog-border-radius, 0);
   bottom: 0;
-  -webkit-box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
-          box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
+  -webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
+          box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
   left: 0;
   max-height: 40vh;
   min-width: 320px;

--- a/dist/toast-dialog/ds6/toast-dialog.css
+++ b/dist/toast-dialog/ds6/toast-dialog.css
@@ -13,6 +13,8 @@
   border-radius: 0;
   border-radius: var(--toast-dialog-border-radius, 0);
   bottom: 0;
+  -webkit-box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
+          box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
   left: 0;
   max-height: 40vh;
   min-width: 320px;

--- a/dist/toast-dialog/ds6/toast-dialog.css
+++ b/dist/toast-dialog/ds6/toast-dialog.css
@@ -2,11 +2,16 @@
   --toast-dialog-background-color: #3665f3;
   --toast-dialog-foreground-color: #fff;
 }
+.skin-experiment-rounded .toast-dialog {
+  --toast-dialog-border-radius: 16px 16px 0 0;
+}
 .toast-dialog {
   background-color: #3665f3;
   background-color: var(--toast-dialog-background-color, #3665f3);
   color: #fff;
   color: var(--toast-dialog-foreground-color, #fff);
+  border-radius: 0;
+  border-radius: var(--toast-dialog-border-radius, 0);
   bottom: 0;
   left: 0;
   max-height: 40vh;
@@ -131,5 +136,10 @@ button.toast-dialog__close:focus {
   }
   .toast-dialog__window {
     margin: 16px 24px 24px;
+  }
+}
+@media (min-width: 601px) {
+  .skin-experiment-rounded .toast-dialog {
+    --toast-dialog-border-radius: 16px;
   }
 }

--- a/dist/tooltip/ds4/tooltip.css
+++ b/dist/tooltip/ds4/tooltip.css
@@ -9,28 +9,30 @@ span.tooltip {
   display: inline-block;
 }
 .tooltip__overlay {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   -webkit-box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15);
           box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
   z-index: 1;
-  border-radius: 0;
-  border-radius: var(--tooltip-border-radius, 0);
   display: none;
   left: -10px;
   margin-top: 16px;
   position: absolute;
 }
 .tooltip__mask {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   position: relative;
   z-index: 1;
   background-color: #0654ba;
   background-color: var(--tooltip-background-color, #0654ba);
   color: #fff;
   color: var(--tooltip-foreground-color, #fff);
-  border-radius: 0;
-  border-radius: var(--tooltip-border-radius, 0);
 }
 span.tooltip__mask {
   display: block;
@@ -81,6 +83,8 @@ button.tooltip__close {
   z-index: 0;
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: calc(50% - 8px);
   background-color: #0654ba;
@@ -89,40 +93,52 @@ button.tooltip__close {
 .tooltip__pointer--top-left {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: 12px;
 }
 .tooltip__pointer--top {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: auto;
   right: 12px;
 }
 .tooltip__pointer--bottom-left {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: 12px;
 }
 .tooltip__pointer--bottom {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: auto;
   right: 12px;
@@ -132,15 +148,19 @@ button.tooltip__close {
   left: -7px;
 }
 .tooltip__pointer--left-bottom {
-  bottom: 12px;
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: 12px;
   left: -7px;
   top: auto;
 }
 .tooltip__pointer--left-top {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
   left: -7px;
   top: 12px;
 }
@@ -148,13 +168,17 @@ button.tooltip__close {
   top: calc(50% - 8px);
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
   left: auto;
   right: -7px;
 }
 .tooltip__pointer--right-bottom {
-  bottom: 12px;
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+  bottom: 12px;
   left: auto;
   right: -7px;
   top: auto;
@@ -162,6 +186,8 @@ button.tooltip__close {
 .tooltip__pointer--right-top {
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
   left: auto;
   right: -7px;
   top: 12px;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -4,7 +4,7 @@
 }
 .skin-experiment-rounded .tooltip__overlay,
 .skin-experiment-rounded .tooltip__mask {
-  --tooltip-border-radius: 8px;
+  --tooltip-border-radius: 4px;
 }
 .tooltip {
   position: relative;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -2,9 +2,13 @@
   --tooltip-background-color: #3665f3;
   --tooltip-foreground-color: #fff;
 }
-.skin-experiment-rounded .tooltip__overlay,
-.skin-experiment-rounded .tooltip__mask {
-  --tooltip-border-radius: 4px;
+.skin-experiment-rounded .tooltip {
+  --bubble-border-radius: 4px;
+  --bubble-base-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-left-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-right-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-bottom-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-top-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
 }
 .tooltip {
   position: relative;
@@ -13,28 +17,30 @@ span.tooltip {
   display: inline-block;
 }
 .tooltip__overlay {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   -webkit-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
           box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5));
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
   z-index: 1;
-  border-radius: 0;
-  border-radius: var(--tooltip-border-radius, 0);
   display: none;
   left: -10px;
   margin-top: 16px;
   position: absolute;
 }
 .tooltip__mask {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   position: relative;
   z-index: 1;
   background-color: #3665f3;
   background-color: var(--tooltip-background-color, #3665f3);
   color: #fff;
   color: var(--tooltip-foreground-color, #fff);
-  border-radius: 0;
-  border-radius: var(--tooltip-border-radius, 0);
 }
 span.tooltip__mask {
   display: block;
@@ -85,6 +91,8 @@ button.tooltip__close {
   z-index: 0;
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: calc(50% - 8px);
   background-color: #3665f3;
@@ -93,40 +101,52 @@ button.tooltip__close {
 .tooltip__pointer--top-left {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: 12px;
 }
 .tooltip__pointer--top {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: calc(50% - 8px);
 }
 .tooltip__pointer--top-right {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: auto;
   right: 12px;
 }
 .tooltip__pointer--bottom-left {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: 12px;
 }
 .tooltip__pointer--bottom {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: calc(50% - 8px);
 }
 .tooltip__pointer--bottom-right {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: auto;
   right: 12px;
@@ -136,15 +156,19 @@ button.tooltip__close {
   left: -7px;
 }
 .tooltip__pointer--left-bottom {
-  bottom: 12px;
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: 12px;
   left: -7px;
   top: auto;
 }
 .tooltip__pointer--left-top {
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
   left: -7px;
   top: 12px;
 }
@@ -152,13 +176,17 @@ button.tooltip__close {
   top: calc(50% - 8px);
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
   left: auto;
   right: -7px;
 }
 .tooltip__pointer--right-bottom {
-  bottom: 12px;
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+  bottom: 12px;
   left: auto;
   right: -7px;
   top: auto;
@@ -166,6 +194,8 @@ button.tooltip__close {
 .tooltip__pointer--right-top {
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
   left: auto;
   right: -7px;
   top: 12px;

--- a/dist/tourtip/ds4/tourtip.css
+++ b/dist/tourtip/ds4/tourtip.css
@@ -9,26 +9,28 @@ span.tourtip {
   display: inline-block;
 }
 .tourtip__overlay {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   -webkit-box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15);
           box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
   z-index: 1;
-  border-radius: 0;
-  border-radius: var(--tourtip-border-radius, 0);
   display: none;
   position: absolute;
 }
 .tourtip__mask {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   position: relative;
   z-index: 1;
   background-color: #0654ba;
   background-color: var(--tourtip-background-color, #0654ba);
   color: #fff;
   color: var(--tourtip-foreground-color, #fff);
-  border-radius: 0;
-  border-radius: var(--tourtip-border-radius, 0);
 }
 span.tourtip__mask {
   display: block;
@@ -91,6 +93,8 @@ button.tourtip__close:focus {
   z-index: 0;
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: calc(50% - 8px);
   background-color: #0654ba;
@@ -99,40 +103,52 @@ button.tourtip__close:focus {
 .tourtip__pointer--top-left {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: 12px;
 }
 .tourtip__pointer--top {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: calc(50% - 8px);
 }
 .tourtip__pointer--top-right {
   -webkit-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(0, 0, 0, 0.15));
   top: -7px;
   left: auto;
   right: 12px;
 }
 .tourtip__pointer--bottom-left {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: 12px;
 }
 .tourtip__pointer--bottom {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: calc(50% - 8px);
 }
 .tourtip__pointer--bottom-right {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: -7px;
   top: auto;
   left: auto;
   right: 12px;
@@ -142,15 +158,19 @@ button.tourtip__close:focus {
   left: -7px;
 }
 .tourtip__pointer--left-bottom {
-  bottom: 12px;
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+  bottom: 12px;
   left: -7px;
   top: auto;
 }
 .tourtip__pointer--left-top {
   -webkit-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(0, 0, 0, 0.15));
   left: -7px;
   top: 12px;
 }
@@ -158,13 +178,17 @@ button.tourtip__close:focus {
   top: calc(50% - 8px);
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
   left: auto;
   right: -7px;
 }
 .tourtip__pointer--right-bottom {
-  bottom: 12px;
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+  bottom: 12px;
   left: auto;
   right: -7px;
   top: auto;
@@ -172,6 +196,8 @@ button.tourtip__close:focus {
 .tourtip__pointer--right-top {
   -webkit-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
           box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(0, 0, 0, 0.15));
   left: auto;
   right: -7px;
   top: 12px;

--- a/dist/tourtip/ds6/tourtip.css
+++ b/dist/tourtip/ds6/tourtip.css
@@ -2,9 +2,13 @@
   --tourtip-background-color: #3665f3;
   --tourtip-foreground-color: #fff;
 }
-.skin-experiment-rounded .tourtip__overlay,
-.skin-experiment-rounded .tourtip__mask {
-  --tourtip-border-radius: 4px;
+.skin-experiment-rounded .tourtip {
+  --bubble-border-radius: 4px;
+  --bubble-base-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-left-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-right-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-bottom-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
+  --bubble-top-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
 }
 .tourtip {
   position: relative;
@@ -13,26 +17,28 @@ span.tourtip {
   display: inline-block;
 }
 .tourtip__overlay {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   -webkit-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
           box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(199, 199, 199, 0.5), 2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5), -2px 0 2px rgba(199, 199, 199, 0.5));
   font-size: 14px;
   max-width: 344px;
   min-width: 320px;
   z-index: 1;
-  border-radius: 0;
-  border-radius: var(--tourtip-border-radius, 0);
   display: none;
   position: absolute;
 }
 .tourtip__mask {
+  border-radius: 0;
+  border-radius: var(--bubble-border-radius, 0);
   position: relative;
   z-index: 1;
   background-color: #3665f3;
   background-color: var(--tourtip-background-color, #3665f3);
   color: #fff;
   color: var(--tourtip-foreground-color, #fff);
-  border-radius: 0;
-  border-radius: var(--tourtip-border-radius, 0);
 }
 span.tourtip__mask {
   display: block;
@@ -95,6 +101,8 @@ button.tourtip__close:focus {
   z-index: 0;
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: calc(50% - 8px);
   background-color: #3665f3;
@@ -103,40 +111,52 @@ button.tourtip__close:focus {
 .tourtip__pointer--top-left {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: 12px;
 }
 .tourtip__pointer--top {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: calc(50% - 8px);
 }
 .tourtip__pointer--top-right {
   -webkit-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-top-box-shadow, -2px -2px 2px rgba(199, 199, 199, 0.5));
   top: -7px;
   left: auto;
   right: 12px;
 }
 .tourtip__pointer--bottom-left {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: 12px;
 }
 .tourtip__pointer--bottom {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: calc(50% - 8px);
 }
 .tourtip__pointer--bottom-right {
-  bottom: -7px;
   -webkit-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-bottom-box-shadow, 2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: -7px;
   top: auto;
   left: auto;
   right: 12px;
@@ -146,15 +166,19 @@ button.tourtip__close:focus {
   left: -7px;
 }
 .tourtip__pointer--left-bottom {
-  bottom: 12px;
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+  bottom: 12px;
   left: -7px;
   top: auto;
 }
 .tourtip__pointer--left-top {
   -webkit-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-left-box-shadow, -2px 2px 2px rgba(199, 199, 199, 0.5));
   left: -7px;
   top: 12px;
 }
@@ -162,13 +186,17 @@ button.tourtip__close:focus {
   top: calc(50% - 8px);
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
   left: auto;
   right: -7px;
 }
 .tourtip__pointer--right-bottom {
-  bottom: 12px;
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+  bottom: 12px;
   left: auto;
   right: -7px;
   top: auto;
@@ -176,6 +204,8 @@ button.tourtip__close:focus {
 .tourtip__pointer--right-top {
   -webkit-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
           box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  -webkit-box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
+          box-shadow: var(--bubble-right-box-shadow, 2px -2px 2px rgba(199, 199, 199, 0.5));
   left: auto;
   right: -7px;
   top: 12px;

--- a/dist/tourtip/ds6/tourtip.css
+++ b/dist/tourtip/ds6/tourtip.css
@@ -4,7 +4,7 @@
 }
 .skin-experiment-rounded .tourtip__overlay,
 .skin-experiment-rounded .tourtip__mask {
-  --tourtip-border-radius: 8px;
+  --tourtip-border-radius: 4px;
 }
 .tourtip {
   position: relative;

--- a/dist/variables/ds4/border-radius-variables.less
+++ b/dist/variables/ds4/border-radius-variables.less
@@ -1,2 +1,4 @@
 @border-radius-none: 0;
 @border-radius-form-control: 3px;
+
+@border-radius-dialog: 16px;

--- a/dist/variables/ds4/bubble-variables.less
+++ b/dist/variables/ds4/bubble-variables.less
@@ -1,3 +1,9 @@
 @import "color-variables.less";
 
 @bubble-box-shadow-color: @color-flyout-box-shadow;
+@bubble-border-radius: @border-radius-none;
+@bubble-base-box-shadow: 0 -2px 2px @bubble-box-shadow-color, 2px 0 2px @bubble-box-shadow-color, 0 2px 2px @bubble-box-shadow-color, -2px 0 2px @bubble-box-shadow-color;
+@bubble-left-box-shadow: -2px 2px 2px @bubble-box-shadow-color;
+@bubble-right-box-shadow: 2px -2px 2px @bubble-box-shadow-color;
+@bubble-bottom-box-shadow: 2px 2px 2px @bubble-box-shadow-color;
+@bubble-top-box-shadow: -2px -2px 2px @bubble-box-shadow-color;

--- a/dist/variables/ds4/dialog-variables.less
+++ b/dist/variables/ds4/dialog-variables.less
@@ -3,6 +3,7 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
+@dialog-border-radius: @border-radius-none;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
 @dialog-max-width: 616px;

--- a/dist/variables/ds4/dropdown-variables.less
+++ b/dist/variables/ds4/dropdown-variables.less
@@ -2,6 +2,7 @@
 
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
+@dropdown-items-border-radius: @border-radius-none;
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/dist/variables/ds4/dropdown-variables.less
+++ b/dist/variables/ds4/dropdown-variables.less
@@ -3,6 +3,7 @@
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
 @dropdown-items-border-radius: @border-radius-none;
+@dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/dist/variables/ds4/infotip-variables.less
+++ b/dist/variables/ds4/infotip-variables.less
@@ -1,3 +1,2 @@
 @infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
-@infotip-border-radius: @border-radius-none;

--- a/dist/variables/ds4/pagination-variables.less
+++ b/dist/variables/ds4/pagination-variables.less
@@ -4,5 +4,6 @@
 @pagination-item-hover-foreground-color: @color-text-default;
 @pagination-item-current-background-color: @color-grey1;
 @pagination-item-current-border-color: transparent;
+@pagination-item-current-border-radius: @border-radius-none;
 @pagination-item-current-foreground-color: @color-text-default;
 @pagination-item-current-font-weight: @font-weight-bold;

--- a/dist/variables/ds4/toast-dialog-variables.less
+++ b/dist/variables/ds4/toast-dialog-variables.less
@@ -1,2 +1,3 @@
 @toast-dialog-background-color: @color-action-primary;
 @toast-dialog-foreground-color: @color-background-default;
+@toast-dialog-border-radius: @border-radius-none;

--- a/dist/variables/ds4/tooltip-variables.less
+++ b/dist/variables/ds4/tooltip-variables.less
@@ -1,3 +1,2 @@
 @tooltip-background-color: @color-action-primary;
 @tooltip-foreground-color: @color-background-default;
-@tooltip-border-radius: @border-radius-none;

--- a/dist/variables/ds4/tourtip-variables.less
+++ b/dist/variables/ds4/tourtip-variables.less
@@ -1,3 +1,2 @@
 @tourtip-background-color: @color-action-primary;
 @tourtip-foreground-color: @color-background-default;
-@tourtip-border-radius: @border-radius-none;

--- a/dist/variables/ds6/border-radius-variables.less
+++ b/dist/variables/ds6/border-radius-variables.less
@@ -8,6 +8,9 @@
 @border-radius-expand-button: @border-radius-small;
 
 @border-radius-overlay: @border-radius-small;
+// These are values required for new rounded corners
+@border-radius-overlay-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
+@border-radius-overlay-border-color: @color-grey1;
 
 @border-radius-notice: @border-radius-small;
 

--- a/dist/variables/ds6/border-radius-variables.less
+++ b/dist/variables/ds6/border-radius-variables.less
@@ -2,8 +2,7 @@
 @border-radius-form-control: 0;
 @border-radius-small: 8px;
 
-@border-radius-button: 20px;
-@border-radius-large-button: 24px;
+@border-radius-button: 48px;
 @border-radius-icon-button: @border-radius-small;
 @border-radius-expand-button: @border-radius-small;
 

--- a/dist/variables/ds6/border-radius-variables.less
+++ b/dist/variables/ds6/border-radius-variables.less
@@ -7,6 +7,7 @@
 @border-radius-expand-button: @border-radius-small;
 
 @border-radius-overlay: 4px;
+@border-radius-overlay-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
 
 @border-radius-dropdown: @border-radius-small;
 // These are values required for new rounded corners

--- a/dist/variables/ds6/border-radius-variables.less
+++ b/dist/variables/ds6/border-radius-variables.less
@@ -6,11 +6,15 @@
 @border-radius-icon-button: @border-radius-small;
 @border-radius-expand-button: @border-radius-small;
 
-@border-radius-overlay: @border-radius-small;
+@border-radius-overlay: 4px;
+
+@border-radius-dropdown: @border-radius-small;
 // These are values required for new rounded corners
-@border-radius-overlay-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
-@border-radius-overlay-border-color: @color-grey1;
+@border-radius-dropdown-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
+@border-radius-dropdown-border-color: @color-grey1;
 
 @border-radius-notice: @border-radius-small;
 
 @border-radius-dialog: 16px;
+
+@border-radius-pagination: @border-radius-small;

--- a/dist/variables/ds6/border-radius-variables.less
+++ b/dist/variables/ds6/border-radius-variables.less
@@ -10,3 +10,5 @@
 @border-radius-overlay: @border-radius-small;
 
 @border-radius-notice: @border-radius-small;
+
+@border-radius-dialog: 16px;

--- a/dist/variables/ds6/bubble-variables.less
+++ b/dist/variables/ds6/bubble-variables.less
@@ -1,3 +1,9 @@
 @import "color-variables.less";
 
 @bubble-box-shadow-color: @color-flyout-box-shadow;
+@bubble-border-radius: @border-radius-none;
+@bubble-base-box-shadow: 0 -2px 2px @bubble-box-shadow-color, 2px 0 2px @bubble-box-shadow-color, 0 2px 2px @bubble-box-shadow-color, -2px 0 2px @bubble-box-shadow-color;
+@bubble-left-box-shadow: -2px 2px 2px @bubble-box-shadow-color;
+@bubble-right-box-shadow: 2px -2px 2px @bubble-box-shadow-color;
+@bubble-bottom-box-shadow: 2px 2px 2px @bubble-box-shadow-color;
+@bubble-top-box-shadow: -2px -2px 2px @bubble-box-shadow-color;

--- a/dist/variables/ds6/dialog-variables.less
+++ b/dist/variables/ds6/dialog-variables.less
@@ -3,6 +3,7 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
+@dialog-border-radius: @border-radius-none;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
 @dialog-max-width: 616px;

--- a/dist/variables/ds6/dropdown-variables.less
+++ b/dist/variables/ds6/dropdown-variables.less
@@ -2,6 +2,7 @@
 
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
+@dropdown-items-border-radius: @border-radius-none;
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/dist/variables/ds6/dropdown-variables.less
+++ b/dist/variables/ds6/dropdown-variables.less
@@ -3,6 +3,7 @@
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
 @dropdown-items-border-radius: @border-radius-none;
+@dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/dist/variables/ds6/infotip-variables.less
+++ b/dist/variables/ds6/infotip-variables.less
@@ -1,3 +1,2 @@
 @infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
-@infotip-border-radius: @border-radius-none;

--- a/dist/variables/ds6/pagination-variables.less
+++ b/dist/variables/ds6/pagination-variables.less
@@ -4,5 +4,6 @@
 @pagination-item-hover-foreground-color: @color-b6;
 @pagination-item-current-background-color: transparent;
 @pagination-item-current-border-color: @color-link-default;
+@pagination-item-current-border-radius: @border-radius-none;
 @pagination-item-current-foreground-color: @color-link-default;
 @pagination-item-current-font-weight: @font-weight-bold;

--- a/dist/variables/ds6/toast-dialog-variables.less
+++ b/dist/variables/ds6/toast-dialog-variables.less
@@ -1,2 +1,3 @@
 @toast-dialog-background-color: @color-action-primary;
 @toast-dialog-foreground-color: @color-background-default;
+@toast-dialog-border-radius: @border-radius-none;

--- a/dist/variables/ds6/tooltip-variables.less
+++ b/dist/variables/ds6/tooltip-variables.less
@@ -1,3 +1,2 @@
 @tooltip-background-color: @color-action-primary;
 @tooltip-foreground-color: @color-background-default;
-@tooltip-border-radius: @border-radius-none;

--- a/dist/variables/ds6/tourtip-variables.less
+++ b/dist/variables/ds6/tourtip-variables.less
@@ -1,3 +1,2 @@
 @tourtip-background-color: @color-action-primary;
 @tourtip-foreground-color: @color-background-default;
-@tourtip-border-radius: @border-radius-none;

--- a/src/less/combobox/ds6/combobox.less
+++ b/src/less/combobox/ds6/combobox.less
@@ -5,8 +5,8 @@
 
 .skin-experiment-rounded {
     .combobox__listbox {
-        --dropdown-items-border-radius: @border-radius-overlay;
-        --dropdown-items-box-shadow: @border-radius-overlay-box-shadow;
-        --dropdown-items-border-color: @border-radius-overlay-border-color;
+        --dropdown-items-border-radius: @border-radius-dropdown;
+        --dropdown-items-box-shadow: @border-radius-dropdown-box-shadow;
+        --dropdown-items-border-color: @border-radius-dropdown-border-color;
     }
 }

--- a/src/less/combobox/ds6/combobox.less
+++ b/src/less/combobox/ds6/combobox.less
@@ -2,3 +2,11 @@
 @import "../../variables/ds6/dropdown-variables.less";
 @import "../../mixins/dropdown/ds6/dropdown-mixins.less";
 @import "../base/combobox.less";
+
+.skin-experiment-rounded {
+    .combobox__listbox {
+        --dropdown-items-border-radius: @border-radius-overlay;
+        --dropdown-items-box-shadow: @border-radius-overlay-box-shadow;
+        --dropdown-items-border-color: @border-radius-overlay-border-color;
+    }
+}

--- a/src/less/drawer-dialog/base/drawer-dialog.less
+++ b/src/less/drawer-dialog/base/drawer-dialog.less
@@ -59,7 +59,7 @@ button.drawer-dialog__close {
 .drawer-dialog__window {
     .dialog-window();
 
-    border-radius: 16px 16px 0 0;
+    border-radius: @border-radius-dialog @border-radius-dialog 0 0;
     max-height: 50%;
     max-width: 100%;
     -webkit-overflow-scrolling: touch;

--- a/src/less/infotip/base/infotip.less
+++ b/src/less/infotip/base/infotip.less
@@ -12,7 +12,6 @@ span.infotip {
     .bubble();
     .customBackgroundColorProperty(infotip-background-color);
     .customColorProperty(infotip-foreground-color);
-    .customBorderRadiusProperty(infotip-border-radius);
 
     display: none;
     left: 0 - 10px;
@@ -24,7 +23,6 @@ span.infotip {
     .bubble-mask();
     .customBackgroundColorProperty(infotip-background-color);
     .customColorProperty(infotip-foreground-color);
-    .customBorderRadiusProperty(infotip-border-radius);
 }
 
 span.infotip__mask {

--- a/src/less/lightbox-dialog/base/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/base/lightbox-dialog.less
@@ -11,6 +11,7 @@
 .lightbox-dialog__compact-window,
 .lightbox-dialog__window {
     .dialog-window();
+    .customBorderRadiusProperty(dialog-border-radius);
 
     // This is needed for IE11 in order to show the right size
     flex-basis: @dialog-max-width;

--- a/src/less/listbox-button/base/listbox-button.less
+++ b/src/less/listbox-button/base/listbox-button.less
@@ -17,7 +17,6 @@ span.listbox-button--fluid .expand-btn {
 
 div.listbox-button__listbox {
     .dropdown();
-    .customBorderRadiusProperty(dropdown-items-border-radius);
 
     border-bottom-color: transparent;
 }

--- a/src/less/listbox-button/base/listbox-button.less
+++ b/src/less/listbox-button/base/listbox-button.less
@@ -17,6 +17,7 @@ span.listbox-button--fluid .expand-btn {
 
 div.listbox-button__listbox {
     .dropdown();
+    .customBorderRadiusProperty(dropdown-items-border-radius);
 
     border-bottom-color: transparent;
 }

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -10,7 +10,6 @@
 .fake-menu-button__menu {
     .dropdown();
     .dropdown-overlay-constraints();
-    .customBorderRadiusProperty(dropdown-items-border-radius);
 
     // In ebayui there is a bug where if tabindex=-1 outside the menu button
     // Any clicks inside will trigger on the outher tabindex=-1. In order to fix it

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -10,6 +10,7 @@
 .fake-menu-button__menu {
     .dropdown();
     .dropdown-overlay-constraints();
+    .customBorderRadiusProperty(dropdown-items-border-radius);
 
     // In ebayui there is a bug where if tabindex=-1 outside the menu button
     // Any clicks inside will trigger on the outher tabindex=-1. In order to fix it

--- a/src/less/mixins/bubble/base/bubble-mixins.less
+++ b/src/less/mixins/bubble/base/bubble-mixins.less
@@ -1,11 +1,10 @@
 // this mixin is used by infotip, tooltip, infotip
 // this mixin is internal only for now
 
-@left-box-shadow: -2px 2px 2px @bubble-box-shadow-color;
-@right-box-shadow: 2px -2px 2px @bubble-box-shadow-color;
-
 .bubble() {
-    box-shadow: 0 -2px 2px @bubble-box-shadow-color, 2px 0 2px @bubble-box-shadow-color, 0 2px 2px @bubble-box-shadow-color, -2px 0 2px @bubble-box-shadow-color,;
+    .customBorderRadiusProperty(bubble-border-radius);
+    .customBoxShadowProperty(bubble-base-box-shadow);
+
     font-size: 14px;
     max-width: 344px;
     min-width: 320px;
@@ -13,6 +12,8 @@
 }
 
 .bubble-mask() {
+    .customBorderRadiusProperty(bubble-border-radius);
+
     position: relative;
     z-index: 1;
 }
@@ -62,8 +63,9 @@
 }
 
 .pointer-bottom() {
+    .customBoxShadowProperty(bubble-bottom-box-shadow);
+
     bottom: -7px;
-    box-shadow: 2px 2px 2px @bubble-box-shadow-color;
     top: auto;
 }
 
@@ -72,7 +74,8 @@
 }
 
 .pointer-top() {
-    box-shadow: -2px -2px 2px @bubble-box-shadow-color;
+    .customBoxShadowProperty(bubble-top-box-shadow);
+
     top: -7px;
 }
 
@@ -123,36 +126,40 @@
 }
 
 .pointer-left-top() {
-    box-shadow: @left-box-shadow;
+    .customBoxShadowProperty(bubble-left-box-shadow);
+
     left: -7px;
     top: 12px;
 }
 
 .pointer-left-bottom() {
+    .customBoxShadowProperty(bubble-left-box-shadow);
+
     bottom: 12px;
-    box-shadow: @left-box-shadow;
     left: -7px;
     top: auto;
 }
 
 .pointer-right() {
     .pointer-side-middle();
+    .customBoxShadowProperty(bubble-right-box-shadow);
 
-    box-shadow: @right-box-shadow;
     left: auto;
     right: -7px;
 }
 
 .pointer-right-top() {
-    box-shadow: @right-box-shadow;
+    .customBoxShadowProperty(bubble-right-box-shadow);
+
     left: auto;
     right: -7px;
     top: 12px;
 }
 
 .pointer-right-bottom() {
+    .customBoxShadowProperty(bubble-right-box-shadow);
+
     bottom: 12px;
-    box-shadow: @right-box-shadow;
     left: auto;
     right: -7px;
     top: auto;

--- a/src/less/mixins/dropdown/base/dropdown-mixins.less
+++ b/src/less/mixins/dropdown/base/dropdown-mixins.less
@@ -1,6 +1,8 @@
 .dropdown-base() {
     .customBackgroundColorProperty(dropdown-items-background-color);
     .customBorderColorProperty(dropdown-items-border-color);
+    .customBorderRadiusProperty(dropdown-items-border-radius);
+    .customBoxShadowProperty(dropdown-items-box-shadow);
 
     border-style: solid;
     border-width: 1px;
@@ -18,7 +20,6 @@
 .dropdown-overlay() {
     .dropdown-overlay-constraints();
 
-    box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
     display: none;
     position: absolute;
     top: calc(100% - 1px);

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -52,6 +52,10 @@
     .customProperty(border-radius, @token);
 }
 
+.customBoxShadowProperty(@token) {
+    .customProperty(box-shadow, @token);
+}
+
 .customFillProperty(@token) {
     .customProperty(fill, @token);
 }

--- a/src/less/pagination/base/pagination.less
+++ b/src/less/pagination/base/pagination.less
@@ -66,6 +66,7 @@ button.pagination__previous {
         .customBackgroundColorProperty(pagination-item-current-background-color);
         .customBorderColorProperty(pagination-item-current-border-color);
         .customColorProperty(pagination-item-current-foreground-color);
+        .customBorderRadiusProperty(pagination-item-current-border-radius);
 
         border-style: solid;
         border-width: 2px;

--- a/src/less/properties/base/pagination-properties.less
+++ b/src/less/properties/base/pagination-properties.less
@@ -4,5 +4,6 @@
     --pagination-item-hover-foreground-color: @pagination-item-hover-foreground-color;
     --pagination-item-current-background-color: @pagination-item-current-background-color;
     --pagination-item-current-border-color: @pagination-item-current-border-color;
+    --pagination-item-current-border-radius: @pagination-item-current-border-radius;
     --pagination-item-current-foreground-color: @pagination-item-current-foreground-color;
 }

--- a/src/less/properties/ds6/button-properties.less
+++ b/src/less/properties/ds6/button-properties.less
@@ -36,7 +36,7 @@
 
     button.btn--large,
     a.fake-btn--large {
-        --button-border-radius: @border-radius-large-button;
+        --button-border-radius: @border-radius-button;
     }
 
     a.fake-btn--icon-only,

--- a/src/less/properties/ds6/cta-button-properties.less
+++ b/src/less/properties/ds6/cta-button-properties.less
@@ -24,6 +24,6 @@
     }
 
     a.cta-button--large {
-        --button-border-radius: @border-radius-large-button;
+        --button-border-radius: @border-radius-button;
     }
 }

--- a/src/less/properties/ds6/infotip-properties.less
+++ b/src/less/properties/ds6/infotip-properties.less
@@ -15,8 +15,12 @@
 }
 
 .skin-experiment-rounded {
-    .infotip__overlay,
-    .infotip__mask {
-        --infotip-border-radius: @border-radius-overlay;
+    .infotip {
+        --bubble-border-radius: @border-radius-overlay;
+        --bubble-base-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-left-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-right-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-bottom-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-top-box-shadow: @border-radius-overlay-box-shadow;
     }
 }

--- a/src/less/properties/ds6/lightbox-dialog-properties.less
+++ b/src/less/properties/ds6/lightbox-dialog-properties.less
@@ -11,3 +11,10 @@
         }
     }
 }
+
+.skin-experiment-rounded {
+    .lightbox-dialog__compact-window,
+    .lightbox-dialog__window {
+        --dialog-border-radius: @border-radius-dialog;
+    }
+}

--- a/src/less/properties/ds6/listbox-button-properties.less
+++ b/src/less/properties/ds6/listbox-button-properties.less
@@ -17,3 +17,9 @@
         }
     }
 }
+
+.skin-experiment-rounded {
+    .listbox-button__listbox {
+        --dropdown-items-border-radius: @border-radius-overlay;
+    }
+}

--- a/src/less/properties/ds6/listbox-button-properties.less
+++ b/src/less/properties/ds6/listbox-button-properties.less
@@ -21,5 +21,7 @@
 .skin-experiment-rounded {
     .listbox-button__listbox {
         --dropdown-items-border-radius: @border-radius-overlay;
+        --dropdown-items-box-shadow: @border-radius-overlay-box-shadow;
+        --dropdown-items-border-color: @border-radius-overlay-border-color;
     }
 }

--- a/src/less/properties/ds6/listbox-button-properties.less
+++ b/src/less/properties/ds6/listbox-button-properties.less
@@ -20,8 +20,8 @@
 
 .skin-experiment-rounded {
     .listbox-button__listbox {
-        --dropdown-items-border-radius: @border-radius-overlay;
-        --dropdown-items-box-shadow: @border-radius-overlay-box-shadow;
-        --dropdown-items-border-color: @border-radius-overlay-border-color;
+        --dropdown-items-border-radius: @border-radius-dropdown;
+        --dropdown-items-box-shadow: @border-radius-dropdown-box-shadow;
+        --dropdown-items-border-color: @border-radius-dropdown-border-color;
     }
 }

--- a/src/less/properties/ds6/menu-button-properties.less
+++ b/src/less/properties/ds6/menu-button-properties.less
@@ -21,5 +21,7 @@
     .menu-button__menu,
     .menu-button__fake-menu {
         --dropdown-items-border-radius: @border-radius-overlay;
+        --dropdown-items-box-shadow: @border-radius-overlay-box-shadow;
+        --dropdown-items-border-color: @border-radius-overlay-border-color;
     }
 }

--- a/src/less/properties/ds6/menu-button-properties.less
+++ b/src/less/properties/ds6/menu-button-properties.less
@@ -16,3 +16,10 @@
         }
     }
 }
+
+.skin-experiment-rounded {
+    .menu-button__menu,
+    .menu-button__fake-menu {
+        --dropdown-items-border-radius: @border-radius-overlay;
+    }
+}

--- a/src/less/properties/ds6/menu-button-properties.less
+++ b/src/less/properties/ds6/menu-button-properties.less
@@ -20,8 +20,8 @@
 .skin-experiment-rounded {
     .menu-button__menu,
     .menu-button__fake-menu {
-        --dropdown-items-border-radius: @border-radius-overlay;
-        --dropdown-items-box-shadow: @border-radius-overlay-box-shadow;
-        --dropdown-items-border-color: @border-radius-overlay-border-color;
+        --dropdown-items-border-radius: @border-radius-dropdown;
+        --dropdown-items-box-shadow: @border-radius-dropdown-box-shadow;
+        --dropdown-items-border-color: @border-radius-dropdown-border-color;
     }
 }

--- a/src/less/properties/ds6/pagination-properties.less
+++ b/src/less/properties/ds6/pagination-properties.less
@@ -12,3 +12,9 @@
         }
     }
 }
+
+.skin-experiment-rounded {
+    .pagination__item[aria-current="page"] {
+        --pagination-item-current-border-radius: @border-radius-pagination;
+    }
+}

--- a/src/less/properties/ds6/select-properties.less
+++ b/src/less/properties/ds6/select-properties.less
@@ -19,4 +19,8 @@
     .select select {
         --select-border-radius: @border-radius-expand-button;
     }
+
+    .select--underline select {
+        --select-border-radius: @border-radius-none;
+    }
 }

--- a/src/less/properties/ds6/toast-dialog-properties.less
+++ b/src/less/properties/ds6/toast-dialog-properties.less
@@ -2,3 +2,9 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/toast-dialog-variables.less";
 @import "../base/toast-dialog-properties.less";
+
+.skin-experiment-rounded {
+    .toast-dialog {
+        --toast-dialog-border-radius: @border-radius-dialog @border-radius-dialog 0 0;
+    }
+}

--- a/src/less/properties/ds6/tooltip-properties.less
+++ b/src/less/properties/ds6/tooltip-properties.less
@@ -5,8 +5,12 @@
 @import "../base/tooltip-properties.less";
 
 .skin-experiment-rounded {
-    .tooltip__overlay,
-    .tooltip__mask {
-        --tooltip-border-radius: @border-radius-overlay;
+    .tooltip {
+        --bubble-border-radius: @border-radius-overlay;
+        --bubble-base-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-left-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-right-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-bottom-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-top-box-shadow: @border-radius-overlay-box-shadow;
     }
 }

--- a/src/less/properties/ds6/tourtip-properties.less
+++ b/src/less/properties/ds6/tourtip-properties.less
@@ -5,8 +5,12 @@
 @import "../base/tourtip-properties.less";
 
 .skin-experiment-rounded {
-    .tourtip__overlay,
-    .tourtip__mask {
-        --tourtip-border-radius: @border-radius-overlay;
+    .tourtip {
+        --bubble-border-radius: @border-radius-overlay;
+        --bubble-base-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-left-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-right-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-bottom-box-shadow: @border-radius-overlay-box-shadow;
+        --bubble-top-box-shadow: @border-radius-overlay-box-shadow;
     }
 }

--- a/src/less/toast-dialog/base/toast-dialog.less
+++ b/src/less/toast-dialog/base/toast-dialog.less
@@ -14,6 +14,7 @@
     .customBorderRadiusProperty(toast-dialog-border-radius);
 
     bottom: 0;
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
     left: 0;
     max-height: 40vh;
     min-width: 320px;

--- a/src/less/toast-dialog/base/toast-dialog.less
+++ b/src/less/toast-dialog/base/toast-dialog.less
@@ -14,7 +14,7 @@
     .customBorderRadiusProperty(toast-dialog-border-radius);
 
     bottom: 0;
-    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.28);
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
     left: 0;
     max-height: 40vh;
     min-width: 320px;

--- a/src/less/toast-dialog/base/toast-dialog.less
+++ b/src/less/toast-dialog/base/toast-dialog.less
@@ -11,6 +11,7 @@
 .toast-dialog {
     .customBackgroundColorProperty(toast-dialog-background-color);
     .customColorProperty(toast-dialog-foreground-color);
+    .customBorderRadiusProperty(toast-dialog-border-radius);
 
     bottom: 0;
     left: 0;

--- a/src/less/toast-dialog/ds6/toast-dialog.less
+++ b/src/less/toast-dialog/ds6/toast-dialog.less
@@ -1,2 +1,13 @@
 @import "../../properties/ds6/toast-dialog-properties.less";
 @import "../base/toast-dialog.less";
+
+// This needs to be put after base is loaded because otherwise it gets
+// hoisted to the previous media query and then taking less prescedence before
+// The mobile style
+@media (min-width: 601px) {
+    .skin-experiment-rounded {
+        .toast-dialog {
+            --toast-dialog-border-radius: @border-radius-dialog;
+        }
+    }
+}

--- a/src/less/tooltip/base/tooltip.less
+++ b/src/less/tooltip/base/tooltip.less
@@ -10,7 +10,6 @@ span.tooltip {
 
 .tooltip__overlay {
     .bubble();
-    .customBorderRadiusProperty(tooltip-border-radius);
 
     display: none;
     left: 0 - 10px;
@@ -22,7 +21,6 @@ span.tooltip {
     .bubble-mask();
     .customBackgroundColorProperty(tooltip-background-color);
     .customColorProperty(tooltip-foreground-color);
-    .customBorderRadiusProperty(tooltip-border-radius);
 }
 
 span.tooltip__mask {

--- a/src/less/tourtip/base/tourtip.less
+++ b/src/less/tourtip/base/tourtip.less
@@ -10,7 +10,6 @@ span.tourtip {
 
 .tourtip__overlay {
     .bubble();
-    .customBorderRadiusProperty(tourtip-border-radius);
 
     display: none;
     position: absolute;
@@ -20,7 +19,6 @@ span.tourtip {
     .bubble-mask();
     .customBackgroundColorProperty(tourtip-background-color);
     .customColorProperty(tourtip-foreground-color);
-    .customBorderRadiusProperty(tourtip-border-radius);
 }
 
 span.tourtip__mask {

--- a/src/less/variables/ds4/border-radius-variables.less
+++ b/src/less/variables/ds4/border-radius-variables.less
@@ -1,2 +1,4 @@
 @border-radius-none: 0;
 @border-radius-form-control: 3px;
+
+@border-radius-dialog: 16px;

--- a/src/less/variables/ds4/bubble-variables.less
+++ b/src/less/variables/ds4/bubble-variables.less
@@ -1,3 +1,9 @@
 @import "color-variables.less";
 
 @bubble-box-shadow-color: @color-flyout-box-shadow;
+@bubble-border-radius: @border-radius-none;
+@bubble-base-box-shadow: 0 -2px 2px @bubble-box-shadow-color, 2px 0 2px @bubble-box-shadow-color, 0 2px 2px @bubble-box-shadow-color, -2px 0 2px @bubble-box-shadow-color;
+@bubble-left-box-shadow: -2px 2px 2px @bubble-box-shadow-color;
+@bubble-right-box-shadow: 2px -2px 2px @bubble-box-shadow-color;
+@bubble-bottom-box-shadow: 2px 2px 2px @bubble-box-shadow-color;
+@bubble-top-box-shadow: -2px -2px 2px @bubble-box-shadow-color;

--- a/src/less/variables/ds4/dialog-variables.less
+++ b/src/less/variables/ds4/dialog-variables.less
@@ -3,6 +3,7 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
+@dialog-border-radius: @border-radius-none;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
 @dialog-max-width: 616px;

--- a/src/less/variables/ds4/dropdown-variables.less
+++ b/src/less/variables/ds4/dropdown-variables.less
@@ -2,6 +2,7 @@
 
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
+@dropdown-items-border-radius: @border-radius-none;
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/src/less/variables/ds4/dropdown-variables.less
+++ b/src/less/variables/ds4/dropdown-variables.less
@@ -3,6 +3,7 @@
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
 @dropdown-items-border-radius: @border-radius-none;
+@dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/src/less/variables/ds4/infotip-variables.less
+++ b/src/less/variables/ds4/infotip-variables.less
@@ -1,3 +1,2 @@
 @infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
-@infotip-border-radius: @border-radius-none;

--- a/src/less/variables/ds4/pagination-variables.less
+++ b/src/less/variables/ds4/pagination-variables.less
@@ -4,5 +4,6 @@
 @pagination-item-hover-foreground-color: @color-text-default;
 @pagination-item-current-background-color: @color-grey1;
 @pagination-item-current-border-color: transparent;
+@pagination-item-current-border-radius: @border-radius-none;
 @pagination-item-current-foreground-color: @color-text-default;
 @pagination-item-current-font-weight: @font-weight-bold;

--- a/src/less/variables/ds4/toast-dialog-variables.less
+++ b/src/less/variables/ds4/toast-dialog-variables.less
@@ -1,2 +1,3 @@
 @toast-dialog-background-color: @color-action-primary;
 @toast-dialog-foreground-color: @color-background-default;
+@toast-dialog-border-radius: @border-radius-none;

--- a/src/less/variables/ds4/tooltip-variables.less
+++ b/src/less/variables/ds4/tooltip-variables.less
@@ -1,3 +1,2 @@
 @tooltip-background-color: @color-action-primary;
 @tooltip-foreground-color: @color-background-default;
-@tooltip-border-radius: @border-radius-none;

--- a/src/less/variables/ds4/tourtip-variables.less
+++ b/src/less/variables/ds4/tourtip-variables.less
@@ -1,3 +1,2 @@
 @tourtip-background-color: @color-action-primary;
 @tourtip-foreground-color: @color-background-default;
-@tourtip-border-radius: @border-radius-none;

--- a/src/less/variables/ds6/border-radius-variables.less
+++ b/src/less/variables/ds6/border-radius-variables.less
@@ -2,16 +2,19 @@
 @border-radius-form-control: 0;
 @border-radius-small: 8px;
 
-@border-radius-button: 20px;
-@border-radius-large-button: 24px;
+@border-radius-button: 48px;
 @border-radius-icon-button: @border-radius-small;
 @border-radius-expand-button: @border-radius-small;
 
-@border-radius-overlay: @border-radius-small;
+@border-radius-overlay: 4px;
+
+@border-radius-dropdown: @border-radius-small;
 // These are values required for new rounded corners
-@border-radius-overlay-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
-@border-radius-overlay-border-color: @color-grey1;
+@border-radius-dropdown-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
+@border-radius-dropdown-border-color: @color-grey1;
 
 @border-radius-notice: @border-radius-small;
 
 @border-radius-dialog: 16px;
+
+@border-radius-pagination: @border-radius-small;

--- a/src/less/variables/ds6/border-radius-variables.less
+++ b/src/less/variables/ds6/border-radius-variables.less
@@ -8,6 +8,9 @@
 @border-radius-expand-button: @border-radius-small;
 
 @border-radius-overlay: @border-radius-small;
+// These are values required for new rounded corners
+@border-radius-overlay-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
+@border-radius-overlay-border-color: @color-grey1;
 
 @border-radius-notice: @border-radius-small;
 

--- a/src/less/variables/ds6/border-radius-variables.less
+++ b/src/less/variables/ds6/border-radius-variables.less
@@ -7,6 +7,7 @@
 @border-radius-expand-button: @border-radius-small;
 
 @border-radius-overlay: 4px;
+@border-radius-overlay-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);;
 
 @border-radius-dropdown: @border-radius-small;
 // These are values required for new rounded corners

--- a/src/less/variables/ds6/border-radius-variables.less
+++ b/src/less/variables/ds6/border-radius-variables.less
@@ -7,7 +7,7 @@
 @border-radius-expand-button: @border-radius-small;
 
 @border-radius-overlay: 4px;
-@border-radius-overlay-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);;
+@border-radius-overlay-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);
 
 @border-radius-dropdown: @border-radius-small;
 // These are values required for new rounded corners

--- a/src/less/variables/ds6/border-radius-variables.less
+++ b/src/less/variables/ds6/border-radius-variables.less
@@ -10,3 +10,5 @@
 @border-radius-overlay: @border-radius-small;
 
 @border-radius-notice: @border-radius-small;
+
+@border-radius-dialog: 16px;

--- a/src/less/variables/ds6/bubble-variables.less
+++ b/src/less/variables/ds6/bubble-variables.less
@@ -1,3 +1,9 @@
 @import "color-variables.less";
 
 @bubble-box-shadow-color: @color-flyout-box-shadow;
+@bubble-border-radius: @border-radius-none;
+@bubble-base-box-shadow: 0 -2px 2px @bubble-box-shadow-color, 2px 0 2px @bubble-box-shadow-color, 0 2px 2px @bubble-box-shadow-color, -2px 0 2px @bubble-box-shadow-color;
+@bubble-left-box-shadow: -2px 2px 2px @bubble-box-shadow-color;
+@bubble-right-box-shadow: 2px -2px 2px @bubble-box-shadow-color;
+@bubble-bottom-box-shadow: 2px 2px 2px @bubble-box-shadow-color;
+@bubble-top-box-shadow: -2px -2px 2px @bubble-box-shadow-color;

--- a/src/less/variables/ds6/dialog-variables.less
+++ b/src/less/variables/ds6/dialog-variables.less
@@ -3,6 +3,7 @@
 
 @dialog-mask-background-color: @color-text-default;
 @dialog-window-background-color: @color-background-default;
+@dialog-border-radius: @border-radius-none;
 @dialog-large-gutter-size: 24px;
 @dialog-small-gutter-size: 16px;
 @dialog-max-width: 616px;

--- a/src/less/variables/ds6/dropdown-variables.less
+++ b/src/less/variables/ds6/dropdown-variables.less
@@ -2,6 +2,7 @@
 
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
+@dropdown-items-border-radius: @border-radius-none;
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/src/less/variables/ds6/dropdown-variables.less
+++ b/src/less/variables/ds6/dropdown-variables.less
@@ -3,6 +3,7 @@
 @dropdown-items-background-color: @color-background-default;
 @dropdown-items-border-color: @color-grey3;
 @dropdown-items-border-radius: @border-radius-none;
+@dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
 @dropdown-item-foreground-color: @color-text-default;
 @dropdown-item-background-color: @dropdown-items-background-color;
 @dropdown-item-border-color: @dropdown-items-background-color;

--- a/src/less/variables/ds6/infotip-variables.less
+++ b/src/less/variables/ds6/infotip-variables.less
@@ -1,3 +1,2 @@
 @infotip-background-color: @color-background-default;
 @infotip-foreground-color: @color-text-default;
-@infotip-border-radius: @border-radius-none;

--- a/src/less/variables/ds6/pagination-variables.less
+++ b/src/less/variables/ds6/pagination-variables.less
@@ -4,5 +4,6 @@
 @pagination-item-hover-foreground-color: @color-b6;
 @pagination-item-current-background-color: transparent;
 @pagination-item-current-border-color: @color-link-default;
+@pagination-item-current-border-radius: @border-radius-none;
 @pagination-item-current-foreground-color: @color-link-default;
 @pagination-item-current-font-weight: @font-weight-bold;

--- a/src/less/variables/ds6/toast-dialog-variables.less
+++ b/src/less/variables/ds6/toast-dialog-variables.less
@@ -1,2 +1,3 @@
 @toast-dialog-background-color: @color-action-primary;
 @toast-dialog-foreground-color: @color-background-default;
+@toast-dialog-border-radius: @border-radius-none;

--- a/src/less/variables/ds6/tooltip-variables.less
+++ b/src/less/variables/ds6/tooltip-variables.less
@@ -1,3 +1,2 @@
 @tooltip-background-color: @color-action-primary;
 @tooltip-foreground-color: @color-background-default;
-@tooltip-border-radius: @border-radius-none;

--- a/src/less/variables/ds6/tourtip-variables.less
+++ b/src/less/variables/ds6/tourtip-variables.less
@@ -1,3 +1,2 @@
 @tourtip-background-color: @color-action-primary;
 @tourtip-foreground-color: @color-background-default;
-@tourtip-border-radius: @border-radius-none;


### PR DESCRIPTION
<!--  Delete any sections below that are not relevant to this PR -->

## Description
* Added rounding to dialog
* Added rounding to menu/listbox overlays
* Added toast rounded corners

## Context
There is an issue with `@media` queries in the properties file.
Basically all media queries are hoisted to the previous media query. If put in the properties, the media query gets loaded in the previous one (which is section notice). This makes it so that it doesn't take prescedence. I had to put it AFTER loading the `base` file in order to get it to work. This is only for toast which has rounded bottom corners on dweb and no rounded bottom corners on mweb.

## References
#1254 

## Screenshots
<img width="165" alt="Screen Shot 2020-10-14 at 11 49 35 AM" src="https://user-images.githubusercontent.com/1755269/96032603-c065da00-0e13-11eb-80a9-fa0de26b5e0a.png">
<img width="181" alt="Screen Shot 2020-10-14 at 11 49 45 AM" src="https://user-images.githubusercontent.com/1755269/96032606-c0fe7080-0e13-11eb-9644-436803e40d92.png">
<img width="563" alt="Screen Shot 2020-10-14 at 11 49 03 AM" src="https://user-images.githubusercontent.com/1755269/96032608-c0fe7080-0e13-11eb-84b6-1d6e3c66f2f8.png">
<img width="451" alt="Screen Shot 2020-10-14 at 11 49 09 AM" src="https://user-images.githubusercontent.com/1755269/96032589-bd6ae980-0e13-11eb-964b-5551da2e89df.png">
<img width="789" alt="Screen Shot 2020-10-14 at 11 49 26 AM" src="https://user-images.githubusercontent.com/1755269/96032599-bf34ad00-0e13-11eb-9464-ebd89306f8c4.png">

