### PR TITLE
Button: added backwards compatibility for DS4 button width

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -32,6 +32,8 @@ a.fake-btn {
   vertical-align: bottom;
   border-radius: 3px;
   border-radius: var(--button-border-radius, 3px);
+  padding: 11px 16px;
+  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
   background-color: transparent;
   border-color: inherit;
   color: inherit;
@@ -39,7 +41,6 @@ a.fake-btn {
   font-size: 0.875rem;
   max-width: 100%;
   min-height: 40px;
-  padding: 11px 16px;
 }
 button.btn--fixed-height,
 a.fake-btn--fixed-height {
@@ -57,6 +58,11 @@ a.fake-btn--truncated span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+button.btn--wide,
+a.fake-btn--wide {
+  padding-left: 48px;
+  padding-right: 48px;
 }
 button.btn[disabled],
 a.fake-btn:not([href]),
@@ -317,9 +323,10 @@ a.fake-btn--delete[aria-disabled="true"] {
 }
 button.btn--large,
 a.fake-btn--large {
+  padding: 14px 16px;
+  padding: var(--button-large-padding-vertical, 14px) var(--button-padding-horizontal, 16px);
   font-size: 1rem;
   min-height: 48px;
-  padding: 14px 16px;
 }
 button.btn--transparent,
 a.fake-btn--transparent {
@@ -352,10 +359,11 @@ a.fake-btn--truncated span {
 }
 button.btn--large-truncated,
 a.fake-btn--large-truncated {
+  padding: 14px 16px;
+  padding: var(--button-large-padding-vertical, 14px) var(--button-padding-horizontal, 16px);
   font-size: 1rem;
   height: 48px;
   min-height: 48px;
-  padding: 14px 16px;
 }
 button.btn--large-truncated,
 a.fake-btn--large-truncated,

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -65,6 +65,8 @@ a.fake-btn {
   vertical-align: bottom;
   border-radius: 0;
   border-radius: var(--button-border-radius, 0);
+  padding: 11px 16px;
+  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
   background-color: transparent;
   border-color: inherit;
   color: inherit;
@@ -72,7 +74,6 @@ a.fake-btn {
   font-size: 0.875rem;
   max-width: 100%;
   min-height: 40px;
-  padding: 11px 16px;
 }
 button.btn--fixed-height,
 a.fake-btn--fixed-height {
@@ -90,6 +91,11 @@ a.fake-btn--truncated span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+button.btn--wide,
+a.fake-btn--wide {
+  padding-left: 48px;
+  padding-right: 48px;
 }
 button.btn[disabled],
 a.fake-btn:not([href]),
@@ -350,9 +356,10 @@ a.fake-btn--delete[aria-disabled="true"] {
 }
 button.btn--large,
 a.fake-btn--large {
+  padding: 14px 16px;
+  padding: var(--button-large-padding-vertical, 14px) var(--button-padding-horizontal, 16px);
   font-size: 1rem;
   min-height: 48px;
-  padding: 14px 16px;
 }
 button.btn--transparent,
 a.fake-btn--transparent {
@@ -385,10 +392,11 @@ a.fake-btn--truncated span {
 }
 button.btn--large-truncated,
 a.fake-btn--large-truncated {
+  padding: 14px 16px;
+  padding: var(--button-large-padding-vertical, 14px) var(--button-padding-horizontal, 16px);
   font-size: 1rem;
   height: 48px;
   min-height: 48px;
-  padding: 14px 16px;
 }
 button.btn--large-truncated,
 a.fake-btn--large-truncated,

--- a/dist/cta-button/ds4/cta-button.css
+++ b/dist/cta-button/ds4/cta-button.css
@@ -24,11 +24,12 @@ a.cta-btn {
   border-radius: var(--button-border-radius, 3px);
   color: #333;
   color: var(--cta-button-foreground-color, #333);
+  padding: 11px 16px;
+  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
   border-color: currentColor;
   display: inline-block;
   font-size: 0.875rem;
   max-width: 100%;
-  padding: 11px 16px;
 }
 a.cta-btn--fixed-height {
   height: 40px;
@@ -65,7 +66,11 @@ a.cta-btn[aria-disabled="true"] {
   color: #ccc;
   color: var(--cta-button-disabled-foreground-color, #ccc);
 }
-a.cta-button--fluid {
+a.cta-btn--wide {
+  padding-left: 48px;
+  padding-right: 48px;
+}
+a.cta-btn--fluid {
   width: 100%;
 }
 span.cta-btn__cell {
@@ -111,22 +116,22 @@ span.cta-btn__cell--fixed-height svg.icon {
   overflow: visible;
   width: 1rem;
 }
-a.cta-button--large {
+a.cta-btn--large {
   font-size: 1rem;
   min-height: 48px;
 }
-a.cta-button--large-truncated {
+a.cta-btn--large-truncated {
   font-size: 1rem;
   height: 48px;
 }
-a.cta-button--large-truncated,
-a.cta-button--large-truncated span {
+a.cta-btn--large-truncated,
+a.cta-btn--large-truncated span {
   line-height: 1.4em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-a.cta-button--large-fixed-height {
+a.cta-btn--large-fixed-height {
   font-size: 1rem;
   height: 48px;
 }

--- a/dist/cta-button/ds6/cta-button.css
+++ b/dist/cta-button/ds6/cta-button.css
@@ -40,11 +40,12 @@ a.cta-btn {
   border-radius: var(--button-border-radius, 0);
   color: #111820;
   color: var(--cta-button-foreground-color, #111820);
+  padding: 11px 16px;
+  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
   border-color: currentColor;
   display: inline-block;
   font-size: 0.875rem;
   max-width: 100%;
-  padding: 11px 16px;
 }
 a.cta-btn--fixed-height {
   height: 40px;
@@ -81,7 +82,11 @@ a.cta-btn[aria-disabled="true"] {
   color: #c7c7c7;
   color: var(--cta-button-disabled-foreground-color, #c7c7c7);
 }
-a.cta-button--fluid {
+a.cta-btn--wide {
+  padding-left: 48px;
+  padding-right: 48px;
+}
+a.cta-btn--fluid {
   width: 100%;
 }
 span.cta-btn__cell {
@@ -127,22 +132,22 @@ span.cta-btn__cell--fixed-height svg.icon {
   overflow: visible;
   width: 1rem;
 }
-a.cta-button--large {
+a.cta-btn--large {
   font-size: 1rem;
   min-height: 48px;
 }
-a.cta-button--large-truncated {
+a.cta-btn--large-truncated {
   font-size: 1rem;
   height: 48px;
 }
-a.cta-button--large-truncated,
-a.cta-button--large-truncated span {
+a.cta-btn--large-truncated,
+a.cta-btn--large-truncated span {
   line-height: 1.4em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-a.cta-button--large-fixed-height {
+a.cta-btn--large-fixed-height {
   font-size: 1rem;
   height: 48px;
 }

--- a/dist/expand-button/ds4/expand-button.css
+++ b/dist/expand-button/ds4/expand-button.css
@@ -25,6 +25,8 @@ button.expand-btn {
   vertical-align: bottom;
   border-radius: 0;
   border-radius: var(--expand-button-border-radius, 0);
+  padding: 11px 16px;
+  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
   background-color: transparent;
   border: 1px solid;
   border-color: inherit;
@@ -32,7 +34,6 @@ button.expand-btn {
   display: inline-block;
   font-size: 1em;
   max-width: 100%;
-  padding: 11px 16px;
 }
 button.expand-btn--fixed-height {
   height: 40px;
@@ -63,6 +64,10 @@ button.expand-btn svg.icon:first-child {
 }
 button.expand-btn svg.icon:last-child {
   margin-left: 8px;
+}
+button.expand-button--wide {
+  padding-left: 48px;
+  padding-right: 48px;
 }
 button.expand-btn--fluid {
   width: 100%;

--- a/dist/expand-button/ds6/expand-button.css
+++ b/dist/expand-button/ds6/expand-button.css
@@ -48,6 +48,8 @@ button.expand-btn {
   vertical-align: bottom;
   border-radius: 0;
   border-radius: var(--expand-button-border-radius, 0);
+  padding: 11px 16px;
+  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
   background-color: transparent;
   border: 1px solid;
   border-color: inherit;
@@ -55,7 +57,6 @@ button.expand-btn {
   display: inline-block;
   font-size: 1em;
   max-width: 100%;
-  padding: 11px 16px;
 }
 button.expand-btn--fixed-height {
   height: 40px;
@@ -86,6 +87,10 @@ button.expand-btn svg.icon:first-child {
 }
 button.expand-btn svg.icon:last-child {
   margin-left: 8px;
+}
+button.expand-button--wide {
+  padding-left: 48px;
+  padding-right: 48px;
 }
 button.expand-btn--fluid {
   width: 100%;

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -28,6 +28,11 @@
     @{property}: var(~"--@{token}", @@token);
 }
 
+.customProperty(@property, @token1, @token2) {
+    @{property}: @@token1 @@token2;
+    @{property}: var(~"--@{token1}", @@token1) var(~"--@{token2}", @@token2);
+}
+
 .customColorProperty(@token) {
     .customProperty(color, @token);
 }
@@ -62,4 +67,8 @@
 
 .customOutlineColorProperty(@token) {
     .customProperty(outline-color, @token);
+}
+
+.customPaddingProperty(@token1, @token2) {
+    .customProperty(padding, @token1, @token2);
 }

--- a/dist/variables/ds4/button-variables.less
+++ b/dist/variables/ds4/button-variables.less
@@ -3,9 +3,15 @@
 @button-border-radius: @border-radius-form-control;
 @button-font-size: @font-size-regular;
 @button-large-font-size: @font-size-medium;
-@button-padding: 11px 16px;
-@button-large-padding: 14px 16px;
 @button-disabled-opacity: @color-action-disabled-opacity;
+
+@button-padding-vertical: 11px;
+@button-padding-horizontal: 16px;
+@button-padding: @button-padding-vertical @button-padding-horizontal;
+@button-large-padding-vertical: 14px;
+@button-large-padding-horizontal: 16px;
+@button-large-padding: @button-large-padding-vertical @button-large-padding-horizontal;
+@button-wide-padding-horizontal: 48px;
 
 @button-primary-font-weight: @font-weight-action-primary;
 @button-primary-background-color: @color-action-primary;

--- a/dist/variables/ds6/button-variables.less
+++ b/dist/variables/ds6/button-variables.less
@@ -3,9 +3,15 @@
 @button-border-radius: @border-radius-form-control;
 @button-font-size: @font-size-regular;
 @button-large-font-size: @font-size-medium;
-@button-padding: 11px 16px;
-@button-large-padding: 14px 16px;
 @button-disabled-opacity: @color-action-disabled-opacity;
+
+@button-padding-vertical: 11px;
+@button-padding-horizontal: 16px;
+@button-padding: @button-padding-vertical @button-padding-horizontal;
+@button-large-padding-vertical: 14px;
+@button-large-padding-horizontal: 16px;
+@button-large-padding: @button-large-padding-vertical @button-large-padding-horizontal;
+@button-wide-padding-horizontal: 48px;
 
 @button-primary-font-weight: @font-weight-action-primary;
 @button-primary-background-color: @color-action-primary;

--- a/docs/_includes/common/button.html
+++ b/docs/_includes/common/button.html
@@ -364,4 +364,18 @@
 </div>
     {% endhighlight %}
 
+    <h3 id="button-wide">Wide Button</h3>
+
+    <p>For a wider button, use the <span class="highlight">btn--wide</span> modifier.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--wide">Button</button>
+        </div>
+    </div>
+
+    {% highlight html %}
+<button class="btn btn--wide">Button</button>
+    {% endhighlight %}
+
 </div>

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -4,6 +4,7 @@ button.btn,
 a.fake-btn {
     .btn-base();
     .customBorderRadiusProperty(button-border-radius);
+    .customPaddingProperty(button-padding-vertical, button-padding-horizontal);
 
     background-color: transparent;
     border-color: inherit;
@@ -12,7 +13,12 @@ a.fake-btn {
     font-size: @font-size-14;
     max-width: 100%;
     min-height: 40px;
-    padding: @button-padding;
+}
+
+button.btn--wide,
+a.fake-btn--wide {
+    padding-left: @button-wide-padding-horizontal;
+    padding-right: @button-wide-padding-horizontal;
 }
 
 button.btn[disabled],
@@ -207,9 +213,10 @@ a.fake-btn--delete[aria-disabled="true"] {
 
 button.btn--large,
 a.fake-btn--large {
+    .customPaddingProperty(button-large-padding-vertical, button-padding-horizontal);
+
     font-size: @button-large-font-size;
     min-height: 48px;
-    padding: @button-large-padding;
 }
 
 button.btn--transparent,
@@ -241,12 +248,12 @@ a.fake-btn--truncated {
 
 button.btn--large-truncated,
 a.fake-btn--large-truncated {
+    .customPaddingProperty(button-large-padding-vertical, button-padding-horizontal);
     .btn-truncate();
 
     font-size: @button-large-font-size;
     height: 48px;
     min-height: 48px;
-    padding: @button-large-padding;
 }
 
 button.btn--icon-only,

--- a/src/less/button/stories/button/base/base.stories.js
+++ b/src/less/button/stories/button/base/base.stories.js
@@ -39,3 +39,5 @@ export const fixedWidth = () => `
 export const formSubmit = () => '<button type="submit" class="btn">Submit</button>';
 
 export const formReset = () => '<button type="reset" class="btn">Reset</button>';
+
+export const wide = () => '<button class="btn btn--wide">Button</button>';

--- a/src/less/cta-button/base/cta-button.less
+++ b/src/less/cta-button/base/cta-button.less
@@ -5,12 +5,12 @@ a.cta-btn {
     .customBackgroundColorProperty(cta-button-background-color);
     .customBorderRadiusProperty(button-border-radius);
     .customColorProperty(cta-button-foreground-color);
+    .customPaddingProperty(button-padding-vertical, button-padding-horizontal);
 
     border-color: currentColor;
     display: inline-block;
     font-size: @button-font-size;
     max-width: 100%;
-    padding: @button-padding;
 }
 
 a.cta-btn:visited {
@@ -31,7 +31,12 @@ a.cta-btn[aria-disabled="true"] {
     .customColorProperty(cta-button-disabled-foreground-color);
 }
 
-a.cta-button--fluid {
+a.cta-btn--wide {
+    padding-left: @button-wide-padding-horizontal;
+    padding-right: @button-wide-padding-horizontal;
+}
+
+a.cta-btn--fluid {
     width: 100%;
 }
 
@@ -56,19 +61,19 @@ span.cta-btn__cell--fixed-height svg.icon {
     width: 1rem;
 }
 
-a.cta-button--large {
+a.cta-btn--large {
     font-size: @font-size-16;
     min-height: 48px;
 }
 
-a.cta-button--large-truncated {
+a.cta-btn--large-truncated {
     .btn-truncate();
 
     font-size: @font-size-16;
     height: 48px;
 }
 
-a.cta-button--large-fixed-height {
+a.cta-btn--large-fixed-height {
     font-size: @font-size-16;
     height: 48px;
 }

--- a/src/less/cta-button/stories/cta-button.stories.js
+++ b/src/less/cta-button/stories/cta-button.stories.js
@@ -10,3 +10,14 @@ export const base = () => `
     </span>
 </a>
 `;
+
+export const wide = () => `
+<a class="cta-btn cta-btn--wide" href="http://www.ebay.com">
+    <span class="cta-btn__cell">
+        <span>Link</span>
+        <svg class="icon icon--cta" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-cta"></use>
+        </svg>
+    </span>
+</a>
+`;

--- a/src/less/expand-button/base/expand-button.less
+++ b/src/less/expand-button/base/expand-button.less
@@ -3,6 +3,7 @@
 button.expand-btn {
     .btn-base();
     .customBorderRadiusProperty(expand-button-border-radius);
+    .customPaddingProperty(button-padding-vertical, button-padding-horizontal);
 
     background-color: transparent;
     border: 1px solid;
@@ -11,7 +12,6 @@ button.expand-btn {
     display: inline-block;
     font-size: 1em;
     max-width: 100%;
-    padding: @button-padding;
 
     &:hover,
     &:focus {
@@ -24,6 +24,11 @@ button.expand-btn svg.icon {
     .btn-icon-base();
 
     flex-shrink: 0;
+}
+
+button.expand-button--wide {
+    padding-left: @button-wide-padding-horizontal;
+    padding-right: @button-wide-padding-horizontal;
 }
 
 button.expand-btn--fluid {

--- a/src/less/expand-button/stories/expand-button.stories.js
+++ b/src/less/expand-button/stories/expand-button.stories.js
@@ -65,3 +65,14 @@ export const fixedWidth = () => `
     </span>
 </button>
 `;
+
+export const wide = () => `
+<button type="button" class="expand-btn expand-btn--wide" aria-expanded="false">
+     <span class="expand-btn__cell">
+         <span>Button</span>
+         <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+             <use xlink:href="#icon-dropdown"></use>
+         </svg>
+     </span>
+ </button>
+`;

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -28,6 +28,11 @@
     @{property}: var(~"--@{token}", @@token);
 }
 
+.customProperty(@property, @token1, @token2) {
+    @{property}: @@token1 @@token2;
+    @{property}: var(~"--@{token1}", @@token1) var(~"--@{token2}", @@token2);
+}
+
 .customColorProperty(@token) {
     .customProperty(color, @token);
 }
@@ -62,4 +67,8 @@
 
 .customOutlineColorProperty(@token) {
     .customProperty(outline-color, @token);
+}
+
+.customPaddingProperty(@token1, @token2) {
+    .customProperty(padding, @token1, @token2);
 }

--- a/src/less/variables/ds4/button-variables.less
+++ b/src/less/variables/ds4/button-variables.less
@@ -3,9 +3,15 @@
 @button-border-radius: @border-radius-form-control;
 @button-font-size: @font-size-regular;
 @button-large-font-size: @font-size-medium;
-@button-padding: 11px 16px;
-@button-large-padding: 14px 16px;
 @button-disabled-opacity: @color-action-disabled-opacity;
+
+@button-padding-vertical: 11px;
+@button-padding-horizontal: 16px;
+@button-padding: @button-padding-vertical @button-padding-horizontal;
+@button-large-padding-vertical: 14px;
+@button-large-padding-horizontal: 16px;
+@button-large-padding: @button-large-padding-vertical @button-large-padding-horizontal;
+@button-wide-padding-horizontal: 48px;
 
 @button-primary-font-weight: @font-weight-action-primary;
 @button-primary-background-color: @color-action-primary;

--- a/src/less/variables/ds6/button-variables.less
+++ b/src/less/variables/ds6/button-variables.less
@@ -3,9 +3,15 @@
 @button-border-radius: @border-radius-form-control;
 @button-font-size: @font-size-regular;
 @button-large-font-size: @font-size-medium;
-@button-padding: 11px 16px;
-@button-large-padding: 14px 16px;
 @button-disabled-opacity: @color-action-disabled-opacity;
+
+@button-padding-vertical: 11px;
+@button-padding-horizontal: 16px;
+@button-padding: @button-padding-vertical @button-padding-horizontal;
+@button-large-padding-vertical: 14px;
+@button-large-padding-horizontal: 16px;
+@button-large-padding: @button-large-padding-vertical @button-large-padding-horizontal;
+@button-wide-padding-horizontal: 48px;
 
 @button-primary-font-weight: @font-weight-action-primary;
 @button-primary-background-color: @color-action-primary;


### PR DESCRIPTION
Fixes #1272

This provides a couple of ways for legacy pages to opt into the old, wider button style when they upgrade to v11:

1. Via a new `.btn--wide` modifier
2. Via a new `--button-padding-horizontal` custom property

## Screenshots

![Screen Shot 2020-10-28 at 2 21 50 PM](https://user-images.githubusercontent.com/38065/97502140-c1c4f580-192f-11eb-8ab5-279b7619e58f.png)
