### PR TITLE
Custom Properties: removed list of props from top of all dist files

### DIFF
--- a/.stylelintrc-less
+++ b/.stylelintrc-less
@@ -1,6 +1,6 @@
 {
   "extends": "stylelint-config-standard",
-  "ignoreFiles": "src/less/bundles/skin/ds4/skin-full.less",
+  "ignoreFiles": ["src/less/bundles/skin/ds4/skin-full.less","**/*.txt"],
   "plugins": [
     "stylelint-order",
     "stylelint-no-unsupported-browser-features"

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,8 +1,4 @@
 .badge {
-  --badge-background-color: #dd1e31;
-  --badge-foreground-color: #fff;
-}
-.badge {
   background-color: #dd1e31;
   background-color: var(--badge-background-color, #dd1e31);
   color: #fff;

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,7 +1,3 @@
-.badge {
-  --badge-background-color: #e62048;
-  --badge-foreground-color: #fff;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .badge {
     --badge-background-color: #e75064;

--- a/dist/breadcrumbs/ds4/breadcrumbs.css
+++ b/dist/breadcrumbs/ds4/breadcrumbs.css
@@ -1,8 +1,3 @@
-.breadcrumbs {
-  --breadcrumbs-item-foreground-color: #333;
-  --breadcrumbs-item-current-foreground-color: #767676;
-  --breadcrumbs-item-hover-foreground-color: #0654ba;
-}
 nav.breadcrumbs {
   color: #333;
   color: var(--breadcrumbs-item-foreground-color, #333);

--- a/dist/breadcrumbs/ds6/breadcrumbs.css
+++ b/dist/breadcrumbs/ds6/breadcrumbs.css
@@ -1,8 +1,3 @@
-.breadcrumbs {
-  --breadcrumbs-item-foreground-color: #111820;
-  --breadcrumbs-item-current-foreground-color: #767676;
-  --breadcrumbs-item-hover-foreground-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .breadcrumbs {
     --breadcrumbs-item-foreground-color: #dcdcdc;

--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -1,27 +1,5 @@
 button.btn,
 a.fake-btn {
-  --button-border-radius: 3px;
-  --button-primary-background-color: #0654ba;
-  --button-primary-border-color: #0654ba;
-  --button-primary-foreground-color: #fff;
-  --button-primary-hover-border-color: #00489f;
-  --button-primary-hover-foreground-color: #fff;
-  --button-primary-disabled-background-color: #0654ba;
-  --button-primary-disabled-border-color: #0654ba;
-  --button-primary-disabled-foreground-color: #fff;
-  --button-secondary-background-color: rgba(238, 238, 238, 0.5);
-  --button-secondary-border-color: #999;
-  --button-secondary-foreground-color: #555;
-  --button-secondary-hover-border-color: #767676;
-  --button-secondary-hover-foreground-color: #555;
-  --button-secondary-disabled-background-color: #ccc;
-  --button-secondary-disabled-border-color: #999;
-  --button-secondary-disabled-foreground-color: #555;
-  --button-delete-background-color: #fff;
-  --button-delete-foreground-color: #dd1e31;
-}
-button.btn,
-a.fake-btn {
   border: 1px solid;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -1,25 +1,3 @@
-button.btn,
-a.fake-btn {
-  --button-border-radius: 0;
-  --button-primary-background-color: #3665f3;
-  --button-primary-border-color: #3665f3;
-  --button-primary-foreground-color: #fff;
-  --button-primary-hover-border-color: #3665f3;
-  --button-primary-hover-foreground-color: #fff;
-  --button-primary-disabled-background-color: #c7c7c7;
-  --button-primary-disabled-border-color: #c7c7c7;
-  --button-primary-disabled-foreground-color: #fff;
-  --button-secondary-background-color: #fff;
-  --button-secondary-border-color: #3665f3;
-  --button-secondary-foreground-color: #3665f3;
-  --button-secondary-hover-border-color: #2b0eaf;
-  --button-secondary-hover-foreground-color: #2b0eaf;
-  --button-secondary-disabled-background-color: #fff;
-  --button-secondary-disabled-border-color: #c7c7c7;
-  --button-secondary-disabled-foreground-color: #c7c7c7;
-  --button-delete-background-color: #fff;
-  --button-delete-foreground-color: #e62048;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode button.btn,
   .skin-experiment-dark-mode a.fake-btn {

--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -1,9 +1,3 @@
-.carousel {
-  --carousel-paddle-background-color: #fff;
-  --carousel-paddle-foreground-color: #333;
-  --carousel-playback-background-color: rgba(0, 0, 0, 0.45);
-  --carousel-playback-foreground-color: #fff;
-}
 /* stylelint-disable no-descending-specificity, comment-empty-line-before */
 .carousel {
   position: relative;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -1,9 +1,3 @@
-.carousel {
-  --carousel-paddle-background-color: #fff;
-  --carousel-paddle-foreground-color: #111820;
-  --carousel-playback-background-color: rgba(0, 0, 0, 0.45);
-  --carousel-playback-foreground-color: #fff;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .carousel {
     --carousel-paddle-background-color: #171717;

--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -1,8 +1,4 @@
 .checkbox {
-  --checkbox-checked-color: #0654ba;
-  --checkbox-unchecked-color: #333;
-}
-.checkbox {
   display: -webkit-inline-box;
   display: inline-flex;
   position: relative;

--- a/dist/checkbox/ds6/checkbox.css
+++ b/dist/checkbox/ds6/checkbox.css
@@ -1,7 +1,3 @@
-.checkbox {
-  --checkbox-checked-color: #3665f3;
-  --checkbox-unchecked-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .checkbox {
     --checkbox-checked-color: #5192ff;

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -1,15 +1,4 @@
 .combobox {
-  --combobox-background-color: #fff;
-  --combobox-border-color: #ccc;
-  --combobox-border-radius: 3px;
-  --combobox-foreground-color: #333;
-  --combobox-focus-border-color: #0654ba;
-  --dropdown-items-background-color: #fff;
-  --dropdown-items-border-color: #ccc;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #eee;
-}
-.combobox {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   line-height: normal;

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -1,14 +1,3 @@
-.combobox {
-  --combobox-background-color: #fff;
-  --combobox-border-color: #a2a2a2;
-  --combobox-border-radius: 0;
-  --combobox-foreground-color: #111820;
-  --combobox-focus-border-color: #3665f3;
-  --dropdown-items-background-color: #fff;
-  --dropdown-items-border-color: #c7c7c7;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #e5e5e5;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .combobox {
     --combobox-background-color: #171717;

--- a/dist/cta-button/ds4/cta-button.css
+++ b/dist/cta-button/ds4/cta-button.css
@@ -1,15 +1,4 @@
 a.cta-btn {
-  --cta-button-background-color: #fff;
-  --cta-button-foreground-color: #333;
-  --cta-button-disabled-background-color: #fff;
-  --cta-button-disabled-border-color: #fff;
-  --cta-button-disabled-foreground-color: #fff;
-  --cta-button-hover-background-color: #333;
-  --cta-button-hover-border-color: #333;
-  --cta-button-hover-foreground-color: #fff;
-  --cta-button-visited-foreground-color: #333;
-}
-a.cta-btn {
   border: 1px solid;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;

--- a/dist/cta-button/ds6/cta-button.css
+++ b/dist/cta-button/ds6/cta-button.css
@@ -1,14 +1,3 @@
-a.cta-btn {
-  --cta-button-background-color: #fff;
-  --cta-button-foreground-color: #111820;
-  --cta-button-disabled-background-color: #fff;
-  --cta-button-disabled-border-color: #fff;
-  --cta-button-disabled-foreground-color: #fff;
-  --cta-button-hover-background-color: #111820;
-  --cta-button-hover-border-color: #111820;
-  --cta-button-hover-foreground-color: #fff;
-  --cta-button-visited-foreground-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode a.cta-btn {
     --cta-button-background-color: #171717;

--- a/dist/details/ds4/details.css
+++ b/dist/details/ds4/details.css
@@ -1,6 +1,3 @@
-.details {
-  --details-summary-foreground-color: #0654ba;
-}
 summary.details__summary {
   color: #0654ba;
   color: var(--details-summary-foreground-color, #0654ba);

--- a/dist/details/ds6/details.css
+++ b/dist/details/ds6/details.css
@@ -1,6 +1,3 @@
-.details {
-  --details-summary-foreground-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode details {
     --details-summary-foreground-color: #5192ff;

--- a/dist/drawer-dialog/ds4/drawer-dialog.css
+++ b/dist/drawer-dialog/ds4/drawer-dialog.css
@@ -1,6 +1,3 @@
-.drawer-dialog {
-  --dialog-window-background-color: #fff;
-}
 /* large screens */
 .drawer-dialog[role="dialog"] {
   background-color: rgba(51, 51, 51, 0.7);

--- a/dist/drawer-dialog/ds6/drawer-dialog.css
+++ b/dist/drawer-dialog/ds6/drawer-dialog.css
@@ -1,6 +1,3 @@
-.drawer-dialog {
-  --dialog-window-background-color: #fff;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .drawer-dialog {
     --dialog-window-background-color: #212121;

--- a/dist/expand-button/ds4/expand-button.css
+++ b/dist/expand-button/ds4/expand-button.css
@@ -1,21 +1,4 @@
 button.expand-btn {
-  --button-border-radius: 3px;
-  --expand-button-hover-foreground-color: #00489f;
-  /* following properties are deprecated  */
-  --button-primary-background-color: #0654ba;
-  --button-primary-border-color: #0654ba;
-  --button-primary-foreground-color: #fff;
-  --button-primary-disabled-background-color: #0654ba;
-  --button-primary-disabled-border-color: #0654ba;
-  --button-primary-disabled-foreground-color: #fff;
-  --button-secondary-background-color: rgba(238, 238, 238, 0.5);
-  --button-secondary-border-color: #999;
-  --button-secondary-foreground-color: #555;
-  --button-secondary-disabled-background-color: #ccc;
-  --button-secondary-disabled-border-color: #999;
-  --button-secondary-disabled-foreground-color: #555;
-}
-button.expand-btn {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   font-family: inherit;

--- a/dist/expand-button/ds6/expand-button.css
+++ b/dist/expand-button/ds6/expand-button.css
@@ -1,20 +1,3 @@
-button.expand-btn {
-  --button-border-radius: 0;
-  --expand-button-hover-foreground-color: #2b0eaf;
-  /* following properties are deprecated  */
-  --button-primary-background-color: #3665f3;
-  --button-primary-border-color: #3665f3;
-  --button-primary-foreground-color: #fff;
-  --button-primary-disabled-background-color: #c7c7c7;
-  --button-primary-disabled-border-color: #c7c7c7;
-  --button-primary-disabled-foreground-color: #fff;
-  --button-secondary-background-color: #fff;
-  --button-secondary-border-color: #3665f3;
-  --button-secondary-foreground-color: #3665f3;
-  --button-secondary-disabled-background-color: #fff;
-  --button-secondary-disabled-border-color: #c7c7c7;
-  --button-secondary-disabled-foreground-color: #c7c7c7;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode button.expand-btn {
     --expand-button-hover-foreground-color: #94bcff;

--- a/dist/filter-button/ds4/filter-button.css
+++ b/dist/filter-button/ds4/filter-button.css
@@ -1,12 +1,3 @@
-button.filter-button,
-a.filter-link,
-button.filter-menu-button__button {
-  --filter-button-background-color: #eee;
-  --filter-button-foreground-color: #333;
-  --filter-button-hover-background-color: #ddd;
-  --filter-button-selected-background-color: #dbeafe;
-  --filter-button-selected-hover-background-color: #a9cdfc;
-}
 div.filter-group {
   display: -webkit-box;
   display: flex;

--- a/dist/filter-button/ds6/filter-button.css
+++ b/dist/filter-button/ds6/filter-button.css
@@ -1,12 +1,3 @@
-button.filter-button,
-a.filter-link,
-button.filter-menu-button__button {
-  --filter-button-background-color: #f5f5f5;
-  --filter-button-foreground-color: #111820;
-  --filter-button-hover-background-color: #e5e5e5;
-  --filter-button-selected-background-color: #e1e8fd;
-  --filter-button-selected-hover-background-color: #c2d0fb;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode button.filter-button,
   .skin-experiment-dark-mode a.filter-link,

--- a/dist/filter-menu-button/ds4/filter-menu-button.css
+++ b/dist/filter-menu-button/ds4/filter-menu-button.css
@@ -1,6 +1,3 @@
-.filter-menu-button {
-  --filter-menu-button-icon-color: #333;
-}
 div.filter-group {
   display: -webkit-box;
   display: flex;

--- a/dist/filter-menu-button/ds6/filter-menu-button.css
+++ b/dist/filter-menu-button/ds6/filter-menu-button.css
@@ -1,6 +1,3 @@
-.filter-menu-button {
-  --filter-menu-button-icon-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .filter-menu-button {
     --filter-menu-button-icon-color: #dcdcdc;

--- a/dist/filter-menu/ds4/filter-menu.css
+++ b/dist/filter-menu/ds4/filter-menu.css
@@ -1,14 +1,4 @@
 .filter-menu,
-.filter-menu-form,
-.filter-menu-button {
-  --filter-menu-border-color: #eee;
-  --filter-menu-item-unchecked-color: #767676;
-  --filter-menu-item-checked-color: #0654ba;
-  --filter-menu-item-background-color: #fff;
-  --filter-menu-item-foreground-color: #333;
-  --filter-menu-item-hover-background-color: #eee;
-}
-.filter-menu,
 .filter-menu-form {
   background-color: #fff;
   background-color: var(--filter-menu-item-background-color, #fff);

--- a/dist/filter-menu/ds6/filter-menu.css
+++ b/dist/filter-menu/ds6/filter-menu.css
@@ -1,13 +1,3 @@
-.filter-menu,
-.filter-menu-form,
-.filter-menu-button {
-  --filter-menu-border-color: #e5e5e5;
-  --filter-menu-item-unchecked-color: #767676;
-  --filter-menu-item-checked-color: #3665f3;
-  --filter-menu-item-background-color: #fff;
-  --filter-menu-item-foreground-color: #111820;
-  --filter-menu-item-hover-background-color: #f5f5f5;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .filter-menu,
   .skin-experiment-dark-mode .filter-menu-form,

--- a/dist/floating-label/ds4/floating-label.css
+++ b/dist/floating-label/ds4/floating-label.css
@@ -1,8 +1,4 @@
 .floating-label {
-  --floating-label-color: #767676;
-  --floating-label-disabled-color: #555;
-}
-.floating-label {
   margin-top: 14px;
   position: relative;
 }

--- a/dist/floating-label/ds6/floating-label.css
+++ b/dist/floating-label/ds6/floating-label.css
@@ -1,7 +1,3 @@
-.floating-label {
-  --floating-label-color: #767676;
-  --floating-label-disabled-color: #e5e5e5;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .floating-label {
     --floating-label-color: #ababab;

--- a/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds4/fullscreen-dialog.css
@@ -1,8 +1,4 @@
 /* large screens */
-.fullscreen-dialog {
-  --dialog-mask-background-color: #333;
-  --dialog-window-background-color: #fff;
-}
 .fullscreen-dialog[role="dialog"] {
   background-color: rgba(51, 51, 51, 0.7);
   bottom: 0;

--- a/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/ds6/fullscreen-dialog.css
@@ -1,8 +1,4 @@
 /* large screens */
-.fullscreen-dialog {
-  --dialog-mask-background-color: #111820;
-  --dialog-window-background-color: #fff;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .fullscreen-dialog {
     --dialog-window-background-color: #212121;

--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -1,10 +1,3 @@
-a.icon-link,
-button.icon-btn {
-  --icon-button-badge-border-color: #fff;
-  --icon-button-icon-foreground-color: #555;
-  --icon-button-icon-active-foreground-color: #555;
-  --icon-button-icon-hover-foreground-color: #333;
-}
 a.icon-link {
   -webkit-box-align: center;
           align-items: center;

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -1,10 +1,3 @@
-a.icon-link,
-button.icon-btn {
-  --icon-button-badge-border-color: #fff;
-  --icon-button-icon-foreground-color: #111820;
-  --icon-button-icon-active-foreground-color: #111820;
-  --icon-button-icon-hover-foreground-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode a.icon-link,
   .skin-experiment-dark-mode button.icon-btn {

--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -1,8 +1,4 @@
 .infotip {
-  --infotip-background-color: #fff;
-  --infotip-foreground-color: #333;
-}
-.infotip {
   position: relative;
 }
 span.infotip {

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -1,7 +1,3 @@
-.infotip {
-  --infotip-background-color: #fff;
-  --infotip-foreground-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .infotip {
     --infotip-background-color: #212121;

--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -1,8 +1,4 @@
 /* large screens */
-.lightbox-dialog {
-  --dialog-mask-background-color: #333;
-  --dialog-window-background-color: #fff;
-}
 .lightbox-dialog[role="dialog"],
 .lightbox-dialog[role="alertdialog"] {
   background-color: rgba(51, 51, 51, 0.7);

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -1,8 +1,4 @@
 /* large screens */
-.lightbox-dialog {
-  --dialog-mask-background-color: #111820;
-  --dialog-window-background-color: #fff;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .lightbox-dialog {
     --dialog-window-background-color: #212121;

--- a/dist/link/ds4/link.css
+++ b/dist/link/ds4/link.css
@@ -1,12 +1,4 @@
 a.nav-link {
-  --nav-link-color: #333;
-  --nav-link-hover-color: #0654ba;
-}
-button.fake-link {
-  --fake-link-color: #0654ba;
-  --fake-link-hover-color: #00489f;
-}
-a.nav-link {
   color: #333;
   color: var(--nav-link-color, #333);
   text-decoration: none;

--- a/dist/link/ds6/link.css
+++ b/dist/link/ds6/link.css
@@ -1,11 +1,3 @@
-a.nav-link {
-  --nav-link-color: #111820;
-  --nav-link-hover-color: #3665f3;
-}
-button.fake-link {
-  --fake-link-color: #3665f3;
-  --fake-link-hover-color: #2b0eaf;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode a.nav-link {
     --nav-link-color: #dcdcdc;

--- a/dist/listbox-button/ds4/listbox-button.css
+++ b/dist/listbox-button/ds4/listbox-button.css
@@ -1,12 +1,4 @@
 .listbox-button {
-  --listbox-button-invalid-border-color: #dd1e31;
-  --dropdown-items-background-color: #fff;
-  --dropdown-items-border-color: #ccc;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #eee;
-  --dropdown-item-active-status-color: #ccc;
-}
-.listbox-button {
   line-height: normal;
   position: relative;
   vertical-align: bottom;

--- a/dist/listbox-button/ds6/listbox-button.css
+++ b/dist/listbox-button/ds6/listbox-button.css
@@ -1,11 +1,3 @@
-.listbox-button {
-  --listbox-button-invalid-border-color: #e62048;
-  --dropdown-items-background-color: #fff;
-  --dropdown-items-border-color: #c7c7c7;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #e5e5e5;
-  --dropdown-item-active-status-color: #c7c7c7;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .listbox-button {
     --dropdown-items-background-color: #171717;

--- a/dist/listbox/ds4/listbox.css
+++ b/dist/listbox/ds4/listbox.css
@@ -1,11 +1,3 @@
-.listbox {
-  --dropdown-items-background-color: #fff;
-  --dropdown-items-border-color: #ccc;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-foreground-color: #333;
-  --dropdown-item-hover-background-color: #eee;
-  --dropdown-item-active-status-color: #ccc;
-}
 div.listbox {
   margin: 16px 0;
 }

--- a/dist/listbox/ds6/listbox.css
+++ b/dist/listbox/ds6/listbox.css
@@ -1,11 +1,3 @@
-.listbox {
-  --dropdown-items-background-color: #fff;
-  --dropdown-items-border-color: #c7c7c7;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-foreground-color: #111820;
-  --dropdown-item-hover-background-color: #e5e5e5;
-  --dropdown-item-active-status-color: #c7c7c7;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .listbox {
     --dropdown-items-background-color: #171717;

--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -1,14 +1,5 @@
 .menu-button,
 .fake-menu-button {
-  --dropdown-separator-color: #eee;
-  --dropdown-items-background-color: #fff;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #eee;
-  --dropdown-item-active-status-color: #ccc;
-  --dropdown-fake-anchor-color: #333;
-}
-.menu-button,
-.fake-menu-button {
   line-height: normal;
   position: relative;
 }

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -1,12 +1,3 @@
-.menu-button,
-.fake-menu-button {
-  --dropdown-separator-color: #e5e5e5;
-  --dropdown-items-background-color: #fff;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #e5e5e5;
-  --dropdown-item-active-status-color: #c7c7c7;
-  --dropdown-fake-anchor-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .menu-button,
   .skin-experiment-dark-mode .fake-menu-button {

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -1,12 +1,3 @@
-.menu,
-.fake-menu {
-  --dropdown-separator-color: #eee;
-  --dropdown-items-background-color: #fff;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #eee;
-  --dropdown-item-active-status-color: #ccc;
-  --dropdown-fake-anchor-color: #333;
-}
 .menu__items,
 .fake-menu__items {
   background-color: #fff;

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -1,12 +1,3 @@
-.menu,
-.fake-menu {
-  --dropdown-separator-color: #e5e5e5;
-  --dropdown-items-background-color: #fff;
-  --dropdown-item-background-color: #fff;
-  --dropdown-item-hover-background-color: #e5e5e5;
-  --dropdown-item-active-status-color: #c7c7c7;
-  --dropdown-fake-anchor-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .menu,
   .skin-experiment-dark-mode .fake-menu {

--- a/dist/page-notice/ds4/page-notice.css
+++ b/dist/page-notice/ds4/page-notice.css
@@ -1,12 +1,4 @@
 .page-notice {
-  --page-notice-attention-background-color: #fff;
-  --page-notice-attention-border-color: #dd1e31;
-  --page-notice-confirmation-background-color: #fff;
-  --page-notice-confirmation-border-color: #5ba71b;
-  --page-notice-information-background-color: #fff;
-  --page-notice-information-border-color: #0654ba;
-}
-.page-notice {
   border-radius: 0;
   border-radius: var(--page-notice-border-radius, 0);
   border-style: solid;

--- a/dist/page-notice/ds6/page-notice.css
+++ b/dist/page-notice/ds6/page-notice.css
@@ -1,11 +1,3 @@
-.page-notice {
-  --page-notice-attention-background-color: #fff5f8;
-  --page-notice-attention-border-color: #e62048;
-  --page-notice-confirmation-background-color: #effef0;
-  --page-notice-confirmation-border-color: #28a443;
-  --page-notice-information-background-color: #f1f8fe;
-  --page-notice-information-border-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .page-notice {
     --page-notice-attention-background-color: #191f1b;

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -1,12 +1,3 @@
-.pagination {
-  --pagination-item-foreground-color: #555;
-  --pagination-item-active-foreground-color: #333;
-  --pagination-item-hover-foreground-color: #333;
-  --pagination-item-current-background-color: #eee;
-  --pagination-item-current-border-color: transparent;
-  --pagination-item-current-border-radius: 0;
-  --pagination-item-current-foreground-color: #333;
-}
 nav.pagination {
   -webkit-box-align: center;
           align-items: center;

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -1,12 +1,3 @@
-.pagination {
-  --pagination-item-foreground-color: #111820;
-  --pagination-item-active-foreground-color: #111820;
-  --pagination-item-hover-foreground-color: #2b0eaf;
-  --pagination-item-current-background-color: transparent;
-  --pagination-item-current-border-color: #3665f3;
-  --pagination-item-current-border-radius: 0;
-  --pagination-item-current-foreground-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .pagination {
     --pagination-item-foreground-color: #dcdcdc;

--- a/dist/panel-dialog/ds4/panel-dialog.css
+++ b/dist/panel-dialog/ds4/panel-dialog.css
@@ -1,8 +1,4 @@
 /* large screens */
-.panel-dialog {
-  --dialog-mask-background-color: #333;
-  --dialog-window-background-color: #fff;
-}
 .panel-dialog[role="dialog"] {
   background-color: rgba(51, 51, 51, 0.7);
   bottom: 0;

--- a/dist/panel-dialog/ds6/panel-dialog.css
+++ b/dist/panel-dialog/ds6/panel-dialog.css
@@ -1,8 +1,4 @@
 /* large screens */
-.panel-dialog {
-  --dialog-mask-background-color: #111820;
-  --dialog-window-background-color: #fff;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .panel-dialog {
     --dialog-window-background-color: #212121;

--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -1,8 +1,4 @@
 .radio {
-  --radio-checked-color: #0654ba;
-  --radio-unchecked-color: #333;
-}
-.radio {
   display: -webkit-inline-box;
   display: inline-flex;
   position: relative;

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -1,7 +1,3 @@
-.radio {
-  --radio-checked-color: #3665f3;
-  --radio-unchecked-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .radio {
     --radio-checked-color: #5192ff;

--- a/dist/section-notice/ds4/section-notice.css
+++ b/dist/section-notice/ds4/section-notice.css
@@ -1,10 +1,4 @@
 .section-notice {
-  --section-notice-default-background-color: #eee;
-  --section-notice-attention-background-color: rgba(221, 30, 49, 0.2);
-  --section-notice-confirmation-background-color: rgba(91, 167, 27, 0.2);
-  --section-notice-information-background-color: rgba(6, 84, 186, 0.2);
-}
-.section-notice {
   background-color: #eee;
   background-color: var(--section-notice-default-background-color, #eee);
   border-radius: 0;

--- a/dist/section-notice/ds6/section-notice.css
+++ b/dist/section-notice/ds6/section-notice.css
@@ -1,9 +1,3 @@
-.section-notice {
-  --section-notice-default-background-color: #f5f5f5;
-  --section-notice-attention-background-color: #fff5f8;
-  --section-notice-confirmation-background-color: #effef0;
-  --section-notice-information-background-color: #f1f8fe;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .section-notice {
     --section-notice-default-background-color: #171717;

--- a/dist/section-title/ds4/section-title.css
+++ b/dist/section-title/ds4/section-title.css
@@ -1,9 +1,4 @@
 .section-title {
-  --section-title-foreground-color: #333;
-  --section-title-subtitle-color: #767676;
-  --section-title-separator-color: #eee;
-}
-.section-title {
   display: -webkit-box;
   display: flex;
   margin: 30px 0 10px 0;

--- a/dist/section-title/ds6/section-title.css
+++ b/dist/section-title/ds6/section-title.css
@@ -1,8 +1,3 @@
-.section-title {
-  --section-title-foreground-color: #111820;
-  --section-title-subtitle-color: #767676;
-  --section-title-separator-color: #e5e5e5;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .section-title {
     --section-title-foreground-color: #dcdcdc;

--- a/dist/select/ds4/select.css
+++ b/dist/select/ds4/select.css
@@ -1,11 +1,4 @@
 .select {
-  --select-background-color: #fff;
-  --select-border-color: #ccc;
-  --select-border-radius: 3px;
-  --select-foreground-color: #333;
-  --select-focus-border-color: #0654ba;
-}
-.select {
   color: #333;
   color: var(--select-foreground-color, #333);
   font-size: 0.875rem;

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -1,10 +1,3 @@
-.select {
-  --select-background-color: #fff;
-  --select-border-color: #a2a2a2;
-  --select-border-radius: 0;
-  --select-foreground-color: #111820;
-  --select-focus-border-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .select {
     --select-background-color: #171717;

--- a/dist/stepper/ds4/stepper.css
+++ b/dist/stepper/ds4/stepper.css
@@ -1,8 +1,3 @@
-.stepper {
-  --stepper-badge-background-color: #fff;
-  --stepper-text-dark-color: #333;
-  --stepper-text-light-color: #767676;
-}
 .stepper__items {
   display: -webkit-box;
   display: flex;

--- a/dist/stepper/ds6/stepper.css
+++ b/dist/stepper/ds6/stepper.css
@@ -1,8 +1,3 @@
-.stepper {
-  --stepper-badge-background-color: #fff;
-  --stepper-text-dark-color: #111820;
-  --stepper-text-light-color: #767676;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .stepper {
     --stepper-badge-background-color: black;

--- a/dist/switch/ds4/switch.css
+++ b/dist/switch/ds4/switch.css
@@ -1,10 +1,4 @@
 .switch {
-  --switch-checked-background-color: #0654ba;
-  --switch-disabled-background-color: #ccc;
-  --switch-unchecked-background-color: #767676;
-  --switch-foreground-color: #fff;
-}
-.switch {
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   height: 40px;

--- a/dist/switch/ds6/switch.css
+++ b/dist/switch/ds6/switch.css
@@ -1,9 +1,3 @@
-.switch {
-  --switch-checked-background-color: #3665f3;
-  --switch-disabled-background-color: #c7c7c7;
-  --switch-unchecked-background-color: #767676;
-  --switch-foreground-color: #fff;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .switch {
     --switch-checked-background-color: #5192ff;

--- a/dist/tabs/ds4/tabs.css
+++ b/dist/tabs/ds4/tabs.css
@@ -1,10 +1,3 @@
-.tabs,
-.fake-tabs {
-  --tabs-item-foreground-color: #767676;
-  --tabs-item-hover-foreground-color: #767676;
-  --tabs-item-hover-border-bottom-color: transparent;
-  --tabs-item-selected-foreground-color: #333;
-}
 span.tabs,
 span.fake-tabs {
   border-bottom: 1px solid transparent;

--- a/dist/tabs/ds6/tabs.css
+++ b/dist/tabs/ds6/tabs.css
@@ -1,10 +1,3 @@
-.tabs,
-.fake-tabs {
-  --tabs-item-foreground-color: #111820;
-  --tabs-item-hover-foreground-color: #3665f3;
-  --tabs-item-hover-border-bottom-color: #3665f3;
-  --tabs-item-selected-foreground-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .tabs,
   .skin-experiment-dark-mode .fake-tabs {

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -1,9 +1,3 @@
-.textbox {
-  --textbox-background-color: #fff;
-  --textbox-foreground-color: #555;
-  --textbox-border-color: #ccc;
-  --textbox-focus-border-color: #0654ba;
-}
 /* stylelint-disable no-descending-specificity */
 .textbox {
   color: #555;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -1,9 +1,3 @@
-.textbox {
-  --textbox-background-color: #fff;
-  --textbox-foreground-color: #111820;
-  --textbox-border-color: #a2a2a2;
-  --textbox-focus-border-color: #3665f3;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .textbox {
     --textbox-background-color: #171717;

--- a/dist/toast-dialog/ds4/toast-dialog.css
+++ b/dist/toast-dialog/ds4/toast-dialog.css
@@ -1,8 +1,4 @@
 .toast-dialog {
-  --toast-dialog-background-color: #0654ba;
-  --toast-dialog-foreground-color: #fff;
-}
-.toast-dialog {
   background-color: #0654ba;
   background-color: var(--toast-dialog-background-color, #0654ba);
   color: #fff;

--- a/dist/toast-dialog/ds6/toast-dialog.css
+++ b/dist/toast-dialog/ds6/toast-dialog.css
@@ -1,7 +1,3 @@
-.toast-dialog {
-  --toast-dialog-background-color: #3665f3;
-  --toast-dialog-foreground-color: #fff;
-}
 .skin-experiment-rounded .toast-dialog {
   --toast-dialog-border-radius: 16px 16px 0 0;
 }

--- a/dist/tooltip/ds4/tooltip.css
+++ b/dist/tooltip/ds4/tooltip.css
@@ -1,8 +1,4 @@
 .tooltip {
-  --tooltip-background-color: #0654ba;
-  --tooltip-foreground-color: #fff;
-}
-.tooltip {
   position: relative;
 }
 span.tooltip {

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -1,7 +1,3 @@
-.tooltip {
-  --tooltip-background-color: #3665f3;
-  --tooltip-foreground-color: #fff;
-}
 .skin-experiment-rounded .tooltip {
   --bubble-border-radius: 4px;
   --bubble-base-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);

--- a/dist/tourtip/ds4/tourtip.css
+++ b/dist/tourtip/ds4/tourtip.css
@@ -1,8 +1,4 @@
 .tourtip {
-  --tourtip-background-color: #0654ba;
-  --tourtip-foreground-color: #fff;
-}
-.tourtip {
   position: relative;
 }
 span.tourtip {

--- a/dist/tourtip/ds6/tourtip.css
+++ b/dist/tourtip/ds6/tourtip.css
@@ -1,7 +1,3 @@
-.tourtip {
-  --tourtip-background-color: #3665f3;
-  --tourtip-foreground-color: #fff;
-}
 .skin-experiment-rounded .tourtip {
   --bubble-border-radius: 4px;
   --bubble-base-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499972);

--- a/dist/typography/ds4/typography.css
+++ b/dist/typography/ds4/typography.css
@@ -1,6 +1,3 @@
-.secondary-text {
-  --typography-secondary-text-color: #767676;
-}
 .giant-text-2 {
   font-size: 2.25rem;
   font-weight: 500;

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -1,6 +1,3 @@
-.secondary-text {
-  --typography-secondary-text-color: #767676;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .secondary-text {
     --typography-secondary-text-color: #9c9c9c;

--- a/dist/window-notice/ds4/window-notice.css
+++ b/dist/window-notice/ds4/window-notice.css
@@ -1,9 +1,4 @@
 .window-notice {
-  --window-notice-background-color: #fff;
-  --window-notice-foreground-color: #457016;
-  --window-notice-title-foreground-color: #333;
-}
-.window-notice {
   background-color: #fff;
   background-color: var(--window-notice-background-color, #fff);
   -webkit-box-sizing: border-box;

--- a/dist/window-notice/ds6/window-notice.css
+++ b/dist/window-notice/ds6/window-notice.css
@@ -1,8 +1,3 @@
-.window-notice {
-  --window-notice-background-color: #fff;
-  --window-notice-foreground-color: #05823f;
-  --window-notice-title-foreground-color: #111820;
-}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .window-notice {
     --window-notice-background-color: #212121;

--- a/src/less/page-notice/base/page-notice.less
+++ b/src/less/page-notice/base/page-notice.less
@@ -64,7 +64,6 @@ span[role="region"].page-notice {
     margin: 0 0 4px 0;
 }
 
-// deprecated
 .page-notice__footer {
     margin-top: 8px;
     padding-left: 0;

--- a/src/less/properties/base/readme.txt
+++ b/src/less/properties/base/readme.txt
@@ -1,0 +1,3 @@
+These base files are currently unused and not imported anywhere. It doesn't look like they are needed and so they are scheduled for deletion.
+
+I will leave them around for now as they do provide a useful "at a glance" list of all available properties. These lists should probably be moved and documented elsewhere though.

--- a/src/less/properties/ds4/badge-properties.less
+++ b/src/less/properties/ds4/badge-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/badge-variables.less";
-@import "../base/badge-properties.less";

--- a/src/less/properties/ds4/breadcrumbs-properties.less
+++ b/src/less/properties/ds4/breadcrumbs-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/breadcrumbs-variables.less";
-@import "../base/breadcrumbs-properties.less";

--- a/src/less/properties/ds4/button-properties.less
+++ b/src/less/properties/ds4/button-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/button-variables.less";
-@import "../base/button-properties.less";

--- a/src/less/properties/ds4/carousel-properties.less
+++ b/src/less/properties/ds4/carousel-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/carousel-variables.less";
-@import "../base/carousel-properties.less";

--- a/src/less/properties/ds4/checkbox-properties.less
+++ b/src/less/properties/ds4/checkbox-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/checkbox-variables.less";
-@import "../base/checkbox-properties.less";

--- a/src/less/properties/ds4/combobox-properties.less
+++ b/src/less/properties/ds4/combobox-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/combobox-variables.less";
 @import "../../variables/ds4/dropdown-variables.less";
-@import "../base/combobox-properties.less";

--- a/src/less/properties/ds4/cta-button-properties.less
+++ b/src/less/properties/ds4/cta-button-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/button-variables.less";
 @import "../../variables/ds4/cta-button-variables.less";
-@import "../base/cta-button-properties.less";

--- a/src/less/properties/ds4/details-properties.less
+++ b/src/less/properties/ds4/details-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/details-variables.less";
-@import "../base/details-properties.less";

--- a/src/less/properties/ds4/drawer-dialog-properties.less
+++ b/src/less/properties/ds4/drawer-dialog-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/drawer-dialog-variables.less";
-@import "../base/drawer-dialog-properties.less";

--- a/src/less/properties/ds4/expand-button-properties.less
+++ b/src/less/properties/ds4/expand-button-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/button-variables.less";
 @import "../../variables/ds4/expand-button-variables.less";
-@import "../base/expand-button-properties.less";

--- a/src/less/properties/ds4/filter-button-properties.less
+++ b/src/less/properties/ds4/filter-button-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/filter-button-variables.less";
-@import "../base/filter-button-properties.less";

--- a/src/less/properties/ds4/filter-menu-button-properties.less
+++ b/src/less/properties/ds4/filter-menu-button-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/filter-menu-button-variables.less";
-@import "../base/filter-menu-button-properties.less";

--- a/src/less/properties/ds4/filter-menu-properties.less
+++ b/src/less/properties/ds4/filter-menu-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/filter-menu-variables.less";
-@import "../base/filter-menu-properties.less";

--- a/src/less/properties/ds4/floating-label-properties.less
+++ b/src/less/properties/ds4/floating-label-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/floating-label-variables.less";
-@import "../base/floating-label-properties.less";

--- a/src/less/properties/ds4/fullscreen-dialog-properties.less
+++ b/src/less/properties/ds4/fullscreen-dialog-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dialog-variables.less";
-@import "../base/fullscreen-dialog-properties.less";

--- a/src/less/properties/ds4/icon-button-properties.less
+++ b/src/less/properties/ds4/icon-button-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/icon-button-variables.less";
-@import "../base/icon-button-properties.less";

--- a/src/less/properties/ds4/infotip-properties.less
+++ b/src/less/properties/ds4/infotip-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/bubble-variables.less";
 @import "../../variables/ds4/infotip-variables.less";
-@import "../base/infotip-properties.less";

--- a/src/less/properties/ds4/inline-notice-properties.less
+++ b/src/less/properties/ds4/inline-notice-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/inline-notice-variables.less";
-@import "../base/inline-notice-properties.less";

--- a/src/less/properties/ds4/lightbox-dialog-properties.less
+++ b/src/less/properties/ds4/lightbox-dialog-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dialog-variables.less";
-@import "../base/lightbox-dialog-properties.less";

--- a/src/less/properties/ds4/link-properties.less
+++ b/src/less/properties/ds4/link-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/link-variables.less";
-@import "../base/link-properties.less";

--- a/src/less/properties/ds4/listbox-button-properties.less
+++ b/src/less/properties/ds4/listbox-button-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dropdown-variables.less";
 @import "../../variables/ds4/listbox-button-variables.less";
-@import "../base/listbox-button-properties.less";

--- a/src/less/properties/ds4/listbox-properties.less
+++ b/src/less/properties/ds4/listbox-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dropdown-variables.less";
 @import "../../variables/ds4/listbox-variables.less";
-@import "../base/listbox-properties.less";

--- a/src/less/properties/ds4/menu-button-properties.less
+++ b/src/less/properties/ds4/menu-button-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dropdown-variables.less";
 @import "../../variables/ds4/menu-button-variables.less";
-@import "../base/menu-button-properties.less";

--- a/src/less/properties/ds4/menu-properties.less
+++ b/src/less/properties/ds4/menu-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dropdown-variables.less";
 @import "../../variables/ds4/menu-variables.less";
-@import "../base/menu-properties.less";

--- a/src/less/properties/ds4/page-notice-properties.less
+++ b/src/less/properties/ds4/page-notice-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/page-notice-variables.less";
-@import "../base/page-notice-properties.less";

--- a/src/less/properties/ds4/pagination-properties.less
+++ b/src/less/properties/ds4/pagination-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/pagination-variables.less";
-@import "../base/pagination-properties.less";

--- a/src/less/properties/ds4/panel-dialog-properties.less
+++ b/src/less/properties/ds4/panel-dialog-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dialog-variables.less";
-@import "../base/panel-dialog-properties.less";

--- a/src/less/properties/ds4/radio-properties.less
+++ b/src/less/properties/ds4/radio-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/radio-variables.less";
-@import "../base/radio-properties.less";

--- a/src/less/properties/ds4/section-notice-properties.less
+++ b/src/less/properties/ds4/section-notice-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/section-notice-variables.less";
-@import "../base/section-notice-properties.less";

--- a/src/less/properties/ds4/section-title-properties.less
+++ b/src/less/properties/ds4/section-title-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/section-title-variables.less";
-@import "../base/section-title-properties.less";

--- a/src/less/properties/ds4/select-properties.less
+++ b/src/less/properties/ds4/select-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/dropdown-variables.less";
 @import "../../variables/ds4/select-variables.less";
-@import "../base/select-properties.less";

--- a/src/less/properties/ds4/stepper-properties.less
+++ b/src/less/properties/ds4/stepper-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/stepper-variables.less";
-@import "../base/stepper-properties.less";

--- a/src/less/properties/ds4/switch-properties.less
+++ b/src/less/properties/ds4/switch-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/switch-variables.less";
-@import "../base/switch-properties.less";

--- a/src/less/properties/ds4/tabs-properties.less
+++ b/src/less/properties/ds4/tabs-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/tabs-variables.less";
-@import "../base/tabs-properties.less";

--- a/src/less/properties/ds4/textbox-properties.less
+++ b/src/less/properties/ds4/textbox-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/textbox-variables.less";
-@import "../base/textbox-properties.less";

--- a/src/less/properties/ds4/toast-dialog-properties.less
+++ b/src/less/properties/ds4/toast-dialog-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/toast-dialog-variables.less";
-@import "../base/toast-dialog-properties.less";

--- a/src/less/properties/ds4/tooltip-properties.less
+++ b/src/less/properties/ds4/tooltip-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/bubble-variables.less";
 @import "../../variables/ds4/tooltip-variables.less";
-@import "../base/tooltip-properties.less";

--- a/src/less/properties/ds4/tourtip-properties.less
+++ b/src/less/properties/ds4/tourtip-properties.less
@@ -2,4 +2,3 @@
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/bubble-variables.less";
 @import "../../variables/ds4/tourtip-variables.less";
-@import "../base/tourtip-properties.less";

--- a/src/less/properties/ds4/typography-properties.less
+++ b/src/less/properties/ds4/typography-properties.less
@@ -1,3 +1,2 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
-@import "../base/typography-properties.less";

--- a/src/less/properties/ds4/window-notice-properties.less
+++ b/src/less/properties/ds4/window-notice-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds4/color-variables.less";
 @import "../../variables/ds4/typography-variables.less";
 @import "../../variables/ds4/window-notice-variables.less";
-@import "../base/window-notice-properties.less";

--- a/src/less/properties/ds6/badge-properties.less
+++ b/src/less/properties/ds6/badge-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/badge-variables.less";
-@import "../base/badge-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/breadcrumbs-properties.less
+++ b/src/less/properties/ds6/breadcrumbs-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/breadcrumbs-variables.less";
-@import "../base/breadcrumbs-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/button-properties.less
+++ b/src/less/properties/ds6/button-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/button-variables.less";
-@import "../base/button-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/carousel-properties.less
+++ b/src/less/properties/ds6/carousel-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/carousel-variables.less";
-@import "../base/carousel-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/checkbox-properties.less
+++ b/src/less/properties/ds6/checkbox-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/checkbox-variables.less";
-@import "../base/checkbox-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/combobox-properties.less
+++ b/src/less/properties/ds6/combobox-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/combobox-variables.less";
 @import "../../variables/ds6/dropdown-variables.less";
-@import "../base/combobox-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/cta-button-properties.less
+++ b/src/less/properties/ds6/cta-button-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/button-variables.less";
 @import "../../variables/ds6/cta-button-variables.less";
-@import "../base/cta-button-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/details-properties.less
+++ b/src/less/properties/ds6/details-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/details-variables.less";
-@import "../base/details-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/drawer-dialog-properties.less
+++ b/src/less/properties/ds6/drawer-dialog-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/drawer-dialog-variables.less";
-@import "../base/drawer-dialog-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/expand-button-properties.less
+++ b/src/less/properties/ds6/expand-button-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/button-variables.less";
 @import "../../variables/ds6/expand-button-variables.less";
-@import "../base/expand-button-properties.less";
 
 // Dark-mode (ds6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/filter-button-properties.less
+++ b/src/less/properties/ds6/filter-button-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/filter-button-variables.less";
-@import "../base/filter-button-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/filter-menu-button-properties.less
+++ b/src/less/properties/ds6/filter-menu-button-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/filter-menu-button-variables.less";
-@import "../base/filter-menu-button-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/filter-menu-properties.less
+++ b/src/less/properties/ds6/filter-menu-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/filter-menu-variables.less";
-@import "../base/filter-menu-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/floating-label-properties.less
+++ b/src/less/properties/ds6/floating-label-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/floating-label-variables.less";
-@import "../base/floating-label-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/fullscreen-dialog-properties.less
+++ b/src/less/properties/ds6/fullscreen-dialog-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dialog-variables.less";
-@import "../base/fullscreen-dialog-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/icon-button-properties.less
+++ b/src/less/properties/ds6/icon-button-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/icon-button-variables.less";
-@import "../base/icon-button-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/infotip-properties.less
+++ b/src/less/properties/ds6/infotip-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/bubble-variables.less";
 @import "../../variables/ds6/infotip-variables.less";
-@import "../base/infotip-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/inline-notice-properties.less
+++ b/src/less/properties/ds6/inline-notice-properties.less
@@ -1,4 +1,3 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/inline-notice-variables.less";
-@import "../base/inline-notice-properties.less";

--- a/src/less/properties/ds6/lightbox-dialog-properties.less
+++ b/src/less/properties/ds6/lightbox-dialog-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dialog-variables.less";
-@import "../base/lightbox-dialog-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/link-properties.less
+++ b/src/less/properties/ds6/link-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/link-variables.less";
-@import "../base/link-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/listbox-button-properties.less
+++ b/src/less/properties/ds6/listbox-button-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dropdown-variables.less";
 @import "../../variables/ds6/listbox-button-variables.less";
-@import "../base/listbox-button-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/listbox-properties.less
+++ b/src/less/properties/ds6/listbox-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dropdown-variables.less";
 @import "../../variables/ds6/listbox-variables.less";
-@import "../base/listbox-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/menu-button-properties.less
+++ b/src/less/properties/ds6/menu-button-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dropdown-variables.less";
 @import "../../variables/ds6/menu-button-variables.less";
-@import "../base/menu-button-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/menu-properties.less
+++ b/src/less/properties/ds6/menu-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dropdown-variables.less";
 @import "../../variables/ds6/menu-variables.less";
-@import "../base/menu-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/page-notice-properties.less
+++ b/src/less/properties/ds6/page-notice-properties.less
@@ -1,8 +1,6 @@
-
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/page-notice-variables.less";
-@import "../base/page-notice-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/pagination-properties.less
+++ b/src/less/properties/ds6/pagination-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/pagination-variables.less";
-@import "../base/pagination-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/panel-dialog-properties.less
+++ b/src/less/properties/ds6/panel-dialog-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dialog-variables.less";
-@import "../base/panel-dialog-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/radio-properties.less
+++ b/src/less/properties/ds6/radio-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/radio-variables.less";
-@import "../base/radio-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/section-notice-properties.less
+++ b/src/less/properties/ds6/section-notice-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/section-notice-variables.less";
-@import "../base/section-notice-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/section-title-properties.less
+++ b/src/less/properties/ds6/section-title-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/section-title-variables.less";
-@import "../base/section-title-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/select-properties.less
+++ b/src/less/properties/ds6/select-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/dropdown-variables.less";
 @import "../../variables/ds6/select-variables.less";
-@import "../base/select-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/stepper-properties.less
+++ b/src/less/properties/ds6/stepper-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/stepper-variables.less";
-@import "../base/stepper-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/switch-properties.less
+++ b/src/less/properties/ds6/switch-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/switch-variables.less";
-@import "../base/switch-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/tabs-properties.less
+++ b/src/less/properties/ds6/tabs-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/tabs-variables.less";
-@import "../base/tabs-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/textbox-properties.less
+++ b/src/less/properties/ds6/textbox-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/textbox-variables.less";
-@import "../base/textbox-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/toast-dialog-properties.less
+++ b/src/less/properties/ds6/toast-dialog-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/toast-dialog-variables.less";
-@import "../base/toast-dialog-properties.less";
 
 .skin-experiment-rounded {
     .toast-dialog {

--- a/src/less/properties/ds6/tooltip-properties.less
+++ b/src/less/properties/ds6/tooltip-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/bubble-variables.less";
 @import "../../variables/ds6/tooltip-variables.less";
-@import "../base/tooltip-properties.less";
 
 .skin-experiment-rounded {
     .tooltip {

--- a/src/less/properties/ds6/tourtip-properties.less
+++ b/src/less/properties/ds6/tourtip-properties.less
@@ -2,7 +2,6 @@
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/bubble-variables.less";
 @import "../../variables/ds6/tourtip-variables.less";
-@import "../base/tourtip-properties.less";
 
 .skin-experiment-rounded {
     .tourtip {

--- a/src/less/properties/ds6/typography-properties.less
+++ b/src/less/properties/ds6/typography-properties.less
@@ -1,6 +1,5 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
-@import "../base/typography-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {

--- a/src/less/properties/ds6/window-notice-properties.less
+++ b/src/less/properties/ds6/window-notice-properties.less
@@ -1,7 +1,6 @@
 @import "../../variables/ds6/color-variables.less";
 @import "../../variables/ds6/typography-variables.less";
 @import "../../variables/ds6/window-notice-variables.less";
-@import "../base/window-notice-properties.less";
 
 // Dark-mode (DS6 only)
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
Fixes #1273

This PR removes all custom properties from the top of the CSS dist files.  Given that we already supply a fallback value as the 2nd parameter of `var()`, it means those additional settings at the top of the files are redundant and we can reduce the payload to the client.

I'll leave the base files around for a little while, as I think having an at a glance view of all available props might be useful, but I will probably end up moving them somewhere else in the filesystem or to the documentation. 