### PR TITLE
Website: updated design system version numbers

### DIFF
--- a/docs/_includes/common/flags.html
+++ b/docs/_includes/common/flags.html
@@ -1,7 +1,7 @@
 <div id="flags">
     <h2>Flags</h2>
     <p>Skin has the ability to switch between different, yes you guessed it, <em>skins</em>. Two skins are currently supported: <span class="highlight">default</span> and <span class="highlight">legacy</span>.</p>
-    <p>Both skins are visual <em>expressions</em> of eBay's 6.5 design system language. All modules have identical markup, whichever skin is chosen; however, not all icons, variables and mixins are supported across versions, therefore be sure to reference the appropriate documentation.</p>
+    <p>Both skins are visual <em>expressions</em> of eBay's design system language. All modules have identical markup, whichever skin is chosen; however, not all icons, variables and mixins are supported across versions, therefore be sure to reference the appropriate documentation.</p>
     <p>To access the older legacy skin, a flag must be used.</p>
 
     <h4>Webpack Setup</h4>

--- a/docs/_includes/common/section-header.html
+++ b/docs/_includes/common/section-header.html
@@ -1,6 +1,6 @@
 <div class="section-header">
     <h2><span class="secondary-text">@ebay/skin/</span>{{ include.name }}</h2>
     {% if page.ds == 6 %}
-    <span class="section-header__version">{{ include.version }}</span>
+    <span class="section-header__version">DS v{{ include.version }}</span>
     {% endif %}
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,51 +4,49 @@ title: eBay Skin
 ds: 6
 static_dir: static
 versions:
-    badge: DS6.5.v1.01
-    breadcrumbs: DS6.5.v1.01
-    button: DS6.5.v1.01
-    carousel: DS6.5 R1
-    checkbox: DS6.5 v1.1
-    color: DS6.v2.01
-    combobox: DS6.v1.01
-    cta-button: DS6.5.v1.01
-    details: DS6.v1.01
-    lightbox-dialog: DS6.5.v1.02
-    drawer-dialog: DS6.5.v1.01
-    expand-button: DS6.5.v1.01
-    filter-button: DS6.5.v1.01
-    filter-menu: DS6.5.v1.01
-    filter-menu-button: DS6.5.v1.01
-    floating-label: DS6.v1.01
-    fullscreen-dialog: DS6.5.v1.02
-    icon: DS6.5.v1.1
-    icon-button: DS6.v1.01
-    infotip: DS6.v1.01
-    inline-notice: DS6.5.v1.01
-    less: DS6.v2.01
-    link: DS6.5 v1.04
-    listbox: DS6.v1.01
-    listbox-button: DS6.v1.01
-    menu: DS6.v1.01
-    menu-button: DS6.v1.01
-    notice: DS6.5.v1.01
-    page-notice: DS6.5.v1.01
-    pagination: DS6.v1.01
-    panel-dialog: DS6.5.v1.02
-    radio: DS6.5 v1.1
-    section-notice: DS6.5.v1.01
-    section-title: DS6.5 R0
-    select: DS6.v1.01
-    spinner: DS4
-    switch: DS6.5 v1.1
-    tabs: DS6.v2.01
-    textbox: DS6.v1.01
-    toast-dialog: DS6.5.v1.01
-    tooltip: DS6.v1.01
-    tourtip: DS6.v1.01
-    typography: DS6.5 v1.1
-    stepper: DS6.v2.01
-    window-notice: DS6.5.v1.01
+    badge: 1.2.0
+    breadcrumbs: 1.2.0
+    button: 1.1.0
+    carousel: 1.1.0
+    checkbox: 1.2.0
+    color: 2.2.0
+    combobox: 2.0.0
+    cta-button: 1.1.0
+    details: 1.2.0
+    lightbox-dialog: 2.0.0
+    drawer-dialog: 1.2.0
+    expand-button: 1.1.0
+    filter-button: 1.1.0
+    filter-menu: 1.1.0
+    filter-menu-button: 1.1.0
+    floating-label: 1.1.0
+    fullscreen-dialog: 2.0.0
+    icon: 1.3.0
+    icon-button: 1.1.0
+    infotip: 1.0.0
+    inline-notice: 1.0.0
+    link: 1.4.0
+    listbox: 1.1.0
+    listbox-button: 1.1.0
+    menu: 1.1.0
+    menu-button: 1.1.0
+    page-notice: 1.0.0
+    pagination: 1.1.0
+    panel-dialog: 2.0.0
+    radio: 1.2.0
+    section-notice: 1.0.0
+    section-title: 1.1.0
+    select: 1.1.0
+    spinner: 2.1.0
+    stepper: 2.1.0
+    switch: 1.2.0
+    tabs: 2.1.0
+    textbox: 1.1.0
+    toast-dialog: 2.1.0
+    tooltip: 1.0.0
+    tourtip: 1.0.0
+    typography: 1.1.0
+    window-notice: 1.0.0
 ---
 
 {% include common/main.html %}


### PR DESCRIPTION
# Fixes #1293 

Quick PR to update version numbers to new system. For rounded modules that are still hidden behind a flag, I have set the semantic version as one minor version lower than displayed in playbook.

I would like to display these numbers on the old legacy (ds4) page too, but that would require some shuffling around of things in Jekyll (because the variables currently live in the ds6 page only).

This can be squashed and merged directly to master.