### PR TITLE
Added legacy textbox module with underline and old floating label

### DIFF
--- a/browser.json
+++ b/browser.json
@@ -46,6 +46,11 @@
       "if-flag": "ds-4"
     },
     {
+      "from": "./dist/legacy-textbox/ds6/legacy-textbox.css",
+      "to": "./dist/legacy-textbox/ds4/legacy-textbox.css",
+      "if-flag": "ds-4"
+    },
+    {
       "from": "./rounded-off.js",
       "to": "./rounded-off[ds-4].js",
       "if-flag": "ds-4"

--- a/dist/legacy-textbox/ds4/legacy-textbox.css
+++ b/dist/legacy-textbox/ds4/legacy-textbox.css
@@ -1,0 +1,93 @@
+input.textbox__control--underline {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #ccc;
+  border-radius: 0;
+  font-weight: bold;
+  height: 1.875rem;
+  padding: 0 0 1px 0;
+}
+input.textbox__control--underline::-webkit-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline::-moz-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline:-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline::-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline::placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-webkit-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-moz-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]:-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::placeholder {
+  color: transparent;
+}
+input.textbox__control--underline:focus::-webkit-input-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus::-moz-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus:-ms-input-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus::-ms-input-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus::placeholder {
+  color: #767676;
+}
+.floating-label {
+  margin-top: 14px;
+  position: relative;
+}
+span.floating-label {
+  display: inline-block;
+}
+div.floating-label {
+  display: block;
+}
+label.floating-label__label {
+  color: #767676;
+  color: var(--floating-label-color, #767676);
+  display: block;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  -webkit-transform: scale(0.75, 0.75) translate(0, -24px);
+          transform: scale(0.75, 0.75) translate(0, -24px);
+  -webkit-transform-origin: left;
+          transform-origin: left;
+  z-index: 1;
+}
+label.floating-label__label--inline {
+  bottom: 0.4375rem;
+  font-size: 0.875rem;
+  -webkit-transform: none;
+          transform: none;
+}
+label.floating-label__label--animate {
+  -webkit-transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+label.floating-label__label--disabled {
+  color: #555;
+  color: var(--floating-label-disabled-color, #555);
+}

--- a/dist/legacy-textbox/ds6/legacy-textbox.css
+++ b/dist/legacy-textbox/ds6/legacy-textbox.css
@@ -1,0 +1,93 @@
+input.textbox__control--underline {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #767676;
+  border-radius: 0;
+  font-weight: bold;
+  height: 1.875rem;
+  padding: 0 0 1px 0;
+}
+input.textbox__control--underline::-webkit-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline::-moz-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline:-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline::-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline::placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-webkit-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-moz-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]:-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::-ms-input-placeholder {
+  color: transparent;
+}
+input.textbox__control--underline[disabled]::placeholder {
+  color: transparent;
+}
+input.textbox__control--underline:focus::-webkit-input-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus::-moz-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus:-ms-input-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus::-ms-input-placeholder {
+  color: #767676;
+}
+input.textbox__control--underline:focus::placeholder {
+  color: #767676;
+}
+.floating-label {
+  margin-top: 14px;
+  position: relative;
+}
+span.floating-label {
+  display: inline-block;
+}
+div.floating-label {
+  display: block;
+}
+label.floating-label__label {
+  color: #767676;
+  color: var(--floating-label-color, #767676);
+  display: block;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  -webkit-transform: scale(0.75, 0.75) translate(0, -24px);
+          transform: scale(0.75, 0.75) translate(0, -24px);
+  -webkit-transform-origin: left;
+          transform-origin: left;
+  z-index: 1;
+}
+label.floating-label__label--inline {
+  bottom: 0.4375rem;
+  font-size: 0.875rem;
+  -webkit-transform: none;
+          transform: none;
+}
+label.floating-label__label--animate {
+  -webkit-transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), -webkit-transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+label.floating-label__label--disabled {
+  color: #a2a2a2;
+  color: var(--floating-label-disabled-color, #a2a2a2);
+}

--- a/legacy-textbox.browser.json
+++ b/legacy-textbox.browser.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "require: ./legacy-textbox"
+    ]
+}

--- a/legacy-textbox.js
+++ b/legacy-textbox.js
@@ -1,0 +1,1 @@
+require('./dist/legacy-textbox/ds6/legacy-textbox.css');

--- a/legacy-textbox[ds-4].js
+++ b/legacy-textbox[ds-4].js
@@ -1,0 +1,1 @@
+require('./dist/legacy-textbox/ds4/legacy-textbox.css');

--- a/scripts/develop-module_proper/code-generators/style-generator.js
+++ b/scripts/develop-module_proper/code-generators/style-generator.js
@@ -12,7 +12,7 @@ const getBaseStyleContent = moduleId => `// This is boilerplate generated style.
 const getReferBaseStyleContent = moduleId => `@import '../base/${moduleId}.less';\n`;
 const getModuleBrowserContent = moduleId => `{
     "dependencies": [
-        "./dist/${moduleId}/ds6/${moduleId}.css"
+        "require: ./${moduleId}"
     ]
 }
 `;
@@ -95,7 +95,7 @@ class StyleGenerator extends BaseGenerator {
     }
 
     _addPackagingIndexDependencies() {
-        this._addDependencies(`        "./${this.moduleId}"`, 'index.browser.json');
+        this._addDependencies(`        "require: ./${this.moduleId}"`, 'index.browser.json');
     }
 
     _addPackagingBrowserDependencies() {
@@ -156,17 +156,17 @@ class StyleGenerator extends BaseGenerator {
     }
 
     _addPackagingStylesDsReference(version) {
-        const filePathFromRoot = `${this.moduleId}${version === 'ds4' ? '[ds-4]' : ''}.less`;
+        const filePathFromRoot = `${this.moduleId}${version === 'ds4' ? '[ds-4]' : ''}.js`;
         if (fs.existsSync(filePathFromRoot)) {
             log.warn('[STYLES][%s] Style already exists!', filePathFromRoot);
             return;
         }
-        fs.writeFileSync(filePathFromRoot, `@import "./dist/${this.moduleId}/${version}/${this.moduleId}.css";\n`);
+        fs.writeFileSync(filePathFromRoot, `require('./dist/${this.moduleId}/${version}/${this.moduleId}.css');\n`);
     }
 
     _addPackagingStylesIndexReference() {
-        const filePathFromRoot = 'index.less';
-        const newLineContent = `@import "./${this.moduleId}";`;
+        const filePathFromRoot = 'index.js';
+        const newLineContent = `require('./${this.moduleId}');`;
         writeLine({
             filePathFromRoot,
             newLineContent,

--- a/src/less/legacy-textbox/base/legacy-textbox.less
+++ b/src/less/legacy-textbox/base/legacy-textbox.less
@@ -1,0 +1,102 @@
+input.textbox__control--underline {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid @textbox-underline-color;
+    border-radius: 0;
+    font-weight: bold;
+    height: 1.875rem; // a11y: has to be relative to the text size
+    padding: 0 0 1px 0;
+
+    &::-webkit-input-placeholder {
+        color: transparent;
+    }
+
+    &::-moz-placeholder {
+        color: transparent;
+    }
+
+    &:-ms-input-placeholder {
+        color: transparent;
+    }
+
+    &::placeholder {
+        color: transparent;
+    }
+
+    &[disabled] {
+        &::-webkit-input-placeholder {
+            color: transparent;
+        }
+
+        &::-moz-placeholder {
+            color: transparent;
+        }
+
+        &:-ms-input-placeholder {
+            color: transparent;
+        }
+
+        &::placeholder {
+            color: transparent;
+        }
+    }
+
+    &:focus {
+        &::-webkit-input-placeholder {
+            color: @textbox-focus-placeholder-color;
+        }
+
+        &::-moz-placeholder {
+            color: @textbox-focus-placeholder-color;
+        }
+
+        &:-ms-input-placeholder {
+            color: @textbox-focus-placeholder-color;
+        }
+
+        &::placeholder {
+            color: @textbox-focus-placeholder-color;
+        }
+    }
+}
+
+@import "../../mixins/utility/utility-mixins.less";
+
+.floating-label {
+    margin-top: 14px;
+    position: relative;
+}
+
+span.floating-label {
+    display: inline-block;
+}
+
+div.floating-label {
+    display: block;
+}
+
+label.floating-label__label {
+    .customColorProperty(floating-label-color);
+
+    display: block;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    transform: scale(0.75, 0.75) translate(0, -24px);
+    transform-origin: left;
+    z-index: 1;
+}
+
+label.floating-label__label--inline {
+    bottom: 0.4375rem; // a11y: the position must be relative to the text size
+    font-size: @floating-label-inline-font-size;
+    transform: none;
+}
+
+label.floating-label__label--animate {
+    transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+label.floating-label__label--disabled {
+    .customColorProperty(floating-label-disabled-color);
+}

--- a/src/less/legacy-textbox/ds4/legacy-textbox.less
+++ b/src/less/legacy-textbox/ds4/legacy-textbox.less
@@ -1,0 +1,10 @@
+@import "../../variables/ds4/color-variables.less";
+@import "../../variables/ds4/typography-variables.less";
+
+@textbox-underline-color: @color-form-control-underline;
+@textbox-focus-placeholder-color: @color-grey5;
+@floating-label-color: @color-text-secondary;
+@floating-label-inline-font-size: @font-size-regular;
+@floating-label-disabled-color: @color-form-control-label-disabled;
+
+@import '../base/legacy-textbox.less';

--- a/src/less/legacy-textbox/ds6/legacy-textbox.less
+++ b/src/less/legacy-textbox/ds6/legacy-textbox.less
@@ -1,0 +1,10 @@
+@import "../../variables/ds6/color-variables.less";
+@import "../../variables/ds6/typography-variables.less";
+
+@textbox-underline-color: @color-form-control-underline;
+@textbox-focus-placeholder-color: @color-grey5;
+@floating-label-color: @color-text-secondary;
+@floating-label-inline-font-size: @font-size-regular;
+@floating-label-disabled-color: @color-form-control-label-disabled;
+
+@import '../base/legacy-textbox.less';

--- a/src/less/legacy-textbox/legacy-textbox.stories.js
+++ b/src/less/legacy-textbox/legacy-textbox.stories.js
@@ -1,0 +1,6 @@
+// Generated test
+export default { title: 'Legacy-textbox' };
+
+export const generatedVariant = () => `
+    <div class="legacy-textbox">Update This Code</div>
+`;


### PR DESCRIPTION
## Description
Added a legacy module, this will basically provide the old styles for floating label and textbox.

## Context
* Added all variables in the module itself so it's easy to remove.
* These should override the other styles as long as it's loaded last
* Also fixed the generator module to apply the correct paths and modules. 

## Screenshots
<img width="564" alt="Screen Shot 2020-12-07 at 3 57 08 PM" src="https://user-images.githubusercontent.com/1755269/101419627-4565f080-38a5-11eb-8ee7-69670c9f2aa2.png">
<img width="493" alt="Screen Shot 2020-12-07 at 3 57 17 PM" src="https://user-images.githubusercontent.com/1755269/101419629-46971d80-38a5-11eb-8c4d-31a4c28fa91f.png">
