### PR TITLE
Fixed padding and backgorund overrides for legacy underline textbox

### DIFF
--- a/dist/legacy-textbox/ds4/legacy-textbox.css
+++ b/dist/legacy-textbox/ds4/legacy-textbox.css
@@ -37,6 +37,9 @@ input.textbox__control--underline[disabled]::-ms-input-placeholder {
 input.textbox__control--underline[disabled]::placeholder {
   color: transparent;
 }
+input.textbox__control--underline:focus {
+  background: transparent;
+}
 input.textbox__control--underline:focus::-webkit-input-placeholder {
   color: #767676;
 }
@@ -90,4 +93,11 @@ label.floating-label__label--animate {
 label.floating-label__label--disabled {
   color: #555;
   color: var(--floating-label-disabled-color, #555);
+}
+.floating-label .textbox__control,
+.floating-label .combobox__control > input,
+.floating-label--large .textbox__control,
+.floating-label--large .combobox__control > input {
+  padding-bottom: auto;
+  padding-top: auto;
 }

--- a/dist/legacy-textbox/ds6/legacy-textbox.css
+++ b/dist/legacy-textbox/ds6/legacy-textbox.css
@@ -37,6 +37,9 @@ input.textbox__control--underline[disabled]::-ms-input-placeholder {
 input.textbox__control--underline[disabled]::placeholder {
   color: transparent;
 }
+input.textbox__control--underline:focus {
+  background: transparent;
+}
 input.textbox__control--underline:focus::-webkit-input-placeholder {
   color: #767676;
 }
@@ -90,4 +93,11 @@ label.floating-label__label--animate {
 label.floating-label__label--disabled {
   color: #a2a2a2;
   color: var(--floating-label-disabled-color, #a2a2a2);
+}
+.floating-label .textbox__control,
+.floating-label .combobox__control > input,
+.floating-label--large .textbox__control,
+.floating-label--large .combobox__control > input {
+  padding-bottom: auto;
+  padding-top: auto;
 }

--- a/src/less/legacy-textbox/base/legacy-textbox.less
+++ b/src/less/legacy-textbox/base/legacy-textbox.less
@@ -57,6 +57,8 @@ input.textbox__control--underline {
         &::placeholder {
             color: @textbox-focus-placeholder-color;
         }
+
+        background: transparent;
     }
 }
 
@@ -99,4 +101,12 @@ label.floating-label__label--animate {
 
 label.floating-label__label--disabled {
     .customColorProperty(floating-label-disabled-color);
+}
+
+.floating-label .textbox__control,
+.floating-label .combobox__control > input,
+.floating-label--large .textbox__control,
+.floating-label--large .combobox__control > input {
+    padding-bottom: auto;
+    padding-top: auto;
 }


### PR DESCRIPTION
## Description
After loading the floating label on ebayui I noticed two issues which are fixed here.
* Removed all padding to align textbox to the center not to the bottom as in the new floating way
* Forced focus background to be transparent on legacy

## Screenshots
<img width="561" alt="Screen Shot 2020-12-08 at 5 07 42 PM" src="https://user-images.githubusercontent.com/1755269/101560386-0d7bad80-3978-11eb-956e-84f63d9c0ce9.png">

