### PR TITLE
Cleaned up background color overrides for legacy-textbox

### DIFF
--- a/dist/legacy-textbox/ds4/legacy-textbox.css
+++ b/dist/legacy-textbox/ds4/legacy-textbox.css
@@ -1,5 +1,5 @@
 input.legacy-textbox-underline {
-  background: transparent;
+  background: #fff;
   border: none;
   border-bottom: 1px solid #ccc;
   border-radius: 0;
@@ -38,7 +38,7 @@ input.legacy-textbox-underline[disabled]::placeholder {
   color: transparent;
 }
 input.legacy-textbox-underline:focus {
-  background: transparent;
+  background: #fff;
 }
 input.legacy-textbox-underline:focus::-webkit-input-placeholder {
   color: #767676;

--- a/dist/legacy-textbox/ds6/legacy-textbox.css
+++ b/dist/legacy-textbox/ds6/legacy-textbox.css
@@ -1,5 +1,5 @@
 input.legacy-textbox-underline {
-  background: transparent;
+  background: #fff;
   border: none;
   border-bottom: 1px solid #767676;
   border-radius: 0;
@@ -38,7 +38,7 @@ input.legacy-textbox-underline[disabled]::placeholder {
   color: transparent;
 }
 input.legacy-textbox-underline:focus {
-  background: transparent;
+  background: #fff;
 }
 input.legacy-textbox-underline:focus::-webkit-input-placeholder {
   color: #767676;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17477,7 +17477,7 @@
       "integrity": "sha512-x1B07Qvz4H5hk5sfTrPNgWF4cPbQfxVWWdlYEyw3Igq9Cy75fGAtTd+HIp9/sxCQl8I9pSp10vi3a+eCpGrM6Q==",
       "dev": true,
       "requires": {
-        "dissolve": "github:deoxxa/dissolve#eeb806f2bad501548138c8e38d0adcf95d4d1bdb",
+        "dissolve": "dissolve@github:deoxxa/dissolve#eeb806f2bad501548138c8e38d0adcf95d4d1bdb",
         "mkdirp": "^0.5.1",
         "property-handlers": "^1.1.1",
         "raptor-async": "^1.1.3",

--- a/src/less/legacy-textbox/base/legacy-textbox.less
+++ b/src/less/legacy-textbox/base/legacy-textbox.less
@@ -1,7 +1,7 @@
 @import "../../mixins/utility/utility-mixins.less";
 
 input.legacy-textbox-underline {
-    background: transparent;
+    background: @color-background-default;
     border: none;
     border-bottom: 1px solid @textbox-underline-color;
     border-radius: 0;
@@ -60,7 +60,7 @@ input.legacy-textbox-underline {
             color: @textbox-focus-placeholder-color;
         }
 
-        background: transparent;
+        background: @color-background-default;
     }
 }
 

--- a/src/less/legacy-textbox/legacy-textbox.stories.js
+++ b/src/less/legacy-textbox/legacy-textbox.stories.js
@@ -1,6 +1,0 @@
-// Generated test
-export default { title: 'Legacy-textbox' };
-
-export const generatedVariant = () => `
-    <div class="legacy-textbox">Update This Code</div>
-`;


### PR DESCRIPTION
## Description
While testing on ebayui I found a couple more issues.
Fixed transparent background to be white like it was in the previous version.
Also removed a generated storybook file.

## Screenshots
<img width="273" alt="Screen Shot 2020-12-09 at 3 28 17 PM" src="https://user-images.githubusercontent.com/1755269/101701677-3a8d9600-3a34-11eb-9218-ba7feb560f89.png">
