### PR TITLE
Added flex-shrink to infotip close button

### DIFF
--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -183,6 +183,7 @@ span.infotip__heading {
   display: block;
 }
 .infotip .icon-btn {
+  flex-shrink: 0;
   height: 20px;
   overflow: visible;
   width: 20px;

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -197,6 +197,7 @@ span.infotip__heading {
   display: block;
 }
 .infotip .icon-btn {
+  flex-shrink: 0;
   height: 20px;
   overflow: visible;
   width: 20px;

--- a/src/less/infotip/base/infotip.less
+++ b/src/less/infotip/base/infotip.less
@@ -109,6 +109,7 @@ span.infotip__heading {
 
 // todo: refactor out this dependency. Use a mixin instead
 .infotip .icon-btn {
+    flex-shrink: 0; // todo: Should move to icon-btn in next major
     height: 20px;
     overflow: visible;
     width: 20px;


### PR DESCRIPTION
## Description
Added `flex-shrink` to infotip close button
We can add it to `icon-btn` next major version

## References
#1306

## Screenshots
<img width="455" alt="Screen Shot 2020-12-14 at 11 30 05 AM" src="https://user-images.githubusercontent.com/1755269/102126286-b9514d00-3dff-11eb-99fb-148c0ba9d2e5.png">
