### PR TITLE
Button: set min-width #1324

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -19,6 +19,7 @@ a.fake-btn {
   font-size: 0.875rem;
   max-width: 100%;
   min-height: 40px;
+  min-width: auto;
 }
 button.btn--fixed-height,
 a.fake-btn--fixed-height {
@@ -356,5 +357,6 @@ button.btn--icon-only,
 a.fake-btn--icon-only {
   border-radius: 3px;
   border-radius: var(--button-icon-border-radius, 3px);
+  min-width: auto;
   padding: 0;
 }

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -40,6 +40,7 @@ a.fake-btn {
   font-size: 0.875rem;
   max-width: 100%;
   min-height: 40px;
+  min-width: 128px;
 }
 button.btn--fixed-height,
 a.fake-btn--fixed-height {
@@ -377,5 +378,6 @@ button.btn--icon-only,
 a.fake-btn--icon-only {
   border-radius: 8px;
   border-radius: var(--button-icon-border-radius, 8px);
+  min-width: auto;
   padding: 0;
 }

--- a/dist/cta-button/ds4/cta-button.css
+++ b/dist/cta-button/ds4/cta-button.css
@@ -14,7 +14,7 @@ a.cta-btn {
   color: #333;
   color: var(--cta-button-foreground-color, #333);
   padding: 11px 16px;
-  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
+  padding: var(--button-padding-vertical, 11px) var(--cta-button-padding-horizontal, 16px);
   border-color: currentColor;
   display: inline-block;
   font-size: 0.875rem;

--- a/dist/cta-button/ds6/cta-button.css
+++ b/dist/cta-button/ds6/cta-button.css
@@ -23,8 +23,8 @@ a.cta-btn {
   border-radius: var(--button-border-radius, 48px);
   color: #111820;
   color: var(--cta-button-foreground-color, #111820);
-  padding: 11px 16px;
-  padding: var(--button-padding-vertical, 11px) var(--button-padding-horizontal, 16px);
+  padding: 11px 20px;
+  padding: var(--button-padding-vertical, 11px) var(--cta-button-padding-horizontal, 20px);
   border-color: currentColor;
   display: inline-block;
   font-size: 0.875rem;

--- a/dist/variables/ds4/button-variables.less
+++ b/dist/variables/ds4/button-variables.less
@@ -6,6 +6,7 @@
 @button-large-font-size: @font-size-medium;
 @button-disabled-opacity: @color-action-disabled-opacity;
 
+@button-min-width: auto;
 @button-padding-vertical: 11px;
 @button-padding-horizontal: 16px;
 @button-padding: @button-padding-vertical @button-padding-horizontal;

--- a/dist/variables/ds4/cta-button-variables.less
+++ b/dist/variables/ds4/cta-button-variables.less
@@ -7,3 +7,4 @@
 @cta-button-disabled-background-color: @color-background-default;
 @cta-button-disabled-border-color: @color-action-disabled;
 @cta-button-disabled-foreground-color: @color-action-disabled;
+@cta-button-padding-horizontal: 16px;

--- a/dist/variables/ds6/button-variables.less
+++ b/dist/variables/ds6/button-variables.less
@@ -6,6 +6,7 @@
 @button-large-font-size: @font-size-medium;
 @button-disabled-opacity: @color-action-disabled-opacity;
 
+@button-min-width: 128px;
 @button-padding-vertical: 11px;
 @button-padding-horizontal: 16px;
 @button-padding: @button-padding-vertical @button-padding-horizontal;

--- a/dist/variables/ds6/cta-button-variables.less
+++ b/dist/variables/ds6/cta-button-variables.less
@@ -7,3 +7,4 @@
 @cta-button-disabled-background-color: @color-background-default;
 @cta-button-disabled-border-color: @color-action-disabled;
 @cta-button-disabled-foreground-color: @color-action-disabled;
+@cta-button-padding-horizontal: 20px;

--- a/docs/_includes/common/button.html
+++ b/docs/_includes/common/button.html
@@ -364,6 +364,8 @@
 </div>
     {% endhighlight %}
 
+    {% if page.ds == 4 %}
+
     <h3 id="button-wide">Wide Button</h3>
 
     <p>For a wider button, use the <span class="highlight">btn--wide</span> modifier.</p>
@@ -377,5 +379,7 @@
     {% highlight html %}
 <button class="btn btn--wide">Button</button>
     {% endhighlight %}
+
+    {% endif %}
 
 </div>

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -13,6 +13,7 @@ a.fake-btn {
     font-size: @font-size-14;
     max-width: 100%;
     min-height: 40px;
+    min-width: @button-min-width;
 }
 
 button.btn--wide,
@@ -260,5 +261,6 @@ button.btn--icon-only,
 a.fake-btn--icon-only {
     .customBorderRadiusProperty(button-icon-border-radius);
 
+    min-width: auto;
     padding: 0;
 }

--- a/src/less/cta-button/base/cta-button.less
+++ b/src/less/cta-button/base/cta-button.less
@@ -5,7 +5,7 @@ a.cta-btn {
     .customBackgroundColorProperty(cta-button-background-color);
     .customBorderRadiusProperty(button-border-radius);
     .customColorProperty(cta-button-foreground-color);
-    .customPaddingProperty(button-padding-vertical, button-padding-horizontal);
+    .customPaddingProperty(button-padding-vertical, cta-button-padding-horizontal);
 
     border-color: currentColor;
     display: inline-block;

--- a/src/less/variables/ds4/button-variables.less
+++ b/src/less/variables/ds4/button-variables.less
@@ -6,6 +6,7 @@
 @button-large-font-size: @font-size-medium;
 @button-disabled-opacity: @color-action-disabled-opacity;
 
+@button-min-width: auto;
 @button-padding-vertical: 11px;
 @button-padding-horizontal: 16px;
 @button-padding: @button-padding-vertical @button-padding-horizontal;

--- a/src/less/variables/ds4/cta-button-variables.less
+++ b/src/less/variables/ds4/cta-button-variables.less
@@ -7,3 +7,4 @@
 @cta-button-disabled-background-color: @color-background-default;
 @cta-button-disabled-border-color: @color-action-disabled;
 @cta-button-disabled-foreground-color: @color-action-disabled;
+@cta-button-padding-horizontal: 16px;

--- a/src/less/variables/ds6/button-variables.less
+++ b/src/less/variables/ds6/button-variables.less
@@ -6,6 +6,7 @@
 @button-large-font-size: @font-size-medium;
 @button-disabled-opacity: @color-action-disabled-opacity;
 
+@button-min-width: 128px;
 @button-padding-vertical: 11px;
 @button-padding-horizontal: 16px;
 @button-padding: @button-padding-vertical @button-padding-horizontal;

--- a/src/less/variables/ds6/cta-button-variables.less
+++ b/src/less/variables/ds6/cta-button-variables.less
@@ -7,3 +7,4 @@
 @cta-button-disabled-background-color: @color-background-default;
 @cta-button-disabled-border-color: @color-action-disabled;
 @cta-button-disabled-foreground-color: @color-action-disabled;
+@cta-button-padding-horizontal: 20px;


### PR DESCRIPTION
## Description

Design system updates:

* min-width changed from auto to 128px for rounded buttons.
* for icon-only buttons, sets min-width to auto
* horizontal padding changed from 16px to 20px for cta buttons

I haven't changed legacy buttons to have a min-width because I'm not sure it makes sense for non-rounded buttons (plus, we would be reverting the breaking changes we made in v11, which might be kind of annoying for teams!). Legacy pages can make use of the `btn--wide` modifier.

## References

Closes #1324

## Screenshots

Button spec
![Screen Shot 2021-01-07 at 10 48 33 AM](https://user-images.githubusercontent.com/38065/104050188-150ebc00-519b-11eb-987f-b4dc4bdf5aff.png)

DS6
![Screen Shot 2021-01-08 at 10 15 28 AM](https://user-images.githubusercontent.com/38065/104050221-2657c880-519b-11eb-8194-65a394f69483.png)

![Screen Shot 2021-01-08 at 10 16 04 AM](https://user-images.githubusercontent.com/38065/104050307-4ab3a500-519b-11eb-8bdb-6f9ce3c242ec.png)


DS4 (no changes)
![Screen Shot 2021-01-08 at 10 15 47 AM](https://user-images.githubusercontent.com/38065/104050248-340d4e00-519b-11eb-989c-b47ca4562b3d.png)

![Screen Shot 2021-01-08 at 10 15 55 AM](https://user-images.githubusercontent.com/38065/104050363-61f29280-519b-11eb-9cf0-41abe6ce5a4f.png)



