### PR TITLE
Added pagination stories and examples for dots

### DIFF
--- a/docs/_includes/common/pagination.html
+++ b/docs/_includes/common/pagination.html
@@ -222,4 +222,227 @@
     </a>
 </nav>
     {% endhighlight html %}
+
+    <h3 id="pagination-fluid">Pagination with dots</h3>
+    <p>Apply an extra item with <span class="highlight">…</span> before the last item in the pagination lists.
+    Then you should hide all extra items and only show them when in the correct range.
+    The dots and the last page should always be visible, unless there is a clear range to the last page.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <nav class="pagination" aria-labelledby="pagination-heading-4" role="navigation">
+                <span aria-live="polite" role="status">
+                    <h2 class="clipped" id="pagination-heading-3">Results Pagination - Page 1</h2>
+                </span>
+                <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+                    <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
+                        {% include common/symbol.html name="pagination-prev" %}
+                    </svg>
+                </a>
+                <ol class="pagination__items">
+                    <li>
+                        <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
+                    </li>
+                    <li>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
+                    </li>
+                    <li>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=4" class="pagination__item">4</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
+                    </li>
+                    <li>
+                        <button class="pagination__item" aria-disabled="true">…</button>
+                    </li>
+                    <li>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
+                    </li>
+                </ol>
+                <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+                    <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
+                        {% include common/symbol.html name="pagination-next" %}
+                    </svg>
+                </a>
+            </nav>
+        </div>
+    </div>
+    {% highlight html %}
+<nav class="pagination pagination--fluid" aria-labelledby="pagination-heading" role="navigation">
+    <span aria-live="off" role="status">
+        <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
+    </span>
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+        <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-prev"></use>
+        </svg>
+    </a>
+    <ol class="pagination__items">
+        <li>
+            <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=4" class="pagination__item">4</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
+        </li>
+        <li>
+            <button class="pagination__item" aria-disabled="true">…</button>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
+        </li>
+    </ol>
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+        <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-next"></use>
+        </svg>
+    </a>
+</nav>
+    {% endhighlight html %}
+
+    <div class="demo">
+        <div class="demo__inner">
+            <nav class="pagination" aria-labelledby="pagination-heading-4" role="navigation">
+                <span aria-live="polite" role="status">
+                    <h2 class="clipped" id="pagination-heading-3">Results Pagination - Page 1</h2>
+                </span>
+                <a aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+                    <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
+                        {% include common/symbol.html name="pagination-prev" %}
+                    </svg>
+                </a>
+                <ol class="pagination__items">
+                    <li hidden>
+                        <a  href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=4" class="pagination__item">4</a>
+                    </li>
+                    <li hidden>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
+                    </li>
+                    <li>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
+                    </li>
+                    <li>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
+                    </li>
+                    <li>
+                        <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
+                    </li>
+                    <li>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
+                    </li>
+                    <li hidden>
+                        <button class="pagination__item" aria-disabled="true">…</button>
+                    </li>
+                    <li>
+                        <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
+                    </li>
+                </ol>
+                <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+                    <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
+                        {% include common/symbol.html name="pagination-next" %}
+                    </svg>
+                </a>
+            </nav>
+        </div>
+    </div>
+    {% highlight html %}
+<nav class="pagination pagination--fluid" aria-labelledby="pagination-heading" role="navigation">
+    <span aria-live="off" role="status">
+        <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
+    </span>
+    <a aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+        <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-prev"></use>
+        </svg>
+    </a>
+    <ol class="pagination__items">
+        <li hidden>
+            <a  href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=4" class="pagination__item">4</a>
+        </li>
+        <li hidden>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
+        </li>
+        <li>
+            <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
+        </li>
+        <li hidden>
+            <button class="pagination__item" aria-disabled="true">…</button>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
+        </li>
+
+    </ol>
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+        <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-next"></use>
+        </svg>
+    </a>
+</nav>
+    {% endhighlight html %}
+
+
+
 </div>

--- a/docs/_includes/common/pagination.html
+++ b/docs/_includes/common/pagination.html
@@ -268,7 +268,7 @@
                         <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
                     </li>
                     <li>
-                        <button class="pagination__item" aria-disabled="true">…</button>
+                        <span class="pagination__item">…</span>
                     </li>
                     <li>
                         <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
@@ -321,7 +321,7 @@
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
         <li>
-            <button class="pagination__item" aria-disabled="true">…</button>
+            <span class="pagination__item">…</span>
         </li>
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
@@ -375,7 +375,7 @@
                         <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
                     </li>
                     <li hidden>
-                        <button class="pagination__item" aria-disabled="true">…</button>
+                        <span class="pagination__item">…</span>
                     </li>
                     <li>
                         <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
@@ -428,7 +428,7 @@
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
         <li hidden>
-            <button class="pagination__item" aria-disabled="true">…</button>
+            <span class="pagination__item">…</span>
         </li>
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>

--- a/src/less/pagination/stories/dots.stories.js
+++ b/src/less/pagination/stories/dots.stories.js
@@ -82,10 +82,10 @@ export const dotsMiddle = () => `
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
         </li>
-        <li hidden>
+        <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
         </li>
-        <li>
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
         </li>
         <li hidden>

--- a/src/less/pagination/stories/dots.stories.js
+++ b/src/less/pagination/stories/dots.stories.js
@@ -26,16 +26,16 @@ export const base = () => `
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
         <li>
@@ -64,10 +64,10 @@ export const dotsMiddle = () => `
         </svg>
     </a>
     <ol class="pagination__items">
-        <li hidden="true">
+        <li hidden>
             <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
         </li>
         <li>
@@ -82,13 +82,13 @@ export const dotsMiddle = () => `
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
         </li>
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
         <li>
@@ -117,13 +117,13 @@ export const dotsHidden = () => `
         </svg>
     </a>
     <ol class="pagination__items">
-        <li hidden="true">
+        <li hidden>
             <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
         </li>
         <li>
@@ -144,7 +144,7 @@ export const dotsHidden = () => `
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
-        <li hidden="true">
+        <li hidden>
             <span class="pagination__item">…</span>
         </li>
         <li>

--- a/src/less/pagination/stories/dots.stories.js
+++ b/src/less/pagination/stories/dots.stories.js
@@ -39,7 +39,7 @@ export const base = () => `
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
         <li>
-            <button class="pagination__item" aria-disabled="true">…</button>
+            <span class="pagination__item">…</span>
         </li>
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
@@ -92,7 +92,7 @@ export const dotsMiddle = () => `
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
         <li>
-            <button class="pagination__item" aria-disabled="true">…</button>
+            <span class="pagination__item">…</span>
         </li>
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
@@ -145,7 +145,7 @@ export const dotsHidden = () => `
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
         </li>
         <li hidden="true">
-            <button class="pagination__item" aria-disabled="true">…</button>
+            <span class="pagination__item">…</span>
         </li>
         <li>
             <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>

--- a/src/less/pagination/stories/dots.stories.js
+++ b/src/less/pagination/stories/dots.stories.js
@@ -1,0 +1,160 @@
+export default { title: 'Pagination/Pagination/Dots' };
+
+export const base = () => `
+<nav class="pagination" aria-labelledby="pagination-heading" role="navigation">
+    <span aria-live="polite" role="status">
+        <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
+    </span>
+    <a aria-disabled="true" aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+        <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-prev"></use>
+        </svg>
+    </a>
+    <ol class="pagination__items">
+        <li>
+            <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=4" class="pagination__item">4</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
+        </li>
+        <li>
+            <button class="pagination__item" aria-disabled="true">…</button>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
+        </li>
+    </ol>
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+        <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-next"></use>
+        </svg>
+    </a>
+</nav>
+`;
+
+export const dotsMiddle = () => `
+<nav class="pagination" aria-labelledby="pagination-heading" role="navigation">
+    <span aria-live="polite" role="status">
+        <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
+    </span>
+    <a aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
+        <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-prev"></use>
+        </svg>
+    </a>
+    <ol class="pagination__items">
+        <li hidden="true">
+            <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=4" class="pagination__item">4</a>
+        </li>
+        <li>
+            <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
+        </li>
+        <li>
+            <button class="pagination__item" aria-disabled="true">…</button>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
+        </li>
+    </ol>
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+        <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-next"></use>
+        </svg>
+    </a>
+</nav>
+`;
+
+
+export const dotsHidden = () => `
+<nav class="pagination" aria-labelledby="pagination-heading" role="navigation">
+    <span aria-live="polite" role="status">
+        <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
+    </span>
+        <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-prev"></use>
+        </svg>
+    </a>
+    <ol class="pagination__items">
+        <li hidden="true">
+            <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars" class="pagination__item">1</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2" class="pagination__item">2</a>
+        </li>
+        <li hidden="true">
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=3" class="pagination__item">3</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=4" class="pagination__item">4</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=5" class="pagination__item">5</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=6" class="pagination__item">6</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=7" class="pagination__item">7</a>
+        </li>
+        <li>
+            <a aria-current="page" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=8" class="pagination__item">8</a>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=9" class="pagination__item">9</a>
+        </li>
+        <li hidden="true">
+            <button class="pagination__item" aria-disabled="true">…</button>
+        </li>
+        <li>
+            <a href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=10" class="pagination__item">10</a>
+        </li>
+    </ol>
+    <a aria-label="Next Page" class="icon-link pagination__next" href="http://www.ebay.com/sch/i.html?_nkw=guitars&_pgn=2">
+        <svg class="icon icon--pagination-next" focusable="false" height="24" width="24" aria-hidden="true">
+            <use xlink:href="#icon-pagination-next"></use>
+        </svg>
+    </a>
+</nav>
+`;


### PR DESCRIPTION
## Description
* Simply added pagination with dots examples.

## Context
For dots I used ascii keycode for three dots. Screen reader read it as `ellipsis` which is good.
I also added `aria-disabled` since the button is not active or does anything.

## References
#1337 

## Screenshots
<img width="1127" alt="Screen Shot 2021-01-28 at 12 40 43 PM" src="https://user-images.githubusercontent.com/1755269/106196254-1150d280-6166-11eb-9781-000b46b0c9f3.png">

