### PR TITLE
Changed breadcrumb icon to use 8 width viewport

### DIFF
--- a/dist/svg/ds6/icons.svg
+++ b/dist/svg/ds6/icons.svg
@@ -494,7 +494,7 @@
     <symbol viewBox="0 0 10 18" id="icon-back">
         <path d="M8.995 18a1.002 1.002 0 01-.709-.29L.296 9.712a1.002 1.002 0 010-1.42L8.286.294a1.002 1.002 0 111.418 1.42l-7.29 7.288 7.29 7.288A1.002 1.002 0 018.995 18z"></path>
     </symbol>
-    <symbol viewBox="0 0 14 14" id="icon-breadcrumb">
+    <symbol viewBox="0 0 8 14" id="icon-breadcrumb">
         <path d="M1.005 14a1 1 0 01-.71-1.71l5.296-5.288L.296 1.714A1.004 1.004 0 011.714.294L7.71 6.292a1 1 0 010 1.41L1.714 13.7a.999.999 0 01-.709.3z"></path>
     </symbol>
     <symbol viewBox="0 0 8 14" id="icon-carousel-next">

--- a/docs/_includes/ds6/symbols.html
+++ b/docs/_includes/ds6/symbols.html
@@ -494,7 +494,7 @@
     <symbol id="icon-back" viewBox="0 0 10 18">
         <path d="M8.995 18a1.002 1.002 0 01-.709-.29L.296 9.712a1.002 1.002 0 010-1.42L8.286.294a1.002 1.002 0 111.418 1.42l-7.29 7.288 7.29 7.288A1.002 1.002 0 018.995 18z"/>
     </symbol>
-    <symbol id="icon-breadcrumb" viewBox="0 0 14 14">
+    <symbol id="icon-breadcrumb" viewBox="0 0 8 14">
         <path d="M1.005 14a1 1 0 01-.71-1.71l5.296-5.288L.296 1.714A1.004 1.004 0 011.714.294L7.71 6.292a1 1 0 010 1.41L1.714 13.7a.999.999 0 01-.709.3z"/>
     </symbol>
     <symbol id="icon-carousel-next" viewBox="0 0 8 14">

--- a/docs/static/ds6/icons.svg
+++ b/docs/static/ds6/icons.svg
@@ -494,7 +494,7 @@
     <symbol viewBox="0 0 10 18" id="icon-back">
         <path d="M8.995 18a1.002 1.002 0 01-.709-.29L.296 9.712a1.002 1.002 0 010-1.42L8.286.294a1.002 1.002 0 111.418 1.42l-7.29 7.288 7.29 7.288A1.002 1.002 0 018.995 18z"></path>
     </symbol>
-    <symbol viewBox="0 0 14 14" id="icon-breadcrumb">
+    <symbol viewBox="0 0 8 14" id="icon-breadcrumb">
         <path d="M1.005 14a1 1 0 01-.71-1.71l5.296-5.288L.296 1.714A1.004 1.004 0 011.714.294L7.71 6.292a1 1 0 010 1.41L1.714 13.7a.999.999 0 01-.709.3z"></path>
     </symbol>
     <symbol viewBox="0 0 8 14" id="icon-carousel-next">

--- a/src/svg/ds6/icons.svg
+++ b/src/svg/ds6/icons.svg
@@ -494,7 +494,7 @@
     <symbol viewBox="0 0 10 18" id="icon-back">
         <path d="M8.995 18a1.002 1.002 0 01-.709-.29L.296 9.712a1.002 1.002 0 010-1.42L8.286.294a1.002 1.002 0 111.418 1.42l-7.29 7.288 7.29 7.288A1.002 1.002 0 018.995 18z"></path>
     </symbol>
-    <symbol viewBox="0 0 14 14" id="icon-breadcrumb">
+    <symbol viewBox="0 0 8 14" id="icon-breadcrumb">
         <path d="M1.005 14a1 1 0 01-.71-1.71l5.296-5.288L.296 1.714A1.004 1.004 0 011.714.294L7.71 6.292a1 1 0 010 1.41L1.714 13.7a.999.999 0 01-.709.3z"></path>
     </symbol>
     <symbol viewBox="0 0 8 14" id="icon-carousel-next">


### PR DESCRIPTION
## Description
Changed `breadcrumb` viewport to be in line with `chevron-right-small`

## References
https://github.com/eBay/skin/issues/1352

## Screenshots
<img width="678" alt="Screen Shot 2021-02-05 at 1 40 41 PM" src="https://user-images.githubusercontent.com/1755269/107092086-c3684a00-67b7-11eb-9e0c-dcb9b9dd7a0d.png">
