### PR TITLE
Focus outline was too tall for radio and checkbox with multi line label

### DIFF
--- a/dist/checkbox/ds4/checkbox.css
+++ b/dist/checkbox/ds4/checkbox.css
@@ -17,7 +17,11 @@
 span.checkbox__icon {
   display: -webkit-inline-box;
   display: inline-flex;
+  height: 18px;
   outline-offset: 1px;
+}
+.checkbox--large span.checkbox__icon {
+  height: 24px;
 }
 span.checkbox__icon[hidden] {
   display: -webkit-inline-box;

--- a/dist/checkbox/ds6/checkbox.css
+++ b/dist/checkbox/ds6/checkbox.css
@@ -23,7 +23,11 @@
 span.checkbox__icon {
   display: -webkit-inline-box;
   display: inline-flex;
+  height: 18px;
   outline-offset: 1px;
+}
+.checkbox--large span.checkbox__icon {
+  height: 24px;
 }
 span.checkbox__icon[hidden] {
   display: -webkit-inline-box;

--- a/dist/radio/ds4/radio.css
+++ b/dist/radio/ds4/radio.css
@@ -17,7 +17,11 @@
 span.radio__icon {
   display: -webkit-inline-box;
   display: inline-flex;
+  height: 18px;
   outline-offset: 1px;
+}
+.radio--large span.radio__icon {
+  height: 24px;
 }
 span.radio__icon[hidden] {
   display: -webkit-inline-box;

--- a/dist/radio/ds6/radio.css
+++ b/dist/radio/ds6/radio.css
@@ -23,7 +23,11 @@
 span.radio__icon {
   display: -webkit-inline-box;
   display: inline-flex;
+  height: 18px;
   outline-offset: 1px;
+}
+.radio--large span.radio__icon {
+  height: 24px;
 }
 span.radio__icon[hidden] {
   display: -webkit-inline-box;

--- a/src/less/checkbox/base/checkbox.less
+++ b/src/less/checkbox/base/checkbox.less
@@ -21,7 +21,12 @@
 
 span.checkbox__icon {
     display: inline-flex;
+    height: @checkbox-dimensions;
     outline-offset: 1px;
+}
+
+.checkbox--large span.checkbox__icon {
+    height: @checkbox-large-dimensions;
 }
 
 // progressive enhancement - override hidden SVG

--- a/src/less/checkbox/stories/checked.stories.js
+++ b/src/less/checkbox/stories/checked.stories.js
@@ -71,3 +71,50 @@ export const customIcon = () => `
     </span>
 </span>
 `;
+
+export const multiLineLabel = () => `
+<legend>Choose an Option</legend>
+    <div style="display: flex;" class="field">
+        <span class="checkbox field__control">
+            <input class="checkbox__control" id="group-checkbox-1" type="checkbox" value="1" name="checkbox-group" checked />
+            <span class="checkbox__icon" hidden>
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-checkbox-1">Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 </label>
+    </div>
+    <div style="display: flex;" class="field">
+        <span class="checkbox field__control">
+            <input class="checkbox__control" id="group-checkbox-2" type="checkbox" value="2" name="checkbox-group" />
+            <span class="checkbox__icon" hidden>
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-checkbox-2">Option 2</label>
+    </div>
+    <div style="display: flex;" class="field">
+        <span class="checkbox field__control">
+            <input class="checkbox__control" id="group-checkbox-3" type="checkbox" value="3" name="checkbox-group" />
+            <span class="checkbox__icon" hidden>
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-checkbox-3">Option 3</label>
+    </div>
+</div>
+`;

--- a/src/less/radio/base/radio.less
+++ b/src/less/radio/base/radio.less
@@ -21,7 +21,12 @@
 
 span.radio__icon {
     display: inline-flex;
+    height: @radio-dimensions;
     outline-offset: 1px;
+}
+
+.radio--large span.radio__icon {
+    height: @radio-large-dimensions;
 }
 
 // progressive enhancement - override hidden SVG
@@ -56,14 +61,6 @@ input.radio__control[type="radio"] {
 .radio--large svg {
     height: @radio-large-dimensions;
     width: @radio-large-dimensions;
-}
-
-.radio span.radio__icon {
-    height: @radio-dimensions;
-}
-
-.radio--large span.radio__icon {
-    height: @radio-large-dimensions;
 }
 
 input.radio__control[type="radio"] + span.radio__icon svg.radio__checked {

--- a/src/less/radio/base/radio.less
+++ b/src/less/radio/base/radio.less
@@ -58,6 +58,14 @@ input.radio__control[type="radio"] {
     width: @radio-large-dimensions;
 }
 
+.radio span.radio__icon {
+    height: @radio-dimensions;
+}
+
+.radio--large span.radio__icon {
+    height: @radio-large-dimensions;
+}
+
 input.radio__control[type="radio"] + span.radio__icon svg.radio__checked {
     display: none;
 }

--- a/src/less/radio/stories/checked.stories.js
+++ b/src/less/radio/stories/checked.stories.js
@@ -71,3 +71,50 @@ export const customIcon = () => `
 </span>
 </span>
 `;
+
+export const multiLineLabel = () => `
+<fieldset>
+    <legend>Choose an Option</legend>
+    <div class="field" style="display: flex;">
+        <span class="field__control radio">
+            <input class="radio__control" id="group-radio-1" type="radio" value="1" name="radio-group" />
+            <span class="radio__icon" hidden>
+                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-unchecked"></use>
+                </svg>
+                <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-radio-1">Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 Option 1 </label>
+    </div>
+    <div class="field" style="display: flex;">
+        <span class="field__control radio">
+            <input class="radio__control" id="group-radio-2" type="radio" value="2" name="radio-group" />
+            <span class="radio__icon" hidden>
+                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-unchecked"></use>
+                </svg>
+                <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-radio-2">Option 2</label>
+    </div>
+    <div class="field" style="display: flex;">
+        <span class="field__control radio">
+            <input class="radio__control" id="group-radio-3" type="radio" value="3" name="radio-group" />
+            <span class="radio__icon" hidden>
+                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-unchecked"></use>
+                </svg>
+                <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-radio-3">Option 3</label>
+    </div>
+</fieldset>`;


### PR DESCRIPTION
## Description
Fixed height on span container for svg to match height of svg.
This was applied in radio and in checkbox.

## References
Closes #1318 

## Screenshots
![Screen Shot 2021-02-08 at 3 08 56 PM](https://user-images.githubusercontent.com/25092249/107294416-34129f00-6a22-11eb-98e9-f1b1f5c29ec8.png)

![Screen Shot 2021-02-08 at 3 29 40 PM](https://user-images.githubusercontent.com/25092249/107294558-7b009480-6a22-11eb-8481-c70ed30e003a.png)

