### PR TITLE
Added mobile/desktop styles for progress stepper

### DIFF
--- a/dist/progress-stepper/ds4/progress-stepper.css
+++ b/dist/progress-stepper/ds4/progress-stepper.css
@@ -29,6 +29,7 @@ hr.progress-stepper__separator {
   top: 11px;
 }
 .progress-stepper__text {
+  font-size: 0.75rem;
   justify-self: center;
   margin-top: 8px;
   text-align: center;
@@ -48,10 +49,11 @@ hr.progress-stepper__separator {
           align-items: center;
   border-radius: 24px;
   border-style: solid;
-  border-width: 1px;
+  border-width: 2px;
   box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
+  font-weight: 500;
   height: 24px;
   -webkit-box-pack: center;
           justify-content: center;
@@ -155,4 +157,13 @@ hr.progress-stepper__separator--upcoming,
 [dir="rtl"] .progress-stepper--vertical .progress-stepper__separator {
   margin-left: inherit;
   margin-right: 11px;
+}
+@media (min-width: 601px) {
+  hr.progress-stepper__separator {
+    min-width: 120px;
+  }
+  .progress-stepper__text {
+    font-size: 0.875rem;
+    width: 120px;
+  }
 }

--- a/dist/progress-stepper/ds6/progress-stepper.css
+++ b/dist/progress-stepper/ds6/progress-stepper.css
@@ -35,6 +35,7 @@ hr.progress-stepper__separator {
   top: 11px;
 }
 .progress-stepper__text {
+  font-size: 0.75rem;
   justify-self: center;
   margin-top: 8px;
   text-align: center;
@@ -54,10 +55,11 @@ hr.progress-stepper__separator {
           align-items: center;
   border-radius: 24px;
   border-style: solid;
-  border-width: 1px;
+  border-width: 2px;
   box-sizing: border-box;
   display: -webkit-inline-box;
   display: inline-flex;
+  font-weight: 700;
   height: 24px;
   -webkit-box-pack: center;
           justify-content: center;
@@ -161,4 +163,13 @@ hr.progress-stepper__separator--upcoming,
 [dir="rtl"] .progress-stepper--vertical .progress-stepper__separator {
   margin-left: inherit;
   margin-right: 11px;
+}
+@media (min-width: 601px) {
+  hr.progress-stepper__separator {
+    min-width: 120px;
+  }
+  .progress-stepper__text {
+    font-size: 0.875rem;
+    width: 120px;
+  }
 }

--- a/dist/variables/ds4/progress-stepper-variables.less
+++ b/dist/variables/ds4/progress-stepper-variables.less
@@ -11,3 +11,7 @@
 @progress-stepper-badge-current-background-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-border-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-color: @color-white;
+@progress-stepper-font-size: @font-size-12;
+@progress-stepper-large-font-size: @font-size-14;
+@progress-stepper-min-width: 80px;
+@progress-stepper-large-min-width: 120px;

--- a/dist/variables/ds6/progress-stepper-variables.less
+++ b/dist/variables/ds6/progress-stepper-variables.less
@@ -11,3 +11,7 @@
 @progress-stepper-badge-current-background-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-border-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-color: @color-white;
+@progress-stepper-font-size: @font-size-12;
+@progress-stepper-large-font-size: @font-size-14;
+@progress-stepper-min-width: 80px;
+@progress-stepper-large-min-width: 120px;

--- a/docs/_includes/common/progress-stepper.html
+++ b/docs/_includes/common/progress-stepper.html
@@ -118,7 +118,7 @@
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="progress-stepper" style="margin: 16px auto; width: 380px;">
+            <div class="progress-stepper" style="margin: 16px auto; width: 390px;">
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
                         <span class="progress-stepper__icon">
@@ -170,7 +170,7 @@
     </div>
 
     {% highlight html %}
-<div class="progress-stepper" style="margin: 16px auto; width: 320px;">
+<div class="progress-stepper" style="margin: 16px auto; width: 390px;">
     <div class="progress-stepper__items" role="list">
         <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
             <span class="progress-stepper__icon">

--- a/src/less/progress-stepper/base/progress-stepper.less
+++ b/src/less/progress-stepper/base/progress-stepper.less
@@ -21,16 +21,17 @@ hr.progress-stepper__separator {
     flex: 1;
     height: 2px;
     margin: 0;
-    min-width: 80px;
+    min-width: @progress-stepper-min-width;
     position: relative;
     top: 11px;
 }
 
 .progress-stepper__text {
+    font-size: @progress-stepper-font-size;
     justify-self: center;
     margin-top: 8px;
     text-align: center;
-    width: 80px;
+    width: @progress-stepper-min-width;
 }
 
 .progress-stepper__icon {
@@ -45,9 +46,10 @@ hr.progress-stepper__separator {
     align-items: center;
     border-radius: @progress-stepper-icon-size;
     border-style: solid;
-    border-width: 1px;
+    border-width: 2px;
     box-sizing: border-box;
     display: inline-flex;
+    font-weight: @font-weight-bold;
     height: @progress-stepper-icon-size;
     justify-content: center;
     top: 0;
@@ -161,5 +163,16 @@ hr.progress-stepper__separator--upcoming,
     .progress-stepper--vertical .progress-stepper__separator {
         margin-left: inherit;
         margin-right: 11px;
+    }
+}
+
+@media (min-width: 601px) {
+    hr.progress-stepper__separator {
+        min-width: @progress-stepper-large-min-width;
+    }
+
+    .progress-stepper__text {
+        font-size: @progress-stepper-large-font-size;
+        width: @progress-stepper-large-min-width;
     }
 }

--- a/src/less/variables/ds4/progress-stepper-variables.less
+++ b/src/less/variables/ds4/progress-stepper-variables.less
@@ -11,3 +11,7 @@
 @progress-stepper-badge-current-background-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-border-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-color: @color-white;
+@progress-stepper-font-size: @font-size-12;
+@progress-stepper-large-font-size: @font-size-14;
+@progress-stepper-min-width: 80px;
+@progress-stepper-large-min-width: 120px;

--- a/src/less/variables/ds6/progress-stepper-variables.less
+++ b/src/less/variables/ds6/progress-stepper-variables.less
@@ -11,3 +11,7 @@
 @progress-stepper-badge-current-background-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-border-color: @progress-stepper-active-color;
 @progress-stepper-badge-current-color: @color-white;
+@progress-stepper-font-size: @font-size-12;
+@progress-stepper-large-font-size: @font-size-14;
+@progress-stepper-min-width: 80px;
+@progress-stepper-large-min-width: 120px;


### PR DESCRIPTION
## Description
Fixed issues with progress-stepper by adding mweb and dweb styles as well as making circle bolded

## References
https://github.com/eBay/skin/issues/1358

## Screenshots
<img width="390" alt="Screen Shot 2021-02-09 at 4 49 36 PM" src="https://user-images.githubusercontent.com/1755269/107448812-40b4f700-6af7-11eb-9c85-42545afaee9a.png">
<img width="1106" alt="Screen Shot 2021-02-09 at 4 49 54 PM" src="https://user-images.githubusercontent.com/1755269/107448814-41e62400-6af7-11eb-9a0c-26cef32f7551.png">
