### PR TITLE
style(toast-dialog): fix hover/focus color #1375

### DIFF
--- a/dist/toast-dialog/ds4/toast-dialog.css
+++ b/dist/toast-dialog/ds4/toast-dialog.css
@@ -116,6 +116,7 @@ button.toast-dialog__close:focus {
 }
 .toast-dialog__footer .btn--secondary:focus,
 .toast-dialog__footer .btn--secondary:hover {
+  background-color: #0654ba;
   border: 1px solid #fff;
   color: #fff;
 }

--- a/dist/toast-dialog/ds6/toast-dialog.css
+++ b/dist/toast-dialog/ds6/toast-dialog.css
@@ -116,6 +116,7 @@ button.toast-dialog__close:focus {
 }
 .toast-dialog__footer .btn--secondary:focus,
 .toast-dialog__footer .btn--secondary:hover {
+  background-color: #3665f3;
   border: 1px solid #fff;
   color: #fff;
 }

--- a/docs/_includes/common/lightbox-dialog.html
+++ b/docs/_includes/common/lightbox-dialog.html
@@ -111,7 +111,7 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-lightbox-button" data-makeup-dialog-button-for="lightbox-dialog-fade-0" type="button">Open Lightbox Dialog with Fade Transition</button>
-            <div aria-labelledby="lightbox-dialog-fade-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-fade-0" role="dialog">
+            <div aria-labelledby="lightbox-dialog-fade-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-fade-0" role="dialog" data-makeup-dialog-has-transitions="true">
                 <div class="lightbox-dialog__window lightbox-dialog__window--fade">
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-fade-title" class="large-text-1 bold-text">Heading</h2>

--- a/docs/_includes/common/snackbar-dialog.html
+++ b/docs/_includes/common/snackbar-dialog.html
@@ -2,16 +2,18 @@
     {% include common/section-header.html name="snackbar-dialog" version=page.versions.snackbar-dialog %}
 
     <p>A snackbar is a non-modal dialog that appears in response to a lightweight user action. It dissapears automatically after a minimum of 6 seconds.</p>
-    <p>The display of the snackbar should be toggled using the <span class="highlight">hidden</span> property.</p>
+    <p>The display of the snackbar should be toggled using the <span class="highlight">hidden</span> property. Please refer to the <a href="#dialog-transitions">Dialog Transitions</a> section for information on how to correctly trigger a CSS transition from a hidden state. With the correct JavaScript in place, applying the <span class="highlight">snackbar-dialog--transition</span> modifier class will opt into a transition that slides in on show, and fades out on hide.</p>
+
     <p><strong>NOTE</strong>: A toast is non-modal and therefore <strong>should not</strong> capture or trap keyboard focus when opened.</p>
 
     <h3 id="snackbar-dialog-default">Default Snackbar</h3>
     <p>The default snackbar displays a short, non-interactive message.</p>
 
+
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-snackbar-button" data-makeup-dialog-button-for="snackbar-dialog-1">Show Default Snackbar</button>
-            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog" id="snackbar-dialog-1" role="dialog" hidden>
+            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog snackbar-dialog--transition" id="snackbar-dialog-1" role="dialog" data-makeup-dialog-has-transitions="true" hidden>
                 <div class="snackbar-dialog__window">
                     <div class="snackbar-dialog__main">
                         <p>1 item deleted from watch list.</p>
@@ -21,7 +23,7 @@
         </div>
     </div>
     {% highlight html %}
-<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog" role="dialog" hidden>
+<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog snackbar-dialog--transition" role="dialog" hidden>
     <div class="snackbar-dialog__window">
         <div class="snackbar-dialog__main">
             <p>1 item deleted from watch list.</p>
@@ -32,13 +34,12 @@
 
     <h3 id="snackbar-dialog-action">Action Snackbar</h3>
     <p>A snackbar can contain a single shortcut action. Typically this is an "undo".</p>
-    <p>In order to give all users adequate time to find and reach the action, the snackbar DOM position must be placed closely after the users current location (i.e. <span class="highlight">document.activeElement</span>). This ensures a natual reading and keyboard order.</p>
-    <p>In addition, an <span class="highlight">accesskey</span> attribute allows quick access via the operating system's <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey">access keys</a>.</p>
+    <p>In order to give all users adequate time to find and reach the action, the snackbar DOM position must be placed closely after the users current location (i.e. <span class="highlight">document.activeElement</span>). This ensures a natual reading and keyboard order. In addition, an <span class="highlight">accesskey</span> attribute allows quick access via the operating system's <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey">access keys</a>.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-snackbar-button" data-makeup-dialog-button-for="snackbar-dialog-2">Show Action Snackbar</button>
-            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog" id="snackbar-dialog-2" role="dialog" hidden>
+            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog snackbar-dialog--transition" id="snackbar-dialog-2" role="dialog" data-makeup-dialog-has-transitions="true" hidden>
                 <div class="snackbar-dialog__window">
                     <div class="snackbar-dialog__main">
                         <p>1 item deleted from watch list.</p>
@@ -51,7 +52,7 @@
         </div>
     </div>
     {% highlight html %}
-<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog" role="dialog" hidden>
+<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog snackbar-dialog--transition" role="dialog" hidden>
     <div class="snackbar-dialog__window">
         <div class="snackbar-dialog__main">
             <p>1 item deleted from watch list.</p>
@@ -64,12 +65,12 @@
     {% endhighlight %}
 
     <h3 id="snackbar-dialog-stacked">Stacked Snackbar</h3>
-    <p>The content and action can be stacked vertically by using the <span class="snackbar-dialog__window--column">snackbar-dialog__window--column</span> modifier.</p>
+    <p>The content and action can be stacked vertically by using the <span class="highlight">snackbar-dialog__window--column</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-snackbar-button" data-makeup-dialog-button-for="snackbar-dialog-3">Show Stacked Snackbar</button>
-            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog" id="snackbar-dialog-3" role="dialog" hidden>
+            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog snackbar-dialog--transition" id="snackbar-dialog-3" role="dialog" data-makeup-dialog-has-transitions="true" hidden>
                 <div class="snackbar-dialog__window snackbar-dialog__window--column">
                     <div class="snackbar-dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -82,7 +83,7 @@
         </div>
     </div>
     {% highlight html %}
-<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog" role="dialog" hidden>
+<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="snackbar-dialog snackbar-dialog--transition" role="dialog" hidden>
     <div class="snackbar-dialog__window snackbar-dialog__window--column">
         <div class="snackbar-dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>

--- a/docs/_includes/common/snackbar-dialog.html
+++ b/docs/_includes/common/snackbar-dialog.html
@@ -2,8 +2,11 @@
     {% include common/section-header.html name="snackbar-dialog" version=page.versions.snackbar-dialog %}
 
     <p>A snackbar is a non-modal dialog that appears in response to a lightweight user action. It dissapears automatically after a minimum of 6 seconds.</p>
-    <p>Toggling the <span class="highlight">hidden</span> attribute will hide and show the snackbar.</p>
-    <p>NOTE: The snackbar <strong>must not</strong> steal or trap keyboard focus when opened.</p>
+    <p>The display of the snackbar should be toggled using the <span class="highlight">hidden</span> property.</p>
+    <p><strong>NOTE</strong>: A toast is non-modal and therefore <strong>should not</strong> capture or trap keyboard focus when opened.</p>
+
+    <h3 id="snackbar-dialog-default">Default Snackbar</h3>
+    <p>The default snackbar displays a short, non-interactive message.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -29,7 +32,7 @@
 
     <h3 id="snackbar-dialog-action">Action Snackbar</h3>
     <p>A snackbar can contain a single shortcut action. Typically this is an "undo".</p>
-    <p>In order to give all users adequate time to find and reach the action, the snackbar DOM position must be placed closely after the users current location (i.e. <span class="highlight">document.activeElement</span>). This ensure a natual reading and keyboard order.</p>
+    <p>In order to give all users adequate time to find and reach the action, the snackbar DOM position must be placed closely after the users current location (i.e. <span class="highlight">document.activeElement</span>). This ensures a natual reading and keyboard order.</p>
     <p>In addition, an <span class="highlight">accesskey</span> attribute allows quick access via the operating system's <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey">access keys</a>.</p>
 
     <div class="demo">

--- a/docs/_includes/common/toast-dialog.html
+++ b/docs/_includes/common/toast-dialog.html
@@ -1,8 +1,9 @@
 <div id="toast-dialog">
     {% include common/section-header.html name="toast-dialog" version=page.versions.toast-dialog %}
 
-    <p>A toast is a non-modal dialog that appears in response to a system-level action</p>
-    <p>The display of the toast should be toggled using the <span class="highlight">hidden</span> property.</p>
+    <p>A toast is a non-modal dialog that appears in response to a system-level action.</p>
+    <p>The display of the toast should be toggled using the <span class="highlight">hidden</span> property. Please refer to the <a href="#dialog-transitions">Dialog Transitions</a> section for information on how to correctly trigger a CSS transition from a hidden state. With the correct JavaScript in place, applying the <span class="highlight">toast-dialog--transition</span> modifier class will opt into a transition that slides in on show, and fades out on hide.</p>
+
     <p><strong>NOTE</strong>: A toast is non-modal and therefore <strong>should not</strong> capture or trap keyboard focus when opened. Keyboard users require a way to quickly access the actions within the toast. This is achieved via the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey">accesskey</a> attribute.</p>
 
     <h3 id="toast-dialog-default">Default Toast</h3>
@@ -11,7 +12,7 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-1">Show Default Toast</button>
-            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog" hidden id="toast-dialog-1" role="dialog">
+            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" hidden id="toast-dialog-1" role="dialog" data-makeup-dialog-has-transitions="true">
                 <div class="toast-dialog__window">
                     <div class="toast-dialog__header">
                         <h3 class="toast-dialog__title">User Privacy Preferences</h3>
@@ -32,7 +33,7 @@
         </div>
     </div>
 {% highlight html %}
-<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog" hidden role="dialog">
+<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" hidden role="dialog">
     <div class="toast-dialog__window">
         <div class="toast-dialog__header">
             <h2 class="toast-dialog__title">User Privacy Preferences</h2>
@@ -58,7 +59,7 @@
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-2">Show Secondary Action Toast</button>
-            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog" hidden id="toast-dialog-2" role="dialog">
+            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" hidden id="toast-dialog-2" role="dialog" data-makeup-dialog-has-transitions="true">
                 <div class="toast-dialog__window">
                     <div class="toast-dialog__header">
                         <h3 class="toast-dialog__title">User Privacy Preferences</h3>
@@ -80,7 +81,7 @@
         </div>
     </div>
 {% highlight html %}
-<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog" hidden role="dialog">
+<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" hidden role="dialog">
     <div class="toast-dialog__window">
         <div class="toast-dialog__header">
             <h2 class="toast-dialog__title">User Privacy Preferences</h2>
@@ -101,54 +102,4 @@
 </aside>
 {% endhighlight %}
 
-
-    <h3 id="toast-dialog-transition">Toast Transitions</h3>
-    <p>Please refer to the <a href="#dialog-transitions">Dialog Transitions</a> section for information on how to correctly trigger a CSS transition from a hidden state.</p>
-    <p>With the correct JavaScript in place, applying the <span class="highlight">toast-dialog--transition</span> modifier class will opt into a transition that slides in on show, and fades out on hide.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-3">Show Transitioned Toast</button>
-            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" data-makeup-dialog-has-transitions="true" hidden id="toast-dialog-3" role="dialog">
-                <div class="toast-dialog__window">
-                    <div class="toast-dialog__header">
-                        <h3 class="toast-dialog__title">User Privacy Preferences</h3>
-                        <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
-                            <svg class="icon icon--close" focusable="false" height="24" width="24">
-                                {% include common/symbol.html name="close" %}
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="toast-dialog__main">
-                        <p>We detected something unusual about a recent sign-in to your eBay account. To help keep you safe, we recommend you change the password.</p>
-                    </div>
-                    <div class="toast-dialog__footer">
-                        <button accesskey="l" class="btn btn--secondary toast-dialog__reject">Later</button>
-                        <button accesskey="v" class="btn btn--primary toast-dialog__confirm">View Account</button>
-                    </div>
-                </div>
-            </aside>
-        </div>
-    </div>
-    {% highlight html %}
-<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" hidden role="dialog">
-    <div class="toast-dialog__window">
-        <div class="toast-dialog__header">
-            <h2 class="toast-dialog__title">User Privacy Preferences</h2>
-            <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
-                <svg class="icon icon--close" focusable="false" height="24" width="24">
-                    <use xlink:href="#icon-close"></use>
-                </svg>
-            </button>
-        </div>
-        <div class="toast-dialog__main">
-            <p>We detected something unusual about a recent sign-in to your eBay account. To help keep you safe, we recommend you change the password.</p>
-        </div>
-        <div class="toast-dialog__footer">
-            <button accesskey="l" class="btn btn--secondary toast-dialog__reject">Later</button>
-            <button accesskey="v" class="btn btn--secondary">View Account</button>
-        </div>
-    </div>
-</aside>
-    {% endhighlight %}
 </div>

--- a/docs/_includes/common/toast-dialog.html
+++ b/docs/_includes/common/toast-dialog.html
@@ -1,13 +1,16 @@
 <div id="toast-dialog">
     {% include common/section-header.html name="toast-dialog" version=page.versions.toast-dialog %}
 
-    <p>A toast is a non-modal dialog spawned by the main web page or application.</p>
-    <p>Toggling the <span class="highlight">hidden</span> attribute will hide and show the toast.</p>
-    <p>A toast is non-modal and therefore should not capture or trap keyboard focus when opened. Keyboard users require a way to quickly access the actions within the toast. This is achieved via the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey">accesskey</a> attribute on each button.</p>
+    <p>A toast is a non-modal dialog that appears in response to a system-level action</p>
+    <p>The display of the toast should be toggled using the <span class="highlight">hidden</span> property.</p>
+    <p><strong>NOTE</strong>: A toast is non-modal and therefore <strong>should not</strong> capture or trap keyboard focus when opened. Keyboard users require a way to quickly access the actions within the toast. This is achieved via the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey">accesskey</a> attribute.</p>
+
+    <h3 id="toast-dialog-default">Default Toast</h3>
+    <p>The default toast displays a single, primary call-to-action.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-1">Show Toast</button>
+            <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-1">Show Default Toast</button>
             <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog" hidden id="toast-dialog-1" role="dialog">
                 <div class="toast-dialog__window">
                     <div class="toast-dialog__header">
@@ -49,18 +52,17 @@
 </aside>
 {% endhighlight %}
 
-    <h3 id="toast-dialog-transition">Toast Transitions</h3>
-    <p>Please refer to the <a href="#dialog-transitions">Dialog Transitions</a> section for information on how to correctly trigger a CSS transition from a hidden state.</p>
-    <p>With the correct JavaScript in place, applying the <span class="highlight">toast-dialog--transition</span> modifier class will opt into a transition that slides in on show, and fades out on hide.</p>
+    <h3 id="toast-dialog-secondary-action">Toast Secondary Action</h3>
+    <p>A secondary action is also supported.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-2">Show Toast</button>
-            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" data-makeup-dialog-has-transitions="true" hidden id="toast-dialog-2" role="dialog">
+            <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-2">Show Secondary Action Toast</button>
+            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog" hidden id="toast-dialog-2" role="dialog">
                 <div class="toast-dialog__window">
                     <div class="toast-dialog__header">
                         <h3 class="toast-dialog__title">User Privacy Preferences</h3>
-                        <button class="toast-dialog__close" type="button" aria-label="Close notification dialog">
+                        <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
                             <svg class="icon icon--close" focusable="false" height="24" width="24">
                                 {% include common/symbol.html name="close" %}
                             </svg>
@@ -70,6 +72,58 @@
                         <p>We detected something unusual about a recent sign-in to your eBay account. To help keep you safe, we recommend you change the password.</p>
                     </div>
                     <div class="toast-dialog__footer">
+                        <button accesskey="l" class="btn btn--secondary toast-dialog__reject">Later</button>
+                        <button accesskey="v" class="btn btn--primary toast-dialog__confirm">View Account</button>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </div>
+{% highlight html %}
+<aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog" hidden role="dialog">
+    <div class="toast-dialog__window">
+        <div class="toast-dialog__header">
+            <h2 class="toast-dialog__title">User Privacy Preferences</h2>
+            <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
+                <svg class="icon icon--close" focusable="false" height="24" width="24">
+                    <use xlink:href="#icon-close"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="toast-dialog__main">
+            <p>We detected something unusual about a recent sign-in to your eBay account. To help keep you safe, we recommend you change the password.</p>
+        </div>
+        <div class="toast-dialog__footer">
+            <button accesskey="l" class="btn btn--secondary toast-dialog__reject">Later</button>
+            <button accesskey="v" class="btn btn--primary">View Account</button>
+        </div>
+    </div>
+</aside>
+{% endhighlight %}
+
+
+    <h3 id="toast-dialog-transition">Toast Transitions</h3>
+    <p>Please refer to the <a href="#dialog-transitions">Dialog Transitions</a> section for information on how to correctly trigger a CSS transition from a hidden state.</p>
+    <p>With the correct JavaScript in place, applying the <span class="highlight">toast-dialog--transition</span> modifier class will opt into a transition that slides in on show, and fades out on hide.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-toast-button" data-makeup-dialog-button-for="toast-dialog-3">Show Transitioned Toast</button>
+            <aside aria-label="Notification" aria-live="polite" aria-modal="false" class="toast-dialog toast-dialog--transition" data-makeup-dialog-has-transitions="true" hidden id="toast-dialog-3" role="dialog">
+                <div class="toast-dialog__window">
+                    <div class="toast-dialog__header">
+                        <h3 class="toast-dialog__title">User Privacy Preferences</h3>
+                        <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
+                            <svg class="icon icon--close" focusable="false" height="24" width="24">
+                                {% include common/symbol.html name="close" %}
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="toast-dialog__main">
+                        <p>We detected something unusual about a recent sign-in to your eBay account. To help keep you safe, we recommend you change the password.</p>
+                    </div>
+                    <div class="toast-dialog__footer">
+                        <button accesskey="l" class="btn btn--secondary toast-dialog__reject">Later</button>
                         <button accesskey="v" class="btn btn--primary toast-dialog__confirm">View Account</button>
                     </div>
                 </div>
@@ -81,7 +135,7 @@
     <div class="toast-dialog__window">
         <div class="toast-dialog__header">
             <h2 class="toast-dialog__title">User Privacy Preferences</h2>
-            <button class="toast-dialog__close" type="button" aria-label="Close notification dialog">
+            <button class="icon-btn toast-dialog__close" type="button" aria-label="Close notification dialog">
                 <svg class="icon icon--close" focusable="false" height="24" width="24">
                     <use xlink:href="#icon-close"></use>
                 </svg>
@@ -91,7 +145,8 @@
             <p>We detected something unusual about a recent sign-in to your eBay account. To help keep you safe, we recommend you change the password.</p>
         </div>
         <div class="toast-dialog__footer">
-            <button accesskey="v" class="btn btn--primary">View Account</button>
+            <button accesskey="l" class="btn btn--secondary toast-dialog__reject">Later</button>
+            <button accesskey="v" class="btn btn--secondary">View Account</button>
         </div>
     </div>
 </aside>

--- a/src/less/toast-dialog/base/toast-dialog.less
+++ b/src/less/toast-dialog/base/toast-dialog.less
@@ -125,6 +125,7 @@ button.toast-dialog__close {
 
     .btn--secondary:focus,
     .btn--secondary:hover {
+        background-color: @toast-dialog-background-color;
         border: 1px solid @toast-dialog-foreground-color;
         color: @toast-dialog-foreground-color;
     }


### PR DESCRIPTION
Fixes #1375

Secondary button was missing a background-colour for focus/hover state.

I also took the opportunity to rejig some of the documentation for toast & snackbar, and added an example of toast with secondary action.

I also noticed that snackbar transitions don't appear to be working. So that can be investigated separately.

Before
![Screen Shot 2021-02-24 at 2 47 26 PM](https://user-images.githubusercontent.com/38065/109080578-b30c0680-76b5-11eb-80a8-7b7c4a0dc494.png)


After

![Screen Shot 2021-02-24 at 2 49 43 PM](https://user-images.githubusercontent.com/38065/109080570-adaebc00-76b5-11eb-92a0-9aeee57856d9.png)

