### PR TITLE
Infotip Spacing Fix

### DIFF
--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -44,6 +44,7 @@ span.infotip__mask {
 .infotip__content {
   -webkit-box-flex: 1;
           flex-grow: 1;
+  margin-right: 16px;
 }
 .infotip__content p {
   margin: 0;

--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -44,7 +44,6 @@ span.infotip__mask {
 .infotip__content {
   -webkit-box-flex: 1;
           flex-grow: 1;
-  margin-right: 16px;
 }
 .infotip__content p {
   margin: 0;
@@ -160,6 +159,7 @@ span.infotip__heading {
 .infotip .icon-btn {
   flex-shrink: 0;
   height: 20px;
+  margin-left: 16px;
   outline-offset: 2px;
   overflow: visible;
   width: 20px;

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -50,6 +50,7 @@ span.infotip__mask {
 .infotip__content {
   -webkit-box-flex: 1;
           flex-grow: 1;
+  margin-right: 16px;
 }
 .infotip__content p {
   margin: 0;

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -50,7 +50,6 @@ span.infotip__mask {
 .infotip__content {
   -webkit-box-flex: 1;
           flex-grow: 1;
-  margin-right: 16px;
 }
 .infotip__content p {
   margin: 0;
@@ -166,6 +165,7 @@ span.infotip__heading {
 .infotip .icon-btn {
   flex-shrink: 0;
   height: 20px;
+  margin-left: 16px;
   outline-offset: 2px;
   overflow: visible;
   width: 20px;

--- a/src/less/infotip/base/infotip.less
+++ b/src/less/infotip/base/infotip.less
@@ -35,8 +35,6 @@ span.infotip__mask {
 
 .infotip__content {
     .bubble-content();
-
-    margin-right: 16px;
 }
 
 .infotip__pointer {
@@ -113,6 +111,7 @@ span.infotip__heading {
 .infotip .icon-btn {
     flex-shrink: 0; // todo: Should move to icon-btn in next major
     height: 20px;
+    margin-left: 16px;
     outline-offset: 2px;
     overflow: visible;
     width: 20px;

--- a/src/less/infotip/base/infotip.less
+++ b/src/less/infotip/base/infotip.less
@@ -35,6 +35,8 @@ span.infotip__mask {
 
 .infotip__content {
     .bubble-content();
+
+    margin-right: 16px;
 }
 
 .infotip__pointer {


### PR DESCRIPTION
## Description
Adds margin to infotip__content class. Fixes #1385 

## Screenshots

<img width="338" alt="Screen Shot 2021-03-23 at 10 43 58 AM" src="https://user-images.githubusercontent.com/25092249/112215983-3d288b80-8bde-11eb-8a42-7f1961d135d1.png">

