### PR TITLE
Mini Lightbox Spacing Fix

### DIFF
--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -49,7 +49,6 @@
   -webkit-box-direction: reverse;
           flex-direction: row-reverse;
   margin-top: 0;
-  max-width: 400px;
   min-height: 72px;
   min-width: 200px;
 }

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -54,7 +54,6 @@
   -webkit-box-direction: reverse;
           flex-direction: row-reverse;
   margin-top: 0;
-  max-width: 400px;
   min-height: 72px;
   min-width: 200px;
 }

--- a/src/less/lightbox-dialog/base/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/base/lightbox-dialog.less
@@ -25,7 +25,6 @@
     border-radius: 7px;
     flex-direction: row-reverse;
     margin-top: 0;
-    max-width: 400px;
     min-height: 72px;
     min-width: 200px;
 }


### PR DESCRIPTION
## Description
There was a case where shrinking the browser caused the mini lightbox window to lose responsiveness and its edges.
Cutting out max-width solves the problem. Closes #1301. 

## References
#1301 

## Screenshots
<img width="328" alt="Screen Shot 2021-03-23 at 12 28 50 PM" src="https://user-images.githubusercontent.com/25092249/112227593-23db0b80-8bed-11eb-9838-491b0da0158b.png">

