### PR TITLE
Infotip Spacing Patch

### DIFF
--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -159,10 +159,13 @@ span.infotip__heading {
 .infotip .icon-btn {
   flex-shrink: 0;
   height: 20px;
-  margin-left: 16px;
   outline-offset: 2px;
   overflow: visible;
   width: 20px;
+}
+button.infotip__close,
+.infotip__close {
+  margin-left: 16px;
 }
 @media (min-width: 601px) {
   .infotip__overlay {

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -165,10 +165,13 @@ span.infotip__heading {
 .infotip .icon-btn {
   flex-shrink: 0;
   height: 20px;
-  margin-left: 16px;
   outline-offset: 2px;
   overflow: visible;
   width: 20px;
+}
+button.infotip__close,
+.infotip__close {
+  margin-left: 16px;
 }
 @media (min-width: 601px) {
   .infotip__overlay {

--- a/src/less/infotip/base/infotip.less
+++ b/src/less/infotip/base/infotip.less
@@ -111,10 +111,14 @@ span.infotip__heading {
 .infotip .icon-btn {
     flex-shrink: 0; // todo: Should move to icon-btn in next major
     height: 20px;
-    margin-left: 16px;
     outline-offset: 2px;
     overflow: visible;
     width: 20px;
+}
+
+button.infotip__close,
+.infotip__close {
+    margin-left: 16px;
 }
 
 @media (min-width: 601px) {


### PR DESCRIPTION
## Description
Applies the margin-left to `button.infotip__close` and `infotip__close` instead of the previous class, `.infotip .icon-btn`

## Context
Previous infotip changed the spacing of the icon... this will be more specific to just the icon close. 

## References
closes #1390 

## Screenshots
<img width="539" alt="Screen Shot 2021-03-29 at 9 25 31 AM" src="https://user-images.githubusercontent.com/25092249/112889723-b9552000-9071-11eb-8484-050e4a455c16.png">

