### PR TITLE
1394 SVG File incorrect file extension

### DIFF
--- a/scripts/generate-imports/index.js
+++ b/scripts/generate-imports/index.js
@@ -39,7 +39,7 @@ function getCSSRequireSyntax(filepath, ext) {
 
 function getJSRequireSyntax(filepath, ext) {
     let fullFilePath = `${filepath}.${ext}`;
-    if (filepath.indexOf('.css') === filepath.length - 4) {
+    if (filepath.indexOf('.css') === filepath.length - 4 || filepath.includes('svg')) {
         fullFilePath = filepath;
     }
     return `require('./${fullFilePath}');\n`;
@@ -115,7 +115,6 @@ async function generateTopLevelFiles() {
     const indexFiles = browserRemap.filter(
         (item) => config.skipIndex.indexOf(item.filename) === -1
     );
-
     const contentJS = indexFiles
         .map((item) => {
             return `require('./${item.filename}.js');\n`;
@@ -131,7 +130,6 @@ async function generateTopLevelFiles() {
             return `@import "./${item.filename}.css";\n`;
         })
         .join('');
-
     await fs.promises.writeFile(
         path.join(currentDir, 'browser.json'),
         prettier.format(JSON.stringify(browser), { parser: 'json' })


### PR DESCRIPTION
## Description
Changed a small section in the generate-imports script to correct the svg file which had an incorrect file extension. 

## References
closes #1394 

## Screenshots

### After running `generate-imports gen`
<img width="386" alt="Screen Shot 2021-04-16 at 7 51 36 PM" src="https://user-images.githubusercontent.com/25092249/115122064-ce371c00-9f6a-11eb-9add-09d059f0a4a0.png">

