### PR TITLE
feat(carousel): added option to hide scrollbar

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -253,6 +253,18 @@ span.carousel__container {
     }
   }
 }
+.carousel.carousel--hidden-scrollbar:not(.carousel__autoplay) {
+  overflow: hidden;
+}
+.carousel--hidden-scrollbar .carousel__container {
+  margin-bottom: -80px;
+}
+.carousel--hidden-scrollbar .carousel__container .carousel__control {
+  margin-top: -40px;
+}
+.carousel--hidden-scrollbar .carousel__container .carousel__list {
+  padding-bottom: 80px;
+}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .carousel {
     --carousel-paddle-background-color: #171717;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -253,6 +253,18 @@ span.carousel__container {
     }
   }
 }
+.carousel.carousel--hidden-scrollbar:not(.carousel__autoplay) {
+  overflow: hidden;
+}
+.carousel--hidden-scrollbar .carousel__container {
+  margin-bottom: -80px;
+}
+.carousel--hidden-scrollbar .carousel__container .carousel__control {
+  margin-top: -40px;
+}
+.carousel--hidden-scrollbar .carousel__container .carousel__list {
+  padding-bottom: 80px;
+}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .carousel {
     --carousel-paddle-background-color: #171717;

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -200,6 +200,22 @@ span.carousel__container {
     }
 }
 
+.carousel.carousel--hidden-scrollbar:not(.carousel__autoplay) {
+    overflow: hidden;
+}
+
+.carousel--hidden-scrollbar .carousel__container {
+    margin-bottom: -80px;
+}
+
+.carousel--hidden-scrollbar .carousel__container .carousel__control {
+    margin-top: -40px;
+}
+
+.carousel--hidden-scrollbar .carousel__container .carousel__list {
+    padding-bottom: 80px;
+}
+
 @media (prefers-color-scheme: dark) {
     .skin-experiment-dark-mode {
         .carousel {

--- a/src/less/carousel/stories/carousel.stories.js
+++ b/src/less/carousel/stories/carousel.stories.js
@@ -157,3 +157,32 @@ export const RTL = () => `
     </div>
 </div>
 `;
+
+export const hiddenScrollbar = () => `
+<div class="carousel carousel--hidden-scrollbar">
+    <div class="carousel__container">
+        <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
+            <svg aria-hidden="true" class="icon icon--carousel-prev" focusable="false">
+                <use xlink:href="#icon-carousel-prev"></use>
+            </svg>
+        </button>
+        <div class="carousel__viewport carousel__viewport--mask">
+            <ul class="carousel__list carousel__list--default-demo">
+                <li>Card 1</li>
+                <li>Card 2</li>
+                <li>Card 3</li>
+                <li>Card 4</li>
+                <li>Card 5</li>
+                <li>Card 6</li>
+                <li>Card 7</li>
+                <li>Card 8</li>
+            </ul>
+        </div>
+        <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
+            <svg aria-hidden="true" class="icon icon--carousel-next" focusable="false">
+                <use xlink:href="#icon-carousel-next"></use>
+            </svg>
+        </button>
+    </div>
+</div>
+`;


### PR DESCRIPTION
## Description
Added `carousel--hidden-scrollbar` option.
Did not add documentation, but did add a story for it

## Context
Copied code from: https://github.com/eBay/skin/pull/1000/files#diff-b09805b2dadcb72d0f450bf2288ad80da20645f864bd78375090bd2838232130L188-L199 which was the same code we had to hide the scrollbar initially.

## References
https://github.com/eBay/skin/issues/1431

## Screenshots
<img width="837" alt="Screen Shot 2021-05-10 at 1 30 51 PM" src="https://user-images.githubusercontent.com/1755269/117720807-f72a8580-b193-11eb-8279-99c32bb6b06e.png">
