### PR TITLE
docs(field): add instructions for field__group #1399

### DIFF
--- a/docs/_includes/common/checkbox.html
+++ b/docs/_includes/common/checkbox.html
@@ -138,7 +138,8 @@
     <h3 id="checkbox-group">Grouped Checkboxes</h3>
     <p>A group of checkboxes allows multi-select (unlike a group of radio buttons which enforces single-select).</p>
     <p>A <span class="highlight">fieldset</span> and <span class="highlight">legend</span> are <strong>required</strong> in order to create the correct grouping semantics. Note that the Skin <span class="highlight">global</span> module removes the default fieldset border and padding.</p>
-    <p><strong>TIP:</strong> To stack checkboxes vertically instead of side-by-side, simply replace the span wrapper with a div wrapper.</p>
+    <p>The following example uses the <a href="#field">field module</a> for simple layout of checkbox fields and labels.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <fieldset>
@@ -234,6 +235,107 @@
         </span>
         <label class="field__label field__label--end" for="group-checkbox-3">Option 3</label>
     </span>
+</fieldset>
+    {% endhighlight %}
+
+    <p><strong>TIP</strong>: For large checkboxes, wrap each label and control inside of a <span class="highlight">field__group</span> element to maintain vertical alignment.</p>
+    <p>To stack checkboxes vertically instead of side-by-side, simply replace the span wrapper with a div wrapper.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <fieldset>
+                <legend>Choose an Option</legend>
+                <div class="field">
+                    <span class="checkbox field__control">
+                        <input class="checkbox__control" id="group-checkbox-4" type="checkbox" value="1" name="checkbox-group" checked />
+                        <span class="checkbox__icon" hidden>
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="checkbox-unchecked" %}
+                            </svg>
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="checkbox-checked" %}
+                            </svg>
+                        </span>
+                    </span>
+                    <label class="field__label field__label--end" for="group-checkbox-4">Option 1</label>
+                </div>
+                <div class="field">
+                    <span class="checkbox field__control">
+                        <input class="checkbox__control" id="group-checkbox-5" type="checkbox" value="2" name="checkbox-group" />
+                        <span class="checkbox__icon" hidden>
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="checkbox-unchecked" %}
+                            </svg>
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="checkbox-checked" %}
+                            </svg>
+                        </span>
+                    </span>
+                    <label class="field__label field__label--end" for="group-checkbox-5">Option 2</label>
+                </div>
+                <div class="field">
+                    <span class="checkbox field__control">
+                        <input class="checkbox__control" id="group-checkbox-6" type="checkbox" value="3" name="checkbox-group" />
+                        <span class="checkbox__icon" hidden>
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="checkbox-unchecked" %}
+                            </svg>
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="checkbox-checked" %}
+                            </svg>
+                        </span>
+                    </span>
+                    <label class="field__label field__label--end" for="group-checkbox-6">Option 3</label>
+                </div>
+            </fieldset>
+        </div>
+    </div>
+
+    {% highlight html %}
+<fieldset>
+    <legend>Choose an Option</legend>
+    <div class="field">
+        <span class="checkbox field__control">
+            <input class="checkbox__control" id="group-checkbox-4" type="checkbox" value="1" name="checkbox-group" checked />
+            <span class="checkbox__icon" hidden>
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-checkbox-4">Option 1</label>
+    </div>
+    <div class="field">
+        <span class="checkbox field__control">
+            <input class="checkbox__control" id="group-checkbox-5" type="checkbox" value="2" name="checkbox-group" />
+            <span class="checkbox__icon" hidden>
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-checkbox-5">Option 2</label>
+    </div>
+    <div class="field">
+        <span class="checkbox field__control">
+            <input class="checkbox__control" id="group-checkbox-6" type="checkbox" value="3" name="checkbox-group" />
+            <span class="checkbox__icon" hidden>
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-unchecked"></use>
+                </svg>
+                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-checkbox-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-checkbox-6">Option 3</label>
+    </div>
 </fieldset>
     {% endhighlight %}
 </div>

--- a/docs/_includes/common/field.html
+++ b/docs/_includes/common/field.html
@@ -1,6 +1,6 @@
 <div id="field">
     <h2><span class="secondary-text">@ebay/skin/</span>field</h2>
-    <p>The field module facilitates the layout of a form control and it's associated label, plus any other applicable text or sub-controls (e.g. error text or help button).</p>
+    <p>The field module facilitates the layout of a form control and its associated label, plus any other applicable text or sub-controls (e.g. error text or help button).</p>
 
     <h3 id="field-unstacked">Unstacked Field</h3>
     <p>The <span class="highlight">field__label</span> &amp; <span class="highlight">field__control</span> elements are inline by default, taking up only as much horizontal space as they need.</p>
@@ -70,7 +70,7 @@
 </span>
     {% endhighlight %}
 
-    <p>Replace the span tag with a div tag to layout fields in blocks, as per the following example.</p>
+    <p>Replace the span tag with a div tag to layout unstacked fields in blocks, as per the following example.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -105,6 +105,37 @@
         </div>
     </div>
 
+    {% highlight html %}
+<div class="field">
+    <label class="field__label" for="field1">Field 1</label>
+    <span class="field__control textbox">
+        <input class="textbox__control" id="field1" type="text" placeholder="placeholder text" />
+    </span>
+</div>
+<div class="field">
+    <label class="field__label" for="field2">Field 2</label>
+    <span class="field__control">
+        <span class="select">
+            <select name="field2" id="field2">
+                <option value="1">Option 1</option>
+                <option value="2">Option 2</option>
+                <option value="3">Option 3</option>
+            </select>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </span>
+</div>
+<div class="field">
+    <label class="field__label" for="field3">Field 3</label>
+    <span class="field__control switch">
+        <input aria-label="Switch Demo" class="switch__control" role="switch" type="checkbox" id="field3" />
+        <span class="switch__button"></span>
+    </span>
+</div>
+    {% endhighlight %}
+
     <p>For a textarea, the label will be vertically aligned to the middle of the field by default. Apply the <span class="highlight">field--align-top</span> modifier to align it to the top.</p>
 
     <div class="demo">
@@ -112,11 +143,20 @@
             <span class="field field--align-top">
                 <label class="field__label" for="field-textarea-1">Field 1</label>
                 <span class="field__control textbox">
-                    <textarea class="textbox__control" id="field-textarea-1" type="text" placeholder="placeholder text"></textarea>
+                    <textarea class="textbox__control" id="field-textarea-1"></textarea>
                 </span>
             </span>
         </div>
     </div>
+
+{% highlight html %}
+<span class="field field--align-top">
+    <label class="field__label" for="field-textarea-1">Field 1</label>
+    <span class="field__control textbox">
+        <textarea class="textbox__control" id="field-textarea-1"></textarea>
+    </span>
+</span>
+{% endhighlight %}
 
     <h3 id="field-stacked">Stacked Field</h3>
     <p>For a label stacked above the control, use the <span class="highlight">field__label--stacked</span> element modifier.</p>
@@ -221,54 +261,18 @@
         </div>
     </div>
 
-    <h3 id="field-fontsize">Field Font-Size</h3>
-    <p>The field label will honour any font-size cascade (so be careful if this is not your intention!).</p>
-    <p>Notice that form controls do not inherit the cascade. This is default browser behaviour.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <span class="field" style="font-size: 18px;">
-                <label class="field__label" for="field-fontsize-1">Field 1</label>
-                <span class="field__control textbox textbox--large">
-                    <input class="textbox__control" id="field-fontsize-1" type="text" placeholder="placeholder text" />
-                </span>
-            </span>
-            <span class="field" style="font-size: 18px;">
-                <label class="field__label" for="field-fontsize-2">Field 2</label>
-                <span class="field__control">
-                    <span class="select">
-                        <select name="field-fontsize-2" id="field-fontsize-2">
-                            <option value="1">Option 1</option>
-                            <option value="2">Option 2</option>
-                            <option value="3">Option 3</option>
-                        </select>
-                        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include common/symbol.html name="dropdown" %}
-                        </svg>
-                    </span>
-                </span>
-            </span>
-            <span class="field" style="font-size: 18px;">
-                <label class="field__label" for="field-fontsize-3">Field 3</label>
-                <span class="field__control switch switch--form">
-                    <input aria-label="Switch Demo" class="switch__control" role="switch" type="checkbox" id="field-fontsize-3" />
-                    <span class="switch__button"></span>
-                </span>
-            </span>
-        </div>
-    </div>
     {% highlight html %}
-<span class="field" style="font-size: 18px;">
-    <label class="field__label" for="email">Field 1</label>
-    <span class="field__control textbox textbox--large">
+<div class="field">
+    <label class="field__label field__label--stacked" for="field1">Field 1</label>
+    <span class="textbox">
         <input class="textbox__control" id="field1" type="text" placeholder="placeholder text" />
     </span>
-</span>
-<span class="field" style="font-size: 18px;">
-    <label class="field__label" for="size">Field 2</label>
+</div>
+<div class="field">
+    <label class="field__label field__label--stacked" for="field2">Field 2</label>
     <span class="field__control">
         <span class="select">
-            <select name="size" id="size">
+            <select name="field2" id="field2">
                 <option value="1">Option 1</option>
                 <option value="2">Option 2</option>
                 <option value="3">Option 3</option>
@@ -278,12 +282,91 @@
             </svg>
         </span>
     </span>
-</span>
-<span class="field" style="font-size: 18px;">
-    <label class="field__label" for="field3">Field 3</label>
+</div>
+<span class="field">
+    <label class="field__label field__label--stacked">Field 3</label>
     <span class="field__control switch">
         <input aria-label="Switch Demo" class="switch__control" role="switch" type="checkbox" id="field3" />
         <span class="switch__button"></span>
+    </span>
+</div>
+    {% endhighlight %}
+
+    <h3 id="field-fontsize">Field Font-Size</h3>
+    <p>The field label will honour any font-size cascade. Wrap the label and control in a <span class="highlight">field__group</span> element to maintain vertical alignment.</p>
+    <p><strong>NOTE</strong>: form controls do not inherit the font-size cascade. This is default browser behaviour.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="field" style="font-size: 18px;">
+                <span class="field__group">
+                    <label class="field__label" for="field-fontsize-1">Field 1</label>
+                    <span class="field__control textbox">
+                        <input class="textbox__control" id="field-fontsize-1" type="text" placeholder="placeholder text" />
+                    </span>
+                </span>
+            </span>
+            <span class="field" style="font-size: 18px;">
+                <span class="field__group">
+                    <label class="field__label" for="field-fontsize-2">Field 2</label>
+                    <span class="field__control">
+                        <span class="select">
+                            <select name="field-fontsize-2" id="field-fontsize-2">
+                                <option value="1">Option 1</option>
+                                <option value="2">Option 2</option>
+                                <option value="3">Option 3</option>
+                            </select>
+                            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                                {% include common/symbol.html name="dropdown" %}
+                            </svg>
+                        </span>
+                    </span>
+                </span>
+            </span>
+            <span class="field" style="font-size: 18px;">
+                <span class="field__group">
+                    <label class="field__label" for="field-fontsize-3">Field 3</label>
+                    <span class="field__control switch switch--form">
+                        <input aria-label="Switch Demo" class="switch__control" role="switch" type="checkbox" id="field-fontsize-3" />
+                        <span class="switch__button"></span>
+                    </span>
+                </span>
+            </span>
+        </div>
+    </div>
+    {% highlight html %}
+<span class="field" style="font-size: 18px;">
+    <span class="field__group">
+        <label class="field__label" for="email">Field 1</label>
+        <span class="field__control textbox">
+            <input class="textbox__control" id="field1" type="text" placeholder="placeholder text" />
+        </span>
+    </span>
+</span>
+<span class="field" style="font-size: 18px;">
+    <span class="field__group">
+        <label class="field__label" for="size">Field 2</label>
+        <span class="field__control">
+            <span class="select">
+                <select name="size" id="size">
+                    <option value="1">Option 1</option>
+                    <option value="2">Option 2</option>
+                    <option value="3">Option 3</option>
+                </select>
+                <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </span>
+        </span>
+    </span>
+</span>
+<span class="field" style="font-size: 18px;">
+    <span class="field__group">
+        <label class="field__label" for="field3">Field 3</label>
+        <span class="field__control switch">
+            <input aria-label="Switch Demo" class="switch__control" role="switch" type="checkbox" id="field3" />
+            <span class="switch__button"></span>
+        </span>
     </span>
 </span>
     {% endhighlight %}

--- a/docs/_includes/common/radio.html
+++ b/docs/_includes/common/radio.html
@@ -105,7 +105,7 @@
     <h3 id="radio-group">Grouped Radio</h3>
     <p>A group of radios enforces single-select (unlike a group of checkboxes which allows multi-select).</p>
     <p>A <span class="highlight">fieldset</span> and <span class="highlight">legend</span> are <strong>required</strong> in order to create the correct grouping semantics. Note that the Skin <span class="highlight">global</span> module removes the default fieldset border and padding.</p>
-    <p><strong>TIP:</strong> To stack radio buttons vertically instead of side-by-side, simply replace the <span class="highlight">span</span> wrapper with a <span class="highlight">div</span> wrapper.</p>
+    <p>The following example uses the <a href="#field">field module</a> for simple layout of radio button fields and labels.</p>
     <div class="demo">
         <div class="demo__inner">
             <fieldset>
@@ -201,6 +201,107 @@
         </span>
         <label class="field__label field__label--end" for="group-radio-3">Option 3</label>
     </span>
+</fieldset>
+    {% endhighlight %}
+
+    <p><strong>TIP</strong>: For large radios, wrap each label and control inside of a <span class="highlight">field__group</span> element to maintain vertical alignment.</p>
+    <p>To stack radio buttons vertically instead of side-by-side, simply replace the <span class="highlight">span</span> wrapper with a <span class="highlight">div</span> wrapper.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <fieldset>
+                <legend>Choose an Option</legend>
+                <div class="field">
+                    <span class="field__control radio">
+                        <input class="radio__control" id="group-radio-4" type="radio" value="1" name="radio-group" />
+                        <span class="radio__icon" hidden>
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="radio-unchecked" %}
+                            </svg>
+                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="radio-checked" %}
+                            </svg>
+                        </span>
+                    </span>
+                    <label class="field__label field__label--end" for="group-radio-4">Option 1</label>
+                </div>
+                <div class="field">
+                    <span class="field__control radio">
+                        <input class="radio__control" id="group-radio-5" type="radio" value="3" name="radio-group" />
+                        <span class="radio__icon" hidden>
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="radio-unchecked" %}
+                            </svg>
+                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="radio-checked" %}
+                            </svg>
+                        </span>
+                    </span>
+                    <label class="field__label field__label--end" for="group-radio-5">Option 2</label>
+                </div>
+                <div class="field">
+                    <span class="field__control radio">
+                        <input class="radio__control" id="group-radio-6" type="radio" value="3" name="radio-group" />
+                        <span class="radio__icon" hidden>
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="radio-unchecked" %}
+                            </svg>
+                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                                {% include common/symbol.html name="radio-checked" %}
+                            </svg>
+                        </span>
+                    </span>
+                    <label class="field__label field__label--end" for="group-radio-6">Option 3</label>
+                </div>
+            </fieldset>
+        </div>
+    </div>
+
+    {% highlight html %}
+<fieldset>
+    <legend>Choose an Option</legend>
+    <div class="field">
+        <span class="field__control radio">
+            <input class="radio__control" id="group-radio-4" type="radio" value="1" name="radio-group" />
+            <span class="radio__icon" hidden>
+                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-unchecked"></use>
+                </svg>
+                <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-radio-4">Option 1</label>
+    </div>
+    <div class="field">
+        <span class="field__control radio">
+            <input class="radio__control" id="group-radio-5" type="radio" value="2" name="radio-group" />
+            <span class="radio__icon" hidden>
+                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-unchecked"></use>
+                </svg>
+                <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-radio-5">Option 2</label>
+    </div>
+    <div class="field">
+        <span class="field__control radio">
+            <input class="radio__control" id="group-radio-6" type="radio" value="3" name="radio-group" />
+            <span class="radio__icon" hidden>
+                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-unchecked"></use>
+                </svg>
+                <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <use xlink:href="#icon-radio-checked"></use>
+                </svg>
+            </span>
+        </span>
+        <label class="field__label field__label--end" for="group-radio-6">Option 3</label>
+    </div>
 </fieldset>
     {% endhighlight %}
 </div>


### PR DESCRIPTION
# Closes #1399

This is a documentation change only. It adds instructions on how to use `field__group` wrapper to ensure vertical alignment of fields and their label when none-default font-sizes or radio/checkbox sizes are used. 

In future we can revisit the field module to see if it makes sense to make this the default behaviour of field without requiring an additional element. I know we can't do it now as it breaks the way a couple of the field variations work.

![Screen Shot 2021-05-11 at 1 00 51 PM](https://user-images.githubusercontent.com/38065/117877298-3ec71500-b259-11eb-889d-d5ba9a1cb72a.png)


