### PR TITLE
fix(imageTreatment): added ::after element to cover whole image

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -59,11 +59,21 @@
 .carousel__list--image-treatment > li {
   -webkit-box-align: center;
           align-items: center;
-  background-color: rgba(0, 0, 0, 0.05);
   display: -webkit-box;
   display: flex;
   -webkit-box-pack: center;
           justify-content: center;
+  position: relative;
+}
+.carousel__list--image-treatment > li::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 .carousel__list--image-treatment > li > img {
   display: inline-block;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -59,11 +59,21 @@
 .carousel__list--image-treatment > li {
   -webkit-box-align: center;
           align-items: center;
-  background-color: rgba(0, 0, 0, 0.05);
   display: -webkit-box;
   display: flex;
   -webkit-box-pack: center;
           justify-content: center;
+  position: relative;
+}
+.carousel__list--image-treatment > li::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 .carousel__list--image-treatment > li > img {
   display: inline-block;

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -95,9 +95,20 @@
 
 .imageTreatment() {
     align-items: center;
-    background-color: rgba(0, 0, 0, 0.05);
     display: flex;
     justify-content: center;
+    position: relative;
+
+    &::after {
+        background: rgba(0, 0, 0, 0.05);
+        bottom: 0;
+        content: "";
+        display: block;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
 
     > img {
         display: inline-block;

--- a/dist/utility/ds4/utility.css
+++ b/dist/utility/ds4/utility.css
@@ -47,11 +47,21 @@
 .image-treatment {
   -webkit-box-align: center;
           align-items: center;
-  background-color: rgba(0, 0, 0, 0.05);
   display: -webkit-box;
   display: flex;
   -webkit-box-pack: center;
           justify-content: center;
+  position: relative;
+}
+.image-treatment::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 .image-treatment > img {
   display: inline-block;

--- a/dist/utility/ds6/utility.css
+++ b/dist/utility/ds6/utility.css
@@ -47,11 +47,21 @@
 .image-treatment {
   -webkit-box-align: center;
           align-items: center;
-  background-color: rgba(0, 0, 0, 0.05);
   display: -webkit-box;
   display: flex;
   -webkit-box-pack: center;
           justify-content: center;
+  position: relative;
+}
+.image-treatment::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 .image-treatment > img {
   display: inline-block;

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -95,9 +95,20 @@
 
 .imageTreatment() {
     align-items: center;
-    background-color: rgba(0, 0, 0, 0.05);
     display: flex;
     justify-content: center;
+    position: relative;
+
+    &::after {
+        background: rgba(0, 0, 0, 0.05);
+        bottom: 0;
+        content: "";
+        display: block;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
 
     > img {
         display: inline-block;


### PR DESCRIPTION
## Description
So our old image layering would only add a background color. However for non transparent images this would not work.
As per playbook, there is a layer placed ontop of the image with a slight grey. This change basically makes it to add a layer on top of the whole image.

## References
https://github.com/eBay/ebayui-core/issues/1362

## Screenshots
Before:
<img width="722" alt="Screen Shot 2021-05-13 at 10 04 14 AM" src="https://user-images.githubusercontent.com/1755269/118160019-99d04780-b3d2-11eb-9ee1-152e997fbe81.png">


After:
<img width="658" alt="Screen Shot 2021-05-13 at 10 00 21 AM" src="https://user-images.githubusercontent.com/1755269/118159961-89b86800-b3d2-11eb-86f7-d1e29bb7bcc3.png">

