### PR TITLE
fix(button): add max-height to svg icon #1322

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -93,7 +93,7 @@ a.fake-btn svg.icon {
   align-self: center;
   flex-shrink: 0;
   height: 100%;
-  max-height: 28px;
+  max-height: 18px;
   width: 1em;
 }
 button.btn svg.icon:first-child,
@@ -140,6 +140,10 @@ a.fake-btn--primary:visited {
 button.btn .spinner {
   height: 19px;
   width: 19px;
+}
+button.btn--large svg.icon,
+a.fake-btn--large svg.icon {
+  max-height: 20px;
 }
 button.btn--confirmation {
   background-color: #5ba71b;

--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -93,6 +93,7 @@ a.fake-btn svg.icon {
   align-self: center;
   flex-shrink: 0;
   height: 100%;
+  max-height: 28px;
   width: 1em;
 }
 button.btn svg.icon:first-child,

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -93,7 +93,7 @@ a.fake-btn svg.icon {
   align-self: center;
   flex-shrink: 0;
   height: 100%;
-  max-height: 28px;
+  max-height: 18px;
   width: 1em;
 }
 button.btn svg.icon:first-child,
@@ -140,6 +140,10 @@ a.fake-btn--primary:visited {
 button.btn .spinner {
   height: 19px;
   width: 19px;
+}
+button.btn--large svg.icon,
+a.fake-btn--large svg.icon {
+  max-height: 20px;
 }
 button.btn--confirmation {
   background-color: #28a443;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -93,6 +93,7 @@ a.fake-btn svg.icon {
   align-self: center;
   flex-shrink: 0;
   height: 100%;
+  max-height: 28px;
   width: 1em;
 }
 button.btn svg.icon:first-child,

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -50,6 +50,7 @@ a.fake-btn svg.icon {
 
     flex-shrink: 0;
     height: 100%;
+    max-height: 28px;
     width: 1em;
 }
 

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -50,7 +50,7 @@ a.fake-btn svg.icon {
 
     flex-shrink: 0;
     height: 100%;
-    max-height: 28px;
+    max-height: 40px - (@button-padding-vertical * 2);
     width: 1em;
 }
 
@@ -85,6 +85,11 @@ a.fake-btn--primary {
 button.btn .spinner {
     height: 19px;
     width: 19px;
+}
+
+button.btn--large svg.icon,
+a.fake-btn--large svg.icon {
+    max-height: 48px - (@button-large-padding-vertical * 2);
 }
 
 button.btn--confirmation {


### PR DESCRIPTION
Fixes #1322 

Adds a max height to SVG icon to avoid HUGE buttons in IE11.

We can probably refactor and simplify this aspect of the button code in next major version when we drop IE completely.

## Before

![Screen Shot 2021-05-14 at 12 54 27 PM](https://user-images.githubusercontent.com/38065/118323483-8fd34500-b4b5-11eb-94ab-2e2b8c1e5e6a.png)


## After

![Screen Shot 2021-05-14 at 12 54 12 PM](https://user-images.githubusercontent.com/38065/118323507-95c92600-b4b5-11eb-8215-93dc040bdeea.png)

