### PR TITLE
fix(progress-stepper): added align:flex-start to vertical-stepper text

### DIFF
--- a/dist/progress-stepper/ds4/progress-stepper.css
+++ b/dist/progress-stepper/ds4/progress-stepper.css
@@ -116,6 +116,7 @@ hr.progress-stepper__separator--upcoming,
   display: block;
 }
 .progress-stepper--vertical .progress-stepper__item .progress-stepper__text {
+  align-self: flex-start;
   margin-left: 16px;
   margin-top: 0;
   text-align: left;

--- a/dist/progress-stepper/ds6/progress-stepper.css
+++ b/dist/progress-stepper/ds6/progress-stepper.css
@@ -116,6 +116,7 @@ hr.progress-stepper__separator--upcoming,
   display: block;
 }
 .progress-stepper--vertical .progress-stepper__item .progress-stepper__text {
+  align-self: flex-start;
   margin-left: 16px;
   margin-top: 0;
   text-align: left;

--- a/src/less/progress-stepper/base/progress-stepper.less
+++ b/src/less/progress-stepper/base/progress-stepper.less
@@ -116,6 +116,7 @@ hr.progress-stepper__separator--upcoming,
 }
 
 .progress-stepper--vertical .progress-stepper__item .progress-stepper__text {
+    align-self: flex-start;
     margin-left: 16px;
     margin-top: 0;
     text-align: left;


### PR DESCRIPTION
## Description
Added a `align-self: flex-start` to vertical stepper text, which should override the `align-self: flex-end` from the normal stepper


## References
https://github.com/eBay/skin/issues/1441

## Screenshots
<img width="498" alt="Screen Shot 2021-05-17 at 9 26 44 AM" src="https://user-images.githubusercontent.com/1755269/118523985-8c78cd00-b6f2-11eb-9b36-73921471946c.png">
