### PR TITLE
fix: removed padding-bottom: 15vh from panel-dialog

### DIFF
--- a/dist/panel-dialog/ds4/panel-dialog.css
+++ b/dist/panel-dialog/ds4/panel-dialog.css
@@ -33,7 +33,6 @@
   border-right: 1px solid rgba(153, 153, 153, 0.18);
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
-  padding-bottom: 15vh;
   width: calc(100% - 32px);
 }
 .panel-dialog__window--end {

--- a/dist/panel-dialog/ds6/panel-dialog.css
+++ b/dist/panel-dialog/ds6/panel-dialog.css
@@ -33,7 +33,6 @@
   border-right: 1px solid rgba(153, 153, 153, 0.18);
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
-  padding-bottom: 15vh;
   width: calc(100% - 32px);
 }
 .panel-dialog__window--end {

--- a/src/less/panel-dialog/base/panel-dialog.less
+++ b/src/less/panel-dialog/base/panel-dialog.less
@@ -12,7 +12,6 @@
     border-right: 1px solid rgba(153, 153, 153, 0.18);
     -webkit-overflow-scrolling: touch;
     overflow-y: auto;
-    padding-bottom: 15vh;
     width: calc(100% - 32px);
 }
 


### PR DESCRIPTION
## Description
Looks like this padding came from dialog refactor. It doesn't seem needed on panel dialog. 

## References
https://github.com/eBay/skin/issues/1455