### PR TITLE
Breadcrumbs now wraps when text is long. Added Scroll Option. Fixed Outline Offset

### DIFF
--- a/dist/breadcrumbs/ds4/breadcrumbs.css
+++ b/dist/breadcrumbs/ds4/breadcrumbs.css
@@ -6,18 +6,14 @@ nav.breadcrumbs {
   height: fit-content;
   margin: 8px 0;
   min-height: 16px;
-  overflow: hidden;
-  position: relative;
-  white-space: nowrap;
 }
 nav.breadcrumbs ul {
   display: -webkit-box;
   display: flex;
-  list-style-type: none;
+  flex-wrap: wrap;
   margin: 0;
   min-width: 100%;
   padding: 0;
-  position: absolute;
   right: 0;
 }
 nav.breadcrumbs li {
@@ -25,6 +21,7 @@ nav.breadcrumbs li {
           align-items: center;
   display: -webkit-box;
   display: flex;
+  flex-wrap: wrap;
 }
 nav.breadcrumbs li svg {
   margin-left: 7px;
@@ -47,7 +44,7 @@ nav.breadcrumbs a:visited {
 nav.breadcrumbs a,
 nav.breadcrumbs button {
   color: inherit;
-  outline-offset: -4px;
+  outline-offset: 5px;
 }
 nav.breadcrumbs a:focus,
 nav.breadcrumbs button:focus,
@@ -66,6 +63,18 @@ nav.breadcrumbs button[aria-current] {
 nav.breadcrumbs a:focus:not(:focus-visible),
 nav.breadcrumbs button:focus:not(:focus-visible) {
   outline: none;
+}
+nav.breadcrumbs--scroll {
+  min-height: 32px;
+  overflow: scroll;
+  position: relative;
+  white-space: nowrap;
+}
+nav.breadcrumbs--scroll li {
+  display: inline;
+}
+nav.breadcrumbs--scroll ul {
+  display: inline;
 }
 @media (min-width: 601px) {
   nav.breadcrumbs {

--- a/dist/breadcrumbs/ds6/breadcrumbs.css
+++ b/dist/breadcrumbs/ds6/breadcrumbs.css
@@ -6,18 +6,14 @@ nav.breadcrumbs {
   height: fit-content;
   margin: 8px 0;
   min-height: 16px;
-  overflow: hidden;
-  position: relative;
-  white-space: nowrap;
 }
 nav.breadcrumbs ul {
   display: -webkit-box;
   display: flex;
-  list-style-type: none;
+  flex-wrap: wrap;
   margin: 0;
   min-width: 100%;
   padding: 0;
-  position: absolute;
   right: 0;
 }
 nav.breadcrumbs li {
@@ -25,6 +21,7 @@ nav.breadcrumbs li {
           align-items: center;
   display: -webkit-box;
   display: flex;
+  flex-wrap: wrap;
 }
 nav.breadcrumbs li svg {
   margin-left: 7px;
@@ -47,7 +44,7 @@ nav.breadcrumbs a:visited {
 nav.breadcrumbs a,
 nav.breadcrumbs button {
   color: inherit;
-  outline-offset: -4px;
+  outline-offset: 5px;
 }
 nav.breadcrumbs a:focus,
 nav.breadcrumbs button:focus,
@@ -66,6 +63,18 @@ nav.breadcrumbs button[aria-current] {
 nav.breadcrumbs a:focus:not(:focus-visible),
 nav.breadcrumbs button:focus:not(:focus-visible) {
   outline: none;
+}
+nav.breadcrumbs--scroll {
+  min-height: 32px;
+  overflow: scroll;
+  position: relative;
+  white-space: nowrap;
+}
+nav.breadcrumbs--scroll li {
+  display: inline;
+}
+nav.breadcrumbs--scroll ul {
+  display: inline;
 }
 @media (min-width: 601px) {
   nav.breadcrumbs {

--- a/docs/_includes/common/breadcrumbs.html
+++ b/docs/_includes/common/breadcrumbs.html
@@ -170,4 +170,124 @@
     </ul>
 </nav>
     {% endhighlight %}
+    <p>Breadcrumbs will wrap around if text is too long</p>
+    <div class="demo">
+        <div class="demo__inner">
+            <nav aria-labelledby="breadcrumbs-heading-1" class="breadcrumbs" role="navigation">
+                <h2 id="breadcrumbs-heading-1" class="clipped">You are here</h2>
+                <ul>
+                    <li>
+                        <a href="https://www.ebay.com/">ebay</a>
+                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                            {% include common/symbol.html name="breadcrumb" %}
+                        </svg>
+                    </li>
+                    <li>
+                        <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches Cell Phones, Smart Watches Cell Phones, Smart Watches Cell Phones, Smart Watches Cell Phones, Smart Watches &amp; Accessories</a>
+                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                            {% include common/symbol.html name="breadcrumb" %}
+                        </svg>
+                    </li>
+                    <li>
+                        <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                            {% include common/symbol.html name="breadcrumb" %}
+                        </svg>
+                    </li>
+                    <li>
+                        <a aria-current="location">Smart Watch Bands</a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+    {% highlight html %}
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+    <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+    <ul>
+        <li>
+            <a href="https://www.ebay.com/">ebay</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a aria-current="location">Smart Watch Bands</a>
+        </li>
+    </ul>
+</nav>
+    {% endhighlight %}
+
+    <p>Breadcrumbs with long text can scroll instead of wrap with the breadcrumbs--scroll class </p>
+    <div class="demo">
+        <div class="demo__inner">
+            <nav aria-labelledby="breadcrumbs-heading-1" class="breadcrumbs breadcrumbs--scroll" role="navigation">
+                <h2 id="breadcrumbs-heading-1" class="clipped">You are here</h2>
+                <ul>
+                    <li>
+                        <a href="https://www.ebay.com/">ebay</a>
+                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                            {% include common/symbol.html name="breadcrumb" %}
+                        </svg>
+                    </li>
+                    <li>
+                        <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches Cell Phones, Smart Watches Cell Phones, Smart Watches Cell Phones, Smart Watches Cell Phones, Smart Watches &amp; Accessories</a>
+                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                            {% include common/symbol.html name="breadcrumb" %}
+                        </svg>
+                    </li>
+                    <li>
+                        <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                            {% include common/symbol.html name="breadcrumb" %}
+                        </svg>
+                    </li>
+                    <li>
+                        <a aria-current="location">Smart Watch Bands</a>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+    {% highlight html %}
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs breadcrumbs--scroll" role="navigation">
+    <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+    <ul>
+        <li>
+            <a href="https://www.ebay.com/">ebay</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a aria-current="location">Smart Watch Bands</a>
+        </li>
+    </ul>
+</nav>
+    {% endhighlight %}
+
 </div>

--- a/src/less/breadcrumbs/base/breadcrumbs.less
+++ b/src/less/breadcrumbs/base/breadcrumbs.less
@@ -7,17 +7,13 @@ nav.breadcrumbs {
     height: fit-content;
     margin: 8px 0;
     min-height: 16px;
-    overflow: hidden; // causing font zoom & keyboard focus issues (#927)
-    position: relative;
-    white-space: nowrap;
 
     ul {
         display: flex;
-        list-style-type: none;
+        flex-wrap: wrap;
         margin: 0;
         min-width: 100%;
         padding: 0;
-        position: absolute;
         right: 0;
     }
 
@@ -26,6 +22,7 @@ nav.breadcrumbs {
     li {
         align-items: center;
         display: flex;
+        flex-wrap: wrap;
     }
 
     li svg {
@@ -54,7 +51,7 @@ nav.breadcrumbs {
     a,
     button {
         color: inherit;
-        outline-offset: -4px; // needed because of hidden overflow
+        outline-offset: 5px;
 
         &:focus,
         &:hover {
@@ -76,6 +73,21 @@ nav.breadcrumbs {
         &:not(:focus-visible) {
             outline: none;
         }
+    }
+}
+
+nav.breadcrumbs--scroll {
+    min-height: 32px; // to see and interact with the scroll bar easier
+    overflow: scroll;
+    position: relative;
+    white-space: nowrap;
+
+    li {
+        display: inline;
+    }
+
+    ul {
+        display: inline;
     }
 }
 


### PR DESCRIPTION
## Description
- This PR allows the breadcrumbs to wrap around when there is long text. 
- An option was added to allow scrolling instead of wrapping with long text -- the `breadcrumbs--scroll` class. 
- I fixed the outline so that it no longer obscures the text.
- I fixed the outline offset size in this PR. I thought about putting that into a separate PR, but it had a comment that was no longer accurate referring to `over-flow: hidden` on the outline-offset line. Therefore I thought it was logical to include that change in this PR as well. 

## References
Closes #1303, #1459 

## Screenshots

Wrap

<img width="1055" alt="Screen Shot 2021-06-03 at 4 00 09 PM" src="https://user-images.githubusercontent.com/25092249/120725626-3e522080-c48b-11eb-8e9a-9eafb8619337.png">

Outline

<img width="611" alt="Screen Shot 2021-06-03 at 3 52 04 PM" src="https://user-images.githubusercontent.com/25092249/120725621-3d20f380-c48b-11eb-9e91-2d1192c692e4.png">
