### PR TITLE
chore: refactor dropdown mixins (#1463)

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -22,30 +22,26 @@ span.combobox {
 }
 .combobox__listbox {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--dropdown-background-color, #fff);
   border-color: #ccc;
-  border-color: var(--dropdown-items-border-color, #ccc);
+  border-color: var(--dropdown-border-color, #ccc);
   border-radius: 0;
-  border-radius: var(--dropdown-items-border-radius, 0);
+  border-radius: var(--dropdown-border-radius, 0);
   box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+  box-shadow: var(--dropdown-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  min-width: 100%;
-  width: auto;
-  max-height: 400px;
-  overflow-y: auto;
-  z-index: 2;
   display: none;
+  max-height: 400px;
+  min-width: 100%;
+  overflow-y: auto;
   position: absolute;
   top: calc(100% + 4px);
+  width: auto;
+  z-index: 2;
 }
 .combobox__option[role^="option"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #333;
-  color: var(--dropdown-item-foreground-color, #333);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -57,6 +53,10 @@ span.combobox {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--listbox-option-border-color, #fff);
+  color: #333;
+  color: var(--listbox-option-foreground-color, #333);
   cursor: default;
   position: relative;
 }
@@ -68,31 +68,31 @@ span.combobox {
 }
 .combobox__option[role^="option"]:hover {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--listbox-option-hover-background-color, #eee);
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--listbox-option-hover-foreground-color, #333);
 }
 .combobox__option[role^="option"]:active {
   font-weight: normal;
 }
 .combobox__option[role^="option"]:first-child {
   border-top-left-radius: 0;
-  border-top-left-radius: var(--dropdown-items-border-radius, 0);
+  border-top-left-radius: var(--dropdown-border-radius, 0);
   border-top-right-radius: 0;
-  border-top-right-radius: var(--dropdown-items-border-radius, 0);
+  border-top-right-radius: var(--dropdown-border-radius, 0);
 }
 .combobox__option[role^="option"]:last-child {
   border-bottom-left-radius: 0;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-left-radius: var(--dropdown-border-radius, 0);
   border-bottom-right-radius: 0;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-right-radius: var(--dropdown-border-radius, 0);
 }
 .combobox__option[role^="option"]:not(:last-child) {
   margin-bottom: 1px;
 }
 .combobox__option[role^="option"]:hover {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--listbox-option-hover-background-color, #eee);
 }
 .combobox__option[role^="option"] svg.icon {
   align-self: center;
@@ -106,7 +106,7 @@ span.combobox {
 }
 .combobox__option--active[role^="option"] {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--listbox-option-hover-background-color, #eee);
 }
 .combobox__option--active[role^="option"] svg.icon {
   opacity: 1;
@@ -129,6 +129,8 @@ span.combobox {
           transform: rotate(180deg);
 }
 .combobox__control > svg.icon--dropdown {
+  color: #333;
+  color: var(--combobox-icon-color, #333);
   margin-left: 8px;
   pointer-events: none;
   position: absolute;
@@ -222,7 +224,7 @@ span.combobox {
 }
 .combobox__option--active[role="option"] {
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--listbox-option-hover-foreground-color, #333);
   font-weight: normal;
 }
 @media all and (-ms-high-contrast: active), all and (-ms-high-contrast: none) {
@@ -263,9 +265,9 @@ span.combobox {
     --combobox-invalid-foreground-color: #e75064;
     --combobox-invalid-background-color: #2a191c;
     --combobox-icon-color: #ababab;
-    --dropdown-items-background-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-hover-foreground-color: #333;
+    --dropdown-background-color: #171717;
+    --listbox-option-foreground-color: #dcdcdc;
+    --listbox-option-border-color: #171717;
+    --listbox-option-hover-foreground-color: #333;
   }
 }

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -22,30 +22,26 @@ span.combobox {
 }
 .combobox__listbox {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--dropdown-background-color, #fff);
   border-color: #f5f5f5;
-  border-color: var(--dropdown-items-border-color, #f5f5f5);
+  border-color: var(--dropdown-border-color, #f5f5f5);
   border-radius: 8px;
-  border-radius: var(--dropdown-items-border-radius, 8px);
+  border-radius: var(--dropdown-border-radius, 8px);
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
-  box-shadow: var(--dropdown-items-box-shadow, 0 5px 15px rgba(0, 0, 0, 0.07));
+  box-shadow: var(--dropdown-box-shadow, 0 5px 15px rgba(0, 0, 0, 0.07));
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  min-width: 100%;
-  width: auto;
-  max-height: 400px;
-  overflow-y: auto;
-  z-index: 2;
   display: none;
+  max-height: 400px;
+  min-width: 100%;
+  overflow-y: auto;
   position: absolute;
   top: calc(100% + 4px);
+  width: auto;
+  z-index: 2;
 }
 .combobox__option[role^="option"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #111820;
-  color: var(--dropdown-item-foreground-color, #111820);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -57,6 +53,10 @@ span.combobox {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--listbox-option-border-color, #fff);
+  color: #111820;
+  color: var(--listbox-option-foreground-color, #111820);
   cursor: default;
   position: relative;
 }
@@ -68,31 +68,31 @@ span.combobox {
 }
 .combobox__option[role^="option"]:hover {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--listbox-option-hover-background-color, #e5e5e5);
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--listbox-option-hover-foreground-color, #111820);
 }
 .combobox__option[role^="option"]:active {
   font-weight: bold;
 }
 .combobox__option[role^="option"]:first-child {
   border-top-left-radius: 8px;
-  border-top-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-left-radius: var(--dropdown-border-radius, 8px);
   border-top-right-radius: 8px;
-  border-top-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-right-radius: var(--dropdown-border-radius, 8px);
 }
 .combobox__option[role^="option"]:last-child {
   border-bottom-left-radius: 8px;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-left-radius: var(--dropdown-border-radius, 8px);
   border-bottom-right-radius: 8px;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-right-radius: var(--dropdown-border-radius, 8px);
 }
 .combobox__option[role^="option"]:not(:last-child) {
   margin-bottom: 1px;
 }
 .combobox__option[role^="option"]:hover {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--listbox-option-hover-background-color, #e5e5e5);
 }
 .combobox__option[role^="option"] svg.icon {
   align-self: center;
@@ -106,7 +106,7 @@ span.combobox {
 }
 .combobox__option--active[role^="option"] {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--listbox-option-hover-background-color, #e5e5e5);
 }
 .combobox__option--active[role^="option"] svg.icon {
   opacity: 1;
@@ -129,6 +129,8 @@ span.combobox {
           transform: rotate(180deg);
 }
 .combobox__control > svg.icon--dropdown {
+  color: #111820;
+  color: var(--combobox-icon-color, #111820);
   margin-left: 8px;
   pointer-events: none;
   position: absolute;
@@ -222,7 +224,7 @@ span.combobox {
 }
 .combobox__option--active[role="option"] {
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--listbox-option-hover-foreground-color, #111820);
   font-weight: bold;
 }
 @media all and (-ms-high-contrast: active), all and (-ms-high-contrast: none) {
@@ -263,9 +265,9 @@ span.combobox {
     --combobox-invalid-foreground-color: #e75064;
     --combobox-invalid-background-color: #2a191c;
     --combobox-icon-color: #ababab;
-    --dropdown-items-background-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-hover-foreground-color: #111820;
+    --dropdown-background-color: #171717;
+    --listbox-option-foreground-color: #dcdcdc;
+    --listbox-option-border-color: #171717;
+    --listbox-option-hover-foreground-color: #111820;
   }
 }

--- a/dist/listbox-button/ds4/listbox-button.css
+++ b/dist/listbox-button/ds4/listbox-button.css
@@ -12,24 +12,24 @@ span.listbox-button--fluid .expand-btn {
 }
 div.listbox-button__listbox {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--dropdown-background-color, #fff);
   border-color: #ccc;
-  border-color: var(--dropdown-items-border-color, #ccc);
+  border-color: var(--dropdown-border-color, #ccc);
   border-radius: 0;
-  border-radius: var(--dropdown-items-border-radius, 0);
+  border-radius: var(--dropdown-border-radius, 0);
   box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+  box-shadow: var(--dropdown-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  min-width: 100%;
-  width: auto;
-  max-height: 400px;
-  overflow-y: auto;
-  z-index: 2;
   display: none;
+  max-height: 400px;
+  min-width: 100%;
+  overflow-y: auto;
   position: absolute;
   top: calc(100% + 4px);
+  width: auto;
+  z-index: 2;
 }
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
   display: block;
@@ -53,7 +53,9 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
 }
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--listbox-option-hover-background-color, #eee);
+  color: #333;
+  color: var(--listbox-option-hover-foreground-color, #333);
 }
 .listbox-button__option svg.icon {
   align-self: center;
@@ -66,22 +68,14 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
   width: 8px;
   margin-left: 8px;
 }
-[dir="rtl"] .listbox-button__option svg.icon {
-  margin-left: 0;
-  margin-right: 8px;
-}
 div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
   opacity: 1;
 }
 div.listbox-button__option[role="option"]:active svg.icon {
   color: #ccc;
-  color: var(--dropdown-item-active-status-color, #ccc);
+  color: var(--listbox-option-active-status-color, #ccc);
 }
 div.listbox-button__option[role="option"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #333;
-  color: var(--dropdown-item-foreground-color, #333);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -93,6 +87,10 @@ div.listbox-button__option[role="option"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--listbox-option-border-color, #fff);
+  color: #333;
+  color: var(--listbox-option-foreground-color, #333);
   cursor: default;
 }
 div.listbox-button__option[role="option"]:not(:last-child) {
@@ -103,24 +101,24 @@ div.listbox-button__option[role="option"]:focus {
 }
 div.listbox-button__option[role="option"]:hover {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--listbox-option-hover-background-color, #eee);
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--listbox-option-hover-foreground-color, #333);
 }
 div.listbox-button__option[role="option"]:active {
   font-weight: normal;
 }
 div.listbox-button__option[role="option"]:first-child {
   border-top-left-radius: 0;
-  border-top-left-radius: var(--dropdown-items-border-radius, 0);
+  border-top-left-radius: var(--dropdown-border-radius, 0);
   border-top-right-radius: 0;
-  border-top-right-radius: var(--dropdown-items-border-radius, 0);
+  border-top-right-radius: var(--dropdown-border-radius, 0);
 }
 div.listbox-button__option[role="option"]:last-child {
   border-bottom-left-radius: 0;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-left-radius: var(--dropdown-border-radius, 0);
   border-bottom-right-radius: 0;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-right-radius: var(--dropdown-border-radius, 0);
 }
 div.listbox-button__option--active[role="option"] {
   font-weight: normal;
@@ -135,13 +133,17 @@ span.listbox-button__value {
 .listbox-button__options:focus:not(:focus-visible) {
   outline: none;
 }
+[dir="rtl"] .listbox-button__option svg.icon {
+  margin-left: 0;
+  margin-right: 8px;
+}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .listbox-button {
-    --dropdown-items-background-color: #171717;
-    --dropdown-items-border-color: #171717;
-    --dropdown-item-background-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-hover-foreground-color: #333;
+    --dropdown-background-color: #171717;
+    --dropdown-border-color: #171717;
+    --listbox-option-background-color: #171717;
+    --listbox-option-foreground-color: #dcdcdc;
+    --listbox-option-border-color: #171717;
+    --listbox-option-hover-foreground-color: #333;
   }
 }

--- a/dist/listbox-button/ds6/listbox-button.css
+++ b/dist/listbox-button/ds6/listbox-button.css
@@ -12,24 +12,24 @@ span.listbox-button--fluid .expand-btn {
 }
 div.listbox-button__listbox {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--dropdown-background-color, #fff);
   border-color: #f5f5f5;
-  border-color: var(--dropdown-items-border-color, #f5f5f5);
+  border-color: var(--dropdown-border-color, #f5f5f5);
   border-radius: 8px;
-  border-radius: var(--dropdown-items-border-radius, 8px);
+  border-radius: var(--dropdown-border-radius, 8px);
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
-  box-shadow: var(--dropdown-items-box-shadow, 0 5px 15px rgba(0, 0, 0, 0.07));
+  box-shadow: var(--dropdown-box-shadow, 0 5px 15px rgba(0, 0, 0, 0.07));
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  min-width: 100%;
-  width: auto;
-  max-height: 400px;
-  overflow-y: auto;
-  z-index: 2;
   display: none;
+  max-height: 400px;
+  min-width: 100%;
+  overflow-y: auto;
   position: absolute;
   top: calc(100% + 4px);
+  width: auto;
+  z-index: 2;
 }
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
   display: block;
@@ -53,7 +53,9 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
 }
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--listbox-option-hover-background-color, #e5e5e5);
+  color: #111820;
+  color: var(--listbox-option-hover-foreground-color, #111820);
 }
 .listbox-button__option svg.icon {
   align-self: center;
@@ -66,22 +68,14 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
   width: 8px;
   margin-left: 8px;
 }
-[dir="rtl"] .listbox-button__option svg.icon {
-  margin-left: 0;
-  margin-right: 8px;
-}
 div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
   opacity: 1;
 }
 div.listbox-button__option[role="option"]:active svg.icon {
   color: #fff;
-  color: var(--dropdown-item-active-status-color, #fff);
+  color: var(--listbox-option-active-status-color, #fff);
 }
 div.listbox-button__option[role="option"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #111820;
-  color: var(--dropdown-item-foreground-color, #111820);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -93,6 +87,10 @@ div.listbox-button__option[role="option"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--listbox-option-border-color, #fff);
+  color: #111820;
+  color: var(--listbox-option-foreground-color, #111820);
   cursor: default;
 }
 div.listbox-button__option[role="option"]:not(:last-child) {
@@ -103,24 +101,24 @@ div.listbox-button__option[role="option"]:focus {
 }
 div.listbox-button__option[role="option"]:hover {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--listbox-option-hover-background-color, #e5e5e5);
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--listbox-option-hover-foreground-color, #111820);
 }
 div.listbox-button__option[role="option"]:active {
   font-weight: bold;
 }
 div.listbox-button__option[role="option"]:first-child {
   border-top-left-radius: 8px;
-  border-top-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-left-radius: var(--dropdown-border-radius, 8px);
   border-top-right-radius: 8px;
-  border-top-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-right-radius: var(--dropdown-border-radius, 8px);
 }
 div.listbox-button__option[role="option"]:last-child {
   border-bottom-left-radius: 8px;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-left-radius: var(--dropdown-border-radius, 8px);
   border-bottom-right-radius: 8px;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-right-radius: var(--dropdown-border-radius, 8px);
 }
 div.listbox-button__option--active[role="option"] {
   font-weight: bold;
@@ -135,13 +133,17 @@ span.listbox-button__value {
 .listbox-button__options:focus:not(:focus-visible) {
   outline: none;
 }
+[dir="rtl"] .listbox-button__option svg.icon {
+  margin-left: 0;
+  margin-right: 8px;
+}
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .listbox-button {
-    --dropdown-items-background-color: #171717;
-    --dropdown-items-border-color: #171717;
-    --dropdown-item-background-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-hover-foreground-color: #111820;
+    --dropdown-background-color: #171717;
+    --dropdown-border-color: #171717;
+    --listbox-option-background-color: #171717;
+    --listbox-option-foreground-color: #dcdcdc;
+    --listbox-option-border-color: #171717;
+    --listbox-option-hover-foreground-color: #111820;
   }
 }

--- a/dist/listbox/ds4/listbox.css
+++ b/dist/listbox/ds4/listbox.css
@@ -7,7 +7,7 @@ span.listbox {
 }
 div.listbox__options[role="listbox"] {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--listbox-background-color, #fff);
   cursor: default;
 }
 span.listbox__options[role="listbox"] {
@@ -20,10 +20,6 @@ div.listbox__options--reverse[role="listbox"] {
   right: 0;
 }
 div.listbox__option[role="option"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #333;
-  color: var(--dropdown-item-foreground-color, #333);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -35,6 +31,10 @@ div.listbox__option[role="option"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--listbox-option-border-color, #fff);
+  color: #333;
+  color: var(--listbox-option-foreground-color, #333);
 }
 div.listbox__option[role="option"]:not(:last-child) {
   margin-bottom: 1px;
@@ -44,24 +44,12 @@ div.listbox__option[role="option"]:focus {
 }
 div.listbox__option[role="option"]:hover {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--listbox-option-hover-background-color, #eee);
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--listbox-option-hover-foreground-color, #333);
 }
 div.listbox__option[role="option"]:active {
   font-weight: normal;
-}
-div.listbox__option[role="option"]:first-child {
-  border-top-left-radius: 0;
-  border-top-left-radius: var(--dropdown-items-border-radius, 0);
-  border-top-right-radius: 0;
-  border-top-right-radius: var(--dropdown-items-border-radius, 0);
-}
-div.listbox__option[role="option"]:last-child {
-  border-bottom-left-radius: 0;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 0);
-  border-bottom-right-radius: 0;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 0);
 }
 span.listbox__value {
   overflow: hidden;
@@ -87,27 +75,26 @@ div.listbox__option svg.icon {
 }
 div.listbox__options[role="listbox"]:focus .listbox__option--active[role="option"] {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--listbox-option-hover-background-color, #eee);
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--listbox-option-hover-foreground-color, #333);
 }
 div.listbox__option[aria-selected="true"] svg.icon {
   opacity: 1;
 }
 div.listbox__option[role="option"]:active svg.icon {
   color: #ccc;
-  color: var(--dropdown-item-active-status-color, #ccc);
+  color: var(--listbox-option-active-status-color, #ccc);
 }
 .listbox__options:focus:not(:focus-visible) {
   outline: none;
 }
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .listbox {
-    --dropdown-items-background-color: #171717;
-    --dropdown-items-border-color: #171717;
-    --dropdown-item-background-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-hover-foreground-color: #333;
+    --listbox-background-color: #171717;
+    --listbox-option-background-color: #171717;
+    --listbox-option-foreground-color: #dcdcdc;
+    --listbox-option-border-color: #171717;
+    --listbox-option-hover-foreground-color: #333;
   }
 }

--- a/dist/listbox/ds6/listbox.css
+++ b/dist/listbox/ds6/listbox.css
@@ -7,7 +7,7 @@ span.listbox {
 }
 div.listbox__options[role="listbox"] {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--listbox-background-color, #fff);
   cursor: default;
 }
 span.listbox__options[role="listbox"] {
@@ -20,10 +20,6 @@ div.listbox__options--reverse[role="listbox"] {
   right: 0;
 }
 div.listbox__option[role="option"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #111820;
-  color: var(--dropdown-item-foreground-color, #111820);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -35,6 +31,10 @@ div.listbox__option[role="option"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--listbox-option-border-color, #fff);
+  color: #111820;
+  color: var(--listbox-option-foreground-color, #111820);
 }
 div.listbox__option[role="option"]:not(:last-child) {
   margin-bottom: 1px;
@@ -44,24 +44,12 @@ div.listbox__option[role="option"]:focus {
 }
 div.listbox__option[role="option"]:hover {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--listbox-option-hover-background-color, #e5e5e5);
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--listbox-option-hover-foreground-color, #111820);
 }
 div.listbox__option[role="option"]:active {
   font-weight: bold;
-}
-div.listbox__option[role="option"]:first-child {
-  border-top-left-radius: 8px;
-  border-top-left-radius: var(--dropdown-items-border-radius, 8px);
-  border-top-right-radius: 8px;
-  border-top-right-radius: var(--dropdown-items-border-radius, 8px);
-}
-div.listbox__option[role="option"]:last-child {
-  border-bottom-left-radius: 8px;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 8px);
-  border-bottom-right-radius: 8px;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 8px);
 }
 span.listbox__value {
   overflow: hidden;
@@ -87,27 +75,26 @@ div.listbox__option svg.icon {
 }
 div.listbox__options[role="listbox"]:focus .listbox__option--active[role="option"] {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--listbox-option-hover-background-color, #e5e5e5);
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--listbox-option-hover-foreground-color, #111820);
 }
 div.listbox__option[aria-selected="true"] svg.icon {
   opacity: 1;
 }
 div.listbox__option[role="option"]:active svg.icon {
   color: #fff;
-  color: var(--dropdown-item-active-status-color, #fff);
+  color: var(--listbox-option-active-status-color, #fff);
 }
 .listbox__options:focus:not(:focus-visible) {
   outline: none;
 }
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .listbox {
-    --dropdown-items-background-color: #171717;
-    --dropdown-items-border-color: #171717;
-    --dropdown-item-background-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-hover-foreground-color: #111820;
+    --listbox-background-color: #171717;
+    --listbox-option-background-color: #171717;
+    --listbox-option-foreground-color: #dcdcdc;
+    --listbox-option-border-color: #171717;
+    --listbox-option-hover-foreground-color: #111820;
   }
 }

--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -6,23 +6,23 @@
 .menu-button__menu,
 .fake-menu-button__menu {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--dropdown-background-color, #fff);
   border-color: #ccc;
-  border-color: var(--dropdown-items-border-color, #ccc);
+  border-color: var(--dropdown-border-color, #ccc);
   border-radius: 0;
-  border-radius: var(--dropdown-items-border-radius, 0);
+  border-radius: var(--dropdown-border-radius, 0);
   box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  box-shadow: var(--dropdown-items-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
+  box-shadow: var(--dropdown-box-shadow, 0 2px 4px 0 rgba(199, 199, 199, 0.5));
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  min-width: 100%;
-  width: auto;
   display: none;
+  max-height: 400px;
+  min-width: 100%;
+  overflow-y: auto;
   position: absolute;
   top: calc(100% + 4px);
-  max-height: 400px;
-  overflow-y: auto;
+  width: auto;
   z-index: 2;
   outline: 0;
 }
@@ -39,10 +39,6 @@ span.fake-menu-button__button {
   padding: 0;
 }
 div.menu-button__item[role^="menuitem"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #333;
-  color: var(--dropdown-item-foreground-color, #333);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -54,6 +50,10 @@ div.menu-button__item[role^="menuitem"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--menu-menuitem-border-color, #fff);
+  color: #333;
+  color: var(--menu-menuitem-foreground-color, #333);
   cursor: default;
 }
 div.menu-button__item[role^="menuitem"]:not(:last-child) {
@@ -64,24 +64,24 @@ div.menu-button__item[role^="menuitem"]:focus {
 }
 div.menu-button__item[role^="menuitem"]:hover {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--menu-menuitem-hover-background-color, #eee);
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--menu-menuitem-hover-foreground-color, #333);
 }
 div.menu-button__item[role^="menuitem"]:active {
   font-weight: normal;
 }
 div.menu-button__item[role^="menuitem"]:first-child {
   border-top-left-radius: 0;
-  border-top-left-radius: var(--dropdown-items-border-radius, 0);
+  border-top-left-radius: var(--dropdown-border-radius, 0);
   border-top-right-radius: 0;
-  border-top-right-radius: var(--dropdown-items-border-radius, 0);
+  border-top-right-radius: var(--dropdown-border-radius, 0);
 }
 div.menu-button__item[role^="menuitem"]:last-child {
   border-bottom-left-radius: 0;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-left-radius: var(--dropdown-border-radius, 0);
   border-bottom-right-radius: 0;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-right-radius: var(--dropdown-border-radius, 0);
 }
 .menu-button__item svg.icon,
 .fake-menu-button__item svg.icon {
@@ -101,7 +101,7 @@ div.menu-button__item[role^="menuitem"]:last-child {
 }
 a.fake-menu-button__item {
   color: #333;
-  color: var(--dropdown-fake-anchor-color, #333);
+  color: var(--menu-anchor-color, #333);
   text-decoration: none;
 }
 a.fake-menu-button__item:focus {
@@ -110,13 +110,13 @@ a.fake-menu-button__item:focus {
 a.fake-menu-button__item:hover,
 a.fake-menu-button__item:visited {
   color: #333;
-  color: var(--dropdown-fake-anchor-color, #333);
+  color: var(--menu-anchor-color, #333);
 }
 button.fake-menu-button__item {
   background-color: #fff;
-  background-color: var(--dropdown-fake-button-background-color, #fff);
+  background-color: var(--menu-button-background-color, #fff);
   color: #333;
-  color: var(--dropdown-fake-button-color, #333);
+  color: var(--menu-button-foreground-color, #333);
   font-family: inherit;
   font-size: 1em;
   text-align: left;
@@ -124,7 +124,7 @@ button.fake-menu-button__item {
 button.fake-menu-button__item:active svg.icon,
 a.fake-menu-button__item:active svg.icon {
   color: #ccc;
-  color: var(--dropdown-item-active-status-color, #ccc);
+  color: var(--menu-menuitem-active-status-color, #ccc);
 }
 a.fake-menu-button__item:not([href]),
 button.fake-menu-button__item[disabled],
@@ -137,17 +137,13 @@ button.fake-menu-button__item[aria-current="page"] svg.icon {
 }
 div.menu-button__item[role^="menuitem"]:active svg.icon {
   color: #ccc;
-  color: var(--dropdown-item-active-status-color, #ccc);
+  color: var(--menu-menuitem-active-status-color, #ccc);
 }
 div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
   opacity: 1;
 }
 .fake-menu-button__menu a.fake-menu-button__item,
 .fake-menu-button__menu button.fake-menu-button__item {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #333;
-  color: var(--dropdown-item-foreground-color, #333);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -159,6 +155,10 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--menu-menuitem-border-color, #fff);
+  color: #333;
+  color: var(--menu-menuitem-foreground-color, #333);
 }
 .fake-menu-button__menu a.fake-menu-button__item:not(:last-child),
 .fake-menu-button__menu button.fake-menu-button__item:not(:last-child) {
@@ -171,9 +171,9 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
 .fake-menu-button__menu a.fake-menu-button__item:hover,
 .fake-menu-button__menu button.fake-menu-button__item:hover {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--menu-menuitem-hover-background-color, #eee);
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--menu-menuitem-hover-foreground-color, #333);
 }
 .fake-menu-button__menu a.fake-menu-button__item:active,
 .fake-menu-button__menu button.fake-menu-button__item:active {
@@ -181,15 +181,15 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
 }
 .fake-menu-button__menu > li:first-child a.fake-menu-button__item {
   border-top-left-radius: 0;
-  border-top-left-radius: var(--dropdown-items-border-radius, 0);
+  border-top-left-radius: var(--dropdown-border-radius, 0);
   border-top-right-radius: 0;
-  border-top-right-radius: var(--dropdown-items-border-radius, 0);
+  border-top-right-radius: var(--dropdown-border-radius, 0);
 }
 .fake-menu-button__menu > li:last-child a.fake-menu-button__item {
   border-bottom-left-radius: 0;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-left-radius: var(--dropdown-border-radius, 0);
   border-bottom-right-radius: 0;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 0);
+  border-bottom-right-radius: var(--dropdown-border-radius, 0);
 }
 .menu-button__menu--fix-width,
 .fake-menu-button__menu--fix-width {
@@ -255,7 +255,7 @@ div.menu-button__option--active[role="option"] {
 }
 hr.menu-button__separator {
   border-color: #eee;
-  border-color: var(--dropdown-separator-color, #eee);
+  border-color: var(--menu-separator-color, #eee);
   border-style: solid;
   border-width: 1px;
   margin: 0;
@@ -266,9 +266,9 @@ div.menu-button__item[role^="menuitem"]:focus:not(:focus-visible) {
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .menu-button,
   .skin-experiment-dark-mode .fake-menu-button {
-    --dropdown-items-background-color: #171717;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-hover-foreground-color: #333;
+    --dropdown-background-color: #171717;
+    --menu-menuitem-border-color: #171717;
+    --menu-menuitem-foreground-color: #dcdcdc;
+    --menu-menuitem-hover-foreground-color: #333;
   }
 }

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -6,23 +6,23 @@
 .menu-button__menu,
 .fake-menu-button__menu {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--dropdown-background-color, #fff);
   border-color: #f5f5f5;
-  border-color: var(--dropdown-items-border-color, #f5f5f5);
+  border-color: var(--dropdown-border-color, #f5f5f5);
   border-radius: 8px;
-  border-radius: var(--dropdown-items-border-radius, 8px);
+  border-radius: var(--dropdown-border-radius, 8px);
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.07);
-  box-shadow: var(--dropdown-items-box-shadow, 0 5px 15px rgba(0, 0, 0, 0.07));
+  box-shadow: var(--dropdown-box-shadow, 0 5px 15px rgba(0, 0, 0, 0.07));
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  min-width: 100%;
-  width: auto;
   display: none;
+  max-height: 400px;
+  min-width: 100%;
+  overflow-y: auto;
   position: absolute;
   top: calc(100% + 4px);
-  max-height: 400px;
-  overflow-y: auto;
+  width: auto;
   z-index: 2;
   outline: 0;
 }
@@ -39,10 +39,6 @@ span.fake-menu-button__button {
   padding: 0;
 }
 div.menu-button__item[role^="menuitem"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #111820;
-  color: var(--dropdown-item-foreground-color, #111820);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -54,6 +50,10 @@ div.menu-button__item[role^="menuitem"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--menu-menuitem-border-color, #fff);
+  color: #111820;
+  color: var(--menu-menuitem-foreground-color, #111820);
   cursor: default;
 }
 div.menu-button__item[role^="menuitem"]:not(:last-child) {
@@ -64,24 +64,24 @@ div.menu-button__item[role^="menuitem"]:focus {
 }
 div.menu-button__item[role^="menuitem"]:hover {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--menu-menuitem-hover-background-color, #e5e5e5);
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--menu-menuitem-hover-foreground-color, #111820);
 }
 div.menu-button__item[role^="menuitem"]:active {
   font-weight: bold;
 }
 div.menu-button__item[role^="menuitem"]:first-child {
   border-top-left-radius: 8px;
-  border-top-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-left-radius: var(--dropdown-border-radius, 8px);
   border-top-right-radius: 8px;
-  border-top-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-right-radius: var(--dropdown-border-radius, 8px);
 }
 div.menu-button__item[role^="menuitem"]:last-child {
   border-bottom-left-radius: 8px;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-left-radius: var(--dropdown-border-radius, 8px);
   border-bottom-right-radius: 8px;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-right-radius: var(--dropdown-border-radius, 8px);
 }
 .menu-button__item svg.icon,
 .fake-menu-button__item svg.icon {
@@ -101,7 +101,7 @@ div.menu-button__item[role^="menuitem"]:last-child {
 }
 a.fake-menu-button__item {
   color: #111820;
-  color: var(--dropdown-fake-anchor-color, #111820);
+  color: var(--menu-anchor-color, #111820);
   text-decoration: none;
 }
 a.fake-menu-button__item:focus {
@@ -110,13 +110,13 @@ a.fake-menu-button__item:focus {
 a.fake-menu-button__item:hover,
 a.fake-menu-button__item:visited {
   color: #111820;
-  color: var(--dropdown-fake-anchor-color, #111820);
+  color: var(--menu-anchor-color, #111820);
 }
 button.fake-menu-button__item {
   background-color: #fff;
-  background-color: var(--dropdown-fake-button-background-color, #fff);
+  background-color: var(--menu-button-background-color, #fff);
   color: #111820;
-  color: var(--dropdown-fake-button-color, #111820);
+  color: var(--menu-button-foreground-color, #111820);
   font-family: inherit;
   font-size: 1em;
   text-align: left;
@@ -124,7 +124,7 @@ button.fake-menu-button__item {
 button.fake-menu-button__item:active svg.icon,
 a.fake-menu-button__item:active svg.icon {
   color: #fff;
-  color: var(--dropdown-item-active-status-color, #fff);
+  color: var(--menu-menuitem-active-status-color, #fff);
 }
 a.fake-menu-button__item:not([href]),
 button.fake-menu-button__item[disabled],
@@ -137,17 +137,13 @@ button.fake-menu-button__item[aria-current="page"] svg.icon {
 }
 div.menu-button__item[role^="menuitem"]:active svg.icon {
   color: #fff;
-  color: var(--dropdown-item-active-status-color, #fff);
+  color: var(--menu-menuitem-active-status-color, #fff);
 }
 div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
   opacity: 1;
 }
 .fake-menu-button__menu a.fake-menu-button__item,
 .fake-menu-button__menu button.fake-menu-button__item {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #111820;
-  color: var(--dropdown-item-foreground-color, #111820);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -159,6 +155,10 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--menu-menuitem-border-color, #fff);
+  color: #111820;
+  color: var(--menu-menuitem-foreground-color, #111820);
 }
 .fake-menu-button__menu a.fake-menu-button__item:not(:last-child),
 .fake-menu-button__menu button.fake-menu-button__item:not(:last-child) {
@@ -171,9 +171,9 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
 .fake-menu-button__menu a.fake-menu-button__item:hover,
 .fake-menu-button__menu button.fake-menu-button__item:hover {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--menu-menuitem-hover-background-color, #e5e5e5);
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--menu-menuitem-hover-foreground-color, #111820);
 }
 .fake-menu-button__menu a.fake-menu-button__item:active,
 .fake-menu-button__menu button.fake-menu-button__item:active {
@@ -181,15 +181,15 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
 }
 .fake-menu-button__menu > li:first-child a.fake-menu-button__item {
   border-top-left-radius: 8px;
-  border-top-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-left-radius: var(--dropdown-border-radius, 8px);
   border-top-right-radius: 8px;
-  border-top-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-top-right-radius: var(--dropdown-border-radius, 8px);
 }
 .fake-menu-button__menu > li:last-child a.fake-menu-button__item {
   border-bottom-left-radius: 8px;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-left-radius: var(--dropdown-border-radius, 8px);
   border-bottom-right-radius: 8px;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 8px);
+  border-bottom-right-radius: var(--dropdown-border-radius, 8px);
 }
 .menu-button__menu--fix-width,
 .fake-menu-button__menu--fix-width {
@@ -255,7 +255,7 @@ div.menu-button__option--active[role="option"] {
 }
 hr.menu-button__separator {
   border-color: #e5e5e5;
-  border-color: var(--dropdown-separator-color, #e5e5e5);
+  border-color: var(--menu-separator-color, #e5e5e5);
   border-style: solid;
   border-width: 1px;
   margin: 0;
@@ -266,9 +266,9 @@ div.menu-button__item[role^="menuitem"]:focus:not(:focus-visible) {
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .menu-button,
   .skin-experiment-dark-mode .fake-menu-button {
-    --dropdown-items-background-color: #171717;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-hover-foreground-color: #111820;
+    --dropdown-background-color: #171717;
+    --menu-menuitem-border-color: #171717;
+    --menu-menuitem-foreground-color: #dcdcdc;
+    --menu-menuitem-hover-foreground-color: #111820;
   }
 }

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -1,7 +1,7 @@
 .menu__items,
 .fake-menu__items {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--menu-background-color, #fff);
   cursor: default;
 }
 span.menu,
@@ -37,7 +37,7 @@ span.fake-menu__items {
 }
 a.fake-menu__item {
   color: #333;
-  color: var(--dropdown-fake-anchor-color, #333);
+  color: var(--menu-anchor-color, #333);
   text-decoration: none;
 }
 button.fake-menu__item {
@@ -46,10 +46,6 @@ button.fake-menu__item {
 button.fake-menu__item,
 a.fake-menu__item,
 div.menu__item[role^="menuitem"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #333;
-  color: var(--dropdown-item-foreground-color, #333);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -61,6 +57,10 @@ div.menu__item[role^="menuitem"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--menu-menuitem-border-color, #fff);
+  color: #333;
+  color: var(--menu-menuitem-foreground-color, #333);
 }
 button.fake-menu__item:not(:last-child),
 a.fake-menu__item:not(:last-child),
@@ -76,30 +76,14 @@ button.fake-menu__item:hover,
 a.fake-menu__item:hover,
 div.menu__item[role^="menuitem"]:hover {
   background-color: #eee;
-  background-color: var(--dropdown-item-hover-background-color, #eee);
+  background-color: var(--menu-menuitem-hover-background-color, #eee);
   color: #333;
-  color: var(--dropdown-item-hover-foreground-color, #333);
+  color: var(--menu-menuitem-hover-foreground-color, #333);
 }
 button.fake-menu__item:active,
 a.fake-menu__item:active,
 div.menu__item[role^="menuitem"]:active {
   font-weight: normal;
-}
-button.fake-menu__item:first-child,
-a.fake-menu__item:first-child,
-div.menu__item[role^="menuitem"]:first-child {
-  border-top-left-radius: 0;
-  border-top-left-radius: var(--dropdown-items-border-radius, 0);
-  border-top-right-radius: 0;
-  border-top-right-radius: var(--dropdown-items-border-radius, 0);
-}
-button.fake-menu__item:last-child,
-a.fake-menu__item:last-child,
-div.menu__item[role^="menuitem"]:last-child {
-  border-bottom-left-radius: 0;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 0);
-  border-bottom-right-radius: 0;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 0);
 }
 a.fake-menu__item:focus {
   text-decoration: underline;
@@ -107,7 +91,7 @@ a.fake-menu__item:focus {
 button.fake-menu__item:active svg.icon,
 a.fake-menu__item:active svg.icon {
   color: #ccc;
-  color: var(--dropdown-item-active-status-color, #ccc);
+  color: var(--menu-menuitem-active-status-color, #ccc);
 }
 a.fake-menu__item[aria-current="page"] svg.icon,
 button.fake-menu__item[aria-current="page"] svg.icon {
@@ -120,7 +104,7 @@ div.menu__item[role^="menuitem"][aria-disabled="true"] {
 }
 div.menu__item[role^="menuitem"]:active svg.icon {
   color: #ccc;
-  color: var(--dropdown-item-active-status-color, #ccc);
+  color: var(--menu-menuitem-active-status-color, #ccc);
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
   opacity: 1;
@@ -164,7 +148,7 @@ div.menu__item[role^="menuitem"] span.badge {
 }
 hr.menu__separator {
   border-color: #eee;
-  border-color: var(--dropdown-separator-color, #eee);
+  border-color: var(--menu-separator-color, #eee);
   border-style: solid;
   border-width: 1px;
 }
@@ -174,9 +158,9 @@ div.menu__item[role^="menuitem"]:focus:not(:focus-visible) {
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .menu,
   .skin-experiment-dark-mode .fake-menu {
-    --dropdown-items-background-color: #171717;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-hover-foreground-color: #333;
+    --menu-background-color: #171717;
+    --menu-menuitem-border-color: #171717;
+    --menu-menuitem-foreground-color: #dcdcdc;
+    --menu-menuitem-hover-foreground-color: #333;
   }
 }

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -1,7 +1,7 @@
 .menu__items,
 .fake-menu__items {
   background-color: #fff;
-  background-color: var(--dropdown-items-background-color, #fff);
+  background-color: var(--menu-background-color, #fff);
   cursor: default;
 }
 span.menu,
@@ -37,7 +37,7 @@ span.fake-menu__items {
 }
 a.fake-menu__item {
   color: #111820;
-  color: var(--dropdown-fake-anchor-color, #111820);
+  color: var(--menu-anchor-color, #111820);
   text-decoration: none;
 }
 button.fake-menu__item {
@@ -46,10 +46,6 @@ button.fake-menu__item {
 button.fake-menu__item,
 a.fake-menu__item,
 div.menu__item[role^="menuitem"] {
-  border-color: #fff;
-  border-color: var(--dropdown-item-border-color, #fff);
-  color: #111820;
-  color: var(--dropdown-item-foreground-color, #111820);
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
@@ -61,6 +57,10 @@ div.menu__item[role^="menuitem"] {
           justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
+  border-color: #fff;
+  border-color: var(--menu-menuitem-border-color, #fff);
+  color: #111820;
+  color: var(--menu-menuitem-foreground-color, #111820);
 }
 button.fake-menu__item:not(:last-child),
 a.fake-menu__item:not(:last-child),
@@ -76,30 +76,14 @@ button.fake-menu__item:hover,
 a.fake-menu__item:hover,
 div.menu__item[role^="menuitem"]:hover {
   background-color: #e5e5e5;
-  background-color: var(--dropdown-item-hover-background-color, #e5e5e5);
+  background-color: var(--menu-menuitem-hover-background-color, #e5e5e5);
   color: #111820;
-  color: var(--dropdown-item-hover-foreground-color, #111820);
+  color: var(--menu-menuitem-hover-foreground-color, #111820);
 }
 button.fake-menu__item:active,
 a.fake-menu__item:active,
 div.menu__item[role^="menuitem"]:active {
   font-weight: bold;
-}
-button.fake-menu__item:first-child,
-a.fake-menu__item:first-child,
-div.menu__item[role^="menuitem"]:first-child {
-  border-top-left-radius: 8px;
-  border-top-left-radius: var(--dropdown-items-border-radius, 8px);
-  border-top-right-radius: 8px;
-  border-top-right-radius: var(--dropdown-items-border-radius, 8px);
-}
-button.fake-menu__item:last-child,
-a.fake-menu__item:last-child,
-div.menu__item[role^="menuitem"]:last-child {
-  border-bottom-left-radius: 8px;
-  border-bottom-left-radius: var(--dropdown-items-border-radius, 8px);
-  border-bottom-right-radius: 8px;
-  border-bottom-right-radius: var(--dropdown-items-border-radius, 8px);
 }
 a.fake-menu__item:focus {
   text-decoration: underline;
@@ -107,7 +91,7 @@ a.fake-menu__item:focus {
 button.fake-menu__item:active svg.icon,
 a.fake-menu__item:active svg.icon {
   color: #fff;
-  color: var(--dropdown-item-active-status-color, #fff);
+  color: var(--menu-menuitem-active-status-color, #fff);
 }
 a.fake-menu__item[aria-current="page"] svg.icon,
 button.fake-menu__item[aria-current="page"] svg.icon {
@@ -120,7 +104,7 @@ div.menu__item[role^="menuitem"][aria-disabled="true"] {
 }
 div.menu__item[role^="menuitem"]:active svg.icon {
   color: #fff;
-  color: var(--dropdown-item-active-status-color, #fff);
+  color: var(--menu-menuitem-active-status-color, #fff);
 }
 div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
   opacity: 1;
@@ -164,7 +148,7 @@ div.menu__item[role^="menuitem"] span.badge {
 }
 hr.menu__separator {
   border-color: #e5e5e5;
-  border-color: var(--dropdown-separator-color, #e5e5e5);
+  border-color: var(--menu-separator-color, #e5e5e5);
   border-style: solid;
   border-width: 1px;
 }
@@ -174,9 +158,9 @@ div.menu__item[role^="menuitem"]:focus:not(:focus-visible) {
 @media (prefers-color-scheme: dark) {
   .skin-experiment-dark-mode .menu,
   .skin-experiment-dark-mode .fake-menu {
-    --dropdown-items-background-color: #171717;
-    --dropdown-item-border-color: #171717;
-    --dropdown-item-foreground-color: #dcdcdc;
-    --dropdown-item-hover-foreground-color: #111820;
+    --menu-background-color: #171717;
+    --menu-menuitem-border-color: #171717;
+    --menu-menuitem-foreground-color: #dcdcdc;
+    --menu-menuitem-hover-foreground-color: #111820;
   }
 }

--- a/dist/mixins/dropdown/base/dropdown-mixins.less
+++ b/dist/mixins/dropdown/base/dropdown-mixins.less
@@ -1,92 +1,30 @@
 .dropdown-base() {
-    .customBackgroundColorProperty(dropdown-items-background-color);
-    .customBorderColorProperty(dropdown-items-border-color);
-    .customBorderRadiusProperty(dropdown-items-border-radius);
-    .customBoxShadowProperty(dropdown-items-box-shadow);
+    .customBackgroundColorProperty(dropdown-background-color);
+    .customBorderColorProperty(dropdown-border-color);
+    .customBorderRadiusProperty(dropdown-border-radius);
+    .customBoxShadowProperty(dropdown-box-shadow);
 
     border-style: solid;
     border-width: 1px;
     box-sizing: border-box;
-    min-width: 100%;
-    width: auto;
-}
-
-.dropdown-overlay-constraints() {
+    display: none;
     max-height: 400px;
+    min-width: 100%;
     overflow-y: auto;
+    position: absolute;
+    top: calc(100% + 4px);
+    width: auto;
     z-index: 2;
 }
 
-.dropdown-overlay() {
-    .dropdown-overlay-constraints();
-
-    display: none;
-    position: absolute;
-    top: calc(100% + 4px);
-}
-
-.dropdown() {
-    .dropdown-base();
-    .dropdown-overlay();
-}
-
-.dropdown-option-color() {
-    .customBorderColorProperty(dropdown-item-border-color);
-    .customColorProperty(dropdown-item-foreground-color);
-
-    background-color: transparent;
-    border-style: solid;
-    border-width: 1px;
-    box-sizing: border-box;
-    display: inline-flex;
-    font-family: inherit;
-    justify-content: space-between;
-    padding: @dropdown-item-padding;
-    width: 100%;
-
-    &:not(:last-child) {
-        margin-bottom: 1px;
-    }
-
-    &:focus {
-        outline-offset: -4px; // offset to accomodate hidden overflow
-    }
-
-    &:hover {
-        .customBackgroundColorProperty(dropdown-item-hover-background-color);
-        .customColorProperty(dropdown-item-hover-foreground-color);
-    }
-
-    &:active {
-        font-weight: @dropdown-item-active-font-weight;
-        // In future add a generic status class used by all dropdowns
-    }
-}
-
-.dropdown-status() {
-    align-self: center;
-    fill: currentColor;
-    height: 8px;
-    margin: 0 auto;
-    opacity: 0;
-    stroke: currentColor;
-    stroke-width: 0;
-    width: 8px;
-}
-
-.dropdown-option-radius() {
+.dropdown-item-border-radius() {
     &:first-child {
-        .customBorderTopLeftRadiusProperty(dropdown-items-border-radius);
-        .customBorderTopRightRadiusProperty(dropdown-items-border-radius);
+        .customBorderTopLeftRadiusProperty(dropdown-border-radius);
+        .customBorderTopRightRadiusProperty(dropdown-border-radius);
     }
 
     &:last-child {
-        .customBorderBottomLeftRadiusProperty(dropdown-items-border-radius);
-        .customBorderBottomRightRadiusProperty(dropdown-items-border-radius);
+        .customBorderBottomLeftRadiusProperty(dropdown-border-radius);
+        .customBorderBottomRightRadiusProperty(dropdown-border-radius);
     }
-}
-
-.dropdown-option-base() {
-    .dropdown-option-color();
-    .dropdown-option-radius();
 }

--- a/dist/mixins/dropdown/ds4/dropdown-mixins.less
+++ b/dist/mixins/dropdown/ds4/dropdown-mixins.less
@@ -1,2 +1,3 @@
 @import "../../../variables/ds4/dropdown-variables.less";
+@import "../../selection-list/ds4/selection-list-mixins.less";
 @import "../base/dropdown-mixins.less";

--- a/dist/mixins/dropdown/ds6/dropdown-mixins.less
+++ b/dist/mixins/dropdown/ds6/dropdown-mixins.less
@@ -1,2 +1,3 @@
 @import "../../../variables/ds6/dropdown-variables.less";
+@import "../../selection-list/ds6/selection-list-mixins.less";
 @import "../base/dropdown-mixins.less";

--- a/dist/mixins/selection-list/base/selection-list-mixins.less
+++ b/dist/mixins/selection-list/base/selection-list-mixins.less
@@ -1,0 +1,70 @@
+.selection-list-item-base() {
+    background-color: transparent;
+    border-style: solid;
+    border-width: 1px;
+    box-sizing: border-box;
+    display: inline-flex;
+    font-family: inherit;
+    justify-content: space-between;
+    padding: @selection-list-item-padding;
+    width: 100%;
+
+    &:not(:last-child) {
+        margin-bottom: 1px;
+    }
+
+    &:focus {
+        outline-offset: -4px; // offset to accomodate hidden overflow
+    }
+}
+
+.selection-list-item-status() {
+    align-self: center;
+    fill: currentColor;
+    height: 8px;
+    margin: 0 auto;
+    opacity: 0;
+    stroke: currentColor;
+    stroke-width: 0;
+    width: 8px;
+}
+
+.listbox-option-base() {
+    .selection-list-item-base();
+
+    .customBorderColorProperty(listbox-option-border-color);
+    .customColorProperty(listbox-option-foreground-color);
+
+    &:hover {
+        .customBackgroundColorProperty(listbox-option-hover-background-color);
+        .customColorProperty(listbox-option-hover-foreground-color);
+    }
+
+    &:active {
+        font-weight: @listbox-option-active-font-weight;
+    }
+}
+
+.listbox-option-status() {
+    .selection-list-item-status();
+}
+
+.menu-menuitem-base() {
+    .selection-list-item-base();
+
+    .customBorderColorProperty(menu-menuitem-border-color);
+    .customColorProperty(menu-menuitem-foreground-color);
+
+    &:hover {
+        .customBackgroundColorProperty(menu-menuitem-hover-background-color);
+        .customColorProperty(menu-menuitem-hover-foreground-color);
+    }
+
+    &:active {
+        font-weight: @menu-menuitem-active-font-weight;
+    }
+}
+
+.menu-menuitem-status() {
+    .selection-list-item-status();
+}

--- a/dist/mixins/selection-list/ds4/selection-list-mixins.less
+++ b/dist/mixins/selection-list/ds4/selection-list-mixins.less
@@ -1,0 +1,2 @@
+@import "../../../variables/ds4/selection-list-variables.less";
+@import "../base/selection-list-mixins.less";

--- a/dist/mixins/selection-list/ds6/selection-list-mixins.less
+++ b/dist/mixins/selection-list/ds6/selection-list-mixins.less
@@ -1,0 +1,2 @@
+@import "../../../variables/ds6/selection-list-variables.less";
+@import "../base/selection-list-mixins.less";

--- a/dist/rounded-off/ds6/rounded-off.css
+++ b/dist/rounded-off/ds6/rounded-off.css
@@ -34,9 +34,9 @@ button.expand-btn {
 .listbox-button__listbox,
 .menu-button__menu,
 .fake-menu-button__menu {
-  --dropdown-items-border-radius: 0;
-  --dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-  --dropdown-items-border-color: #fff;
+  --dropdown-border-radius: 0;
+  --dropdown-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+  --dropdown-border-color: #fff;
 }
 .page-notice {
   --page-notice-border-radius: 0;

--- a/dist/variables/base/combobox-variables.less
+++ b/dist/variables/base/combobox-variables.less
@@ -12,4 +12,4 @@
 @combobox-invalid-foreground-color: @color-status-attention;
 @combobox-focus-border-color: @color-action-primary;
 @combobox-focus-background-color: @color-background-default;
-@combobox-item-active-font-weight: @font-weight-dropdown-item-active;
+@combobox-icon-color: @color-text-default;

--- a/dist/variables/base/dropdown-variables.less
+++ b/dist/variables/base/dropdown-variables.less
@@ -1,16 +1,1 @@
-@dropdown-items-background-color: @color-background-default;
-@dropdown-item-foreground-color: @color-text-default;
-@dropdown-item-background-color: @dropdown-items-background-color;
-@dropdown-item-border-color: @dropdown-items-background-color;
-@dropdown-item-padding: 8px 15px;
-@dropdown-item-hover-background-color: @color-dropdown-item-hover-background;
-@dropdown-item-hover-foreground-color: @color-text-default;
-@dropdown-item-active-status-color: @color-dropdown-item-active-background;
-@dropdown-item-active-font-weight: @font-weight-dropdown-item-active;
-
-@dropdown-fake-anchor-color: @color-text-default;
-@dropdown-fake-button-background-color: @color-background-default;
-@dropdown-fake-button-color: @color-text-default;
-
-@dropdown-status-color: @color-text-default;
-@dropdown-separator-color: @color-divider;
+@dropdown-background-color: @color-background-default;

--- a/dist/variables/base/listbox-button-variables.less
+++ b/dist/variables/base/listbox-button-variables.less
@@ -1,2 +1,2 @@
 @listbox-button-invalid-border-color: @color-r4;
-@listbox-button-item-active-font-weight: @font-weight-dropdown-item-active;
+@listbox-button-option-active-font-weight: @font-weight-selection-list-item-active;

--- a/dist/variables/base/listbox-variables.less
+++ b/dist/variables/base/listbox-variables.less
@@ -1,1 +1,8 @@
-// file intentionally empty (no variables for this module)
+@listbox-background-color: @selection-list-background-color;
+@listbox-option-foreground-color: @selection-list-item-foreground-color;
+@listbox-option-background-color: @selection-list-item-background-color;
+@listbox-option-border-color: @selection-list-item-border-color;
+@listbox-option-hover-background-color: @selection-list-item-hover-background-color;
+@listbox-option-hover-foreground-color: @selection-list-item-hover-foreground-color;
+@listbox-option-active-status-color: @selection-list-item-active-status-color;
+@listbox-option-active-font-weight: @selection-list-item-active-font-weight;

--- a/dist/variables/base/menu-button-variables.less
+++ b/dist/variables/base/menu-button-variables.less
@@ -1,2 +1,1 @@
-@menu-button-item-active-font-weight: @font-weight-dropdown-item-active;
-@menu-button-item-disabled-foreground-color: @color-text-disabled;
+@menu-button-menuitem-active-font-weight: @font-weight-selection-list-item-active;

--- a/dist/variables/base/menu-variables.less
+++ b/dist/variables/base/menu-variables.less
@@ -1,1 +1,15 @@
-@menu-item-disabled-foreground-color: @color-text-disabled;
+@menu-background-color: @selection-list-background-color;
+@menu-separator-color: @selection-list-separator-color;
+
+@menu-menuitem-disabled-foreground-color: @color-text-disabled;
+@menu-menuitem-foreground-color: @selection-list-item-foreground-color;
+@menu-menuitem-background-color: @selection-list-item-background-color;
+@menu-menuitem-border-color: @selection-list-item-border-color;
+@menu-menuitem-active-status-color: @selection-list-item-active-status-color;
+@menu-menuitem-active-font-weight: @selection-list-item-active-font-weight;
+@menu-menuitem-hover-background-color: @selection-list-item-hover-background-color;
+@menu-menuitem-hover-foreground-color: @selection-list-item-hover-foreground-color;
+
+@menu-anchor-color: @selection-list-anchor-color;
+@menu-button-background-color: @selection-list-button-background-color;
+@menu-button-foreground-color: @selection-list-button-foreground-color;

--- a/dist/variables/base/selection-list-variables.less
+++ b/dist/variables/base/selection-list-variables.less
@@ -1,0 +1,15 @@
+@selection-list-background-color: @color-background-default;
+@selection-list-separator-color: @color-divider;
+
+@selection-list-item-foreground-color: @color-text-default;
+@selection-list-item-background-color: @selection-list-background-color;
+@selection-list-item-border-color: @selection-list-background-color;
+@selection-list-item-padding: 8px 15px;
+@selection-list-item-hover-background-color: @color-selection-list-item-hover-background;
+@selection-list-item-hover-foreground-color: @color-text-default;
+@selection-list-item-active-status-color: @color-selection-list-item-active-background;
+@selection-list-item-active-font-weight: @font-weight-selection-list-item-active;
+
+@selection-list-anchor-color: @color-text-default;
+@selection-list-button-background-color: @color-background-default;
+@selection-list-button-foreground-color: @color-text-default;

--- a/dist/variables/ds4/color-variables.less
+++ b/dist/variables/ds4/color-variables.less
@@ -108,8 +108,8 @@
 @color-form-control-disabled-placeholder: @color-action-disabled;
 @color-form-control-readonly-foreground: @color-grey6;
 @color-form-control-label-disabled: @color-core-gray-davys;
-@color-dropdown-item-hover-background: @color-grey1;
-@color-dropdown-item-active-background: @color-grey3;
+@color-selection-list-item-hover-background: @color-grey1;
+@color-selection-list-item-active-background: @color-grey3;
 @color-filter-selected-background: lighten(@color-b4, 55%);
 @color-filter-selected-hover-background: lighten(@color-b4, 45%);
 

--- a/dist/variables/ds4/combobox-variables.less
+++ b/dist/variables/ds4/combobox-variables.less
@@ -1,4 +1,5 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/combobox-variables.less";
 
 @combobox-background-color: @color-background-default;

--- a/dist/variables/ds4/dropdown-variables.less
+++ b/dist/variables/ds4/dropdown-variables.less
@@ -1,6 +1,6 @@
 @import "core-variables.less";
 @import "../base/dropdown-variables.less";
 
-@dropdown-items-border-color: @color-grey3;
-@dropdown-items-border-radius: @border-radius-none;
-@dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+@dropdown-border-color: @color-grey3;
+@dropdown-border-radius: @border-radius-none;
+@dropdown-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);

--- a/dist/variables/ds4/listbox-button-variables.less
+++ b/dist/variables/ds4/listbox-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-button-variables.less";

--- a/dist/variables/ds4/listbox-variables.less
+++ b/dist/variables/ds4/listbox-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-variables.less";

--- a/dist/variables/ds4/menu-button-variables.less
+++ b/dist/variables/ds4/menu-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-button-variables.less";

--- a/dist/variables/ds4/menu-variables.less
+++ b/dist/variables/ds4/menu-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-variables.less";

--- a/dist/variables/ds4/selection-list-variables.less
+++ b/dist/variables/ds4/selection-list-variables.less
@@ -1,0 +1,2 @@
+@import "core-variables.less";
+@import "../base/selection-list-variables.less";

--- a/dist/variables/ds4/typography-variables.less
+++ b/dist/variables/ds4/typography-variables.less
@@ -4,7 +4,7 @@
 @font-weight-regular: 400;
 @font-weight-bold: 500;
 @font-weight-action-primary: normal;
-@font-weight-dropdown-item-active: normal;
+@font-weight-selection-list-item-active: normal;
 
 @font-size-form-control-large: @font-size-medium;
 

--- a/dist/variables/ds6/color-variables.less
+++ b/dist/variables/ds6/color-variables.less
@@ -151,8 +151,8 @@
 @color-form-control-disabled-placeholder: @color-grey4;
 @color-form-control-readonly-foreground: @color-grey4;
 @color-form-control-label-disabled: @color-grey4;
-@color-dropdown-item-hover-background: @color-grey2;
-@color-dropdown-item-active-background: @color-background-default;
+@color-selection-list-item-hover-background: @color-grey2;
+@color-selection-list-item-active-background: @color-background-default;
 @color-filter-selected-background: #e1e8fd; // non-palette colour
 @color-filter-selected-hover-background: #c2d0fb; // non-palette colour
 

--- a/dist/variables/ds6/combobox-variables.less
+++ b/dist/variables/ds6/combobox-variables.less
@@ -1,4 +1,5 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/combobox-variables.less";
 
 @combobox-background-color: @color-grey1;

--- a/dist/variables/ds6/dropdown-variables.less
+++ b/dist/variables/ds6/dropdown-variables.less
@@ -1,6 +1,6 @@
 @import "core-variables.less";
 @import "../base/dropdown-variables.less";
 
-@dropdown-items-border-color: @border-radius-dropdown-border-color;
-@dropdown-items-border-radius: @border-radius-dropdown;
-@dropdown-items-box-shadow: @border-radius-dropdown-box-shadow;
+@dropdown-border-color: @border-radius-dropdown-border-color;
+@dropdown-border-radius: @border-radius-dropdown;
+@dropdown-box-shadow: @border-radius-dropdown-box-shadow;

--- a/dist/variables/ds6/listbox-button-variables.less
+++ b/dist/variables/ds6/listbox-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-button-variables.less";

--- a/dist/variables/ds6/listbox-variables.less
+++ b/dist/variables/ds6/listbox-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-variables.less";

--- a/dist/variables/ds6/menu-button-variables.less
+++ b/dist/variables/ds6/menu-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-button-variables.less";

--- a/dist/variables/ds6/menu-variables.less
+++ b/dist/variables/ds6/menu-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-variables.less";

--- a/dist/variables/ds6/selection-list-variables.less
+++ b/dist/variables/ds6/selection-list-variables.less
@@ -1,0 +1,2 @@
+@import "core-variables.less";
+@import "../base/selection-list-variables.less";

--- a/dist/variables/ds6/typography-variables.less
+++ b/dist/variables/ds6/typography-variables.less
@@ -4,7 +4,7 @@
 @font-weight-regular: 500;
 @font-weight-bold: 700;
 @font-weight-action-primary: bold;
-@font-weight-dropdown-item-active: bold;
+@font-weight-selection-list-item-active: bold;
 
 @font-size-form-control-large: @font-size-18;
 

--- a/docs/_includes/common/combobox.html
+++ b/docs/_includes/common/combobox.html
@@ -1,24 +1,24 @@
 <div id="combobox">
     {% include common/section-header.html name="combobox" version=page.versions.combobox %}
 
-    <p>An enhanced <a href="#textbox">textbox</a> that allows its value to be constructed via manual text entry, selection from a list of options, or a combination of both (i.e. select an option then type more text); hence the term 'combo', because it is a combination of a textbox and a listbox.</p>
+    <p>A combobox is a combination of textbox and listbox. The textbox value can be constructed via manual text entry as normal, <em>or</em> via selection from the listbox options, <em>or</em> a combination of both.</p>
     <p><strong>TIP</strong>: A combobox can be further enhanced with <a href="https://ebay.github.io/mindpatterns/input/combobox/index.html">autocomplete behaviour</a>.</p>
 
     <h3>Default Combobox</h3>
-    <p>Selecting an option should simply fill the textbox with that value. Options may not have state or any other kind of behaviour.</p>
+    <p>Selecting an option should simply fill the textbox with that value. Options may not have state or any other kind of secondary behaviour.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <form action="index.html">
                 <span class="combobox">
                     <span class="combobox__control">
-                        <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox1" />
+                        <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox-1" />
                         <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                             {% include common/symbol.html name="dropdown" %}
                         </svg>
                     </span>
                     <div class="combobox__listbox">
-                        <div id="listbox1" class="combobox__options" role="listbox">
+                        <div id="listbox-1" class="combobox__options" role="listbox">
                             <div class="combobox__option" role="option">
                                 <span>Option 1</span>
                             </div>
@@ -38,13 +38,13 @@
     {% highlight html %}
 <span class="combobox">
     <span class="combobox__control">
-        <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox1" />
+        <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox-1" />
         <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
             <use xlink:href="#icon-dropdown"></use>
         </svg>
     </span>
     <div class="combobox__listbox">
-        <div id="listbox1" class="combobox__options" role="listbox">
+        <div id="listbox-1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
             </div>
@@ -59,36 +59,6 @@
 </span>
     {% endhighlight %}
 
-    <!--
-    <h3 id="combobox-overflow">Overflow Combobox</h3>
-    <p>The combobox overlay becomes automatically scrollable at a height of 400px.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <form action="index.html">
-                <span class="combobox">
-                    <span class="combobox__control">
-                        <input name="combobox-scrollable" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox2" />
-                        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include common/symbol.html name="dropdown" %}
-                        </svg>
-                    </span>
-                    <div class="combobox__listbox">
-                        <div id="listbox2" class="combobox__options" role="listbox">
-                            {% for number in (1...50) %}
-                            <div class="combobox__option" role="option">
-                                <span>Option {{number}}</span>
-                            </div>
-                            {% endfor %}
-                        </div>
-                    </div>
-                </span>
-            </form>
-        </div>
-    </div>
-
-    -->
-
     <h3 id="combobox-disabled">Disabled Combobox</h3>
     <p>Apply the <span class="highlight">disabled</span> property to disable the combobox.</p>
 
@@ -97,13 +67,13 @@
             <form action="index.html">
                 <span class="combobox">
                     <span class="combobox__control">
-                        <input name="combobox-disabled" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox3" disabled />
+                        <input name="combobox-disabled" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox-2" disabled />
                         <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                             {% include common/symbol.html name="dropdown" %}
                         </svg>
                     </span>
                     <div class="combobox__listbox">
-                        <div id="listbox3" class="combobox__options" role="listbox">
+                        <div id="listbox-2" class="combobox__options" role="listbox">
                             <div class="combobox__option" role="option">
                                 <span>Option 1</span>
                             </div>
@@ -123,13 +93,13 @@
     {% highlight html %}
 <span class="combobox">
     <span class="combobox__control">
-        <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox2" disabled />
+        <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox-2" disabled />
         <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
             <use xlink:href="#icon-dropdown"></use>
         </svg>
     </span>
     <div class="combobox__listbox">
-        <div id="listbox2" class="combobox__options" role="listbox">
+        <div id="listbox-2" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
             </div>

--- a/docs/_includes/common/listbox-button.html
+++ b/docs/_includes/common/listbox-button.html
@@ -3,7 +3,7 @@
 
     <p>A listbox button is intended for use as a custom implementation of the native HTML select element's <em>single</em>-select use case.</p>
     <p>Because a button element does not store form data, its value will not be submitted along with other form data without the assistance of JavaScript.</p>
-    <p><strong>NOTE</strong>: only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit the <a href="https://ebay.github.io/mindpatterns/input/listbox-button/index.html">eBay MIND Pattern for Listbox Button</a>.</p>
+    <p><strong>NOTE</strong>: only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit our <a href="https://ebay.github.io/mindpatterns/input/listbox-button/index.html">listbox-button pattern</a>.</p>
 
     <h3 id="listbox-button-default">Default</h3>
     <p>By default, the first option should be selected if the user does not specify a selection. This matches the behaviour of a native HTML select element.</p>

--- a/docs/_includes/common/listbox.html
+++ b/docs/_includes/common/listbox.html
@@ -1,9 +1,8 @@
 <div id="listbox">
     {% include common/section-header.html name="listbox" version=page.versions.listbox %}
 
-    <p>A listbox is intended for use as a custom implementation of the native HTML select element's <em>muti</em>-select use case.</p>
-    <p>Because this control is custom, its value will not be submitted along with other form data without the assistance of JavaScript.</p>
-    <p><strong>NOTE</strong>: only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit the <a href="https://ebay.github.io/mindpatterns/input/listbox/index.html">eBay MIND Pattern for Listbox</a>.</p>
+    <p>A listbox is intended for use as a custom, non-form based implementation of the native HTML select element.</p>
+    <p><strong>NOTE</strong>: only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit our <a href="https://ebay.github.io/mindpatterns/input/listbox/index.html">listbox pattern</a>.</p>
 
     <h3 id="listbox-default">Default</h3>
     <p>By default, no option is selected until interacting with the widget. This matches the behaviour of a native HTML select element.</p>

--- a/docs/_includes/common/menu-button.html
+++ b/docs/_includes/common/menu-button.html
@@ -4,7 +4,7 @@
     <p>A menu button follows the principal of <a href="https://en.wikipedia.org/wiki/Progressive_disclosure">progressive disclosure</a>, it keeps secondary commands hidden from view until needed.</p>
     <p>A menu is <strong>not</strong> a form control. If you wish to submit form data natively, without JavaScript, please consider <a href="#checkbox">checkbox</a>, <a href="#combobox">combobox</a>, <a href="#select">select</a>, or <a href="#radio">radio</a> instead.</p>
     <p>Selecting a menu item command should update the page <strong>without</strong> a full page reload (i.e. acting similar to buttons, checkboxes or radios). If a full page load is required instead (i.e. acting like links), please refer to the <a href="#menu-button-fake">fake menu button</a>.</p>
-    <p><strong>NOTE: </strong>Only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit the <a href="https://ebay.github.io/mindpatterns/input/menu-button/index.html">eBay MIND Pattern for Menu</a>.</p>
+    <p><strong>NOTE: </strong>Only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit our <a href="https://ebay.github.io/mindpatterns/input/menu-button/index.html">menu-button pattern</a>.</p>
 
     <h3 id="menu-button-default">Default Menu Button</h3>
     <p>The default menu button opens a <em>stateless</em> menu. Each item has a role of <span class="highlight">menuitem</span>.</p>
@@ -479,8 +479,6 @@
 </span>
     {% endhighlight %}
 
-    <p><strong>TIP:</strong> A fake menu button can contain a mix of anchor tags and button tags.</p>
-
     <h3 id="menu-button-growth">Fixed Width Menu Button</h3>
     <p>Use the <span class="highlight">menu-button__menu--fix-width</span> or <span class="highlight">fake-menu-button__menu--fix-width</span> element modifier to fix the width of any menu items to the button width. This is useful in cases where the menu overlay needs to be constrained to the button width, usually to accomodate spacing and layout.</p>
     <p><strong>NOTE: </strong> Fixed width is currently only available on menu buttons that use a <span class="highlight">span</span> root tag.</p>
@@ -596,85 +594,4 @@
 </span>
     {% endhighlight %}
 
-    <!-- button hierarchy is deprecated -->
-    <!--
-    <h3 id="menu-button-custom">Custom Menu Button</h3>
-    <p>Any menu can use any kind of button hierarchy as defined in the <a href="#button">button</a> module (e.g. <span class="highlight">.expand-btn--primary</span>).</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <span class="menu-button">
-                <button class="expand-btn expand-btn--primary" aria-expanded="false" aria-haspopup="true" type="button">
-                    <span class="expand-btn__cell">
-                        <span class="expand-btn__text">Button</span>
-                        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include common/symbol.html name="dropdown" %}
-                        </svg>
-                    </span>
-                </button>
-                <div class="menu-button__menu">
-                    <div class="menu-button__items" role="menu">
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Menu Item 1</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Menu Item 2</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Menu Item 3</span>
-                        </div>
-                    </div>
-                </div>
-            </span>
-            <span class="menu-button">
-                <button class="expand-btn expand-btn--secondary" aria-expanded="false" aria-haspopup="true" type="button">
-                    <span class="expand-btn__cell">
-                        <span class="expand-btn__text">Button</span>
-                        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include common/symbol.html name="dropdown" %}
-                        </svg>
-                    </span>
-                </button>
-                <div class="menu-button__menu">
-                    <div class="menu-button__items" role="menu">
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Menu Item 1</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Menu Item 2</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Menu Item 3</span>
-                        </div>
-                    </div>
-                </div>
-            </span>
-        </div>
-    </div>
-
-    {% highlight html %}
-<span class="menu-button">
-    <button class="expand-btn expand-btn--primary" aria-expanded="false" aria-haspopup="true" type="button">
-        <span class="expand-btn__cell">
-            <span class="expand-btn__text">Button</span>
-            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
-            </svg>
-        </span>
-    </button>
-</span>
-
-<span class="menu-button">
-    <button class="expand-btn expand-btn--secondary" aria-expanded="false" aria-haspopup="true" type="button">
-        <span class="expand-btn__cell">
-            <span class="expand-btn__text">Button</span>
-            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
-            </svg>
-        </span>
-    </button>
-</span>
-    {% endhighlight %}
-
-    -->
 </div>

--- a/docs/_includes/common/menu.html
+++ b/docs/_includes/common/menu.html
@@ -3,7 +3,7 @@
 
     <p>A menu is <strong>not</strong> a form control. If you wish to submit form data natively, without JavaScript, please consider <a href="#checkbox">checkbox</a>, <a href="#combobox">combobox</a>, <a href="#select">select</a>, or <a href="#radio">radio</a> instead.</p>
     <p>Selecting a menu item command should update the page <strong>without</strong> a full page reload (i.e. acting similar to buttons, checkboxes or radios). If a full page load is required instead (i.e. acting like links), please refer to the <a href="#menu-fake">fake menu</a>.</p>
-    <p><strong>NOTE: </strong>Only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit the <a href="https://ebay.github.io/mindpatterns/input/menu-button/index.html">eBay MIND Pattern for Menu</a>.</p>
+    <p><strong>NOTE: </strong>Only limited JavaScript behaviour has been implemented in these examples. For detailed behaviour requirements, please visit our <a href="https://ebay.github.io/mindpatterns/input/menu-button/index.html">menu pattern</a>.</p>
 
     <h3 id="menu-default">Default Menu</h3>
     <p>The default menu is a <em>stateless</em> menu. Each item has a role of <span class="highlight">menuitem</span>.</p>
@@ -259,7 +259,7 @@
             </div>
 
             <hr class="menu__separator" role="separator" />
-            
+
             <div class="menu__item" role="menuitemcheckbox" aria-checked="true" data-menuitemcheckbox-name="sort">
                 <span>Item 2</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8" aria-hidden="true">

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -26,11 +26,12 @@ span.combobox {
 }
 
 .combobox__listbox {
-    .dropdown();
+    .dropdown-base();
 }
 
 .combobox__option[role^="option"] {
-    .dropdown-option-base();
+    .listbox-option-base();
+    .dropdown-item-border-radius();
 
     cursor: default; // needed to override text cursor
     position: relative; // needed for icon to show properly
@@ -40,23 +41,22 @@ span.combobox {
     }
 
     &:hover {
-        .customBackgroundColorProperty(dropdown-item-hover-background-color);
+        .customBackgroundColorProperty(listbox-option-hover-background-color);
     }
 
     svg.icon {
-        .dropdown-status();
+        .listbox-option-status();
     }
 }
 
 .combobox__option--active[role^="option"] {
-    .customBackgroundColorProperty(dropdown-item-hover-background-color);
+    .customBackgroundColorProperty(listbox-option-hover-background-color);
 
     svg.icon {
         opacity: 1;
     }
 }
 
-// refactor in v11 to use .combobox__control--actionable (added in 10.3.0)
 .combobox__control {
     button.icon-btn {
         padding: 0;
@@ -80,6 +80,8 @@ span.combobox {
 }
 
 .combobox__control > svg.icon--dropdown {
+    .customColorProperty(combobox-icon-color);
+
     margin-left: 8px;
     pointer-events: none;
     position: absolute;
@@ -178,9 +180,9 @@ span.combobox {
 }
 
 .combobox__option--active[role="option"] {
-    .customColorProperty(dropdown-item-hover-foreground-color);
+    .customColorProperty(listbox-option-hover-foreground-color);
 
-    font-weight: @combobox-item-active-font-weight;
+    font-weight: @listbox-option-active-font-weight;
 }
 
 @media all and (-ms-high-contrast: active), all and (-ms-high-contrast: none) {
@@ -230,10 +232,10 @@ span.combobox {
             --combobox-invalid-foreground-color: @color-r4-dark-mode;
             --combobox-invalid-background-color: @color-textbox-invalid-dark-mode;
             --combobox-icon-color: @color-grey6-dark-mode;
-            --dropdown-items-background-color: @color-black-dark-mode;
-            --dropdown-item-foreground-color: @color-text-default-dark-mode;
-            --dropdown-item-border-color: @color-black-dark-mode;
-            --dropdown-item-hover-foreground-color: @color-text-default;
+            --dropdown-background-color: @color-black-dark-mode;
+            --listbox-option-foreground-color: @color-text-default-dark-mode;
+            --listbox-option-border-color: @color-black-dark-mode;
+            --listbox-option-hover-foreground-color: @color-text-default;
         }
     }
 }

--- a/src/less/combobox/ds4/combobox.less
+++ b/src/less/combobox/ds4/combobox.less
@@ -1,4 +1,4 @@
+@import "../../variables/ds4/listbox-variables.less";
 @import "../../variables/ds4/combobox-variables.less";
-@import "../../variables/ds4/dropdown-variables.less";
 @import "../../mixins/dropdown/ds4/dropdown-mixins.less";
 @import "../base/combobox.less";

--- a/src/less/combobox/ds6/combobox.less
+++ b/src/less/combobox/ds6/combobox.less
@@ -1,4 +1,4 @@
+@import "../../variables/ds6/listbox-variables.less";
 @import "../../variables/ds6/combobox-variables.less";
-@import "../../variables/ds6/dropdown-variables.less";
 @import "../../mixins/dropdown/ds6/dropdown-mixins.less";
 @import "../base/combobox.less";

--- a/src/less/listbox-button/base/listbox-button.less
+++ b/src/less/listbox-button/base/listbox-button.less
@@ -16,7 +16,7 @@ span.listbox-button--fluid .expand-btn {
 }
 
 div.listbox-button__listbox {
-    .dropdown();
+    .dropdown-base();
 }
 
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
@@ -27,7 +27,6 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
     .customBorderColorProperty(listbox-button-invalid-border-color);
 }
 
-// todo: refactor to use a button mixin rather than .expand-btn class
 .listbox-button button.expand-btn--borderless {
     background-color: transparent;
     border-color: transparent;
@@ -45,18 +44,14 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox {
 }
 
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {
-    .customBackgroundColorProperty(dropdown-item-hover-background-color);
+    .customBackgroundColorProperty(listbox-option-hover-background-color);
+    .customColorProperty(listbox-option-hover-foreground-color);
 }
 
 .listbox-button__option svg.icon {
-    .dropdown-status();
+    .listbox-option-status();
 
     margin-left: 8px;
-}
-
-[dir="rtl"] .listbox-button__option svg.icon {
-    margin-left: 0;
-    margin-right: 8px;
 }
 
 div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
@@ -64,17 +59,18 @@ div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
 }
 
 div.listbox-button__option[role="option"]:active svg.icon {
-    .customColorProperty(dropdown-item-active-status-color);
+    .customColorProperty(listbox-option-active-status-color);
 }
 
 div.listbox-button__option[role="option"] {
-    .dropdown-option-base();
+    .listbox-option-base();
+    .dropdown-item-border-radius();
 
     cursor: default; // needed to override text cursor
 }
 
 div.listbox-button__option--active[role="option"] {
-    font-weight: @listbox-button-item-active-font-weight;
+    font-weight: @listbox-button-option-active-font-weight;
 }
 
 span.listbox-button__value {
@@ -88,15 +84,24 @@ span.listbox-button__value {
     outline: none;
 }
 
+// stylelint-disable no-descending-specificity
+[dir="rtl"] {
+    .listbox-button__option svg.icon {
+        margin-left: 0;
+        margin-right: 8px;
+    }
+}
+// stylelint-enable no-descending-specificity
+
 @media (prefers-color-scheme: dark) {
     .skin-experiment-dark-mode {
         .listbox-button {
-            --dropdown-items-background-color: @color-black-dark-mode;
-            --dropdown-items-border-color: @color-black-dark-mode;
-            --dropdown-item-background-color: @color-black-dark-mode;
-            --dropdown-item-foreground-color: @color-text-default-dark-mode;
-            --dropdown-item-border-color: @color-black-dark-mode;
-            --dropdown-item-hover-foreground-color: @color-text-default;
+            --dropdown-background-color: @color-black-dark-mode;
+            --dropdown-border-color: @color-black-dark-mode;
+            --listbox-option-background-color: @color-black-dark-mode;
+            --listbox-option-foreground-color: @color-text-default-dark-mode;
+            --listbox-option-border-color: @color-black-dark-mode;
+            --listbox-option-hover-foreground-color: @color-text-default;
         }
     }
 }

--- a/src/less/listbox-button/ds4/listbox-button.less
+++ b/src/less/listbox-button/ds4/listbox-button.less
@@ -1,3 +1,4 @@
+@import "../../variables/ds4/listbox-variables.less";
 @import "../../variables/ds4/listbox-button-variables.less";
 @import "../../mixins/dropdown/ds4/dropdown-mixins.less";
 @import "../base/listbox-button.less";

--- a/src/less/listbox-button/ds6/listbox-button.less
+++ b/src/less/listbox-button/ds6/listbox-button.less
@@ -1,3 +1,4 @@
+@import "../../variables/ds6/listbox-variables.less";
 @import "../../variables/ds6/listbox-button-variables.less";
 @import "../../mixins/dropdown/ds6/dropdown-mixins.less";
 @import "../base/listbox-button.less";

--- a/src/less/listbox/base/listbox.less
+++ b/src/less/listbox/base/listbox.less
@@ -10,7 +10,7 @@ span.listbox {
 }
 
 div.listbox__options[role="listbox"] {
-    .customBackgroundColorProperty(dropdown-items-background-color);
+    .customBackgroundColorProperty(listbox-background-color);
 
     cursor: default; // needed to override text cursor
 }
@@ -28,7 +28,7 @@ div.listbox__options--reverse[role="listbox"] {
 }
 
 div.listbox__option[role="option"] {
-    .dropdown-option-base();
+    .listbox-option-base();
 }
 
 span.listbox__value {
@@ -38,7 +38,7 @@ span.listbox__value {
 }
 
 div.listbox__option svg.icon {
-    .dropdown-status();
+    .listbox-option-status();
 
     margin-left: 8px;
 }
@@ -49,8 +49,8 @@ div.listbox__option svg.icon {
 }
 
 div.listbox__options[role="listbox"]:focus .listbox__option--active[role="option"] {
-    .customBackgroundColorProperty(dropdown-item-hover-background-color);
-    .customColorProperty(dropdown-item-hover-foreground-color);
+    .customBackgroundColorProperty(listbox-option-hover-background-color);
+    .customColorProperty(listbox-option-hover-foreground-color);
 }
 
 div.listbox__option[aria-selected="true"] svg.icon {
@@ -58,7 +58,7 @@ div.listbox__option[aria-selected="true"] svg.icon {
 }
 
 div.listbox__option[role="option"]:active svg.icon {
-    .customColorProperty(dropdown-item-active-status-color);
+    .customColorProperty(listbox-option-active-status-color);
 }
 
 // https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/
@@ -69,12 +69,11 @@ div.listbox__option[role="option"]:active svg.icon {
 @media (prefers-color-scheme: dark) {
     .skin-experiment-dark-mode {
         .listbox {
-            --dropdown-items-background-color: @color-black-dark-mode;
-            --dropdown-items-border-color: @color-black-dark-mode;
-            --dropdown-item-background-color: @color-black-dark-mode;
-            --dropdown-item-foreground-color: @color-text-default-dark-mode;
-            --dropdown-item-border-color: @color-black-dark-mode;
-            --dropdown-item-hover-foreground-color: @color-text-default;
+            --listbox-background-color: @color-black-dark-mode;
+            --listbox-option-background-color: @color-black-dark-mode;
+            --listbox-option-foreground-color: @color-text-default-dark-mode;
+            --listbox-option-border-color: @color-black-dark-mode;
+            --listbox-option-hover-foreground-color: @color-text-default;
         }
     }
 }

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -8,8 +8,7 @@
 
 .menu-button__menu,
 .fake-menu-button__menu {
-    .dropdown();
-    .dropdown-overlay-constraints();
+    .dropdown-base();
 
     // In ebayui there is a bug where if tabindex=-1 outside the menu button
     // Any clicks inside will trigger on the outher tabindex=-1. In order to fix it
@@ -33,14 +32,15 @@ span.fake-menu-button__button {
 }
 
 div.menu-button__item[role^="menuitem"] {
-    .dropdown-option-base();
+    .menu-menuitem-base();
+    .dropdown-item-border-radius();
 
     cursor: default; // needed to override text cursor
 }
 
 .menu-button__item svg.icon,
 .fake-menu-button__item svg.icon {
-    .dropdown-status();
+    .menu-menuitem-status();
 }
 
 .menu-button__item svg.icon:last-child,
@@ -51,7 +51,7 @@ div.menu-button__item[role^="menuitem"] {
 
 // anchor tag specific
 a.fake-menu-button__item {
-    .customColorProperty(dropdown-fake-anchor-color);
+    .customColorProperty(menu-anchor-color);
 
     text-decoration: none;
 
@@ -61,14 +61,14 @@ a.fake-menu-button__item {
 
     &:hover,
     &:visited {
-        .customColorProperty(dropdown-fake-anchor-color);
+        .customColorProperty(menu-anchor-color);
     }
 }
 
 // button tag specific
 button.fake-menu-button__item {
-    .customBackgroundColorProperty(dropdown-fake-button-background-color);
-    .customColorProperty(dropdown-fake-button-color);
+    .customBackgroundColorProperty(menu-button-background-color);
+    .customColorProperty(menu-button-foreground-color);
 
     font-family: inherit;
     font-size: 1em;
@@ -77,13 +77,13 @@ button.fake-menu-button__item {
 
 button.fake-menu-button__item:active svg.icon,
 a.fake-menu-button__item:active svg.icon {
-    .customColorProperty(dropdown-item-active-status-color);
+    .customColorProperty(menu-menuitem-active-status-color);
 }
 
 a.fake-menu-button__item:not([href]),
 button.fake-menu-button__item[disabled],
 div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
-    color: @menu-button-item-disabled-foreground-color;
+    color: @menu-menuitem-disabled-foreground-color;
 }
 
 a.fake-menu-button__item[aria-current="page"] svg.icon,
@@ -92,7 +92,7 @@ button.fake-menu-button__item[aria-current="page"] svg.icon {
 }
 
 div.menu-button__item[role^="menuitem"]:active svg.icon {
-    .customColorProperty(dropdown-item-active-status-color);
+    .customColorProperty(menu-menuitem-active-status-color);
 }
 
 div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
@@ -101,17 +101,17 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
 
 .fake-menu-button__menu a.fake-menu-button__item,
 .fake-menu-button__menu button.fake-menu-button__item {
-    .dropdown-option-color();
+    .menu-menuitem-base();
 }
 
 .fake-menu-button__menu > li:first-child a.fake-menu-button__item {
-    .customBorderTopLeftRadiusProperty(dropdown-items-border-radius);
-    .customBorderTopRightRadiusProperty(dropdown-items-border-radius);
+    .customBorderTopLeftRadiusProperty(dropdown-border-radius);
+    .customBorderTopRightRadiusProperty(dropdown-border-radius);
 }
 
 .fake-menu-button__menu > li:last-child a.fake-menu-button__item {
-    .customBorderBottomLeftRadiusProperty(dropdown-items-border-radius);
-    .customBorderBottomRightRadiusProperty(dropdown-items-border-radius);
+    .customBorderBottomLeftRadiusProperty(dropdown-border-radius);
+    .customBorderBottomRightRadiusProperty(dropdown-border-radius);
 }
 
 .menu-button__menu--fix-width,
@@ -160,7 +160,6 @@ div.menu-button__item[role^="menuitem"] span.badge {
     }
 }
 
-// TODO: Remove below .expand-btn selectors and instead only rely on .menu-button__button.
 .menu-button__button[aria-expanded="true"] ~ .menu-button__menu,
 .fake-menu-button__button[aria-expanded="true"] ~ .fake-menu-button__menu,
 .menu-button .expand-btn[aria-expanded="true"] ~ .menu-button__menu,
@@ -168,7 +167,6 @@ div.menu-button__item[role^="menuitem"] span.badge {
     display: block;
 }
 
-// TODO: Remove below .expand-btn selectors and instead only rely on .menu-button__button.
 .menu-button__button ~ .menu-button__menu--static,
 .fake-menu-button__button ~ .fake-menu-button__menu--static,
 .expand-btn ~ .menu-button__menu--static,
@@ -182,11 +180,11 @@ div.menu-button__item[role^="menuitem"] span.badge {
 }
 
 div.menu-button__option--active[role="option"] {
-    font-weight: @menu-button-item-active-font-weight;
+    font-weight: @menu-button-menuitem-active-font-weight;
 }
 
 hr.menu-button__separator {
-    .customBorderColorProperty(dropdown-separator-color);
+    .customBorderColorProperty(menu-separator-color);
 
     border-style: solid;
     border-width: 1px;
@@ -202,10 +200,10 @@ div.menu-button__item[role^="menuitem"]:focus:not(:focus-visible) {
     .skin-experiment-dark-mode {
         .menu-button,
         .fake-menu-button {
-            --dropdown-items-background-color: @color-black-dark-mode;
-            --dropdown-item-border-color: @color-black-dark-mode;
-            --dropdown-item-foreground-color: @color-text-default-dark-mode;
-            --dropdown-item-hover-foreground-color: @color-text-default;
+            --dropdown-background-color: @color-black-dark-mode;
+            --menu-menuitem-border-color: @color-black-dark-mode;
+            --menu-menuitem-foreground-color: @color-text-default-dark-mode;
+            --menu-menuitem-hover-foreground-color: @color-text-default;
         }
     }
 }

--- a/src/less/menu-button/ds4/menu-button.less
+++ b/src/less/menu-button/ds4/menu-button.less
@@ -1,3 +1,4 @@
+@import "../../variables/ds4/menu-variables.less";
 @import "../../variables/ds4/menu-button-variables.less";
 @import "../../mixins/dropdown/ds4/dropdown-mixins.less";
 @import "../base/menu-button.less";

--- a/src/less/menu-button/ds6/menu-button.less
+++ b/src/less/menu-button/ds6/menu-button.less
@@ -1,3 +1,4 @@
+@import "../../variables/ds6/menu-variables.less";
 @import "../../variables/ds6/menu-button-variables.less";
 @import "../../mixins/dropdown/ds6/dropdown-mixins.less";
 @import "../base/menu-button.less";

--- a/src/less/menu/base/menu.less
+++ b/src/less/menu/base/menu.less
@@ -2,7 +2,7 @@
 
 .menu__items,
 .fake-menu__items {
-    .customBackgroundColorProperty(dropdown-items-background-color);
+    .customBackgroundColorProperty(menu-background-color);
 
     cursor: default; // override text cursor
 }
@@ -26,7 +26,7 @@ span.fake-menu__items {
 
 .menu__item > svg.icon,
 .fake-menu__item > svg.icon {
-    .dropdown-status();
+    .menu-menuitem-status();
 }
 
 .menu__item > svg.icon:last-child,
@@ -37,7 +37,7 @@ span.fake-menu__items {
 }
 
 a.fake-menu__item {
-    .customColorProperty(dropdown-fake-anchor-color);
+    .customColorProperty(menu-anchor-color);
 
     text-decoration: none;
 }
@@ -49,7 +49,7 @@ button.fake-menu__item {
 button.fake-menu__item,
 a.fake-menu__item,
 div.menu__item[role^="menuitem"] {
-    .dropdown-option-base();
+    .menu-menuitem-base();
 }
 
 a.fake-menu__item:focus {
@@ -58,7 +58,7 @@ a.fake-menu__item:focus {
 
 button.fake-menu__item:active svg.icon,
 a.fake-menu__item:active svg.icon {
-    .customColorProperty(dropdown-item-active-status-color);
+    .customColorProperty(menu-menuitem-active-status-color);
 }
 
 a.fake-menu__item[aria-current="page"] svg.icon,
@@ -69,11 +69,11 @@ button.fake-menu__item[aria-current="page"] svg.icon {
 a.fake-menu__item:not([href]),
 button.fake-menu__item[disabled],
 div.menu__item[role^="menuitem"][aria-disabled="true"] {
-    color: @menu-item-disabled-foreground-color;
+    color: @menu-menuitem-disabled-foreground-color;
 }
 
 div.menu__item[role^="menuitem"]:active svg.icon {
-    .customColorProperty(dropdown-item-active-status-color);
+    .customColorProperty(menu-menuitem-active-status-color);
 }
 
 div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
@@ -122,7 +122,7 @@ div.menu__item[role^="menuitem"] span.badge {
 }
 
 hr.menu__separator {
-    .customBorderColorProperty(dropdown-separator-color);
+    .customBorderColorProperty(menu-separator-color);
 
     border-style: solid;
     border-width: 1px;
@@ -137,10 +137,10 @@ div.menu__item[role^="menuitem"]:focus:not(:focus-visible) {
     .skin-experiment-dark-mode {
         .menu,
         .fake-menu {
-            --dropdown-items-background-color: @color-black-dark-mode;
-            --dropdown-item-border-color: @color-black-dark-mode;
-            --dropdown-item-foreground-color: @color-text-default-dark-mode;
-            --dropdown-item-hover-foreground-color: @color-text-default;
+            --menu-background-color: @color-black-dark-mode;
+            --menu-menuitem-border-color: @color-black-dark-mode;
+            --menu-menuitem-foreground-color: @color-text-default-dark-mode;
+            --menu-menuitem-hover-foreground-color: @color-text-default;
         }
     }
 }

--- a/src/less/mixins/dropdown/base/dropdown-mixins.less
+++ b/src/less/mixins/dropdown/base/dropdown-mixins.less
@@ -1,92 +1,30 @@
 .dropdown-base() {
-    .customBackgroundColorProperty(dropdown-items-background-color);
-    .customBorderColorProperty(dropdown-items-border-color);
-    .customBorderRadiusProperty(dropdown-items-border-radius);
-    .customBoxShadowProperty(dropdown-items-box-shadow);
+    .customBackgroundColorProperty(dropdown-background-color);
+    .customBorderColorProperty(dropdown-border-color);
+    .customBorderRadiusProperty(dropdown-border-radius);
+    .customBoxShadowProperty(dropdown-box-shadow);
 
     border-style: solid;
     border-width: 1px;
     box-sizing: border-box;
-    min-width: 100%;
-    width: auto;
-}
-
-.dropdown-overlay-constraints() {
+    display: none;
     max-height: 400px;
+    min-width: 100%;
     overflow-y: auto;
+    position: absolute;
+    top: calc(100% + 4px);
+    width: auto;
     z-index: 2;
 }
 
-.dropdown-overlay() {
-    .dropdown-overlay-constraints();
-
-    display: none;
-    position: absolute;
-    top: calc(100% + 4px);
-}
-
-.dropdown() {
-    .dropdown-base();
-    .dropdown-overlay();
-}
-
-.dropdown-option-color() {
-    .customBorderColorProperty(dropdown-item-border-color);
-    .customColorProperty(dropdown-item-foreground-color);
-
-    background-color: transparent;
-    border-style: solid;
-    border-width: 1px;
-    box-sizing: border-box;
-    display: inline-flex;
-    font-family: inherit;
-    justify-content: space-between;
-    padding: @dropdown-item-padding;
-    width: 100%;
-
-    &:not(:last-child) {
-        margin-bottom: 1px;
-    }
-
-    &:focus {
-        outline-offset: -4px; // offset to accomodate hidden overflow
-    }
-
-    &:hover {
-        .customBackgroundColorProperty(dropdown-item-hover-background-color);
-        .customColorProperty(dropdown-item-hover-foreground-color);
-    }
-
-    &:active {
-        font-weight: @dropdown-item-active-font-weight;
-        // In future add a generic status class used by all dropdowns
-    }
-}
-
-.dropdown-status() {
-    align-self: center;
-    fill: currentColor;
-    height: 8px;
-    margin: 0 auto;
-    opacity: 0;
-    stroke: currentColor;
-    stroke-width: 0;
-    width: 8px;
-}
-
-.dropdown-option-radius() {
+.dropdown-item-border-radius() {
     &:first-child {
-        .customBorderTopLeftRadiusProperty(dropdown-items-border-radius);
-        .customBorderTopRightRadiusProperty(dropdown-items-border-radius);
+        .customBorderTopLeftRadiusProperty(dropdown-border-radius);
+        .customBorderTopRightRadiusProperty(dropdown-border-radius);
     }
 
     &:last-child {
-        .customBorderBottomLeftRadiusProperty(dropdown-items-border-radius);
-        .customBorderBottomRightRadiusProperty(dropdown-items-border-radius);
+        .customBorderBottomLeftRadiusProperty(dropdown-border-radius);
+        .customBorderBottomRightRadiusProperty(dropdown-border-radius);
     }
-}
-
-.dropdown-option-base() {
-    .dropdown-option-color();
-    .dropdown-option-radius();
 }

--- a/src/less/mixins/dropdown/ds4/dropdown-mixins.less
+++ b/src/less/mixins/dropdown/ds4/dropdown-mixins.less
@@ -1,2 +1,3 @@
 @import "../../../variables/ds4/dropdown-variables.less";
+@import "../../selection-list/ds4/selection-list-mixins.less";
 @import "../base/dropdown-mixins.less";

--- a/src/less/mixins/dropdown/ds6/dropdown-mixins.less
+++ b/src/less/mixins/dropdown/ds6/dropdown-mixins.less
@@ -1,2 +1,3 @@
 @import "../../../variables/ds6/dropdown-variables.less";
+@import "../../selection-list/ds6/selection-list-mixins.less";
 @import "../base/dropdown-mixins.less";

--- a/src/less/mixins/selection-list/base/selection-list-mixins.less
+++ b/src/less/mixins/selection-list/base/selection-list-mixins.less
@@ -1,0 +1,70 @@
+.selection-list-item-base() {
+    background-color: transparent;
+    border-style: solid;
+    border-width: 1px;
+    box-sizing: border-box;
+    display: inline-flex;
+    font-family: inherit;
+    justify-content: space-between;
+    padding: @selection-list-item-padding;
+    width: 100%;
+
+    &:not(:last-child) {
+        margin-bottom: 1px;
+    }
+
+    &:focus {
+        outline-offset: -4px; // offset to accomodate hidden overflow
+    }
+}
+
+.selection-list-item-status() {
+    align-self: center;
+    fill: currentColor;
+    height: 8px;
+    margin: 0 auto;
+    opacity: 0;
+    stroke: currentColor;
+    stroke-width: 0;
+    width: 8px;
+}
+
+.listbox-option-base() {
+    .selection-list-item-base();
+
+    .customBorderColorProperty(listbox-option-border-color);
+    .customColorProperty(listbox-option-foreground-color);
+
+    &:hover {
+        .customBackgroundColorProperty(listbox-option-hover-background-color);
+        .customColorProperty(listbox-option-hover-foreground-color);
+    }
+
+    &:active {
+        font-weight: @listbox-option-active-font-weight;
+    }
+}
+
+.listbox-option-status() {
+    .selection-list-item-status();
+}
+
+.menu-menuitem-base() {
+    .selection-list-item-base();
+
+    .customBorderColorProperty(menu-menuitem-border-color);
+    .customColorProperty(menu-menuitem-foreground-color);
+
+    &:hover {
+        .customBackgroundColorProperty(menu-menuitem-hover-background-color);
+        .customColorProperty(menu-menuitem-hover-foreground-color);
+    }
+
+    &:active {
+        font-weight: @menu-menuitem-active-font-weight;
+    }
+}
+
+.menu-menuitem-status() {
+    .selection-list-item-status();
+}

--- a/src/less/mixins/selection-list/ds4/selection-list-mixins.less
+++ b/src/less/mixins/selection-list/ds4/selection-list-mixins.less
@@ -1,0 +1,2 @@
+@import "../../../variables/ds4/selection-list-variables.less";
+@import "../base/selection-list-mixins.less";

--- a/src/less/mixins/selection-list/ds6/selection-list-mixins.less
+++ b/src/less/mixins/selection-list/ds6/selection-list-mixins.less
@@ -1,0 +1,2 @@
+@import "../../../variables/ds6/selection-list-variables.less";
+@import "../base/selection-list-mixins.less";

--- a/src/less/rounded-off/ds6/rounded-off.less
+++ b/src/less/rounded-off/ds6/rounded-off.less
@@ -46,9 +46,9 @@ button.expand-btn {
 .listbox-button__listbox,
 .menu-button__menu,
 .fake-menu-button__menu {
-    --dropdown-items-border-radius: @border-radius-none;
-    --dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
-    --dropdown-items-border-color: @dropdown-items-background-color;
+    --dropdown-border-radius: @border-radius-none;
+    --dropdown-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+    --dropdown-border-color: @dropdown-background-color;
 }
 
 .page-notice {

--- a/src/less/variables/base/combobox-variables.less
+++ b/src/less/variables/base/combobox-variables.less
@@ -12,4 +12,4 @@
 @combobox-invalid-foreground-color: @color-status-attention;
 @combobox-focus-border-color: @color-action-primary;
 @combobox-focus-background-color: @color-background-default;
-@combobox-item-active-font-weight: @font-weight-dropdown-item-active;
+@combobox-icon-color: @color-text-default;

--- a/src/less/variables/base/dropdown-variables.less
+++ b/src/less/variables/base/dropdown-variables.less
@@ -1,16 +1,1 @@
-@dropdown-items-background-color: @color-background-default;
-@dropdown-item-foreground-color: @color-text-default;
-@dropdown-item-background-color: @dropdown-items-background-color;
-@dropdown-item-border-color: @dropdown-items-background-color;
-@dropdown-item-padding: 8px 15px;
-@dropdown-item-hover-background-color: @color-dropdown-item-hover-background;
-@dropdown-item-hover-foreground-color: @color-text-default;
-@dropdown-item-active-status-color: @color-dropdown-item-active-background;
-@dropdown-item-active-font-weight: @font-weight-dropdown-item-active;
-
-@dropdown-fake-anchor-color: @color-text-default;
-@dropdown-fake-button-background-color: @color-background-default;
-@dropdown-fake-button-color: @color-text-default;
-
-@dropdown-status-color: @color-text-default;
-@dropdown-separator-color: @color-divider;
+@dropdown-background-color: @color-background-default;

--- a/src/less/variables/base/listbox-button-variables.less
+++ b/src/less/variables/base/listbox-button-variables.less
@@ -1,2 +1,2 @@
 @listbox-button-invalid-border-color: @color-r4;
-@listbox-button-item-active-font-weight: @font-weight-dropdown-item-active;
+@listbox-button-option-active-font-weight: @font-weight-selection-list-item-active;

--- a/src/less/variables/base/listbox-variables.less
+++ b/src/less/variables/base/listbox-variables.less
@@ -1,1 +1,8 @@
-// file intentionally empty (no variables for this module)
+@listbox-background-color: @selection-list-background-color;
+@listbox-option-foreground-color: @selection-list-item-foreground-color;
+@listbox-option-background-color: @selection-list-item-background-color;
+@listbox-option-border-color: @selection-list-item-border-color;
+@listbox-option-hover-background-color: @selection-list-item-hover-background-color;
+@listbox-option-hover-foreground-color: @selection-list-item-hover-foreground-color;
+@listbox-option-active-status-color: @selection-list-item-active-status-color;
+@listbox-option-active-font-weight: @selection-list-item-active-font-weight;

--- a/src/less/variables/base/menu-button-variables.less
+++ b/src/less/variables/base/menu-button-variables.less
@@ -1,2 +1,1 @@
-@menu-button-item-active-font-weight: @font-weight-dropdown-item-active;
-@menu-button-item-disabled-foreground-color: @color-text-disabled;
+@menu-button-menuitem-active-font-weight: @font-weight-selection-list-item-active;

--- a/src/less/variables/base/menu-variables.less
+++ b/src/less/variables/base/menu-variables.less
@@ -1,1 +1,15 @@
-@menu-item-disabled-foreground-color: @color-text-disabled;
+@menu-background-color: @selection-list-background-color;
+@menu-separator-color: @selection-list-separator-color;
+
+@menu-menuitem-disabled-foreground-color: @color-text-disabled;
+@menu-menuitem-foreground-color: @selection-list-item-foreground-color;
+@menu-menuitem-background-color: @selection-list-item-background-color;
+@menu-menuitem-border-color: @selection-list-item-border-color;
+@menu-menuitem-active-status-color: @selection-list-item-active-status-color;
+@menu-menuitem-active-font-weight: @selection-list-item-active-font-weight;
+@menu-menuitem-hover-background-color: @selection-list-item-hover-background-color;
+@menu-menuitem-hover-foreground-color: @selection-list-item-hover-foreground-color;
+
+@menu-anchor-color: @selection-list-anchor-color;
+@menu-button-background-color: @selection-list-button-background-color;
+@menu-button-foreground-color: @selection-list-button-foreground-color;

--- a/src/less/variables/base/selection-list-variables.less
+++ b/src/less/variables/base/selection-list-variables.less
@@ -1,0 +1,15 @@
+@selection-list-background-color: @color-background-default;
+@selection-list-separator-color: @color-divider;
+
+@selection-list-item-foreground-color: @color-text-default;
+@selection-list-item-background-color: @selection-list-background-color;
+@selection-list-item-border-color: @selection-list-background-color;
+@selection-list-item-padding: 8px 15px;
+@selection-list-item-hover-background-color: @color-selection-list-item-hover-background;
+@selection-list-item-hover-foreground-color: @color-text-default;
+@selection-list-item-active-status-color: @color-selection-list-item-active-background;
+@selection-list-item-active-font-weight: @font-weight-selection-list-item-active;
+
+@selection-list-anchor-color: @color-text-default;
+@selection-list-button-background-color: @color-background-default;
+@selection-list-button-foreground-color: @color-text-default;

--- a/src/less/variables/ds4/color-variables.less
+++ b/src/less/variables/ds4/color-variables.less
@@ -108,8 +108,8 @@
 @color-form-control-disabled-placeholder: @color-action-disabled;
 @color-form-control-readonly-foreground: @color-grey6;
 @color-form-control-label-disabled: @color-core-gray-davys;
-@color-dropdown-item-hover-background: @color-grey1;
-@color-dropdown-item-active-background: @color-grey3;
+@color-selection-list-item-hover-background: @color-grey1;
+@color-selection-list-item-active-background: @color-grey3;
 @color-filter-selected-background: lighten(@color-b4, 55%);
 @color-filter-selected-hover-background: lighten(@color-b4, 45%);
 

--- a/src/less/variables/ds4/combobox-variables.less
+++ b/src/less/variables/ds4/combobox-variables.less
@@ -1,4 +1,5 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/combobox-variables.less";
 
 @combobox-background-color: @color-background-default;

--- a/src/less/variables/ds4/dropdown-variables.less
+++ b/src/less/variables/ds4/dropdown-variables.less
@@ -1,6 +1,6 @@
 @import "core-variables.less";
 @import "../base/dropdown-variables.less";
 
-@dropdown-items-border-color: @color-grey3;
-@dropdown-items-border-radius: @border-radius-none;
-@dropdown-items-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);
+@dropdown-border-color: @color-grey3;
+@dropdown-border-radius: @border-radius-none;
+@dropdown-box-shadow: 0 2px 4px 0 rgba(199, 199, 199, 0.5);

--- a/src/less/variables/ds4/listbox-button-variables.less
+++ b/src/less/variables/ds4/listbox-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-button-variables.less";

--- a/src/less/variables/ds4/listbox-variables.less
+++ b/src/less/variables/ds4/listbox-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-variables.less";

--- a/src/less/variables/ds4/menu-button-variables.less
+++ b/src/less/variables/ds4/menu-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-button-variables.less";

--- a/src/less/variables/ds4/menu-variables.less
+++ b/src/less/variables/ds4/menu-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-variables.less";

--- a/src/less/variables/ds4/selection-list-variables.less
+++ b/src/less/variables/ds4/selection-list-variables.less
@@ -1,0 +1,2 @@
+@import "core-variables.less";
+@import "../base/selection-list-variables.less";

--- a/src/less/variables/ds4/typography-variables.less
+++ b/src/less/variables/ds4/typography-variables.less
@@ -4,7 +4,7 @@
 @font-weight-regular: 400;
 @font-weight-bold: 500;
 @font-weight-action-primary: normal;
-@font-weight-dropdown-item-active: normal;
+@font-weight-selection-list-item-active: normal;
 
 @font-size-form-control-large: @font-size-medium;
 

--- a/src/less/variables/ds6/color-variables.less
+++ b/src/less/variables/ds6/color-variables.less
@@ -151,8 +151,8 @@
 @color-form-control-disabled-placeholder: @color-grey4;
 @color-form-control-readonly-foreground: @color-grey4;
 @color-form-control-label-disabled: @color-grey4;
-@color-dropdown-item-hover-background: @color-grey2;
-@color-dropdown-item-active-background: @color-background-default;
+@color-selection-list-item-hover-background: @color-grey2;
+@color-selection-list-item-active-background: @color-background-default;
 @color-filter-selected-background: #e1e8fd; // non-palette colour
 @color-filter-selected-hover-background: #c2d0fb; // non-palette colour
 

--- a/src/less/variables/ds6/combobox-variables.less
+++ b/src/less/variables/ds6/combobox-variables.less
@@ -1,4 +1,5 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/combobox-variables.less";
 
 @combobox-background-color: @color-grey1;

--- a/src/less/variables/ds6/dropdown-variables.less
+++ b/src/less/variables/ds6/dropdown-variables.less
@@ -1,6 +1,6 @@
 @import "core-variables.less";
 @import "../base/dropdown-variables.less";
 
-@dropdown-items-border-color: @border-radius-dropdown-border-color;
-@dropdown-items-border-radius: @border-radius-dropdown;
-@dropdown-items-box-shadow: @border-radius-dropdown-box-shadow;
+@dropdown-border-color: @border-radius-dropdown-border-color;
+@dropdown-border-radius: @border-radius-dropdown;
+@dropdown-box-shadow: @border-radius-dropdown-box-shadow;

--- a/src/less/variables/ds6/listbox-button-variables.less
+++ b/src/less/variables/ds6/listbox-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-button-variables.less";

--- a/src/less/variables/ds6/listbox-variables.less
+++ b/src/less/variables/ds6/listbox-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/listbox-variables.less";

--- a/src/less/variables/ds6/menu-button-variables.less
+++ b/src/less/variables/ds6/menu-button-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-button-variables.less";

--- a/src/less/variables/ds6/menu-variables.less
+++ b/src/less/variables/ds6/menu-variables.less
@@ -1,2 +1,3 @@
 @import "core-variables.less";
+@import "selection-list-variables.less";
 @import "../base/menu-variables.less";

--- a/src/less/variables/ds6/selection-list-variables.less
+++ b/src/less/variables/ds6/selection-list-variables.less
@@ -1,0 +1,2 @@
+@import "core-variables.less";
+@import "../base/selection-list-variables.less";

--- a/src/less/variables/ds6/typography-variables.less
+++ b/src/less/variables/ds6/typography-variables.less
@@ -4,7 +4,7 @@
 @font-weight-regular: 500;
 @font-weight-bold: 700;
 @font-weight-action-primary: bold;
-@font-weight-dropdown-item-active: bold;
+@font-weight-selection-list-item-active: bold;
 
 @font-size-form-control-large: @font-size-18;
 


### PR DESCRIPTION
Closes #1463

Listbox and menu modules were using the same "dropdown" mixins as listbox-button and menu-button. The problem is that listbox and menu are not considered "dropdowns", and can be deployed directly onto the page without any button (most often this happens inside of panel dialogs) and so we are going to run into issues with them sharing the exact same mixins and vars.

I have reorganised like so:

* dropdown: now refers only to the dropdown overlay/flyout
* selection-list-item: new generic term for an `option` or `menuitem`
* option: new specific term for items in any aria listbox 
* menuitem: new specific term for items in any aria menu

In a nutshell, most of the dropdown vars and mixins have been moved over to selection-list vars and mixins. Most option and menuitem mixins/vars are simple aliases to selection-list-item.

Not expecting reviewer to look through every file or line here, just a quick scan of this description and see if direction makes sense.
