### PR TITLE
fix(carousel): hide vertical scrollbar

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -224,6 +224,7 @@ span.carousel__container {
     border-color: rgba(0, 0, 0, 0);
     -webkit-overflow-scrolling: touch;
     overflow-x: auto;
+    overflow-y: hidden;
     padding-bottom: 10px;
     scroll-behavior: smooth;
     -webkit-scroll-snap-type: mandatory;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -224,6 +224,7 @@ span.carousel__container {
     border-color: rgba(0, 0, 0, 0);
     -webkit-overflow-scrolling: touch;
     overflow-x: auto;
+    overflow-y: hidden;
     padding-bottom: 10px;
     scroll-behavior: smooth;
     -webkit-scroll-snap-type: mandatory;

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -156,6 +156,7 @@ span.carousel__container {
             border-color: rgba(0, 0, 0, 0);
             -webkit-overflow-scrolling: touch;
             overflow-x: auto; // also used in js to determine scroll behavior
+            overflow-y: hidden;
             padding-bottom: 10px;
             scroll-behavior: smooth;
             -webkit-scroll-snap-type: mandatory;


### PR DESCRIPTION
## Description
There's a weird bug where the overflow on the horizontal is shown and the scrollbar shows up. This fix is supposed to resolve that.

## Screenshots
Before
<img width="345" alt="Screen Shot 2021-06-11 at 9 01 27 AM" src="https://user-images.githubusercontent.com/1755269/121715434-bcb65000-ca93-11eb-8383-ec32529b7556.png">
After
<img width="312" alt="Screen Shot 2021-06-11 at 9 01 45 AM" src="https://user-images.githubusercontent.com/1755269/121715441-be801380-ca93-11eb-8cf7-bceda0b7c43f.png">

