### PR TITLE
fix(generate-bundle): added skip autoprefixer for file

### DIFF
--- a/scripts/generate-bundle.js
+++ b/scripts/generate-bundle.js
@@ -136,7 +136,10 @@ class CssProcesser {
         const cdnPath = getCDNPath(this.args.name, this.dsVersion);
         rimraf.sync(cdnPath);
         return makeDir(cdnPath).then(() =>
-            writeFile(`${cdnPath}/skin.${this.minify ? 'min.' : ''}css`, raw)
+            writeFile(
+                `${cdnPath}/skin.${this.minify ? 'min.' : ''}css`,
+                `/* autoprefixer: off */\n${raw}\n/* autoprefixer: on */`
+            )
         );
     }
 }


### PR DESCRIPTION
## Description
In some cases this css would be executed in autoprefixer and strip out some needed lines. 
Changed this in order to skip all autoprefixing by adding a snippet to the beginning of the file and end to ignore running autuoprefixer since it was already run on less compilation.

