### PR TITLE
fix(floating-label): dropped margin

### DIFF
--- a/dist/floating-label/ds4/floating-label.css
+++ b/dist/floating-label/ds4/floating-label.css
@@ -1,5 +1,4 @@
 .floating-label {
-  margin-top: 14px;
   position: relative;
 }
 span.floating-label {

--- a/dist/floating-label/ds6/floating-label.css
+++ b/dist/floating-label/ds6/floating-label.css
@@ -1,5 +1,4 @@
 .floating-label {
-  margin-top: 14px;
   position: relative;
 }
 span.floating-label {

--- a/src/less/floating-label/base/floating-label.less
+++ b/src/less/floating-label/base/floating-label.less
@@ -1,7 +1,6 @@
 @import "../../mixins/utility/utility-mixins.less";
 
 .floating-label {
-    margin-top: 14px;
     position: relative;
 }
 


### PR DESCRIPTION
## Description
Removed margin from floating label.

## References
closes #1481 

## Screenshots

<img width="251" alt="Screen Shot 2021-06-24 at 12 23 54 PM" src="https://user-images.githubusercontent.com/25092249/123320787-13397a80-d4e7-11eb-8d88-5f0e62c878b6.png">
<img width="237" alt="Screen Shot 2021-06-24 at 12 24 00 PM" src="https://user-images.githubusercontent.com/25092249/123320792-13d21100-d4e7-11eb-8517-0a6b8e18b7e5.png">
