### PR TITLE
fix(textbox): vertically centered icon button with large textbox

### DIFF
--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -8,6 +8,7 @@
 .textbox button.icon-btn {
   display: -webkit-inline-box;
   display: inline-flex;
+  height: 100%;
   -webkit-box-pack: center;
           justify-content: center;
   padding: 0;

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -8,6 +8,7 @@
 .textbox button.icon-btn {
   display: -webkit-inline-box;
   display: inline-flex;
+  height: 100%;
   -webkit-box-pack: center;
           justify-content: center;
   padding: 0;

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -10,6 +10,7 @@
 
     button.icon-btn {
         display: inline-flex;
+        height: 100%;
         justify-content: center;
         padding: 0;
         position: absolute;
@@ -148,6 +149,7 @@ input.textbox__control--large {
     }
 }
 
+// deprecated: remove in v13.0.0
 .textbox--large {
     input.textbox__control,
     textarea.textbox__control {

--- a/src/less/textbox/stories/icon.stories.js
+++ b/src/less/textbox/stories/icon.stories.js
@@ -54,3 +54,28 @@ export const dualActionable = () => `
     </button>
 </span>
 `;
+
+export const actionableLarge = () => `
+<span class="textbox textbox--icon-end">
+    <input class="textbox__control textbox__control--large" type="text" placeholder="placeholder text" />
+    <button class="icon-btn" type="button" aria-label="Choose Contact">
+        <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
+            <use xlink:href="#icon-messages"></use>
+        </svg>
+    </button>
+</span>
+`;
+
+export const dualActionableLarge = () => `
+<span class="textbox textbox--icon-end">
+    <svg class="icon icon--search" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="#icon-search"></use>
+    </svg>
+    <input class="textbox__control textbox__control--large" type="text" placeholder="placeholder text" />
+    <button class="icon-btn" type="button" aria-label="Choose Contact">
+        <svg class="icon icon--messages" focusable="false" width="16" height="16" aria-hidden="true">
+            <use xlink:href="#icon-messages"></use>
+        </svg>
+    </button>
+</span>
+`;


### PR DESCRIPTION
## Description
Vertically centered icon button in large textbox scenario. Added stories. 

## Context


## Screenshots

### Before
![Screen Shot 2021-06-29 at 8 24 09 PM](https://user-images.githubusercontent.com/25092249/123897296-03230000-d918-11eb-84a5-3ff760adf492.png)


### After
![Screen Shot 2021-06-29 at 8 19 20 PM](https://user-images.githubusercontent.com/25092249/123897055-a6bfe080-d917-11eb-903d-3f5d77e62a36.png)

