### PR TITLE
fix(video): changed play icon size and fixed error container

### DIFF
--- a/dist/video/ds4/video.css
+++ b/dist/video/ds4/video.css
@@ -4,6 +4,7 @@
 .video-player__overlay {
   -webkit-box-align: center;
           align-items: center;
+  background-color: rgba(0, 0, 0, 0.6);
   bottom: 0;
   color: #fff;
   cursor: pointer;
@@ -20,8 +21,7 @@
   text-align: center;
   top: 0;
 }
-.video-player__overlay-text,
-.video-player__overlay .icon {
+.video-player__overlay-text {
   margin: 20px 20px 0;
 }
 .video-player__overlay--hidden {
@@ -40,6 +40,7 @@
   padding: 0;
   width: auto;
 }
+.video-player .icon--video-play,
 .video-player .shaka-play-button svg {
   height: 48px;
   width: 48px;

--- a/dist/video/ds6/video.css
+++ b/dist/video/ds6/video.css
@@ -4,6 +4,7 @@
 .video-player__overlay {
   -webkit-box-align: center;
           align-items: center;
+  background-color: rgba(0, 0, 0, 0.6);
   bottom: 0;
   color: #fff;
   cursor: pointer;
@@ -20,8 +21,7 @@
   text-align: center;
   top: 0;
 }
-.video-player__overlay-text,
-.video-player__overlay .icon {
+.video-player__overlay-text {
   margin: 20px 20px 0;
 }
 .video-player__overlay--hidden {
@@ -40,6 +40,7 @@
   padding: 0;
   width: auto;
 }
+.video-player .icon--video-play,
 .video-player .shaka-play-button svg {
   height: 48px;
   width: 48px;

--- a/src/less/video/base/video.less
+++ b/src/less/video/base/video.less
@@ -4,6 +4,7 @@
 
 .video-player__overlay {
     align-items: center;
+    background-color: rgba(0, 0, 0, 0.6);
     bottom: 0;
     color: @color-white;
     cursor: pointer;
@@ -17,8 +18,7 @@
     top: 0;
 }
 
-.video-player__overlay-text,
-.video-player__overlay .icon {
+.video-player__overlay-text {
     margin: 20px 20px 0;
 }
 
@@ -41,6 +41,7 @@
     width: auto;
 }
 
+.video-player .icon--video-play,
 .video-player .shaka-play-button svg {
     height: 48px;
     width: 48px;


### PR DESCRIPTION
## Description
* Added play icon css changes so that both the icon in the shaka player and on our overlay do not jump
* Fixed overlay to have a background color with opacity (should be good for color contrast hopefully)

<img width="532" alt="Screen Shot 2021-07-02 at 1 46 12 PM" src="https://user-images.githubusercontent.com/1755269/124326774-e23af480-db3b-11eb-98fa-ee9587603d42.png">
