### PR TITLE
fix(video): fixed icon size, controls color contrast, and container size

### DIFF
--- a/dist/video/ds4/video.css
+++ b/dist/video/ds4/video.css
@@ -1,6 +1,10 @@
 .video-player {
   position: relative;
 }
+.video-player video {
+  height: 100%;
+  width: 100%;
+}
 .video-player__overlay {
   -webkit-box-align: center;
           align-items: center;
@@ -44,4 +48,8 @@
 .video-player .shaka-play-button svg {
   height: 48px;
   width: 48px;
+}
+.video-player .shaka-controls-button-panel {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 8px;
 }

--- a/dist/video/ds6/video.css
+++ b/dist/video/ds6/video.css
@@ -1,6 +1,10 @@
 .video-player {
   position: relative;
 }
+.video-player video {
+  height: 100%;
+  width: 100%;
+}
 .video-player__overlay {
   -webkit-box-align: center;
           align-items: center;
@@ -44,4 +48,8 @@
 .video-player .shaka-play-button svg {
   height: 48px;
   width: 48px;
+}
+.video-player .shaka-controls-button-panel {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 8px;
 }

--- a/src/less/video/base/video.less
+++ b/src/less/video/base/video.less
@@ -2,6 +2,11 @@
     position: relative;
 }
 
+.video-player video {
+    height: 100%;
+    width: 100%;
+}
+
 .video-player__overlay {
     align-items: center;
     background-color: rgba(0, 0, 0, 0.6);
@@ -28,8 +33,8 @@
 
 .video-player .shaka-overflow-menu svg {
     height: 24px;
-    padding-left: 10px;
-    padding-right: 10px;
+    margin-left: 10px;
+    margin-right: 10px;
     width: 24px;
 }
 
@@ -45,4 +50,9 @@
 .video-player .shaka-play-button svg {
     height: 48px;
     width: 48px;
+}
+
+.video-player .shaka-controls-button-panel {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-radius: 8px;
 }


### PR DESCRIPTION

## Description
* Fixed size of video to be 100% of container. Container will resize in ebayui (https://github.com/eBay/ebayui-core/issues/1447)
* Fixed shaka controls to have a transparent grey background with opacity of `0.7` (https://github.com/eBay/ebayui-core/issues/1437)
* Fixed issue with padding on report icon shrinking. Changed to margin

<img width="444" alt="Screen Shot 2021-07-08 at 4 53 52 PM" src="https://user-images.githubusercontent.com/1755269/125003897-21ba8280-e00d-11eb-8b13-6466a4ffb48b.png">

<img width="483" alt="Screen Shot 2021-07-08 at 4 54 00 PM" src="https://user-images.githubusercontent.com/1755269/125003895-1d8e6500-e00d-11eb-92df-fce2417d82b6.png">
