### PR TITLE
fix(progress-bar): remove min attribute from stories #1514

### DIFF
--- a/src/less/progress-bar/stories/progress-bar.stories.js
+++ b/src/less/progress-bar/stories/progress-bar.stories.js
@@ -1,13 +1,13 @@
 export default { title: 'Progress Bar/Progress Bar' };
 
-export const empty = () => `<progress class="progress" value=1 min=0 max=100>0%</progress>`;
+export const empty = () => `<progress class="progress" value=1 max=100>0%</progress>`;
 
 empty.storyName = 'Empty';
 
-export const half = () => `<progress class="progress" value=50 min=0 max=100>0%</progress>`;
+export const half = () => `<progress class="progress" value=50 max=100>0%</progress>`;
 
 half.storyName = 'Half';
 
-export const full = () => `<progress class="progress" value=100 min=0 max=100>0%</progress>`;
+export const full = () => `<progress class="progress" value=100 max=100>0%</progress>`;
 
 full.storyName = 'Full';


### PR DESCRIPTION
## Description
Removed `min` from `progress-bar` examples, as it is not a valid HTML attribute for the `<progress/>` tag.

## Context
https://github.com/eBay/skin/issues/1514