### PR TITLE
feat(badge): evo updates #1493

### DIFF
--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -9,7 +9,7 @@
   height: 16px;
   line-height: 16px;
   min-width: 16px;
-  padding: 1px 5px;
+  padding: 1px 4px 1px 5px;
   text-align: center;
   white-space: nowrap;
 }

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,18 +1,16 @@
 .badge {
-  align-items: center;
   background-color: var(--badge-background-color, #dd1e31);
-  border-radius: 20px;
+  border-radius: 16px;
   box-sizing: border-box;
   color: var(--badge-foreground-color, #fff);
-  display: inline-flex;
-  font-size: 0.75rem;
-  font-weight: 500;
-  height: 20px;
-  justify-content: center;
-  min-width: 20px;
-  padding: 1px 7px 0;
-  position: relative;
-  top: calc(50% - 18px);
+  display: inline-block;
+  font-family: "Market Sans", Arial, sans-serif;
+  font-size: 10px;
+  height: 16px;
+  line-height: 16px;
+  min-width: 16px;
+  padding: 1px 5px;
+  text-align: center;
   white-space: nowrap;
 }
 @media (prefers-color-scheme: dark) {

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,18 +1,16 @@
 .badge {
-  align-items: center;
   background-color: var(--badge-background-color, #e0103a);
-  border-radius: 20px;
+  border-radius: 16px;
   box-sizing: border-box;
   color: var(--badge-foreground-color, #fff);
-  display: inline-flex;
-  font-size: 0.75rem;
-  font-weight: 700;
-  height: 20px;
-  justify-content: center;
-  min-width: 20px;
-  padding: 1px 7px 0;
-  position: relative;
-  top: calc(50% - 18px);
+  display: inline-block;
+  font-family: "Market Sans", Arial, sans-serif;
+  font-size: 10px;
+  height: 16px;
+  line-height: 16px;
+  min-width: 16px;
+  padding: 1px 5px;
+  text-align: center;
   white-space: nowrap;
 }
 @media (prefers-color-scheme: dark) {

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -9,7 +9,7 @@
   height: 16px;
   line-height: 16px;
   min-width: 16px;
-  padding: 1px 5px;
+  padding: 1px 4px 1px 5px;
   text-align: center;
   white-space: nowrap;
 }

--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -69,19 +69,14 @@ a.icon-link--badged {
 }
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
-  border-color: var(--icon-button-badge-border-color, #fff);
-  border-style: solid;
-  border-width: 2px;
-  display: block;
-  height: 24px;
-  left: 16px;
-  line-height: 16px;
-  min-width: 24px;
-  padding-top: 2px;
+  border: var(--icon-button-badge-border-width, 2px) var(--icon-button-badge-border-style, solid) var(--icon-button-badge-border-color, #fff);
+  left: 24px;
+  line-height: 14px;
+  min-width: 14px;
+  padding: 0 3px;
   pointer-events: none;
   position: absolute;
-  text-align: center;
-  top: -2px;
+  top: -6px;
   z-index: 1;
 }
 @media (prefers-color-scheme: dark) {

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -69,19 +69,14 @@ a.icon-link--badged {
 }
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
-  border-color: var(--icon-button-badge-border-color, #fff);
-  border-style: solid;
-  border-width: 2px;
-  display: block;
-  height: 24px;
-  left: 16px;
-  line-height: 16px;
-  min-width: 24px;
-  padding-top: 2px;
+  border: var(--icon-button-badge-border-width, 2px) var(--icon-button-badge-border-style, solid) var(--icon-button-badge-border-color, #fff);
+  left: 24px;
+  line-height: 14px;
+  min-width: 14px;
+  padding: 0 3px;
   pointer-events: none;
   position: absolute;
-  text-align: center;
-  top: -2px;
+  top: -6px;
   z-index: 1;
 }
 @media (prefers-color-scheme: dark) {

--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -81,8 +81,7 @@ div.menu-button__item[role^="menuitem"]:last-child {
   width: 8px;
 }
 .menu-button__item svg.icon:last-child,
-.fake-menu-button__item svg.icon:last-child,
-.menu-button__item .badge {
+.fake-menu-button__item svg.icon:last-child {
   margin-left: 8px;
 }
 a.fake-menu-button__item {
@@ -172,16 +171,25 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
   white-space: nowrap;
   width: 100%;
 }
-a.fake-menu-button__item span,
-button.fake-menu-button__item span,
-div.menu-button__item[role^="menuitem"] span {
+a.fake-menu-button__item > span,
+button.fake-menu-button__item > span,
+div.menu-button__item[role^="menuitem"] > span {
   flex: 1 0 auto;
   white-space: nowrap;
 }
-a.fake-menu-button__item span.badge,
-button.fake-menu-button__item span.badge,
-div.menu-button__item[role^="menuitem"] span.badge {
-  flex: initial;
+a.fake-menu-button__item--badged,
+button.fake-menu-button__item--badged,
+div.menu-button__item--badged[role^="menuitem"] {
+  padding-right: 36px;
+  position: relative;
+}
+a.fake-menu-button__item--badged .badge,
+button.fake-menu-button__item--badged .badge,
+div.menu-button__item--badged[role^="menuitem"] .badge {
+  margin-left: 4px;
+  position: absolute;
+  top: 0;
+  z-index: 1;
 }
 .menu-button__menu--scroll {
   overflow-y: scroll;

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -81,8 +81,7 @@ div.menu-button__item[role^="menuitem"]:last-child {
   width: 8px;
 }
 .menu-button__item svg.icon:last-child,
-.fake-menu-button__item svg.icon:last-child,
-.menu-button__item .badge {
+.fake-menu-button__item svg.icon:last-child {
   margin-left: 8px;
 }
 a.fake-menu-button__item {
@@ -172,16 +171,25 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
   white-space: nowrap;
   width: 100%;
 }
-a.fake-menu-button__item span,
-button.fake-menu-button__item span,
-div.menu-button__item[role^="menuitem"] span {
+a.fake-menu-button__item > span,
+button.fake-menu-button__item > span,
+div.menu-button__item[role^="menuitem"] > span {
   flex: 1 0 auto;
   white-space: nowrap;
 }
-a.fake-menu-button__item span.badge,
-button.fake-menu-button__item span.badge,
-div.menu-button__item[role^="menuitem"] span.badge {
-  flex: initial;
+a.fake-menu-button__item--badged,
+button.fake-menu-button__item--badged,
+div.menu-button__item--badged[role^="menuitem"] {
+  padding-right: 36px;
+  position: relative;
+}
+a.fake-menu-button__item--badged .badge,
+button.fake-menu-button__item--badged .badge,
+div.menu-button__item--badged[role^="menuitem"] .badge {
+  margin-left: 4px;
+  position: absolute;
+  top: 0;
+  z-index: 1;
 }
 .menu-button__menu--scroll {
   overflow-y: scroll;

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -99,17 +99,24 @@ div.menu__item[role^="menuitem"]:active svg.icon {
 div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
   opacity: 1;
 }
-a.fake-menu__item span,
-button.fake-menu__item span,
-div.menu__item[role^="menuitem"] span {
+a.fake-menu__item > span,
+button.fake-menu__item > span,
+div.menu__item[role^="menuitem"] > span {
   flex: 0 0 auto;
   text-align: left;
   white-space: nowrap;
 }
-a.fake-menu__item span.badge,
-button.fake-menu__item span.badge,
-div.menu__item[role^="menuitem"] span.badge {
-  flex: initial;
+a.fake-menu__item--badged,
+button.fake-menu__item--badged,
+div.menu__item--badged[role^="menuitem"] {
+  position: relative;
+}
+a.fake-menu__item--badged span.badge,
+button.fake-menu__item--badged span.badge,
+div.menu__item--badged[role^="menuitem"] span.badge {
+  position: absolute;
+  top: 0;
+  z-index: 1;
 }
 .menu__items--scroll[role="menu"] {
   overflow-y: scroll;

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -114,6 +114,7 @@ div.menu__item--badged[role^="menuitem"] {
 a.fake-menu__item--badged span.badge,
 button.fake-menu__item--badged span.badge,
 div.menu__item--badged[role^="menuitem"] span.badge {
+  padding: 1px 5px;
   position: absolute;
   top: 0;
   z-index: 1;

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -99,17 +99,24 @@ div.menu__item[role^="menuitem"]:active svg.icon {
 div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
   opacity: 1;
 }
-a.fake-menu__item span,
-button.fake-menu__item span,
-div.menu__item[role^="menuitem"] span {
+a.fake-menu__item > span,
+button.fake-menu__item > span,
+div.menu__item[role^="menuitem"] > span {
   flex: 0 0 auto;
   text-align: left;
   white-space: nowrap;
 }
-a.fake-menu__item span.badge,
-button.fake-menu__item span.badge,
-div.menu__item[role^="menuitem"] span.badge {
-  flex: initial;
+a.fake-menu__item--badged,
+button.fake-menu__item--badged,
+div.menu__item--badged[role^="menuitem"] {
+  position: relative;
+}
+a.fake-menu__item--badged span.badge,
+button.fake-menu__item--badged span.badge,
+div.menu__item--badged[role^="menuitem"] span.badge {
+  position: absolute;
+  top: 0;
+  z-index: 1;
 }
 .menu__items--scroll[role="menu"] {
   overflow-y: scroll;

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -114,6 +114,7 @@ div.menu__item--badged[role^="menuitem"] {
 a.fake-menu__item--badged span.badge,
 button.fake-menu__item--badged span.badge,
 div.menu__item--badged[role^="menuitem"] span.badge {
+  padding: 1px 5px;
   position: absolute;
   top: 0;
   z-index: 1;

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -31,12 +31,21 @@
     @{property}: var(~"--@{token1}", @@token1) var(~"--@{token2}", @@token2);
 }
 
+.customProperty(@property, @token1, @token2, @token3) {
+    @{property}: var(~"--@{token1}", @@token1) var(~"--@{token2}", @@token2)
+        var(~"--@{token3}", @@token3);
+}
+
 .background-color(@token) {
     .customProperty(background-color, @token);
 }
 
 .background-image(@token) {
     .customProperty(background-image, @token);
+}
+
+.border(@token1, @token2, @token3) {
+    .customProperty(border, @token1, @token2, @token3);
 }
 
 .border-bottom-color(@token) {

--- a/docs/_includes/common/badge.html
+++ b/docs/_includes/common/badge.html
@@ -2,16 +2,19 @@
     {% include common/section-header.html name="badge" version=page.versions.badge %}
 
     <p>A badge is a visual indicator added to an element to convey quantity, newness or both. Badges are intended to remind a user of previous actions taken, or to alert them of new actions that they should consider.</p>
-
-    <p>The badge module contains the basic, base styles for a static badge element. Badges can also be placed inside of the <a href="#icon-button">icon button</a> and <a href="#menu">menu</a> modules.</p>
+    <p>The badge module contains the basic, base styles for a static badge element. Badges can also be placed inside of the <a href="#icon-button-badged">icon button</a> and <a href="#menu-badged">menu</a> modules.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <span class="badge" role="img" aria-label="1 notification">1</span>
+            <span class="badge" role="img" aria-label="2 notifications">2</span>
+            <span class="badge" role="img" aria-label="24 notifications">24</span>
+            <span class="badge" role="img" aria-label="99+ notifications">99+</span>
         </div>
     </div>
     {% highlight html %}
-<span class="badge" role="img" aria-label="1 notification">1</span>
+<span class="badge" role="img" aria-label="2 notifications">2</span>
+<span class="badge" role="img" aria-label="24 notifications">24</span>
+<span class="badge" role="img" aria-label="99+ notifications">99+</span>
     {% endhighlight %}
 
 </div>

--- a/docs/_includes/common/icon-button.html
+++ b/docs/_includes/common/icon-button.html
@@ -37,33 +37,33 @@
 
     <div class="demo">
         <div class="demo__inner">
-            <button aria-label="Menu (4 notifications)" class="icon-btn icon-btn--badged" type="button">
-                <svg class="icon icon--menu" focusable="false" width="24" height="24" aria-hidden="true">
-                    {% include common/symbol.html name="menu" %}
+            <button aria-label="Watchlist (4 notifications)" class="icon-btn icon-btn--badged" type="button">
+                <svg class="icon icon--save" focusable="false" width="24" height="24" aria-hidden="true">
+                    {% include common/symbol.html name="save" %}
                 </svg>
                 <span aria-hidden="true" class="badge">4</span>
             </button>
-            <a aria-label="Settings (4 notifications)" class="icon-link icon-link--badged" href="http://www.ebay.com">
-                <svg class="icon icon--settings" focusable="false" width="24" height="24" aria-hidden="true">
-                    {% include common/symbol.html name="settings" %}
+            <a aria-label="Inbox (4 notifications)" class="icon-link icon-link--badged" href="http://www.ebay.com">
+                <svg class="icon icon--notification" focusable="false" width="24" height="24" aria-hidden="true">
+                    {% include common/symbol.html name="notification" %}
                 </svg>
-                <span aria-hidden="true" class="badge">4</span>
+                <span aria-hidden="true" class="badge">99+</span>
             </a>
         </div>
     </div>
     {% highlight html %}
-<button aria-label="Menu (4 notifications)" class="icon-btn icon-btn--badged" type="button">
-    <svg class="icon icon--menu" focusable="false" width="24" height="24" aria-hidden="true">
-        <use xlink:href="#icon-menu"></use>
+<button aria-label="Watchlist (4 notifications)" class="icon-btn icon-btn--badged" type="button">
+    <svg class="icon icon--save" focusable="false" width="24" height="24" aria-hidden="true">
+        <use xlink:href="#icon-save"></use>
     </svg>
     <span aria-hidden="true" class="badge">4</span>
 </button>
-<a aria-label="Settings (4 notifications)" class="icon-link icon-link--badged" href="http://www.ebay.com">
-    <svg class="icon icon--settings" focusable="false" width="24" height="24" aria-hidden="true">
-        <use xlink:href="#icon-settings"></use>
+<a aria-label="Inbox (4 notifications)" class="icon-link icon-link--badged" href="http://www.ebay.com">
+    <svg class="icon icon--notification" focusable="false" width="24" height="24" aria-hidden="true">
+        <use xlink:href="#icon-notification"></use>
     </svg>
-    <span aria-hidden="true" class="badge">4</span>
+    <span aria-hidden="true" class="badge">99+</span>
 </a>
     {% endhighlight %}
-
+    
 </div>

--- a/docs/_includes/common/menu.html
+++ b/docs/_includes/common/menu.html
@@ -44,14 +44,15 @@
 
     <h3 id="menu-badged">Badged Menu</h3>
     <p>A menu item can be badged using the <a href="#badge">badge</a> module.</p>
+    <p>The menuitem element requires an additional <span class="highlight">menu__item--badged</span> modifier.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="menu">
                 <div class="menu__items" role="menu">
-                    <div aria-label="Item 1 (3 notifications)" class="menu__item" role="menuitem"><span aria-hidden="true">Item 1<span class="badge">3</span></span></div>
-                    <div aria-label="Item 2 (77 notifications)" class="menu__item" role="menuitem"><span aria-hidden="true">Item 2<span class="badge">77</span></span></div>
-                    <div class="menu__item" role="menuitem"><span>Item 3</span></div>
+                    <div aria-label="Item 1 (3 notifications)" class="menu__item menu__item--badged" role="menuitem"><span aria-hidden="true">Item 1<span class="badge">3</span></span></div>
+                    <div aria-label="Item 2 (77 notifications)" class="menu__item menu__item--badged" role="menuitem"><span aria-hidden="true">Item 2<span class="badge">77</span></span></div>
+                    <div class="menu__item menu__item--badged" role="menuitem"><span>Item 3</span></div>
                 </div>
             </span>
         </div>
@@ -59,13 +60,13 @@
     {% highlight html %}
 <span class="menu">
     <div class="menu__items" role="menu">
-        <div aria-label="Item 1 (3 notifications)" class="menu__item" role="menuitem">
+        <div aria-label="Item 1 (3 notifications)" class="menu__item menu__item--badged" role="menuitem">
             <span aria-hidden="true">Item 1<span class="badge">3</span></span>
         </div>
-        <div aria-label="Item 2 (77 notifications)" class="menu__item" role="menuitem">
+        <div aria-label="Item 2 (77 notifications)" class="menu__item menu__item--badged" role="menuitem">
             <span aria-hidden="true">Item 2<span class="badge">77</span></span>
         </div>
-        <div class="menu__item" role="menuitem">
+        <div class="menu__item menu__item--badged" role="menuitem">
             <span>Item 3</span>
         </div>
     </div>

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -4,20 +4,18 @@
 @badge-foreground-color: @color-background-default;
 
 .badge {
-    align-items: center;
     .background-color(badge-background-color);
-    border-radius: 20px;
+    border-radius: 16px;
     box-sizing: border-box;
     .color(badge-foreground-color);
-    display: inline-flex;
-    font-size: @font-size-12;
-    font-weight: @font-weight-bold;
-    height: 20px;
-    justify-content: center;
-    min-width: 20px;
-    padding: 1px 7px 0;
-    position: relative;
-    top: calc(50% - 18px);
+    display: inline-block;
+    font-family: @font-family-market-sans;
+    font-size: 10px;
+    height: 16px;
+    line-height: 16px;
+    min-width: 16px;
+    padding: 1px 5px;
+    text-align: center;
     white-space: nowrap;
 }
 

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -14,7 +14,7 @@
     height: 16px;
     line-height: 16px;
     min-width: 16px;
-    padding: 1px 5px;
+    padding: 1px 4px 1px 5px;
     text-align: center;
     white-space: nowrap;
 }

--- a/src/less/icon-button/base/icon-button.less
+++ b/src/less/icon-button/base/icon-button.less
@@ -1,6 +1,8 @@
 @import "../../mixins/utility/utility-mixins.less";
 
 @icon-button-badge-border-color: @color-background-default;
+@icon-button-badge-border-style: solid;
+@icon-button-badge-border-width: 2px;
 @icon-button-badge-font-size: @font-size-small;
 @icon-button-icon-foreground-color: @color-icon-actionable-default;
 @icon-button-icon-active-foreground-color: @color-icon-actionable-active;
@@ -88,19 +90,14 @@ a.icon-link--badged {
     position: relative;
 
     .badge {
-        .border-color(icon-button-badge-border-color);
-        border-style: solid;
-        border-width: 2px;
-        display: block;
-        height: 24px;
-        left: 16px;
-        line-height: 16px;
-        min-width: 24px;
-        padding-top: 2px;
+        .border(icon-button-badge-border-width, icon-button-badge-border-style, icon-button-badge-border-color);
+        left: 24px;
+        line-height: 14px;
+        min-width: 14px;
+        padding: 0 3px;
         pointer-events: none;
         position: absolute;
-        text-align: center;
-        top: -2px;
+        top: -6px;
         z-index: 1;
     }
 }

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -46,8 +46,7 @@ div.menu-button__item[role^="menuitem"] {
 }
 
 .menu-button__item svg.icon:last-child,
-.fake-menu-button__item svg.icon:last-child,
-.menu-button__item .badge {
+.fake-menu-button__item svg.icon:last-child {
     margin-left: 8px;
 }
 
@@ -125,17 +124,27 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
     }
 }
 
-a.fake-menu-button__item span,
-button.fake-menu-button__item span,
-div.menu-button__item[role^="menuitem"] span {
+a.fake-menu-button__item > span,
+button.fake-menu-button__item > span,
+div.menu-button__item[role^="menuitem"] > span {
     flex: 1 0 auto;
     white-space: nowrap;
 }
 
-a.fake-menu-button__item span.badge,
-button.fake-menu-button__item span.badge,
-div.menu-button__item[role^="menuitem"] span.badge {
-    flex: initial;
+a.fake-menu-button__item--badged,
+button.fake-menu-button__item--badged,
+div.menu-button__item--badged[role^="menuitem"] {
+    padding-right: 36px;
+    position: relative;
+}
+
+a.fake-menu-button__item--badged .badge,
+button.fake-menu-button__item--badged .badge,
+div.menu-button__item--badged[role^="menuitem"] .badge {
+    margin-left: 4px;
+    position: absolute;
+    top: 0;
+    z-index: 1;
 }
 
 .menu-button__menu--scroll {

--- a/src/less/menu-button/stories/menu-button.stories.js
+++ b/src/less/menu-button/stories/menu-button.stories.js
@@ -52,6 +52,32 @@ export const expanded = () => `
 </span>
 `;
 
+export const badged = () => `
+<span class="menu-button">
+    <button class="expand-btn" type="button" aria-expanded="true" aria-haspopup="true">
+        <span class="expand-btn__cell">
+            <span class="expand-btn__text">Button</span>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="menu-button__menu">
+        <div class="menu-button__items" role="menu">
+            <div class="menu-button__item menu-button__item--badged" role="menuitem" tabindex="0">
+                <span>Item 10000<span class="badge">2</span></span>
+            </div>
+            <div class="menu-button__item menu-button__item--badged" role="menuitem">
+                <span>Item 20000<span class="badge">24</span></span>
+            </div>
+            <div class="menu-button__item menu-button__item--badged" role="menuitem">
+                <span>Item 30000<span class="badge">99+</span></span>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
 export const RTL = () => `
 <div dir="rtl">
     <span class="menu-button">

--- a/src/less/menu/base/menu.less
+++ b/src/less/menu/base/menu.less
@@ -95,6 +95,7 @@ div.menu__item--badged[role^="menuitem"] {
 a.fake-menu__item--badged span.badge,
 button.fake-menu__item--badged span.badge,
 div.menu__item--badged[role^="menuitem"] span.badge {
+    padding: 1px 5px;
     position: absolute;
     top: 0;
     z-index: 1;

--- a/src/less/menu/base/menu.less
+++ b/src/less/menu/base/menu.less
@@ -78,18 +78,26 @@ div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
     opacity: 1;
 }
 
-a.fake-menu__item span,
-button.fake-menu__item span,
-div.menu__item[role^="menuitem"] span {
+a.fake-menu__item > span,
+button.fake-menu__item > span,
+div.menu__item[role^="menuitem"] > span {
     flex: 0 0 auto;
     text-align: left;
     white-space: nowrap;
 }
 
-a.fake-menu__item span.badge,
-button.fake-menu__item span.badge,
-div.menu__item[role^="menuitem"] span.badge {
-    flex: initial;
+a.fake-menu__item--badged,
+button.fake-menu__item--badged,
+div.menu__item--badged[role^="menuitem"] {
+    position: relative;
+}
+
+a.fake-menu__item--badged span.badge,
+button.fake-menu__item--badged span.badge,
+div.menu__item--badged[role^="menuitem"] span.badge {
+    position: absolute;
+    top: 0;
+    z-index: 1;
 }
 
 .menu__items--scroll[role="menu"] {

--- a/src/less/menu/stories/menu/misc.stories.js
+++ b/src/less/menu/stories/menu/misc.stories.js
@@ -13,9 +13,9 @@ export const stateless = () => `
 export const badged = () => `
 <span class="menu">
     <span class="menu__items" role="menu">
-        <div class="menu__item" role="menuitem"><span>Button 1<span class="badge">1</span></span></div>
-        <div class="menu__item" role="menuitem"><span>Button 2<span class="badge">10</span></span></div>
-        <div class="menu__item" role="menuitem"><span>Button 3<span class="badge">99+</span></span></div>
+        <div class="menu__item menu__item--badged" role="menuitem"><span>Button 1<span class="badge">1</span></span></div>
+        <div class="menu__item menu__item--badged" role="menuitem"><span>Button 2<span class="badge">10</span></span></div>
+        <div class="menu__item menu__item--badged" role="menuitem"><span>Button 3<span class="badge">99+</span></span></div>
     </span>
 </span>
 `;

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -31,12 +31,21 @@
     @{property}: var(~"--@{token1}", @@token1) var(~"--@{token2}", @@token2);
 }
 
+.customProperty(@property, @token1, @token2, @token3) {
+    @{property}: var(~"--@{token1}", @@token1) var(~"--@{token2}", @@token2)
+        var(~"--@{token3}", @@token3);
+}
+
 .background-color(@token) {
     .customProperty(background-color, @token);
 }
 
 .background-image(@token) {
     .customProperty(background-image, @token);
+}
+
+.border(@token1, @token2, @token3) {
+    .customProperty(border, @token1, @token2, @token3);
 }
 
 .border-bottom-color(@token) {


### PR DESCRIPTION
Close #1493 

Updates badge, icon-button, menu & menu-button with latest badge styles from evo.

There's a little bit of hackery with padding to get the text lining up right. Some numbers can look a little uncentered across different browsers. The outer padding when number grows to 2 digit isn't exactly in line with the designs either. I think this is about the most precision we can get though without going and adding a new flex element inside the badge (i.e. a nested span). I'm not opposed to doing that if we have to.

Also, I'll probably come back and fine tune the position of the badge on the icon button. The `top` and `left` might need a little adjustment.

I also had to add a new `menu__item--badged` modifier.  This will need adding in coreui.

![Screen Shot 2021-07-19 at 3 53 53 PM](https://user-images.githubusercontent.com/38065/126241081-fc26e87c-cac9-47f1-b2e3-b121def40596.png)
![Screen Shot 2021-07-19 at 3 52 49 PM](https://user-images.githubusercontent.com/38065/126241089-25a9964f-f34c-4423-9adc-d68974bab2e3.png)

![Screen Shot 2021-07-19 at 4 37 25 PM](https://user-images.githubusercontent.com/38065/126241048-e7ce1102-5ef7-40fe-8317-338bab668363.png)
![Screen Shot 2021-07-19 at 4 37 39 PM](https://user-images.githubusercontent.com/38065/126241046-bdebf531-48a6-432b-9549-34f34a687faa.png)

![Screen Shot 2021-07-19 at 3 53 46 PM](https://user-images.githubusercontent.com/38065/126241084-2cadcbc5-ea40-49e3-8edd-c626ef998fd6.png)
![Screen Shot 2021-07-19 at 3 53 36 PM](https://user-images.githubusercontent.com/38065/126241085-1631cd82-41fd-4ea6-8247-3eaa2b223259.png)

![Screen Shot 2021-07-19 at 4 34 01 PM](https://user-images.githubusercontent.com/38065/126241060-192e15e7-7ef2-4bae-8e53-94408e371b58.png)

