### PR TITLE
fix(carousel): scrollbar on windows firefox shows only on hover

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -232,14 +232,16 @@ span.carousel__container {
     -ms-scroll-snap-type: x mandatory;
     scroll-snap-type: mandatory;
     scroll-snap-type: x mandatory;
+    scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
     scrollbar-width: thin;
-    -webkit-transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
-    transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
-    transition: border-color 0.5s, transform 0.45s ease-in-out;
-    transition: border-color 0.5s, transform 0.45s ease-in-out, -webkit-transform 0.45s ease-in-out;
+    -webkit-transition: border-color 0.5s, scrollbar-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, scrollbar-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, scrollbar-color 0.5s, transform 0.45s ease-in-out;
+    transition: border-color 0.5s, scrollbar-color 0.5s, transform 0.45s ease-in-out, -webkit-transform 0.45s ease-in-out;
   }
   .carousel:not(.carousel__autoplay) .carousel__list:hover {
     border-color: rgba(0, 0, 0, 0.4);
+    scrollbar-color: rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0);
   }
   .carousel:not(.carousel__autoplay) .carousel__list::-webkit-scrollbar {
     height: 5px;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -232,14 +232,16 @@ span.carousel__container {
     -ms-scroll-snap-type: x mandatory;
     scroll-snap-type: mandatory;
     scroll-snap-type: x mandatory;
+    scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
     scrollbar-width: thin;
-    -webkit-transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
-    transition: border-color 0.5s, -webkit-transform 0.45s ease-in-out;
-    transition: border-color 0.5s, transform 0.45s ease-in-out;
-    transition: border-color 0.5s, transform 0.45s ease-in-out, -webkit-transform 0.45s ease-in-out;
+    -webkit-transition: border-color 0.5s, scrollbar-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, scrollbar-color 0.5s, -webkit-transform 0.45s ease-in-out;
+    transition: border-color 0.5s, scrollbar-color 0.5s, transform 0.45s ease-in-out;
+    transition: border-color 0.5s, scrollbar-color 0.5s, transform 0.45s ease-in-out, -webkit-transform 0.45s ease-in-out;
   }
   .carousel:not(.carousel__autoplay) .carousel__list:hover {
     border-color: rgba(0, 0, 0, 0.4);
+    scrollbar-color: rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0);
   }
   .carousel:not(.carousel__autoplay) .carousel__list::-webkit-scrollbar {
     height: 5px;

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -165,12 +165,14 @@ span.carousel__container {
             -ms-scroll-snap-type: x mandatory;
             scroll-snap-type: mandatory;
             scroll-snap-type: x mandatory;
+            scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
             scrollbar-width: thin; // Firefox scrollbar
-            transition: border-color 0.5s,
+            transition: border-color 0.5s, scrollbar-color 0.5s,
                 transform @ebay-carousel-transition-time @ebay-carousel-transition-function;
 
             &:hover {
                 border-color: rgba(0, 0, 0, 0.4);
+                scrollbar-color: rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0);
             }
 
             &::-webkit-scrollbar {


### PR DESCRIPTION
## Description
Just needed to add `scrollbar-color` in a couple places to fix. 

## References
closes #1517 

## Screenshots
![carousel-windows-firefox-scrollbar](https://user-images.githubusercontent.com/25092249/126568779-fd9de487-f286-441c-967e-67116b5e7b32.gif)


