### PR TITLE
feat(pagination): evo updates part 1 (#1435)

### DIFF
--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -32,7 +32,7 @@ button.icon-btn:focus > svg,
 a.icon-link:focus > svg,
 button.icon-btn:hover > svg,
 a.icon-link:hover > svg {
-  fill: var(--icon-button-icon-hover-foreground-color, #333);
+  fill: var(--icon-button-icon-hover-foreground-color, #555);
 }
 button.icon-btn:not(:focus-visible),
 a.icon-link:not(:focus-visible) {
@@ -60,7 +60,7 @@ a[aria-disabled="true"].icon-link:hover > svg {
 }
 a.icon-link:visited:hover > svg,
 a.icon-link:visited:focus > svg {
-  fill: var(--icon-button-icon-hover-foreground-color, #333);
+  fill: var(--icon-button-icon-hover-foreground-color, #555);
 }
 button.icon-btn--badged,
 a.icon-link--badged {
@@ -86,6 +86,6 @@ a.icon-link--badged .badge {
     --icon-button-badge-border-color: #171717;
     --icon-button-icon-foreground-color: #dcdcdc;
     --icon-button-icon-active-foreground-color: #dcdcdc;
-    --icon-button-icon-hover-foreground-color: #5192ff;
+    --icon-button-icon-hover-foreground-color: #dcdcdc;
   }
 }

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -32,7 +32,7 @@ button.icon-btn:focus > svg,
 a.icon-link:focus > svg,
 button.icon-btn:hover > svg,
 a.icon-link:hover > svg {
-  fill: var(--icon-button-icon-hover-foreground-color, #3665f3);
+  fill: var(--icon-button-icon-hover-foreground-color, #111820);
 }
 button.icon-btn:not(:focus-visible),
 a.icon-link:not(:focus-visible) {
@@ -60,7 +60,7 @@ a[aria-disabled="true"].icon-link:hover > svg {
 }
 a.icon-link:visited:hover > svg,
 a.icon-link:visited:focus > svg {
-  fill: var(--icon-button-icon-hover-foreground-color, #3665f3);
+  fill: var(--icon-button-icon-hover-foreground-color, #111820);
 }
 button.icon-btn--badged,
 a.icon-link--badged {
@@ -86,6 +86,6 @@ a.icon-link--badged .badge {
     --icon-button-badge-border-color: #171717;
     --icon-button-icon-foreground-color: #dcdcdc;
     --icon-button-icon-active-foreground-color: #dcdcdc;
-    --icon-button-icon-hover-foreground-color: #5192ff;
+    --icon-button-icon-hover-foreground-color: #dcdcdc;
   }
 }

--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -2,7 +2,7 @@ nav.pagination {
   align-items: center;
   display: inline-flex;
   justify-content: center;
-  color: var(--pagination-item-foreground-color, #555);
+  color: var(--pagination-item-foreground-color, #707070);
   font-family: inherit;
   font-size: 1rem;
   margin: 8px 0;
@@ -19,10 +19,9 @@ ol.pagination__items {
   justify-content: center;
   box-sizing: border-box;
   flex-wrap: wrap;
-  height: 48px;
+  height: 44px;
   list-style-type: none;
   margin: 0;
-  overflow: hidden;
   padding: 0;
 }
 ol.pagination__items li:not([hidden]) {
@@ -37,7 +36,14 @@ button.pagination__previous {
   align-items: center;
   display: inline-flex;
   justify-content: center;
-  outline-offset: -4px;
+}
+a.pagination__next,
+button.pagination__next {
+  margin-left: 8px;
+}
+a.pagination__previous,
+button.pagination__previous {
+  margin-right: 8px;
 }
 .pagination__item {
   align-items: center;
@@ -45,27 +51,35 @@ button.pagination__previous {
   justify-content: center;
   box-sizing: border-box;
   font-weight: 400;
-  height: 48px;
-  margin: 0 4px;
-  outline-offset: -4px;
-  width: 48px;
+  height: 44px;
+  width: 44px;
 }
 .pagination__item:active {
   color: var(--pagination-item-active-foreground-color, #333);
 }
 .pagination__item:focus,
 .pagination__item:hover {
-  color: var(--pagination-item-hover-foreground-color, #333);
-  text-decoration: underline;
+  color: var(--pagination-item-hover-foreground-color, #00489f);
 }
 .pagination__item[aria-current="page"] {
-  background-color: var(--pagination-item-current-background-color, #eee);
-  border-color: var(--pagination-item-current-border-color, transparent);
-  border-radius: var(--pagination-item-current-border-radius, 0);
-  border-style: solid;
-  border-width: 2px;
   color: var(--pagination-item-current-foreground-color, #333);
   font-weight: 500;
+  position: relative;
+}
+.pagination__item[aria-current="page"]::after {
+  background-color: currentColor;
+  border-radius: 4px;
+  bottom: 0;
+  content: "";
+  display: block;
+  height: 2px;
+  left: calc(50% - 10px);
+  position: absolute;
+  width: 20px;
+}
+.pagination__item[aria-current="page"]:hover,
+.pagination__item[aria-current="page"]:focus {
+  color: #00489f;
 }
 button.pagination__item {
   background: none;
@@ -89,14 +103,26 @@ a.pagination__item:focus:not(:focus-visible),
 button.pagination__item:focus:not(:focus-visible) {
   outline: none;
 }
-@media (min-width: 601px) {
+[dir="rtl"] a.pagination__next,
+[dir="rtl"] button.pagination__next {
+  margin-left: 0;
+  margin-right: 8px;
+}
+[dir="rtl"] a.pagination__previous,
+[dir="rtl"] button.pagination__previous {
+  margin-left: 8px;
+  margin-right: 0;
+}
+@media (min-width: 600px) {
   nav.pagination {
     margin: 16px 0;
   }
 }
 @media (prefers-color-scheme: dark) {
   .pagination {
-    --pagination-item-foreground-color: #dcdcdc;
+    --pagination-item-foreground-color: #9c9c9c;
+    --pagination-item-current-foreground-color: #dcdcdc;
     --pagination-item-hover-foreground-color: #5192ff;
+    --pagination-item-active-foreground-color: #dcdcdc;
   }
 }

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -2,7 +2,7 @@ nav.pagination {
   align-items: center;
   display: inline-flex;
   justify-content: center;
-  color: var(--pagination-item-foreground-color, #111820);
+  color: var(--pagination-item-foreground-color, #707070);
   font-family: inherit;
   font-size: 1rem;
   margin: 8px 0;
@@ -19,10 +19,9 @@ ol.pagination__items {
   justify-content: center;
   box-sizing: border-box;
   flex-wrap: wrap;
-  height: 48px;
+  height: 44px;
   list-style-type: none;
   margin: 0;
-  overflow: hidden;
   padding: 0;
 }
 ol.pagination__items li:not([hidden]) {
@@ -37,7 +36,14 @@ button.pagination__previous {
   align-items: center;
   display: inline-flex;
   justify-content: center;
-  outline-offset: -4px;
+}
+a.pagination__next,
+button.pagination__next {
+  margin-left: 8px;
+}
+a.pagination__previous,
+button.pagination__previous {
+  margin-right: 8px;
 }
 .pagination__item {
   align-items: center;
@@ -45,10 +51,8 @@ button.pagination__previous {
   justify-content: center;
   box-sizing: border-box;
   font-weight: 500;
-  height: 48px;
-  margin: 0 4px;
-  outline-offset: -4px;
-  width: 48px;
+  height: 44px;
+  width: 44px;
 }
 .pagination__item:active {
   color: var(--pagination-item-active-foreground-color, #111820);
@@ -56,16 +60,26 @@ button.pagination__previous {
 .pagination__item:focus,
 .pagination__item:hover {
   color: var(--pagination-item-hover-foreground-color, #2b0eaf);
-  text-decoration: underline;
 }
 .pagination__item[aria-current="page"] {
-  background-color: var(--pagination-item-current-background-color, transparent);
-  border-color: var(--pagination-item-current-border-color, #3665f3);
-  border-radius: var(--pagination-item-current-border-radius, 8px);
-  border-style: solid;
-  border-width: 2px;
-  color: var(--pagination-item-current-foreground-color, #3665f3);
+  color: var(--pagination-item-current-foreground-color, #111820);
   font-weight: 700;
+  position: relative;
+}
+.pagination__item[aria-current="page"]::after {
+  background-color: currentColor;
+  border-radius: 4px;
+  bottom: 0;
+  content: "";
+  display: block;
+  height: 2px;
+  left: calc(50% - 10px);
+  position: absolute;
+  width: 20px;
+}
+.pagination__item[aria-current="page"]:hover,
+.pagination__item[aria-current="page"]:focus {
+  color: #2b0eaf;
 }
 button.pagination__item {
   background: none;
@@ -89,14 +103,26 @@ a.pagination__item:focus:not(:focus-visible),
 button.pagination__item:focus:not(:focus-visible) {
   outline: none;
 }
-@media (min-width: 601px) {
+[dir="rtl"] a.pagination__next,
+[dir="rtl"] button.pagination__next {
+  margin-left: 0;
+  margin-right: 8px;
+}
+[dir="rtl"] a.pagination__previous,
+[dir="rtl"] button.pagination__previous {
+  margin-left: 8px;
+  margin-right: 0;
+}
+@media (min-width: 600px) {
   nav.pagination {
     margin: 16px 0;
   }
 }
 @media (prefers-color-scheme: dark) {
   .pagination {
-    --pagination-item-foreground-color: #dcdcdc;
+    --pagination-item-foreground-color: #9c9c9c;
+    --pagination-item-current-foreground-color: #dcdcdc;
     --pagination-item-hover-foreground-color: #5192ff;
+    --pagination-item-active-foreground-color: #dcdcdc;
   }
 }

--- a/docs/_includes/common/pagination.html
+++ b/docs/_includes/common/pagination.html
@@ -339,7 +339,7 @@
         <div class="demo__inner">
             <nav class="pagination" aria-labelledby="pagination-heading-4" role="navigation">
                 <span aria-live="polite" role="status">
-                    <h2 class="clipped" id="pagination-heading-3">Results Pagination - Page 1</h2>
+                    <h2 class="clipped" id="pagination-heading-3">Results Pagination - Page 2</h2>
                 </span>
                 <a aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
                     <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
@@ -392,7 +392,7 @@
     {% highlight html %}
 <nav class="pagination pagination--fluid" aria-labelledby="pagination-heading" role="navigation">
     <span aria-live="off" role="status">
-        <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
+        <h2 class="clipped" id="pagination-heading">Results Pagination - Page 2</h2>
     </span>
     <a aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">

--- a/src/less/icon-button/base/icon-button.less
+++ b/src/less/icon-button/base/icon-button.less
@@ -6,7 +6,7 @@
 @icon-button-badge-font-size: @font-size-small;
 @icon-button-icon-foreground-color: @color-icon-actionable-default;
 @icon-button-icon-active-foreground-color: @color-icon-actionable-active;
-@icon-button-icon-hover-foreground-color: @color-icon-actionable-hover;
+@icon-button-icon-hover-foreground-color: @icon-button-icon-foreground-color;
 @icon-button-background-color: @color-grey1;
 
 a.icon-link {
@@ -109,6 +109,6 @@ a.icon-link--badged {
         --icon-button-badge-border-color: @color-background-default-dark-mode;
         --icon-button-icon-foreground-color: @color-text-default-dark-mode;
         --icon-button-icon-active-foreground-color: @color-text-default-dark-mode;
-        --icon-button-icon-hover-foreground-color: @color-b4-dark-mode;
+        --icon-button-icon-hover-foreground-color: @color-text-default-dark-mode;
     }
 }

--- a/src/less/pagination/base/pagination.less
+++ b/src/less/pagination/base/pagination.less
@@ -1,7 +1,10 @@
 @import "../../mixins/utility/utility-mixins.less";
 
 @pagination-item-font-weight: @font-weight-regular;
+@pagination-item-foreground-color: @color-grey5;
+@pagination-item-hover-foreground-color: @color-b6;
 @pagination-item-active-foreground-color: @color-text-default;
+@pagination-item-current-foreground-color: @color-text-default;
 @pagination-item-current-font-weight: @font-weight-bold;
 
 nav.pagination {
@@ -25,10 +28,9 @@ ol.pagination__items {
 
     box-sizing: border-box;
     flex-wrap: wrap;
-    height: 48px;
+    height: 44px;
     list-style-type: none;
     margin: 0;
-    overflow: hidden; // causes keyboard focus outline to be obscured (#927)
     padding: 0;
 
     li:not([hidden]) {
@@ -41,8 +43,16 @@ a.pagination__previous,
 button.pagination__next,
 button.pagination__previous {
     .inline-flex-items-centered();
+}
 
-    outline-offset: -4px; // match items, needed because of hidden overflow
+a.pagination__next,
+button.pagination__next {
+    margin-left: 8px;
+}
+
+a.pagination__previous,
+button.pagination__previous {
+    margin-right: 8px;
 }
 
 .pagination__item {
@@ -50,10 +60,8 @@ button.pagination__previous {
 
     box-sizing: border-box;
     font-weight: @pagination-item-font-weight;
-    height: 48px;
-    margin: 0 4px;
-    outline-offset: -4px; // needed because of hidden overflow
-    width: 48px;
+    height: 44px;
+    width: 44px;
 
     &:active {
         .color(pagination-item-active-foreground-color);
@@ -62,17 +70,29 @@ button.pagination__previous {
     &:focus,
     &:hover {
         .color(pagination-item-hover-foreground-color);
-        text-decoration: underline;
     }
 
     &[aria-current="page"] {
-        .background-color(pagination-item-current-background-color);
-        .border-color(pagination-item-current-border-color);
-        .border-radius(pagination-item-current-border-radius);
-        border-style: solid;
-        border-width: 2px;
         .color(pagination-item-current-foreground-color);
         font-weight: @pagination-item-current-font-weight;
+        position: relative;
+    }
+
+    &[aria-current="page"]::after {
+        background-color: currentColor;
+        border-radius: 4px;
+        bottom: 0;
+        content: "";
+        display: block;
+        height: 2px;
+        left: calc(50% - 10px);
+        position: absolute;
+        width: 20px;
+    }
+
+    &[aria-current="page"]:hover,
+    &[aria-current="page"]:focus {
+        color: @pagination-item-hover-foreground-color;
     }
 }
 
@@ -107,7 +127,21 @@ button.pagination__item:focus {
     }
 }
 
-@media (min-width: 601px) {
+[dir="rtl"] {
+    a.pagination__next,
+    button.pagination__next {
+        margin-left: 0;
+        margin-right: 8px;
+    }
+
+    a.pagination__previous,
+    button.pagination__previous {
+        margin-left: 8px;
+        margin-right: 0;
+    }
+}
+
+@media (min-width: @screen-size-3) {
     nav.pagination {
         margin: 16px 0;
     }
@@ -115,7 +149,9 @@ button.pagination__item:focus {
 
 @media (prefers-color-scheme: dark) {
     .pagination {
-        --pagination-item-foreground-color: @color-text-default-dark-mode;
+        --pagination-item-foreground-color: @color-grey5-dark-mode;
+        --pagination-item-current-foreground-color: @color-text-default-dark-mode;
         --pagination-item-hover-foreground-color: @color-b4-dark-mode;
+        --pagination-item-active-foreground-color: @color-text-default-dark-mode;
     }
 }

--- a/src/less/pagination/ds4/pagination.less
+++ b/src/less/pagination/ds4/pagination.less
@@ -1,10 +1,2 @@
 @import "../../tokens/ds4/tokens.less";
-
-@pagination-item-foreground-color: @color-icon-actionable-default;
-@pagination-item-hover-foreground-color: @color-text-default;
-@pagination-item-current-background-color: @color-grey1;
-@pagination-item-current-border-color: transparent;
-@pagination-item-current-border-radius: @border-radius-none;
-@pagination-item-current-foreground-color: @color-text-default;
-
 @import "../base/pagination.less";

--- a/src/less/pagination/ds6/pagination.less
+++ b/src/less/pagination/ds6/pagination.less
@@ -1,10 +1,2 @@
 @import "../../tokens/ds6/tokens.less";
-
-@pagination-item-foreground-color: @color-text-default;
-@pagination-item-hover-foreground-color: @color-b6;
-@pagination-item-current-background-color: transparent;
-@pagination-item-current-border-color: @color-link-default;
-@pagination-item-current-border-radius: @border-radius-small;
-@pagination-item-current-foreground-color: @color-link-default;
-
 @import "../base/pagination.less";

--- a/src/less/pagination/stories/dots.stories.js
+++ b/src/less/pagination/stories/dots.stories.js
@@ -111,6 +111,7 @@ export const dotsHidden = () => `
     <span aria-live="polite" role="status">
         <h2 class="clipped" id="pagination-heading">Results Pagination - Page 1</h2>
     </span>
+    <a aria-label="Previous Page" class="icon-link pagination__previous" href="http://www.ebay.com/sch/i.html?_nkw=guitars">
         <svg class="icon icon--pagination-prev" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-pagination-prev"></use>
         </svg>


### PR DESCRIPTION
This PR updates the colors, and changes the current item from having a full border to a bottom border only.

There is one hover color not quite right in dark mode. I will address it in Part 2. Also, I may need to reduce the spacing between the digits and the bottom-border.

DS4 is now normalized with DS6 (i.e. the only difference now being the color palette/primitives).

![Screen Shot 2021-07-21 at 3 10 45 PM](https://user-images.githubusercontent.com/38065/126569952-baf8c69b-e8d7-4a2d-b44c-01fa33a7e1cb.png)

![Screen Shot 2021-07-21 at 3 19 07 PM](https://user-images.githubusercontent.com/38065/126569951-ce62bdfe-bdbd-4579-af57-82a2069a4e81.png)
