### PR TITLE
fix(signal): used flex and inner span to center text

### DIFF
--- a/dist/signal/ds4/signal.css
+++ b/dist/signal/ds4/signal.css
@@ -8,7 +8,7 @@
   font-weight: bold;
   letter-spacing: 0.5px;
   margin: 8px 0;
-  padding: 1px 12px;
+  padding: 2px 12px 1px;
   text-align: center;
   text-transform: uppercase;
 }

--- a/dist/signal/ds6/signal.css
+++ b/dist/signal/ds6/signal.css
@@ -8,7 +8,7 @@
   font-weight: bold;
   letter-spacing: 0.5px;
   margin: 8px 0;
-  padding: 1px 12px;
+  padding: 2px 12px 1px;
   text-align: center;
   text-transform: uppercase;
 }

--- a/src/less/signal/base/signal.less
+++ b/src/less/signal/base/signal.less
@@ -10,7 +10,7 @@
     font-weight: bold;
     letter-spacing: 0.5px;
     margin: 8px 0;
-    padding: 1px 12px;
+    padding: 2px 12px 1px;
 
     text-align: center;
     text-transform: uppercase;


### PR DESCRIPTION
## Description
Centers the text in the signal, which was off in Chrome 92 and Firefox, at least in Mac. This isn't a 100% solution but gets us 90% there.

## References
closes #1525 

## Screenshots

### Chrome 92
![chrome-signal](https://user-images.githubusercontent.com/25092249/128755635-77ff2058-c40e-43fe-8623-173f32ff6e48.png)

### Firefox
![firefox-signal](https://user-images.githubusercontent.com/25092249/128758423-12a27470-ac93-4f3a-8c0c-ec65e2633544.png)


### Edge
![edge-signal](https://user-images.githubusercontent.com/25092249/128755654-833bdd6d-aed2-46ff-8968-8cf27f317538.png)



