### PR TITLE
fix(generate-imports): reverted css imports

### DIFF
--- a/scripts/generate-imports/config.json
+++ b/scripts/generate-imports/config.json
@@ -4,7 +4,7 @@
         "combo": ["core", "lightbox-dialog", "form", "progress-spinner"],
         "form": ["button", "checkbox", "field", "radio", "select", "switch", "textbox"]
     },
-    "skip": ["mixins", "primitives", "tokens"],
+    "skip": ["mixins", "primitives", "tokens", "svg"],
     "skipIndex": ["legacy-textbox", "rounded-off"],
     "dsVersions": ["6", "4"],
     "defaultDS": "6",


### PR DESCRIPTION

## Description
There was an issue with imports when linking to ebayui that lasso cannot resolve `css` imports from a js file. 
Changed the code to basically revert back to the old way of doing things (while keeping the new changes we added, like mjs)
