### PR TITLE
fix(pagination): removed flex-wrap and added overflow:hidden

### DIFF
--- a/dist/pagination/ds4/pagination.css
+++ b/dist/pagination/ds4/pagination.css
@@ -18,10 +18,10 @@ ol.pagination__items {
   display: inline-flex;
   justify-content: center;
   box-sizing: border-box;
-  flex-wrap: wrap;
   height: 44px;
   list-style-type: none;
   margin: 0;
+  overflow: hidden;
   padding: 0;
 }
 ol.pagination__items li:not([hidden]) {

--- a/dist/pagination/ds6/pagination.css
+++ b/dist/pagination/ds6/pagination.css
@@ -18,10 +18,10 @@ ol.pagination__items {
   display: inline-flex;
   justify-content: center;
   box-sizing: border-box;
-  flex-wrap: wrap;
   height: 44px;
   list-style-type: none;
   margin: 0;
+  overflow: hidden;
   padding: 0;
 }
 ol.pagination__items li:not([hidden]) {

--- a/src/less/pagination/base/pagination.less
+++ b/src/less/pagination/base/pagination.less
@@ -29,10 +29,10 @@ ol.pagination__items {
     .inline-flex-items-centered();
 
     box-sizing: border-box;
-    flex-wrap: wrap;
     height: 44px;
     list-style-type: none;
     margin: 0;
+    overflow: hidden;
     padding: 0;
 
     li:not([hidden]) {


### PR DESCRIPTION
## Description
When calculating row size in ebayui, it tried to make the flex go 100% and then calculate available space. 
However, there is an issue if overflow is not hidden, then it actually fills in more than it can (because the arrows are outside of the flow). 
This was initially solved by flex-wrap. However, because the items are smaller, they sometimes actually show up and wrap.

