### PR TITLE
fix(listbox-mixins): ensure hidden property is hidden #1549

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -57,6 +57,9 @@ span.combobox {
 .combobox__option[role^="option"]:focus {
   outline-offset: -4px;
 }
+.combobox__option[role^="option"][hidden] {
+  display: none;
+}
 .combobox__option[role^="option"]:hover {
   background-color: var(--listbox-option-hover-background-color, #eee);
   color: var(--listbox-option-hover-foreground-color, #333);

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -57,6 +57,9 @@ span.combobox {
 .combobox__option[role^="option"]:focus {
   outline-offset: -4px;
 }
+.combobox__option[role^="option"][hidden] {
+  display: none;
+}
 .combobox__option[role^="option"]:hover {
   background-color: var(--listbox-option-hover-background-color, #e5e5e5);
   color: var(--listbox-option-hover-foreground-color, #111820);

--- a/dist/listbox-button/ds4/listbox-button.css
+++ b/dist/listbox-button/ds4/listbox-button.css
@@ -87,6 +87,9 @@ div.listbox-button__option[role="option"]:not(:last-child) {
 div.listbox-button__option[role="option"]:focus {
   outline-offset: -4px;
 }
+div.listbox-button__option[role="option"][hidden] {
+  display: none;
+}
 div.listbox-button__option[role="option"]:hover {
   background-color: var(--listbox-option-hover-background-color, #eee);
   color: var(--listbox-option-hover-foreground-color, #333);

--- a/dist/listbox-button/ds6/listbox-button.css
+++ b/dist/listbox-button/ds6/listbox-button.css
@@ -87,6 +87,9 @@ div.listbox-button__option[role="option"]:not(:last-child) {
 div.listbox-button__option[role="option"]:focus {
   outline-offset: -4px;
 }
+div.listbox-button__option[role="option"][hidden] {
+  display: none;
+}
 div.listbox-button__option[role="option"]:hover {
   background-color: var(--listbox-option-hover-background-color, #e5e5e5);
   color: var(--listbox-option-hover-foreground-color, #111820);

--- a/dist/listbox/ds4/listbox.css
+++ b/dist/listbox/ds4/listbox.css
@@ -37,6 +37,9 @@ div.listbox__option[role="option"]:not(:last-child) {
 div.listbox__option[role="option"]:focus {
   outline-offset: -4px;
 }
+div.listbox__option[role="option"][hidden] {
+  display: none;
+}
 div.listbox__option[role="option"]:hover {
   background-color: var(--listbox-option-hover-background-color, #eee);
   color: var(--listbox-option-hover-foreground-color, #333);

--- a/dist/listbox/ds6/listbox.css
+++ b/dist/listbox/ds6/listbox.css
@@ -37,6 +37,9 @@ div.listbox__option[role="option"]:not(:last-child) {
 div.listbox__option[role="option"]:focus {
   outline-offset: -4px;
 }
+div.listbox__option[role="option"][hidden] {
+  display: none;
+}
 div.listbox__option[role="option"]:hover {
   background-color: var(--listbox-option-hover-background-color, #e5e5e5);
   color: var(--listbox-option-hover-foreground-color, #111820);

--- a/dist/mixins/listbox/base/listbox-mixins.less
+++ b/dist/mixins/listbox/base/listbox-mixins.less
@@ -13,6 +13,10 @@
     .border-color(listbox-option-border-color);
     .color(listbox-option-foreground-color);
 
+    &[hidden] {
+        display: none; // https://css-tricks.com/the-hidden-attribute-is-visibly-weak/
+    }
+
     &:hover {
         .background-color(listbox-option-hover-background-color);
         .color(listbox-option-hover-foreground-color);

--- a/src/less/mixins/listbox/base/listbox-mixins.less
+++ b/src/less/mixins/listbox/base/listbox-mixins.less
@@ -13,6 +13,10 @@
     .border-color(listbox-option-border-color);
     .color(listbox-option-foreground-color);
 
+    &[hidden] {
+        display: none; // https://css-tricks.com/the-hidden-attribute-is-visibly-weak/
+    }
+
     &:hover {
         .background-color(listbox-option-hover-background-color);
         .color(listbox-option-hover-foreground-color);


### PR DESCRIPTION
Fixes #1549

Solves "weak" `hidden` property when applied on listbox options.

https://css-tricks.com/the-hidden-attribute-is-visibly-weak/