### PR TITLE
chore: remove redundant font-family styles

### DIFF
--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -4,7 +4,6 @@
   box-sizing: border-box;
   color: var(--badge-foreground-color, #fff);
   display: inline-block;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 10px;
   height: 16px;
   line-height: 16px;

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -4,7 +4,6 @@
   box-sizing: border-box;
   color: var(--badge-foreground-color, #fff);
   display: inline-block;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 10px;
   height: 16px;
   line-height: 16px;

--- a/dist/filter-button/ds4/filter-button.css
+++ b/dist/filter-button/ds4/filter-button.css
@@ -12,7 +12,6 @@ a.filter-link {
   display: inline-flex;
   flex: 0 1 auto;
   flex-direction: column;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   height: 32px;
   justify-content: center;

--- a/dist/filter-button/ds6/filter-button.css
+++ b/dist/filter-button/ds6/filter-button.css
@@ -12,7 +12,6 @@ a.filter-link {
   display: inline-flex;
   flex: 0 1 auto;
   flex-direction: column;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   height: 32px;
   justify-content: center;

--- a/dist/filter-menu-button/ds4/filter-menu-button.css
+++ b/dist/filter-menu-button/ds4/filter-menu-button.css
@@ -18,7 +18,6 @@ button.filter-menu-button__button {
   display: inline-flex;
   flex: 0 1 auto;
   flex-direction: column;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   height: 32px;
   justify-content: center;

--- a/dist/filter-menu-button/ds6/filter-menu-button.css
+++ b/dist/filter-menu-button/ds6/filter-menu-button.css
@@ -18,7 +18,6 @@ button.filter-menu-button__button {
   display: inline-flex;
   flex: 0 1 auto;
   flex-direction: column;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   height: 32px;
   justify-content: center;

--- a/dist/mixins/filter-button/base/filter-button-mixins.less
+++ b/dist/mixins/filter-button/base/filter-button-mixins.less
@@ -14,7 +14,6 @@
     display: inline-flex;
     flex: 0 1 auto;
     flex-direction: column;
-    font-family: @font-family-market-sans;
     font-size: @font-size-14;
     height: 32px;
     justify-content: center;

--- a/dist/mixins/typography/base/typography-mixins.less
+++ b/dist/mixins/typography/base/typography-mixins.less
@@ -94,25 +94,21 @@
 // large screen titles
 
 .title-giant-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-30;
     line-height: 36px;
 }
 
 .title-large-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-24;
     line-height: 30px;
 }
 
 .title-medium-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-20;
     line-height: 24px;
 }
 
 .title-small-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-16;
     line-height: 20px;
 }
@@ -120,25 +116,21 @@
 // small screen titles
 
 .title-giant-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-24;
     line-height: 30px;
 }
 
 .title-large-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-20;
     line-height: 24px;
 }
 
 .title-medium-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-16;
     line-height: 20px;
 }
 
 .title-small-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-14;
     line-height: 16px;
 }

--- a/dist/primitives/base/primitives.less
+++ b/dist/primitives/base/primitives.less
@@ -19,8 +19,7 @@
 @marketsans-filename-bold: "MarketSans-SemiBold-WebS";
 
 // FONT-FAMILY
-@font-family-default: Arial, sans-serif;
-@font-family-market-sans: @marketsans-fontname, @font-family-default;
+@font-family-default: @marketsans-fontname, Arial, sans-serif;
 
 // TYPOGRAPHY
 @font-size-12: 0.75rem;

--- a/dist/section-title/ds4/section-title.css
+++ b/dist/section-title/ds4/section-title.css
@@ -9,7 +9,6 @@
   font-size: 1rem;
   line-height: 24px;
   font-weight: 500;
-  font-family: "Market Sans", Arial, sans-serif;
   margin: 0;
 }
 .section-title__subtitle {

--- a/dist/section-title/ds6/section-title.css
+++ b/dist/section-title/ds6/section-title.css
@@ -9,7 +9,6 @@
   font-size: 1rem;
   line-height: 24px;
   font-weight: 700;
-  font-family: "Market Sans", Arial, sans-serif;
   margin: 0;
 }
 .section-title__subtitle {

--- a/dist/signal/ds4/signal.css
+++ b/dist/signal/ds4/signal.css
@@ -3,7 +3,6 @@
   border-radius: 16px;
   box-sizing: border-box;
   display: inline-block;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.75rem;
   font-weight: bold;
   letter-spacing: 0.5px;

--- a/dist/signal/ds6/signal.css
+++ b/dist/signal/ds6/signal.css
@@ -3,7 +3,6 @@
   border-radius: 16px;
   box-sizing: border-box;
   display: inline-block;
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.75rem;
   font-weight: bold;
   letter-spacing: 0.5px;

--- a/dist/typography/ds4/typography.css
+++ b/dist/typography/ds4/typography.css
@@ -55,25 +55,21 @@
 }
 .giant-product-title,
 .giant-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.5rem;
   line-height: 30px;
 }
 .large-product-title,
 .large-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.25rem;
   line-height: 24px;
 }
 .medium-product-title,
 .medium-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1rem;
   line-height: 20px;
 }
 .small-product-title,
 .small-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   line-height: 16px;
 }
@@ -86,25 +82,21 @@
 @media (min-width: 601px) {
   .giant-product-title,
   .giant-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1.875rem;
     line-height: 36px;
   }
   .large-product-title,
   .large-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1.5rem;
     line-height: 30px;
   }
   .medium-product-title,
   .medium-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1.25rem;
     line-height: 24px;
   }
   .small-product-title,
   .small-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1rem;
     line-height: 20px;
   }

--- a/dist/typography/ds6/typography.css
+++ b/dist/typography/ds6/typography.css
@@ -55,25 +55,21 @@
 }
 .giant-product-title,
 .giant-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.5rem;
   line-height: 30px;
 }
 .large-product-title,
 .large-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1.25rem;
   line-height: 24px;
 }
 .medium-product-title,
 .medium-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 1rem;
   line-height: 20px;
 }
 .small-product-title,
 .small-section-title {
-  font-family: "Market Sans", Arial, sans-serif;
   font-size: 0.875rem;
   line-height: 16px;
 }
@@ -86,25 +82,21 @@
 @media (min-width: 601px) {
   .giant-product-title,
   .giant-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1.875rem;
     line-height: 36px;
   }
   .large-product-title,
   .large-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1.5rem;
     line-height: 30px;
   }
   .medium-product-title,
   .medium-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1.25rem;
     line-height: 24px;
   }
   .small-product-title,
   .small-section-title {
-    font-family: "Market Sans", Arial, sans-serif;
     font-size: 1rem;
     line-height: 20px;
   }

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -9,7 +9,6 @@
     box-sizing: border-box;
     .color(badge-foreground-color);
     display: inline-block;
-    font-family: @font-family-market-sans;
     font-size: 10px;
     height: 16px;
     line-height: 16px;

--- a/src/less/eek/base/eek.less
+++ b/src/less/eek/base/eek.less
@@ -14,7 +14,7 @@
 .eek {
     align-items: stretch;
     display: inline-flex;
-    font-family: @font-family-default;
+    font-family: Arial, sans-serif;
     font-weight: 700;
     height: 28px;
     position: relative;

--- a/src/less/global/base/global.less
+++ b/src/less/global/base/global.less
@@ -17,7 +17,7 @@
 body {
     .background-color(color-background-default);
     .color(color-text-default);
-    font-family: @font-family-market-sans;
+    font-family: @font-family-default;
     font-size: @font-size-regular;
     -webkit-text-size-adjust: 100%;
 }

--- a/src/less/mixins/filter-button/base/filter-button-mixins.less
+++ b/src/less/mixins/filter-button/base/filter-button-mixins.less
@@ -14,7 +14,6 @@
     display: inline-flex;
     flex: 0 1 auto;
     flex-direction: column;
-    font-family: @font-family-market-sans;
     font-size: @font-size-14;
     height: 32px;
     justify-content: center;

--- a/src/less/mixins/typography/base/typography-mixins.less
+++ b/src/less/mixins/typography/base/typography-mixins.less
@@ -94,25 +94,21 @@
 // large screen titles
 
 .title-giant-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-30;
     line-height: 36px;
 }
 
 .title-large-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-24;
     line-height: 30px;
 }
 
 .title-medium-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-20;
     line-height: 24px;
 }
 
 .title-small-screen-large() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-16;
     line-height: 20px;
 }
@@ -120,25 +116,21 @@
 // small screen titles
 
 .title-giant-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-24;
     line-height: 30px;
 }
 
 .title-large-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-20;
     line-height: 24px;
 }
 
 .title-medium-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-16;
     line-height: 20px;
 }
 
 .title-small-screen-small() {
-    font-family: @font-family-market-sans;
     font-size: @font-size-14;
     line-height: 16px;
 }

--- a/src/less/primitives/base/primitives.less
+++ b/src/less/primitives/base/primitives.less
@@ -19,8 +19,7 @@
 @marketsans-filename-bold: "MarketSans-SemiBold-WebS";
 
 // FONT-FAMILY
-@font-family-default: Arial, sans-serif;
-@font-family-market-sans: @marketsans-fontname, @font-family-default;
+@font-family-default: @marketsans-fontname, Arial, sans-serif;
 
 // TYPOGRAPHY
 @font-size-12: 0.75rem;

--- a/src/less/section-title/base/section-title.less
+++ b/src/less/section-title/base/section-title.less
@@ -16,7 +16,6 @@
 .section-title__title {
     .typography-medium-bold();
 
-    font-family: @font-family-market-sans;
     margin: 0;
 }
 

--- a/src/less/signal/base/signal.less
+++ b/src/less/signal/base/signal.less
@@ -11,7 +11,6 @@
     border-radius: @signal-border-radius;
     box-sizing: border-box;
     display: inline-block;
-    font-family: @font-family-market-sans;
     font-size: @font-size-small;
     font-weight: bold;
     letter-spacing: 0.5px;


### PR DESCRIPTION
Just removes a bunch of redundant font-family styles that we no longer need now that Market Sans is the default for the entire page.