### PR TITLE
feat(bubble): added width: max-content to shink correctly

### DIFF
--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -9,7 +9,8 @@ span.infotip {
   box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
   font-size: 14px;
   max-width: 344px;
-  min-width: 320px;
+  width: -webkit-max-content;
+  width: max-content;
   z-index: 1;
   background-color: var(--infotip-background-color, #fff);
   color: var(--infotip-foreground-color, #333);

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -9,7 +9,8 @@ span.infotip {
   box-shadow: var(--bubble-base-box-shadow, 0 0 3px rgba(17, 24, 32, 0.499972));
   font-size: 14px;
   max-width: 344px;
-  min-width: 320px;
+  width: -webkit-max-content;
+  width: max-content;
   z-index: 1;
   background-color: var(--infotip-background-color, #fff);
   color: var(--infotip-foreground-color, #111820);

--- a/dist/mixins/bubble/base/bubble-mixins.less
+++ b/dist/mixins/bubble/base/bubble-mixins.less
@@ -8,7 +8,7 @@
     .box-shadow(bubble-base-box-shadow);
     font-size: 14px;
     max-width: 344px;
-    min-width: 320px;
+    width: max-content;
     z-index: 1;
 }
 

--- a/dist/tooltip/ds4/tooltip.css
+++ b/dist/tooltip/ds4/tooltip.css
@@ -9,7 +9,8 @@ span.tooltip {
   box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
   font-size: 14px;
   max-width: 344px;
-  min-width: 320px;
+  width: -webkit-max-content;
+  width: max-content;
   z-index: 1;
   display: none;
   left: -10px;

--- a/dist/tooltip/ds6/tooltip.css
+++ b/dist/tooltip/ds6/tooltip.css
@@ -9,7 +9,8 @@ span.tooltip {
   box-shadow: var(--bubble-base-box-shadow, 0 0 3px rgba(17, 24, 32, 0.499972));
   font-size: 14px;
   max-width: 344px;
-  min-width: 320px;
+  width: -webkit-max-content;
+  width: max-content;
   z-index: 1;
   display: none;
   left: -10px;

--- a/dist/tourtip/ds4/tourtip.css
+++ b/dist/tourtip/ds4/tourtip.css
@@ -9,7 +9,8 @@ span.tourtip {
   box-shadow: var(--bubble-base-box-shadow, 0 -2px 2px rgba(0, 0, 0, 0.15), 2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15), -2px 0 2px rgba(0, 0, 0, 0.15));
   font-size: 14px;
   max-width: 344px;
-  min-width: 320px;
+  width: -webkit-max-content;
+  width: max-content;
   z-index: 1;
   display: none;
   position: absolute;

--- a/dist/tourtip/ds6/tourtip.css
+++ b/dist/tourtip/ds6/tourtip.css
@@ -9,7 +9,8 @@ span.tourtip {
   box-shadow: var(--bubble-base-box-shadow, 0 0 3px rgba(17, 24, 32, 0.499972));
   font-size: 14px;
   max-width: 344px;
-  min-width: 320px;
+  width: -webkit-max-content;
+  width: max-content;
   z-index: 1;
   display: none;
   position: absolute;

--- a/src/less/mixins/bubble/base/bubble-mixins.less
+++ b/src/less/mixins/bubble/base/bubble-mixins.less
@@ -8,7 +8,7 @@
     .box-shadow(bubble-base-box-shadow);
     font-size: 14px;
     max-width: 344px;
-    min-width: 320px;
+    width: max-content;
     z-index: 1;
 }
 


### PR DESCRIPTION

## Description
* Had `min-width` which was taking prescedence in width of infotip/tooltip. By removing that and adding `width: max-content` it will stretch out correctly. Browser support is good (no ie)

## References
https://github.com/eBay/skin/issues/1559

## Screenshots
<img width="167" alt="Screen Shot 2021-09-17 at 9 07 40 AM" src="https://user-images.githubusercontent.com/1755269/133825915-4673c01e-5c0e-4e69-8cb1-e2d93b7aa819.png">
<img width="418" alt="Screen Shot 2021-09-17 at 9 08 04 AM" src="https://user-images.githubusercontent.com/1755269/133825918-2a61f3c4-b580-4aa9-9acf-5fe0920bf01a.png">

