### PR TITLE
fix(badge): changed styles to align correctly

### DIFF
--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -1,14 +1,13 @@
 .badge {
+  align-items: center;
   background-color: var(--badge-background-color, var(--color-status-attention, #dd1e31));
   border-radius: 16px;
-  box-sizing: border-box;
   color: var(--badge-foreground-color, var(--color-background-default, #fff));
-  display: inline-block;
+  display: inline-flex;
   font-size: 10px;
   height: 16px;
-  line-height: 16px;
+  justify-content: center;
   min-width: 16px;
-  padding: 1px 4px 1px 5px;
-  text-align: center;
+  padding: 2px;
   white-space: nowrap;
 }

--- a/dist/badge/ds4/badge.css
+++ b/dist/badge/ds4/badge.css
@@ -7,7 +7,7 @@
   font-size: 10px;
   height: 16px;
   justify-content: center;
-  min-width: 16px;
-  padding: 2px;
+  min-width: 8px;
+  padding: 2px 6px;
   white-space: nowrap;
 }

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -1,14 +1,13 @@
 .badge {
+  align-items: center;
   background-color: var(--badge-background-color, var(--color-status-attention, #e0103a));
   border-radius: 16px;
-  box-sizing: border-box;
   color: var(--badge-foreground-color, var(--color-background-default, #fff));
-  display: inline-block;
+  display: inline-flex;
   font-size: 10px;
   height: 16px;
-  line-height: 16px;
+  justify-content: center;
   min-width: 16px;
-  padding: 1px 4px 1px 5px;
-  text-align: center;
+  padding: 2px;
   white-space: nowrap;
 }

--- a/dist/badge/ds6/badge.css
+++ b/dist/badge/ds6/badge.css
@@ -7,7 +7,7 @@
   font-size: 10px;
   height: 16px;
   justify-content: center;
-  min-width: 16px;
-  padding: 2px;
+  min-width: 8px;
+  padding: 2px 6px;
   white-space: nowrap;
 }

--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -91,15 +91,9 @@ a.icon-link--badged {
 }
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
-  border-color: var(--icon-button-badge-border-color, var(--color-background-default, #fff));
-  border-style: solid;
-  border-width: 2px;
   left: 24px;
-  line-height: 14px;
-  min-width: 14px;
-  padding: 0 3px;
   pointer-events: none;
   position: absolute;
-  top: -6px;
+  top: -12px;
   z-index: 1;
 }

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -91,15 +91,9 @@ a.icon-link--badged {
 }
 button.icon-btn--badged .badge,
 a.icon-link--badged .badge {
-  border-color: var(--icon-button-badge-border-color, var(--color-background-default, #fff));
-  border-style: solid;
-  border-width: 2px;
   left: 24px;
-  line-height: 14px;
-  min-width: 14px;
-  padding: 0 3px;
   pointer-events: none;
   position: absolute;
-  top: -6px;
+  top: -12px;
   z-index: 1;
 }

--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -188,7 +188,7 @@ button.fake-menu-button__item--badged .badge,
 div.menu-button__item--badged[role^="menuitem"] .badge {
   margin-left: 4px;
   position: absolute;
-  top: 0;
+  top: 6px;
   z-index: 1;
 }
 .menu-button__menu--scroll {

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -188,7 +188,7 @@ button.fake-menu-button__item--badged .badge,
 div.menu-button__item--badged[role^="menuitem"] .badge {
   margin-left: 4px;
   position: absolute;
-  top: 0;
+  top: 6px;
   z-index: 1;
 }
 .menu-button__menu--scroll {

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -9,7 +9,7 @@
     font-size: 10px;
     height: 16px;
     justify-content: center;
-    min-width: 16px;
-    padding: 2px;
+    min-width: 8px;
+    padding: 2px 6px;
     white-space: nowrap;
 }

--- a/src/less/badge/base/badge.less
+++ b/src/less/badge/base/badge.less
@@ -1,16 +1,15 @@
 @import "../../mixins/utility/utility-mixins.less";
 
 .badge {
+    align-items: center;
     .background-color-token(badge-background-color, color-status-attention);
     border-radius: 16px;
-    box-sizing: border-box;
     .color-token(badge-foreground-color, color-background-default);
-    display: inline-block;
+    display: inline-flex;
     font-size: 10px;
     height: 16px;
-    line-height: 16px;
+    justify-content: center;
     min-width: 16px;
-    padding: 1px 4px 1px 5px;
-    text-align: center;
+    padding: 2px;
     white-space: nowrap;
 }

--- a/src/less/icon-button/base/icon-button.less
+++ b/src/less/icon-button/base/icon-button.less
@@ -100,16 +100,10 @@ a.icon-link--badged {
     position: relative;
 
     .badge {
-        .border-color-token(icon-button-badge-border-color, color-background-default);
-        border-style: solid;
-        border-width: 2px;
         left: 24px;
-        line-height: 14px;
-        min-width: 14px;
-        padding: 0 3px;
         pointer-events: none;
         position: absolute;
-        top: -6px;
+        top: -12px;
         z-index: 1;
     }
 }

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -141,7 +141,7 @@ button.fake-menu-button__item--badged .badge,
 div.menu-button__item--badged[role^="menuitem"] .badge {
     margin-left: 4px;
     position: absolute;
-    top: 0;
+    top: 6px;
     z-index: 1;
 }
 


### PR DESCRIPTION
## Description
Changed some styles in badge (added flex, removed box-border, changed padding to be equal)
On the large one the text is very close to the sides, but this can only be fixed by adding an unequal padding, causing the badge to not be a circle. If that's fine I can change it.


## Screenshots
<img width="888" alt="Screen Shot 2021-09-30 at 8 23 23 AM" src="https://user-images.githubusercontent.com/1755269/135486525-fdd31b1e-5b9c-40a3-a0ce-60aa8ae87cac.png">

