### PR TITLE
fix(tabs): removed fake tabs --current modifier

### DIFF
--- a/dist/tabs/ds4/tabs.css
+++ b/dist/tabs/ds4/tabs.css
@@ -53,11 +53,11 @@ li.fake-tabs__item > a::after {
   width: 100%;
 }
 div.tabs__item[role="tab"][aria-selected="true"] > span,
-li.fake-tabs__item--current > a[aria-current] {
+li.fake-tabs__item > a[aria-current] {
   color: var(--tabs-item-selected-foreground-color, var(--color-text-default, #333));
 }
 div.tabs__item[role="tab"][aria-selected="true"] > span::after,
-li.fake-tabs__item--current > a[aria-current]::after {
+li.fake-tabs__item > a[aria-current]::after {
   background-color: currentColor;
 }
 div.tabs__item[role="tab"]:focus:not(:focus-visible),

--- a/dist/tabs/ds6/tabs.css
+++ b/dist/tabs/ds6/tabs.css
@@ -53,11 +53,11 @@ li.fake-tabs__item > a::after {
   width: 100%;
 }
 div.tabs__item[role="tab"][aria-selected="true"] > span,
-li.fake-tabs__item--current > a[aria-current] {
+li.fake-tabs__item > a[aria-current] {
   color: var(--tabs-item-selected-foreground-color, var(--color-text-default, #111820));
 }
 div.tabs__item[role="tab"][aria-selected="true"] > span::after,
-li.fake-tabs__item--current > a[aria-current]::after {
+li.fake-tabs__item > a[aria-current]::after {
   background-color: currentColor;
 }
 div.tabs__item[role="tab"]:focus:not(:focus-visible),

--- a/docs/_includes/tabs.html
+++ b/docs/_includes/tabs.html
@@ -97,8 +97,7 @@
         behaves more like a simple navigational widget, rather than a dynamic user interface control.</p>
     <p>A valid HREF attribute is <strong>required</strong> for all anchor tags. A value of "javascript" (or any such variant)
         is <strong>not</strong> a valid URL!</p>
-    <p>The <span class="highlight">fake-tabs__item--current</span> class is used to visually denote the current link. The
-        <span class="highlight">aria-current</span> attribute is used to programmatically denote the current page state.</p>
+    <p>The <span class="highlight">aria-current</span> attribute is used to programmatically denote the current page state and current link.</p>
 
     <p>Use child element modifier <span class="highlight">fake-tabs__items--large</span> to opt into larger font-size for fake tabs.</p>
 
@@ -106,7 +105,7 @@
         <div class="demo__inner">
             <div class="fake-tabs">
                 <ul class="fake-tabs__items">
-                    <li class="fake-tabs__item fake-tabs__item--current">
+                    <li class="fake-tabs__item">
                         <a aria-current="page" href="http://www.ebay.com">Page 1</a>
                     </li>
                     <li class="fake-tabs__item">
@@ -128,7 +127,7 @@
     {% highlight html %}
 <div class="fake-tabs">
     <ul class="fake-tabs__items">
-        <li class="fake-tabs__item fake-tabs__item--current">
+        <li class="fake-tabs__item">
             <a aria-current="page" href="http://www.ebay.com">Page 1</a>
         </li>
         <li class="fake-tabs__item">

--- a/src/less/tabs/base/tabs.less
+++ b/src/less/tabs/base/tabs.less
@@ -64,7 +64,7 @@ li.fake-tabs__item > a {
 }
 
 div.tabs__item[role="tab"][aria-selected="true"] > span,
-li.fake-tabs__item--current > a[aria-current] {
+li.fake-tabs__item > a[aria-current] {
     .color-token(tabs-item-selected-foreground-color, color-text-default);
 
     &::after {


### PR DESCRIPTION
## Description
Seems like a leftover from previous versions. 
This was causing an issue on ebayui
We could patch ebayui to support this class but it makes no sense since we are relying on `aria-current`

## References
https://github.com/eBay/ebayui-core/issues/1535

## Screenshots
<img width="1142" alt="Screen Shot 2021-10-08 at 9 02 44 AM" src="https://user-images.githubusercontent.com/1755269/136588328-0902baf2-92ab-4bbd-9c1d-4fbc9ab0e92d.png">

