### PR TITLE
fix(generate-imports): changed browser.json require to js files

### DIFF
--- a/scripts/generate-imports/index.js
+++ b/scripts/generate-imports/index.js
@@ -28,7 +28,7 @@ function getFilePath(filename, ds) {
 }
 
 function getBrowserRequireSyntax(filename) {
-    return `"./${filename}.css"`;
+    return `"./${filename}.js"`;
 }
 
 function getCSSRequireSyntax(filepath, ext) {


### PR DESCRIPTION
## Description
There's an issue since we are requiring `.css` files in browser.json that lasso does not support imports from css files.
Changed it to js files which is what we had it in version 12. 

## Screenshots
```
(~/build/ebay/skin) % cat typography.browser.json                                                                                           
{ "dependencies": ["./typography.js"] }
```