### PR TITLE
fix: carousel firefox now scrolls to last slide

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -214,8 +214,10 @@ span.carousel__container {
     -webkit-scroll-snap-type: x mandatory;
     -ms-scroll-snap-type: mandatory;
     -ms-scroll-snap-type: x mandatory;
-    scroll-snap-type: mandatory;
-    scroll-snap-type: x mandatory;
+    scroll-snap-type: proximity;
+    -webkit-scroll-snap-type: x proximity;
+        -ms-scroll-snap-type: x proximity;
+            scroll-snap-type: x proximity;
     scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
     scrollbar-width: thin;
     transition: border-color 0.5s, scrollbar-color 0.5s, transform 0.45s ease-in-out;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -214,8 +214,10 @@ span.carousel__container {
     -webkit-scroll-snap-type: x mandatory;
     -ms-scroll-snap-type: mandatory;
     -ms-scroll-snap-type: x mandatory;
-    scroll-snap-type: mandatory;
-    scroll-snap-type: x mandatory;
+    scroll-snap-type: proximity;
+    -webkit-scroll-snap-type: x proximity;
+        -ms-scroll-snap-type: x proximity;
+            scroll-snap-type: x proximity;
     scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
     scrollbar-width: thin;
     transition: border-color 0.5s, scrollbar-color 0.5s, transform 0.45s ease-in-out;

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -253,7 +253,7 @@ span.carousel__container {
             -ms-scroll-snap-type: mandatory;
             -ms-scroll-snap-type: x mandatory;
             scroll-snap-type: mandatory;
-            scroll-snap-type: x mandatory;
+            scroll-snap-type: x proximity;
             scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
             scrollbar-width: thin; // Firefox scrollbar
             transition: border-color 0.5s, scrollbar-color 0.5s,


### PR DESCRIPTION
## Description
Fixes carousel issue on Firefox where the carousel wouldn't scroll to the end. 

I have one question on this - how do I turn off the prefixer for webkit and ms? (We could probably drop the ms prefixes as well because we no longer support IE.) The prefixer added the webkit-scroll and ms-scroll which I don't want here.

UPDATE: tested on Edge, so works with chromium

## References
closes #1593 , [Core UI 1513](https://github.com/eBay/ebayui-core/issues/1513)

## Screenshots

## Before 
![before-change-firefox-carousel](https://user-images.githubusercontent.com/25092249/139943528-35e5445d-bcbf-4b08-bc3e-4d5612f8b204.gif)

## After
![after-change-firefox-carousel](https://user-images.githubusercontent.com/25092249/139943516-ed269258-bde9-404d-aa07-05392fe3fd86.gif)


