### PR TITLE
feat(image-treatment): ds evo updates #1451

### DIFF
--- a/dist/carousel/ds4/carousel.css
+++ b/dist/carousel/ds4/carousel.css
@@ -51,8 +51,10 @@
 }
 .carousel__list--image-treatment > li {
   align-items: center;
+  border-radius: 8px;
   display: flex;
   justify-content: center;
+  overflow: hidden;
   position: relative;
 }
 .carousel__list--image-treatment > li::after {
@@ -66,6 +68,30 @@
   top: 0;
 }
 .carousel__list--image-treatment > li > img {
+  display: inline-block;
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+.carousel__list--image-treatment-large > li {
+  align-items: center;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+.carousel__list--image-treatment-large > li::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.carousel__list--image-treatment-large > li > img {
   display: inline-block;
   max-height: 100%;
   max-width: 100%;

--- a/dist/carousel/ds6/carousel.css
+++ b/dist/carousel/ds6/carousel.css
@@ -51,8 +51,10 @@
 }
 .carousel__list--image-treatment > li {
   align-items: center;
+  border-radius: 8px;
   display: flex;
   justify-content: center;
+  overflow: hidden;
   position: relative;
 }
 .carousel__list--image-treatment > li::after {
@@ -66,6 +68,30 @@
   top: 0;
 }
 .carousel__list--image-treatment > li > img {
+  display: inline-block;
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+.carousel__list--image-treatment-large > li {
+  align-items: center;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+.carousel__list--image-treatment-large > li::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.carousel__list--image-treatment-large > li > img {
   display: inline-block;
   max-height: 100%;
   max-width: 100%;

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -23,10 +23,12 @@
     white-space: nowrap;
 }
 
-.imageTreatment() {
+.imageTreatment(@border-radius: 8px) {
     align-items: center;
+    border-radius: @border-radius;
     display: flex;
     justify-content: center;
+    overflow: hidden;
     position: relative;
 
     &::after {

--- a/dist/utility/ds4/utility.css
+++ b/dist/utility/ds4/utility.css
@@ -43,8 +43,10 @@
 }
 .image-treatment {
   align-items: center;
+  border-radius: 8px;
   display: flex;
   justify-content: center;
+  overflow: hidden;
   position: relative;
 }
 .image-treatment::after {
@@ -58,6 +60,30 @@
   top: 0;
 }
 .image-treatment > img {
+  display: inline-block;
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+.image-treatment-large {
+  align-items: center;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+.image-treatment-large::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.image-treatment-large > img {
   display: inline-block;
   max-height: 100%;
   max-width: 100%;

--- a/dist/utility/ds6/utility.css
+++ b/dist/utility/ds6/utility.css
@@ -43,8 +43,10 @@
 }
 .image-treatment {
   align-items: center;
+  border-radius: 8px;
   display: flex;
   justify-content: center;
+  overflow: hidden;
   position: relative;
 }
 .image-treatment::after {
@@ -58,6 +60,30 @@
   top: 0;
 }
 .image-treatment > img {
+  display: inline-block;
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+.image-treatment-large {
+  align-items: center;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+.image-treatment-large::after {
+  background: rgba(0, 0, 0, 0.05);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.image-treatment-large > img {
   display: inline-block;
   max-height: 100%;
   max-width: 100%;

--- a/docs/custom-styles.html
+++ b/docs/custom-styles.html
@@ -2,7 +2,6 @@
 
     .carousel__list--default-demo li {
         background-color: grey;
-        border-radius: 8px;
         font-size: 24px;
         font-weight: bold;
         height: 120px;
@@ -13,7 +12,6 @@
     }
 
     .carousel__list--image-treatment-demo li {
-        border-radius: 8px;
         font-size: 24px;
         font-weight: bold;
         height: 120px;
@@ -25,7 +23,6 @@
 
     .carousel__list--discrete-demo li {
         background-color: grey;
-        border-radius: 8px;
         box-sizing: border-box;
         font-size: 24px;
         font-weight: bold;
@@ -42,7 +39,6 @@
 
     .carousel__list--slideshow-demo li {
         background-color: grey;
-        border-radius: 8px;
         font-size: 36px;
         font-weight: bold;
         height: 300px;

--- a/src/less/carousel/base/carousel.less
+++ b/src/less/carousel/base/carousel.less
@@ -165,6 +165,10 @@
     .imageTreatment();
 }
 
+.carousel__list--image-treatment-large > li {
+    .imageTreatment(16px);
+}
+
 div.carousel {
     margin: 16px 0;
 }

--- a/src/less/carousel/stories/carousel.stories.js
+++ b/src/less/carousel/stories/carousel.stories.js
@@ -58,6 +58,35 @@ export const imageTreatment = () => `
 </div>
 `;
 
+export const imageTreatmentLarge = () => `
+<div class="carousel">
+    <div class="carousel__container">
+        <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
+            <svg aria-hidden="true" class="icon icon--carousel-prev" focusable="false">
+                <use xlink:href="#icon-carousel-prev"></use>
+            </svg>
+        </button>
+        <div class="carousel__viewport carousel__viewport--mask">
+            <ul class="carousel__list carousel__list--image-treatment-large carousel__list--image-treatment-demo">
+                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/aztec-pyramid.jpeg" /></li>
+                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/falls.jpeg" /></li>
+                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg" /></li>
+                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/shoes.jpeg"/></li>
+                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/tall-cat.jpeg" /></li>
+                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/wide-cat.jpeg"/></li>
+                <li>Card 7</li>
+                <li>Card 8</li>
+            </ul>
+        </div>
+        <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
+            <svg aria-hidden="true" class="icon icon--carousel-next" focusable="false">
+                <use xlink:href="#icon-carousel-next"></use>
+            </svg>
+        </button>
+    </div>
+</div>
+`;
+
 export const slides = () => `
 <div class="carousel carousel--slides">
     <div class="carousel__container">

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -23,10 +23,12 @@
     white-space: nowrap;
 }
 
-.imageTreatment() {
+.imageTreatment(@border-radius: 8px) {
     align-items: center;
+    border-radius: @border-radius;
     display: flex;
     justify-content: center;
+    overflow: hidden;
     position: relative;
 
     &::after {

--- a/src/less/utility/base/utility.less
+++ b/src/less/utility/base/utility.less
@@ -64,6 +64,11 @@
     .imageTreatment();
 }
 
+// Image will have border-radius of 16px; this should be applied to images larger than 40px
+.image-treatment-large {
+    .imageTreatment(16px);
+}
+
 .text-truncate {
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Description
Adds Image Treatment Large mixin for images larger than 40px; adds border-radius 16px to them; adds border-radius 8px to the image treatment class; dropped border radius from demo classes.

## References
closes #1451 



## Screenshots

## Image Treatment
<img width="1516" alt="Screen Shot 2021-11-02 at 3 43 04 PM" src="https://user-images.githubusercontent.com/25092249/139956107-53a10115-b482-4df3-9662-d50b9235d43d.png">
 
## Image Treatment Large
<img width="1490" alt="Screen Shot 2021-11-02 at 3 43 18 PM" src="https://user-images.githubusercontent.com/25092249/139956119-5a8a5011-16f0-4bf0-a443-7755d9b19c42.png">
