### PR TITLE
fix(icon-button): proper colors for certain filled icons - informatio…

### DIFF
--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -97,3 +97,39 @@ a.icon-link--badged .badge {
   top: -12px;
   z-index: 1;
 }
+button.icon-btn > svg.icon--confirmation-filled,
+button.icon-btn > svg.icon--confirmation-filled-small,
+a.icon-link > svg.icon--confirmation-filled,
+a.icon-link > svg.icon--confirmation-filled-small {
+  fill: var(--color-status-confirmation, #5ba71b);
+}
+button.icon-btn > svg.icon--confirmation-filled:hover,
+button.icon-btn > svg.icon--confirmation-filled-small:hover,
+a.icon-link > svg.icon--confirmation-filled:hover,
+a.icon-link > svg.icon--confirmation-filled-small:hover {
+  fill: var(--color-status-confirmation, #5ba71b);
+}
+button.icon-btn > svg.icon--attention-filled,
+button.icon-btn > svg.icon--attention-filled-small,
+a.icon-link > svg.icon--attention-filled,
+a.icon-link > svg.icon--attention-filled-small {
+  fill: var(--color-status-attention, #dd1e31);
+}
+button.icon-btn > svg.icon--attention-filled:hover,
+button.icon-btn > svg.icon--attention-filled-small:hover,
+a.icon-link > svg.icon--attention-filled:hover,
+a.icon-link > svg.icon--attention-filled-small:hover {
+  fill: var(--color-status-attention, #dd1e31);
+}
+button.icon-btn > svg.icon--information-filled,
+button.icon-btn > svg.icon--information-filled-small,
+a.icon-link > svg.icon--information-filled,
+a.icon-link > svg.icon--information-filled-small {
+  fill: var(--color-status-information, #0654ba);
+}
+button.icon-btn > svg.icon--information-filled:hover,
+button.icon-btn > svg.icon--information-filled-small:hover,
+a.icon-link > svg.icon--information-filled:hover,
+a.icon-link > svg.icon--information-filled-small:hover {
+  fill: var(--color-status-information, #0654ba);
+}

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -97,3 +97,39 @@ a.icon-link--badged .badge {
   top: -12px;
   z-index: 1;
 }
+button.icon-btn > svg.icon--confirmation-filled,
+button.icon-btn > svg.icon--confirmation-filled-small,
+a.icon-link > svg.icon--confirmation-filled,
+a.icon-link > svg.icon--confirmation-filled-small {
+  fill: var(--color-status-confirmation, #05823f);
+}
+button.icon-btn > svg.icon--confirmation-filled:hover,
+button.icon-btn > svg.icon--confirmation-filled-small:hover,
+a.icon-link > svg.icon--confirmation-filled:hover,
+a.icon-link > svg.icon--confirmation-filled-small:hover {
+  fill: var(--color-status-confirmation, #05823f);
+}
+button.icon-btn > svg.icon--attention-filled,
+button.icon-btn > svg.icon--attention-filled-small,
+a.icon-link > svg.icon--attention-filled,
+a.icon-link > svg.icon--attention-filled-small {
+  fill: var(--color-status-attention, #e0103a);
+}
+button.icon-btn > svg.icon--attention-filled:hover,
+button.icon-btn > svg.icon--attention-filled-small:hover,
+a.icon-link > svg.icon--attention-filled:hover,
+a.icon-link > svg.icon--attention-filled-small:hover {
+  fill: var(--color-status-attention, #e0103a);
+}
+button.icon-btn > svg.icon--information-filled,
+button.icon-btn > svg.icon--information-filled-small,
+a.icon-link > svg.icon--information-filled,
+a.icon-link > svg.icon--information-filled-small {
+  fill: var(--color-status-information, #3665f3);
+}
+button.icon-btn > svg.icon--information-filled:hover,
+button.icon-btn > svg.icon--information-filled-small:hover,
+a.icon-link > svg.icon--information-filled:hover,
+a.icon-link > svg.icon--information-filled-small:hover {
+  fill: var(--color-status-information, #3665f3);
+}

--- a/docs/_includes/icon-button.html
+++ b/docs/_includes/icon-button.html
@@ -15,16 +15,6 @@
                     {% include symbol.html name="settings" %}
                 </svg>
             </a>
-            <button class="icon-btn" type="button" aria-label="confirmation">
-                <svg class="icon icon--confirmation-filled" focusable="false" width="16" height="16" aria-hidden="true">
-                    {% include symbol.html name="confirmation-filled" %}
-                </svg>
-            </button>
-            <a class="icon-link" href="http://www.ebay.com" aria-label="attention">
-                <svg class="icon icon--attention-filled" focusable="false" width="16" height="16" aria-hidden="true">
-                    {% include symbol.html name="attention-filled" %}
-                </svg>
-            </a>
         </div>
     </div>
 
@@ -39,19 +29,37 @@
         <use xlink:href="icons.svg#icon-settings"></use>
     </svg>
 </a>
-<button class="icon-btn" type="button" aria-label="attention">
+    {% endhighlight %}
+
+    <p>To remove the background colour and hover states, apply the <span class="highlight">icon-btn--transparent</span> modifier. This is typically needed if the icon button is placed on a non-default background colour or if the icon has a colour fill (as in the case below).</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="icon-btn icon-btn--transparent" type="button" aria-label="Confirmation">
+                <svg class="icon icon--confirmation-filled" focusable="false" width="16" height="16" aria-hidden="true">
+                    {% include symbol.html name="confirmation-filled" %}
+                </svg>
+            </button>
+            <a class="icon-link icon-link--transparent" href="http://www.ebay.com" aria-label="Attention">
+                <svg class="icon icon--attention-filled" focusable="false" width="16" height="16" aria-hidden="true">
+                    {% include symbol.html name="attention-filled" %}
+                </svg>
+            </a>
+        </div>
+    </div>
+
+    {% highlight html %}
+<button class="icon-btn icon-btn--transparent" type="button" aria-label="Confirmation">
     <svg class="icon icon--confirmation-filled" focusable="false" width="16" height="16" aria-hidden="true">
         <use xlink:href="icons.svg#icon-confirmation-filled"></use>
     </svg>
 </button>
-<a class="icon-link" href="http://www.ebay.com" aria-label="attention">
+<a class="icon-link icon-link--transparent" href="http://www.ebay.com" aria-label="Attention">
     <svg class="icon icon--attention-filled" focusable="false" width="16" height="16" aria-hidden="true">
         <use xlink:href="icons.svg#icon-attention-filled"></use>
     </svg>
 </a>
     {% endhighlight %}
-
-    <p>To remove the background colour and hover states, apply the <span class="highlight">icon-btn--transparent</span> modifier. This is typically needed if the icon button is placed on a non-default background color or requires some other customization.</p>
 
     <h3 id="icon-button-badged">Badged Icon Button</h3>
     <p>An icon button can be badged using the <a href="#badge">badge</a> module.</p>

--- a/docs/_includes/icon-button.html
+++ b/docs/_includes/icon-button.html
@@ -15,6 +15,16 @@
                     {% include symbol.html name="settings" %}
                 </svg>
             </a>
+            <button class="icon-btn" type="button" aria-label="confirmation">
+                <svg class="icon icon--confirmation-filled" focusable="false" width="16" height="16" aria-hidden="true">
+                    {% include symbol.html name="confirmation-filled" %}
+                </svg>
+            </button>
+            <a class="icon-link" href="http://www.ebay.com" aria-label="attention">
+                <svg class="icon icon--attention-filled" focusable="false" width="16" height="16" aria-hidden="true">
+                    {% include symbol.html name="attention-filled" %}
+                </svg>
+            </a>
         </div>
     </div>
 
@@ -27,6 +37,16 @@
 <a class="icon-link" href="http://www.ebay.com" aria-label="Settings">
     <svg class="icon icon--settings" focusable="false" width="16" height="16" aria-hidden="true">
         <use xlink:href="icons.svg#icon-settings"></use>
+    </svg>
+</a>
+<button class="icon-btn" type="button" aria-label="attention">
+    <svg class="icon icon--confirmation-filled" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="icons.svg#icon-confirmation-filled"></use>
+    </svg>
+</button>
+<a class="icon-link" href="http://www.ebay.com" aria-label="attention">
+    <svg class="icon icon--attention-filled" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="icons.svg#icon-attention-filled"></use>
     </svg>
 </a>
     {% endhighlight %}

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@ versions:
     floating-label: 2.0.3
     fullscreen-dialog: 2.1.0
     icon: 1.3.0
-    icon-button: 1.1.0
+    icon-button: 1.5.0
     infotip: 1.1.0
     inline-notice: 1.3.0
     lightbox-dialog: 2.1.0

--- a/src/less/icon-button/base/icon-button.less
+++ b/src/less/icon-button/base/icon-button.less
@@ -107,3 +107,34 @@ a.icon-link--badged {
         z-index: 1;
     }
 }
+
+// color-filled icons need to be filled with their color at this specificity level, because of other fill rules above
+button.icon-btn > svg.icon--confirmation-filled,
+button.icon-btn > svg.icon--confirmation-filled-small,
+a.icon-link > svg.icon--confirmation-filled,
+a.icon-link > svg.icon--confirmation-filled-small {
+    .fill-token(color-status-confirmation);
+    &:hover {
+        .fill-token(color-status-confirmation);
+    }
+}
+
+button.icon-btn > svg.icon--attention-filled,
+button.icon-btn > svg.icon--attention-filled-small,
+a.icon-link > svg.icon--attention-filled,
+a.icon-link > svg.icon--attention-filled-small {
+    .fill-token(color-status-attention);
+    &:hover {
+        .fill-token(color-status-attention);
+    }
+}
+
+button.icon-btn > svg.icon--information-filled,
+button.icon-btn > svg.icon--information-filled-small,
+a.icon-link > svg.icon--information-filled,
+a.icon-link > svg.icon--information-filled-small {
+    .fill-token(color-status-information);
+    &:hover {
+        .fill-token(color-status-information);
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes the issue with confirmation, attention, and information icons. I added a new selector that fills the svg with the proper color. 

The one question I had was how to handle the visited styles for the icon link - let me know if I need to change those up. 

## References
closes #1596 



## Screenshots
<img width="323" alt="Screen Shot 2021-11-18 at 10 27 48 AM" src="https://user-images.githubusercontent.com/25092249/142579559-df1fcde6-d14d-4086-8119-861df9d4c51b.png">

<img width="323" alt="Screen Shot 2021-11-18 at 10 27 57 AM" src="https://user-images.githubusercontent.com/25092249/142579561-ba864135-18d2-4f13-921b-537ceb64bb00.png">

