### PR TITLE
fix(progress-stepper): added accessible title

### DIFF
--- a/docs/_includes/progress-stepper.html
+++ b/docs/_includes/progress-stepper.html
@@ -15,7 +15,8 @@
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="progress-stepper">
+            <div class="progress-stepper" aria-labelledby="progress-stepper-header-1">
+                <h2 class="clipped" id="progress-stepper-header-1">Shipment Progress</h2>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item" role="listitem">
                         <span class="progress-stepper__icon">
@@ -65,7 +66,8 @@
         </div>
     </div>
     {% highlight html %}
-<div class="progress-stepper">
+<div class="progress-stepper" aria-labelledby="progress-stepper-header">
+    <h2 class="clipped" id="progress-stepper-header">Shipment Progress</h2>
     <div class="progress-stepper__items" role="list">
         <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
             <span class="progress-stepper__icon">
@@ -118,7 +120,8 @@
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="progress-stepper" style="margin: 16px auto; width: 390px;">
+            <div class="progress-stepper" aria-labelledby="progress-stepper-header-2" style="margin: 16px auto; width: 390px;">
+                <h2 class="clipped" id="progress-stepper-header-2">Shipment Progress</h2>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
                         <span class="progress-stepper__icon">
@@ -170,7 +173,8 @@
     </div>
 
     {% highlight html %}
-<div class="progress-stepper" style="margin: 16px auto; width: 390px;">
+<div class="progress-stepper" aria-labelledby="progress-stepper-header" style="margin: 16px auto; width: 390px;">
+    <h2 class="clipped" id="progress-stepper-header">Shipment Progress</h2>
     <div class="progress-stepper__items" role="list">
         <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
             <span class="progress-stepper__icon">
@@ -307,7 +311,8 @@
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="progress-stepper">
+            <div class="progress-stepper" aria-labelledby="progress-stepper-header-3">
+                <h2 class="clipped" id="progress-stepper-header-3">Shipment Progress</h2>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
                         <span class="progress-stepper__icon">
@@ -349,7 +354,8 @@
     </div>
 
     {% highlight html %}
-<div class="progress-stepper">
+<div class="progress-stepper" aria-labelledby="progress-stepper-header">
+    <h2 class="clipped" id="progress-stepper-header">Shipment Progress</h2>
     <div class="progress-stepper__items" role="list">
         <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
             <span class="progress-stepper__icon">
@@ -390,7 +396,8 @@
 
     <div class="demo">
         <div class="demo__inner">
-            <div class="progress-stepper">
+            <div class="progress-stepper" aria-labelledby="progress-stepper-header-4">
+                <h2 class="clipped" id="progress-stepper-header-4">Shipment Progress</h2>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
                         <span class="progress-stepper__icon">
@@ -431,7 +438,8 @@
     </div>
 
     {% highlight html %}
-<div class="progress-stepper">
+<div class="progress-stepper" aria-labelledby="progress-stepper-header">
+    <h2 class="clipped" id="progress-stepper-header">Shipment Progress</h2>
     <div class="progress-stepper__items" role="list">
         <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
             <span class="progress-stepper__icon">


### PR DESCRIPTION
## Description
Updated docs for stepper to have a hidden h2 for the title

## References
https://github.com/eBay/skin/issues/1615

## Screenshots
<img width="1513" alt="Screen Shot 2021-12-14 at 8 10 53 AM" src="https://user-images.githubusercontent.com/1755269/146035787-f844a62d-429b-445b-99b0-334aa6bd06e0.png">

