### PR TITLE
fix(progress-stepper): fixed heading strcture

### DIFF
--- a/dist/progress-stepper/ds4/progress-stepper.css
+++ b/dist/progress-stepper/ds4/progress-stepper.css
@@ -27,15 +27,20 @@ hr.progress-stepper__separator {
 }
 .progress-stepper__text h2,
 .progress-stepper__text h3,
-.progress-stepper__text h4 {
+.progress-stepper__text h4,
+.progress-stepper__text h5,
+.progress-stepper__text h6 {
   color: var(--progress-stepper-text-color, var(--color-text-primary, #333));
+  font-size: 0.75rem;
 }
 .progress-stepper__text p {
   color: var(--progress-stepper-text-light-color, var(--color-text-secondary, #707070));
 }
 .progress-stepper__icon {
   color: var(--progress-stepper-active-color, var(--color-status-information, #0654ba));
+  height: 24px;
   margin: auto;
+  width: 24px;
 }
 .progress-stepper__icon > [role="img"] {
   align-items: center;
@@ -149,5 +154,12 @@ hr.progress-stepper__separator--upcoming,
   .progress-stepper__text {
     font-size: 0.875rem;
     width: 120px;
+  }
+  .progress-stepper__text h2,
+  .progress-stepper__text h3,
+  .progress-stepper__text h4,
+  .progress-stepper__text h5,
+  .progress-stepper__text h6 {
+    font-size: 0.875rem;
   }
 }

--- a/dist/progress-stepper/ds6/progress-stepper.css
+++ b/dist/progress-stepper/ds6/progress-stepper.css
@@ -27,15 +27,20 @@ hr.progress-stepper__separator {
 }
 .progress-stepper__text h2,
 .progress-stepper__text h3,
-.progress-stepper__text h4 {
+.progress-stepper__text h4,
+.progress-stepper__text h5,
+.progress-stepper__text h6 {
   color: var(--progress-stepper-text-color, var(--color-text-primary, #111820));
+  font-size: 0.75rem;
 }
 .progress-stepper__text p {
   color: var(--progress-stepper-text-light-color, var(--color-text-secondary, #707070));
 }
 .progress-stepper__icon {
   color: var(--progress-stepper-active-color, var(--color-status-information, #3665f3));
+  height: 24px;
   margin: auto;
+  width: 24px;
 }
 .progress-stepper__icon > [role="img"] {
   align-items: center;
@@ -149,5 +154,12 @@ hr.progress-stepper__separator--upcoming,
   .progress-stepper__text {
     font-size: 0.875rem;
     width: 120px;
+  }
+  .progress-stepper__text h2,
+  .progress-stepper__text h3,
+  .progress-stepper__text h4,
+  .progress-stepper__text h5,
+  .progress-stepper__text h6 {
+    font-size: 0.875rem;
   }
 }

--- a/docs/_includes/progress-stepper.html
+++ b/docs/_includes/progress-stepper.html
@@ -16,7 +16,7 @@
     <div class="demo">
         <div class="demo__inner">
             <div class="progress-stepper" aria-labelledby="progress-stepper-header-1">
-                <h2 class="clipped" id="progress-stepper-header-1">Shipment Progress</h2>
+                <h4 class="clipped" id="progress-stepper-header-1">Shipment Progress</h4>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item" role="listitem">
                         <span class="progress-stepper__icon">
@@ -25,7 +25,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Started</h4>
+                            <h5>Started</h5>
                             <p>July 3rd</p>
                         </span>
                     </div>
@@ -37,7 +37,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Shipped</h4>
+                            <h5>Shipped</h5>
                             <p>July 4th</p>
                         </span>
                     </div>
@@ -47,7 +47,7 @@
                             <span role="img" aria-label="current"></span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Transit</h4>
+                            <h5>Transit</h5>
                             <p>July 5th</p>
                         </span>
                     </div>
@@ -57,7 +57,7 @@
                             <span role="img" aria-label="upcoming"></span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Delivered</h4>
+                            <h5>Delivered</h5>
                             <p>July 6th</p>
                         </span>
                     </div>
@@ -121,7 +121,7 @@
     <div class="demo">
         <div class="demo__inner">
             <div class="progress-stepper" aria-labelledby="progress-stepper-header-2" style="margin: 16px auto; width: 390px;">
-                <h2 class="clipped" id="progress-stepper-header-2">Shipment Progress</h2>
+                <h4 class="clipped" id="progress-stepper-header-2">Shipment Progress</h4>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
                         <span class="progress-stepper__icon">
@@ -130,7 +130,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Started</h4>
+                            <h5>Started</h5>
                             <p>July 3rd</p>
                         </span>
                     </div>
@@ -142,7 +142,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Shipped</h4>
+                            <h5>Shipped</h5>
                             <p>July 4th</p>
                         </span>
                     </div>
@@ -152,7 +152,7 @@
                             <span role="img" aria-label="current"></span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Transit</h4>
+                            <h5>Transit</h5>
                             <p>July 5th</p>
                         </span>
                     </div>
@@ -162,7 +162,7 @@
                             <span role="img" aria-label="upcoming"></span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Delivered</h4>
+                            <h5>Delivered</h5>
                             <p>July 6th</p>
                         </span>
                     </div>
@@ -237,7 +237,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h3>Order placed</h3>
+                            <h5>Order placed</h5>
                             <p>New Mens Addidas Ultra Boost</p>
                             <p>Order total $220</p>
                         </span>
@@ -248,7 +248,7 @@
                             <span role="img" aria-label="2">2</span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h3>Preparing for shipment</h3>
+                            <h5>Preparing for shipment</h5>
                             <p>We will notify you once it ships.</p>
                         </span>
                     </div>
@@ -258,7 +258,7 @@
                             <span role="img" aria-label="current"></span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h3>Delivered</h3>
+                            <h5>Delivered</h5>
                             <p>Guaranteed Wednesday, October 09.</p>
                         </span>
                     </div>
@@ -312,7 +312,7 @@
     <div class="demo">
         <div class="demo__inner">
             <div class="progress-stepper" aria-labelledby="progress-stepper-header-3">
-                <h2 class="clipped" id="progress-stepper-header-3">Shipment Progress</h2>
+                <h4 class="clipped" id="progress-stepper-header-3">Shipment Progress</h4>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
                         <span class="progress-stepper__icon">
@@ -321,7 +321,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Started</h4>
+                            <h5>Started</h5>
                             <p>July 3rd</p>
                         </span>
                     </div>
@@ -334,7 +334,7 @@
 
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>On Hold</h4>
+                            <h5>On Hold</h5>
                             <p>July 5th</p>
                         </span>
                     </div>
@@ -344,7 +344,7 @@
                             <span role="img" aria-label="upcoming"></span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Delivery</h4>
+                            <h5>Delivery</h5>
                             <p>July 6th</p>
                         </span>
                     </div>
@@ -397,7 +397,7 @@
     <div class="demo">
         <div class="demo__inner">
             <div class="progress-stepper" aria-labelledby="progress-stepper-header-4">
-                <h2 class="clipped" id="progress-stepper-header-4">Shipment Progress</h2>
+                <h4 class="clipped" id="progress-stepper-header-4">Shipment Progress</h4>
                 <div class="progress-stepper__items" role="list">
                     <div class="progress-stepper__item progress-stepper__item--confirmation" role="listitem">
                         <span class="progress-stepper__icon">
@@ -406,7 +406,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Started</h4>
+                            <h5>Started</h5>
                             <p>July 3rd</p>
                         </span>
                     </div>
@@ -418,7 +418,7 @@
                             </svg>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Blocked</h4>
+                            <h5>Blocked</h5>
                             <p>July 5th</p>
                         </span>
                     </div>
@@ -428,7 +428,7 @@
                             <span role="img" aria-label="upcoming"></span>
                         </span>
                         <span class="progress-stepper__text">
-                            <h4>Delivery</h4>
+                            <h5>Delivery</h5>
                             <p>July 6th</p>
                         </span>
                     </div>

--- a/src/less/progress-stepper/base/progress-stepper.less
+++ b/src/less/progress-stepper/base/progress-stepper.less
@@ -37,16 +37,24 @@ hr.progress-stepper__separator {
 
 .progress-stepper__text h2,
 .progress-stepper__text h3,
-.progress-stepper__text h4 {
+.progress-stepper__text h4,
+.progress-stepper__text h5,
+.progress-stepper__text h6 {
     .color-token(progress-stepper-text-color, color-text-primary);
+
+    font-size: @font-size-12;
 }
+
 .progress-stepper__text p {
     .color-token(progress-stepper-text-light-color, color-text-secondary);
 }
 
 .progress-stepper__icon {
     .color-token(progress-stepper-active-color, color-status-information);
+
+    height: 24px;
     margin: auto;
+    width: 24px;
 }
 
 .progress-stepper__icon > [role="img"] {
@@ -182,5 +190,13 @@ hr.progress-stepper__separator--upcoming,
     .progress-stepper__text {
         font-size: @font-size-14;
         width: @progress-stepper-large-min-width;
+    }
+
+    .progress-stepper__text h2,
+    .progress-stepper__text h3,
+    .progress-stepper__text h4,
+    .progress-stepper__text h5,
+    .progress-stepper__text h6 {
+        font-size: @font-size-14;
     }
 }


### PR DESCRIPTION
## Description
Fixed heading structure for html code. Left it intact for examples
Structure should be: 
`h2` -> stepper section title
`h3` -> each stepper type title
`h4` -> stepper example title
`h5` -> each step title

## Context
Added styles to force font sizes for headers so it matches design
Also found a spacing problem with some width that was fixed

## References
https://github.com/eBay/skin/issues/1618

## Screenshots
<img width="1556" alt="Screen Shot 2021-12-15 at 9 45 42 AM" src="https://user-images.githubusercontent.com/1755269/146238456-9e126e78-06e8-4e46-a5e2-1f5576ff70e8.png">
