### PR TITLE
fix(textbox): icon button outline no longer goes past textbox border

### DIFF
--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -51,6 +51,7 @@ a.icon-link:not(:focus-visible) {
 button.icon-btn--transparent,
 a.icon-link--transparent {
   background-color: transparent;
+  outline-offset: -10px;
 }
 button.icon-btn--transparent:active,
 a.icon-link--transparent:active,

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -51,6 +51,7 @@ a.icon-link:not(:focus-visible) {
 button.icon-btn--transparent,
 a.icon-link--transparent {
   background-color: transparent;
+  outline-offset: -10px;
 }
 button.icon-btn--transparent:active,
 a.icon-link--transparent:active,

--- a/docs/_includes/textbox.html
+++ b/docs/_includes/textbox.html
@@ -158,7 +158,7 @@
         <div class="demo__inner">
             <span class="textbox textbox--icon-end">
                 <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
-                <button class="icon-btn" type="button" aria-label="Choose Contact">
+                <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
                     <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
                         {% include symbol.html name="clear" %}
                     </svg>
@@ -170,7 +170,7 @@
     {% highlight html %}
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
-    <button class="icon-btn" type="button" aria-label="Choose Contact">
+    <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
         <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
             <use xlink:href="#icon-clear"></use>
         </svg>
@@ -187,7 +187,7 @@
                     {% include symbol.html name="search" %}
                 </svg>
                 <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
-                <button class="icon-btn" type="button" aria-label="Choose Contact">
+                <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
                     <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
                         {% include symbol.html name="clear" %}
                     </svg>
@@ -202,9 +202,9 @@
         <use xlink:href="#icon-search"></use>
     </svg>
     <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
-    <button class="icon-btn" type="button" aria-label="Choose Contact">
-        <svg aria-hidden="true" class="icon icon--messages" focusable="false" width="16" height="16">
-            <use xlink:href="#icon-messages"></use>
+    <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
+        <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
+            <use xlink:href="#icon-clear"></use>
         </svg>
     </button>
 </span>

--- a/src/less/icon-button/base/icon-button.less
+++ b/src/less/icon-button/base/icon-button.less
@@ -54,6 +54,7 @@ a.icon-link {
 button.icon-btn--transparent,
 a.icon-link--transparent {
     background-color: transparent;
+    outline-offset: -10px;
 
     &:active,
     &:focus,


### PR DESCRIPTION
## Description
added the outline offset and updated the skin website with the `icon-btn--transparent` class

## References
closes #1625 

## Screenshots
### Safari
<img width="269" alt="Screen Shot 2022-01-03 at 12 54 33 PM" src="https://user-images.githubusercontent.com/25092249/147963394-68055420-d0e5-4331-b34a-c9267443141c.png">

### Chrome
<img width="247" alt="Screen Shot 2022-01-03 at 12 54 51 PM" src="https://user-images.githubusercontent.com/25092249/147963395-d5162427-b72d-4244-8921-444f5d45a899.png">

