### PR TITLE
fix(progress-stepper): added span to [role=img] selector

### DIFF
--- a/dist/progress-stepper/ds4/progress-stepper.css
+++ b/dist/progress-stepper/ds4/progress-stepper.css
@@ -42,7 +42,7 @@ hr.progress-stepper__separator {
   margin: auto;
   width: 24px;
 }
-.progress-stepper__icon > [role="img"] {
+.progress-stepper__icon > span[role="img"] {
   align-items: center;
   border-color: var(--progress-stepper-badge-current-border-color, var(--color-status-information, #0654ba));
   border-radius: 24px;
@@ -85,9 +85,9 @@ hr.progress-stepper__separator--upcoming,
   height: 32px;
   width: auto;
 }
-.progress-stepper__items--upcoming .progress-stepper__item,
+.progress-stepper__items--upcoming .progress-stepper__item > [role="img"],
 .progress-stepper__item--upcoming,
-.progress-stepper__item[aria-current] ~ .progress-stepper__item {
+.progress-stepper__item[aria-current] ~ .progress-stepper__item > [role="img"] {
   color: var(--progress-stepper-text-light-color, var(--color-text-secondary, #707070));
 }
 /* prettier-ignore */
@@ -98,7 +98,7 @@ hr.progress-stepper__separator--upcoming,
   border-color: var(--progress-stepper-badge-upcoming-border-color, var(--color-text-disabled, #999));
   color: var(--progress-stepper-badge-upcoming-color, var(--color-text-secondary, #707070));
 }
-.progress-stepper__item--attention .progress-stepper__icon {
+.progress-stepper__item--attention .progress-stepper__icon > [role="img"] {
   color: var(--progress-stepper-attention-color, var(--color-status-attention, #dd1e31));
 }
 .progress-stepper--vertical .progress-stepper__items {

--- a/dist/progress-stepper/ds6/progress-stepper.css
+++ b/dist/progress-stepper/ds6/progress-stepper.css
@@ -42,7 +42,7 @@ hr.progress-stepper__separator {
   margin: auto;
   width: 24px;
 }
-.progress-stepper__icon > [role="img"] {
+.progress-stepper__icon > span[role="img"] {
   align-items: center;
   border-color: var(--progress-stepper-badge-current-border-color, var(--color-status-information, #3665f3));
   border-radius: 24px;
@@ -85,9 +85,9 @@ hr.progress-stepper__separator--upcoming,
   height: 32px;
   width: auto;
 }
-.progress-stepper__items--upcoming .progress-stepper__item,
+.progress-stepper__items--upcoming .progress-stepper__item > [role="img"],
 .progress-stepper__item--upcoming,
-.progress-stepper__item[aria-current] ~ .progress-stepper__item {
+.progress-stepper__item[aria-current] ~ .progress-stepper__item > [role="img"] {
   color: var(--progress-stepper-text-light-color, var(--color-text-secondary, #707070));
 }
 /* prettier-ignore */
@@ -98,7 +98,7 @@ hr.progress-stepper__separator--upcoming,
   border-color: var(--progress-stepper-badge-upcoming-border-color, var(--color-text-disabled, #c7c7c7));
   color: var(--progress-stepper-badge-upcoming-color, var(--color-text-secondary, #707070));
 }
-.progress-stepper__item--attention .progress-stepper__icon {
+.progress-stepper__item--attention .progress-stepper__icon > [role="img"] {
   color: var(--progress-stepper-attention-color, var(--color-status-attention, #e0103a));
 }
 .progress-stepper--vertical .progress-stepper__items {

--- a/src/less/progress-stepper/base/progress-stepper.less
+++ b/src/less/progress-stepper/base/progress-stepper.less
@@ -57,7 +57,7 @@ hr.progress-stepper__separator {
     width: 24px;
 }
 
-.progress-stepper__icon > [role="img"] {
+.progress-stepper__icon > span[role="img"] {
     align-items: center;
     .border-color-token(progress-stepper-badge-current-border-color, color-status-information);
     border-radius: @progress-stepper-icon-size;
@@ -107,9 +107,9 @@ hr.progress-stepper__separator--upcoming,
     width: auto;
 }
 
-.progress-stepper__items--upcoming .progress-stepper__item,
+.progress-stepper__items--upcoming .progress-stepper__item > [role="img"],
 .progress-stepper__item--upcoming,
-.progress-stepper__item[aria-current] ~ .progress-stepper__item {
+.progress-stepper__item[aria-current] ~ .progress-stepper__item > [role="img"] {
     .color-token(progress-stepper-text-light-color, color-text-secondary);
 }
 
@@ -122,7 +122,7 @@ hr.progress-stepper__separator--upcoming,
     .color-token(progress-stepper-badge-upcoming-color, color-text-secondary);
 }
 
-.progress-stepper__item--attention .progress-stepper__icon {
+.progress-stepper__item--attention .progress-stepper__icon > [role="img"] {
     .color-token(progress-stepper-attention-color, color-status-attention);
 }
 


### PR DESCRIPTION
## Description
By changing all SVGs to have `role=img` this caused a selector to trigger which is only intended to `span[role="img"]` Changed the selector to only target spans

## References
https://github.com/eBay/skin/issues/1630

## Screenshots
<img width="1178" alt="Screen Shot 2022-01-10 at 11 00 58 AM" src="https://user-images.githubusercontent.com/1755269/148823714-033d5b3c-7d90-472d-81be-df134459b67d.png">

