### PR TITLE
fix(progress-spinner): reverted spinner to not use tokens

### DIFF
--- a/dist/progress-spinner/ds4/progress-spinner.css
+++ b/dist/progress-spinner/ds4/progress-spinner.css
@@ -1,6 +1,7 @@
 .progress-spinner {
   animation: spin 600ms linear infinite;
-  background-image: var(--progress-spinner-image-url, var(--url-image-progress-spinner, url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-small.svg")));
+  /* We should use a token here, but because of issues processing the url, need to revert to just use backgorund-image */
+  background-image: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-small.svg");
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
@@ -17,7 +18,7 @@
   }
 }
 .progress-spinner--large {
-  background-image: var(--progress-spinner-large-image-url, var(--url-image-progress-spinner-large, url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-large.svg")));
+  background-image: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-large.svg");
   height: 60px;
   width: 60px;
 }

--- a/dist/progress-spinner/ds6/progress-spinner.css
+++ b/dist/progress-spinner/ds6/progress-spinner.css
@@ -1,6 +1,7 @@
 .progress-spinner {
   animation: spin 600ms linear infinite;
-  background-image: var(--progress-spinner-image-url, var(--url-image-progress-spinner, url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-small.svg")));
+  /* We should use a token here, but because of issues processing the url, need to revert to just use backgorund-image */
+  background-image: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-small.svg");
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
@@ -17,7 +18,7 @@
   }
 }
 .progress-spinner--large {
-  background-image: var(--progress-spinner-large-image-url, var(--url-image-progress-spinner-large, url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-large.svg")));
+  background-image: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v2/spinner-large.svg");
   height: 60px;
   width: 60px;
 }

--- a/src/less/progress-spinner/base/progress-spinner.less
+++ b/src/less/progress-spinner/base/progress-spinner.less
@@ -2,7 +2,8 @@
 
 .progress-spinner {
     animation: spin 600ms linear infinite;
-    .background-image-token(progress-spinner-image-url, url-image-progress-spinner);
+    /* We should use a token here, but because of issues processing the url, need to revert to just use backgorund-image */
+    background-image: @url-image-progress-spinner;
     background-position: center center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -22,7 +23,7 @@
 }
 
 .progress-spinner--large {
-    .background-image-token(progress-spinner-large-image-url, url-image-progress-spinner-large);
+    background-image: @url-image-progress-spinner-large;
     height: 60px;
     width: 60px;
 }


### PR DESCRIPTION
## Description
When spinner url gets processed, it downloads the SVG and injects it into the CSS. With `var(`  it messes it up and does not load the SVG properly. Reverted the use of tokens for spinner.

## References
https://github.com/eBay/skin/issues/1641

## Screenshots
<img width="748" alt="Screen Shot 2022-01-20 at 11 18 43 AM" src="https://user-images.githubusercontent.com/1755269/150407329-981631f8-831e-4e1e-af8a-ba5110909462.png">

