### PR TITLE
fix(lightbox-dialog): removed outline-offset from button 

### DIFF
--- a/dist/lightbox-dialog/ds4/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds4/lightbox-dialog.css
@@ -84,7 +84,6 @@
 button.lightbox-dialog__close {
   align-self: center;
   border: 0;
-  outline-offset: -8px;
   position: relative;
   z-index: 1;
 }

--- a/dist/lightbox-dialog/ds6/lightbox-dialog.css
+++ b/dist/lightbox-dialog/ds6/lightbox-dialog.css
@@ -84,7 +84,6 @@
 button.lightbox-dialog__close {
   align-self: center;
   border: 0;
-  outline-offset: -8px;
   position: relative;
   z-index: 1;
 }

--- a/src/less/lightbox-dialog/base/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/base/lightbox-dialog.less
@@ -40,7 +40,6 @@
 button.lightbox-dialog__close {
     align-self: center;
     border: 0;
-    outline-offset: -8px;
     position: relative;
     z-index: 1;
 }


### PR DESCRIPTION

## Description
Initially when we had a non outlined button we had a negative outline-offset to make the focus ring closer to the icon. Now since we have a background it's not needed anymore. 


## References
#1636

## Screenshots
<img width="667" alt="Screen Shot 2022-01-20 at 3 48 42 PM" src="https://user-images.githubusercontent.com/1755269/150440236-0d11ce8d-3551-4d0b-be2d-4a76dad51127.png">

