### PR TITLE
fix(legacy-theme): removed perfers-color-scheme light

### DIFF
--- a/dist/legacy-theme/ds4/legacy-theme.css
+++ b/dist/legacy-theme/ds4/legacy-theme.css
@@ -1,84 +1,82 @@
-@media (prefers-color-scheme: light) {
-  button.btn,
-  a.fake-btn {
-    --btn-secondary-background-color: rgba(238, 238, 238, 0.5);
-    --btn-secondary-border-color: #999;
-    --btn-secondary-foreground-color: #555;
-    --btn-secondary-hover-background-color: rgba(221, 221, 221, 0.5);
-    --btn-secondary-hover-border-color: #707070;
-    --btn-secondary-hover-foreground-color: #555;
-    --btn-secondary-disabled-background-color: #ccc;
-    --btn-secondary-disabled-border-color: #999;
-    --btn-secondary-disabled-foreground-color: #555;
-  }
-  .combobox {
-    --combobox-textbox-background-color: #fff;
-    --combobox-textbox-border-color: #ccc;
-    --combobox-textbox-foreground-color: #555;
-    --combobox-textbox-focus-background-color: #fff;
-    --combobox-textbox-readonly-foreground-color: #333;
-    --combobox-textbox-disabled-border-color: #ccc;
-    --combobox-textbox-disabled-foreground-color: #ccc;
-    --combobox-textbox-disabled-placeholder-color: #ccc;
-    --combobox-textbox-invalid-background-color: #eee;
-    --combobox-textbox-border-radius: 4px;
-  }
-  button.icon-btn,
-  a.icon-link {
-    --icon-button-background-color: #fff;
-    --icon-button-icon-foreground-color: #555;
-    --icon-button-hover-background-color: #fff;
-    --icon-button-icon-hover-foreground-color: #333;
-    --icon-button-icon-active-foreground-color: #555;
-  }
-  .tooltip,
-  .tourtip,
-  .infotip {
-    --bubble-border-radius: 0;
-    --bubble-base-box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15),
-            2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15),
-            -2px 0 2px rgba(0, 0, 0, 0.15);
-    --bubble-left-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
-    --bubble-right-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
-    --bubble-bottom-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
-    --bubble-top-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
-  }
-  .page-notice {
-    --page-notice-color: #333;
-    --page-notice-general-background-color: #fff;
-    --page-notice-attention-background-color: #fff;
-    --page-notice-confirmation-background-color: #fff;
-    --page-notice-information-background-color: #fff;
-    --page-notice-attention-icon-color: #dd1e31;
-    --page-notice-confirmation-icon-color: #5ba71b;
-    --page-notice-information-icon-color: #0654ba;
-  }
-  .progress-spinner {
-    --progress-spinner-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
-    --progress-spinner-large-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
-  }
-  .section-notice {
-    --section-notice-border-radius: 0;
-  }
-  .select {
-    --select-background-color: #fff;
-    --select-border-color: #ccc;
-    --select-border-radius: 4px;
-    --select-disabled-foregound-color: #ccc;
-    --select-invalid-background-color: #fff;
-    --select-invalid-foreground-color: #333;
-    --select-borderless-disabled-background-color: #fff;
-  }
-  .textbox {
-    --textbox-background-color: #fff;
-    --textbox-border-color: #ccc;
-    --textbox-foreground-color: #555;
-    --textbox-focus-background-color: #fff;
-    --textbox-readonly-foreground-color: #333;
-    --textbox-disabled-border-color: #ccc;
-    --textbox-disabled-foreground-color: #ccc;
-    --textbox-disabled-placeholder-color: #ccc;
-    --textbox-invalid-background-color: #eee;
-    --textbox-border-radius: 4px;
-  }
+button.btn,
+a.fake-btn {
+  --btn-secondary-background-color: rgba(238, 238, 238, 0.5);
+  --btn-secondary-border-color: #999;
+  --btn-secondary-foreground-color: #555;
+  --btn-secondary-hover-background-color: rgba(221, 221, 221, 0.5);
+  --btn-secondary-hover-border-color: #707070;
+  --btn-secondary-hover-foreground-color: #555;
+  --btn-secondary-disabled-background-color: #ccc;
+  --btn-secondary-disabled-border-color: #999;
+  --btn-secondary-disabled-foreground-color: #555;
+}
+.combobox {
+  --combobox-textbox-background-color: #fff;
+  --combobox-textbox-border-color: #ccc;
+  --combobox-textbox-foreground-color: #555;
+  --combobox-textbox-focus-background-color: #fff;
+  --combobox-textbox-readonly-foreground-color: #333;
+  --combobox-textbox-disabled-border-color: #ccc;
+  --combobox-textbox-disabled-foreground-color: #ccc;
+  --combobox-textbox-disabled-placeholder-color: #ccc;
+  --combobox-textbox-invalid-background-color: #eee;
+  --combobox-textbox-border-radius: 4px;
+}
+button.icon-btn,
+a.icon-link {
+  --icon-button-background-color: #fff;
+  --icon-button-icon-foreground-color: #555;
+  --icon-button-hover-background-color: #fff;
+  --icon-button-icon-hover-foreground-color: #333;
+  --icon-button-icon-active-foreground-color: #555;
+}
+.tooltip,
+.tourtip,
+.infotip {
+  --bubble-border-radius: 0;
+  --bubble-base-box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.15),
+        2px 0 2px rgba(0, 0, 0, 0.15), 0 2px 2px rgba(0, 0, 0, 0.15),
+        -2px 0 2px rgba(0, 0, 0, 0.15);
+  --bubble-left-box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.15);
+  --bubble-right-box-shadow: 2px -2px 2px rgba(0, 0, 0, 0.15);
+  --bubble-bottom-box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+  --bubble-top-box-shadow: -2px -2px 2px rgba(0, 0, 0, 0.15);
+}
+.page-notice {
+  --page-notice-color: #333;
+  --page-notice-general-background-color: #fff;
+  --page-notice-attention-background-color: #fff;
+  --page-notice-confirmation-background-color: #fff;
+  --page-notice-information-background-color: #fff;
+  --page-notice-attention-icon-color: #dd1e31;
+  --page-notice-confirmation-icon-color: #5ba71b;
+  --page-notice-information-icon-color: #0654ba;
+}
+.progress-spinner {
+  --progress-spinner-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
+  --progress-spinner-large-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
+}
+.section-notice {
+  --section-notice-border-radius: 0;
+}
+.select {
+  --select-background-color: #fff;
+  --select-border-color: #ccc;
+  --select-border-radius: 4px;
+  --select-disabled-foregound-color: #ccc;
+  --select-invalid-background-color: #fff;
+  --select-invalid-foreground-color: #333;
+  --select-borderless-disabled-background-color: #fff;
+}
+.textbox {
+  --textbox-background-color: #fff;
+  --textbox-border-color: #ccc;
+  --textbox-foreground-color: #555;
+  --textbox-focus-background-color: #fff;
+  --textbox-readonly-foreground-color: #333;
+  --textbox-disabled-border-color: #ccc;
+  --textbox-disabled-foreground-color: #ccc;
+  --textbox-disabled-placeholder-color: #ccc;
+  --textbox-invalid-background-color: #eee;
+  --textbox-border-radius: 4px;
 }

--- a/dist/legacy-theme/ds6/legacy-theme.css
+++ b/dist/legacy-theme/ds6/legacy-theme.css
@@ -1,84 +1,82 @@
-@media (prefers-color-scheme: light) {
-  button.btn,
-  a.fake-btn {
-    --btn-secondary-background-color: rgba(247, 247, 247, 0.5);
-    --btn-secondary-border-color: #a2a2a2;
-    --btn-secondary-foreground-color: #555;
-    --btn-secondary-hover-background-color: rgba(229, 229, 229, 0.5);
-    --btn-secondary-hover-border-color: #707070;
-    --btn-secondary-hover-foreground-color: #555;
-    --btn-secondary-disabled-background-color: #c7c7c7;
-    --btn-secondary-disabled-border-color: #a2a2a2;
-    --btn-secondary-disabled-foreground-color: #555;
-  }
-  .combobox {
-    --combobox-textbox-background-color: #fff;
-    --combobox-textbox-border-color: #c7c7c7;
-    --combobox-textbox-foreground-color: #555;
-    --combobox-textbox-focus-background-color: #fff;
-    --combobox-textbox-readonly-foreground-color: #414141;
-    --combobox-textbox-disabled-border-color: #c7c7c7;
-    --combobox-textbox-disabled-foreground-color: #c7c7c7;
-    --combobox-textbox-disabled-placeholder-color: #c7c7c7;
-    --combobox-textbox-invalid-background-color: #f7f7f7;
-    --combobox-textbox-border-radius: 4px;
-  }
-  button.icon-btn,
-  a.icon-link {
-    --icon-button-background-color: #fff;
-    --icon-button-icon-foreground-color: #555;
-    --icon-button-hover-background-color: #fff;
-    --icon-button-icon-hover-foreground-color: #414141;
-    --icon-button-icon-active-foreground-color: #555;
-  }
-  .tooltip,
-  .tourtip,
-  .infotip {
-    --bubble-border-radius: 0;
-    --bubble-base-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5),
-            2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5),
-            -2px 0 2px rgba(199, 199, 199, 0.5);
-    --bubble-left-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
-    --bubble-right-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
-    --bubble-bottom-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
-    --bubble-top-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
-  }
-  .page-notice {
-    --page-notice-color: #111820;
-    --page-notice-general-background-color: #fff;
-    --page-notice-attention-background-color: #fff;
-    --page-notice-confirmation-background-color: #fff;
-    --page-notice-information-background-color: #fff;
-    --page-notice-attention-icon-color: #e0103a;
-    --page-notice-confirmation-icon-color: #05823f;
-    --page-notice-information-icon-color: #3665f3;
-  }
-  .progress-spinner {
-    --progress-spinner-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
-    --progress-spinner-large-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
-  }
-  .section-notice {
-    --section-notice-border-radius: 0;
-  }
-  .select {
-    --select-background-color: #fff;
-    --select-border-color: #c7c7c7;
-    --select-border-radius: 4px;
-    --select-disabled-foregound-color: #c7c7c7;
-    --select-invalid-background-color: #fff;
-    --select-invalid-foreground-color: #111820;
-    --select-borderless-disabled-background-color: #fff;
-  }
-  .textbox {
-    --textbox-background-color: #fff;
-    --textbox-border-color: #c7c7c7;
-    --textbox-foreground-color: #555;
-    --textbox-focus-background-color: #fff;
-    --textbox-readonly-foreground-color: #414141;
-    --textbox-disabled-border-color: #c7c7c7;
-    --textbox-disabled-foreground-color: #c7c7c7;
-    --textbox-disabled-placeholder-color: #c7c7c7;
-    --textbox-invalid-background-color: #f7f7f7;
-    --textbox-border-radius: 4px;
-  }
+button.btn,
+a.fake-btn {
+  --btn-secondary-background-color: rgba(247, 247, 247, 0.5);
+  --btn-secondary-border-color: #a2a2a2;
+  --btn-secondary-foreground-color: #555;
+  --btn-secondary-hover-background-color: rgba(229, 229, 229, 0.5);
+  --btn-secondary-hover-border-color: #707070;
+  --btn-secondary-hover-foreground-color: #555;
+  --btn-secondary-disabled-background-color: #c7c7c7;
+  --btn-secondary-disabled-border-color: #a2a2a2;
+  --btn-secondary-disabled-foreground-color: #555;
+}
+.combobox {
+  --combobox-textbox-background-color: #fff;
+  --combobox-textbox-border-color: #c7c7c7;
+  --combobox-textbox-foreground-color: #555;
+  --combobox-textbox-focus-background-color: #fff;
+  --combobox-textbox-readonly-foreground-color: #414141;
+  --combobox-textbox-disabled-border-color: #c7c7c7;
+  --combobox-textbox-disabled-foreground-color: #c7c7c7;
+  --combobox-textbox-disabled-placeholder-color: #c7c7c7;
+  --combobox-textbox-invalid-background-color: #f7f7f7;
+  --combobox-textbox-border-radius: 4px;
+}
+button.icon-btn,
+a.icon-link {
+  --icon-button-background-color: #fff;
+  --icon-button-icon-foreground-color: #555;
+  --icon-button-hover-background-color: #fff;
+  --icon-button-icon-hover-foreground-color: #414141;
+  --icon-button-icon-active-foreground-color: #555;
+}
+.tooltip,
+.tourtip,
+.infotip {
+  --bubble-border-radius: 0;
+  --bubble-base-box-shadow: 0 -2px 2px rgba(199, 199, 199, 0.5),
+        2px 0 2px rgba(199, 199, 199, 0.5), 0 2px 2px rgba(199, 199, 199, 0.5),
+        -2px 0 2px rgba(199, 199, 199, 0.5);
+  --bubble-left-box-shadow: -2px 2px 2px rgba(199, 199, 199, 0.5);
+  --bubble-right-box-shadow: 2px -2px 2px rgba(199, 199, 199, 0.5);
+  --bubble-bottom-box-shadow: 2px 2px 2px rgba(199, 199, 199, 0.5);
+  --bubble-top-box-shadow: -2px -2px 2px rgba(199, 199, 199, 0.5);
+}
+.page-notice {
+  --page-notice-color: #111820;
+  --page-notice-general-background-color: #fff;
+  --page-notice-attention-background-color: #fff;
+  --page-notice-confirmation-background-color: #fff;
+  --page-notice-information-background-color: #fff;
+  --page-notice-attention-icon-color: #e0103a;
+  --page-notice-confirmation-icon-color: #05823f;
+  --page-notice-information-icon-color: #3665f3;
+}
+.progress-spinner {
+  --progress-spinner-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
+  --progress-spinner-large-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
+}
+.section-notice {
+  --section-notice-border-radius: 0;
+}
+.select {
+  --select-background-color: #fff;
+  --select-border-color: #c7c7c7;
+  --select-border-radius: 4px;
+  --select-disabled-foregound-color: #c7c7c7;
+  --select-invalid-background-color: #fff;
+  --select-invalid-foreground-color: #111820;
+  --select-borderless-disabled-background-color: #fff;
+}
+.textbox {
+  --textbox-background-color: #fff;
+  --textbox-border-color: #c7c7c7;
+  --textbox-foreground-color: #555;
+  --textbox-focus-background-color: #fff;
+  --textbox-readonly-foreground-color: #414141;
+  --textbox-disabled-border-color: #c7c7c7;
+  --textbox-disabled-foreground-color: #c7c7c7;
+  --textbox-disabled-placeholder-color: #c7c7c7;
+  --textbox-invalid-background-color: #f7f7f7;
+  --textbox-border-radius: 4px;
 }

--- a/src/less/legacy-theme/base/legacy-theme.less
+++ b/src/less/legacy-theme/base/legacy-theme.less
@@ -1,92 +1,90 @@
-@media (prefers-color-scheme: light) {
-    button.btn,
-    a.fake-btn {
-        --btn-secondary-background-color: fade(@color-grey1, 50%);
-        --btn-secondary-border-color: @color-grey4;
-        --btn-secondary-foreground-color: #555;
-        --btn-secondary-hover-background-color: fade(@color-grey2, 50%);
-        --btn-secondary-hover-border-color: @color-grey5;
-        --btn-secondary-hover-foreground-color: #555;
-        --btn-secondary-disabled-background-color: @color-grey3;
-        --btn-secondary-disabled-border-color: @color-grey4;
-        --btn-secondary-disabled-foreground-color: #555;
-    }
+button.btn,
+a.fake-btn {
+    --btn-secondary-background-color: fade(@color-grey1, 50%);
+    --btn-secondary-border-color: @color-grey4;
+    --btn-secondary-foreground-color: #555;
+    --btn-secondary-hover-background-color: fade(@color-grey2, 50%);
+    --btn-secondary-hover-border-color: @color-grey5;
+    --btn-secondary-hover-foreground-color: #555;
+    --btn-secondary-disabled-background-color: @color-grey3;
+    --btn-secondary-disabled-border-color: @color-grey4;
+    --btn-secondary-disabled-foreground-color: #555;
+}
 
-    .combobox {
-        --combobox-textbox-background-color: @color-background-default;
-        --combobox-textbox-border-color: @color-grey3;
-        --combobox-textbox-foreground-color: #555;
-        --combobox-textbox-focus-background-color: @color-background-default;
-        --combobox-textbox-readonly-foreground-color: @color-grey6;
-        --combobox-textbox-disabled-border-color: @color-disabled;
-        --combobox-textbox-disabled-foreground-color: @color-disabled;
-        --combobox-textbox-disabled-placeholder-color: @color-action-disabled;
-        --combobox-textbox-invalid-background-color: @color-form-control-background;
-        --combobox-textbox-border-radius: @border-radius-extra-small;
-    }
+.combobox {
+    --combobox-textbox-background-color: @color-background-default;
+    --combobox-textbox-border-color: @color-grey3;
+    --combobox-textbox-foreground-color: #555;
+    --combobox-textbox-focus-background-color: @color-background-default;
+    --combobox-textbox-readonly-foreground-color: @color-grey6;
+    --combobox-textbox-disabled-border-color: @color-disabled;
+    --combobox-textbox-disabled-foreground-color: @color-disabled;
+    --combobox-textbox-disabled-placeholder-color: @color-action-disabled;
+    --combobox-textbox-invalid-background-color: @color-form-control-background;
+    --combobox-textbox-border-radius: @border-radius-extra-small;
+}
 
-    button.icon-btn,
-    a.icon-link {
-        --icon-button-background-color: @color-background-default;
-        --icon-button-icon-foreground-color: #555;
-        --icon-button-hover-background-color: @color-background-default;
-        --icon-button-icon-hover-foreground-color: @color-grey6;
-        --icon-button-icon-active-foreground-color: #555;
-    }
+button.icon-btn,
+a.icon-link {
+    --icon-button-background-color: @color-background-default;
+    --icon-button-icon-foreground-color: #555;
+    --icon-button-hover-background-color: @color-background-default;
+    --icon-button-icon-hover-foreground-color: @color-grey6;
+    --icon-button-icon-active-foreground-color: #555;
+}
 
-    .tooltip,
-    .tourtip,
-    .infotip {
-        --bubble-border-radius: @border-radius-none;
-        --bubble-base-box-shadow: 0 -2px 2px @color-flyout-box-shadow,
-            2px 0 2px @color-flyout-box-shadow, 0 2px 2px @color-flyout-box-shadow,
-            -2px 0 2px @color-flyout-box-shadow;
-        --bubble-left-box-shadow: -2px 2px 2px @color-flyout-box-shadow;
-        --bubble-right-box-shadow: 2px -2px 2px @color-flyout-box-shadow;
-        --bubble-bottom-box-shadow: 2px 2px 2px @color-flyout-box-shadow;
-        --bubble-top-box-shadow: -2px -2px 2px @color-flyout-box-shadow;
-    }
+.tooltip,
+.tourtip,
+.infotip {
+    --bubble-border-radius: @border-radius-none;
+    --bubble-base-box-shadow: 0 -2px 2px @color-flyout-box-shadow,
+        2px 0 2px @color-flyout-box-shadow, 0 2px 2px @color-flyout-box-shadow,
+        -2px 0 2px @color-flyout-box-shadow;
+    --bubble-left-box-shadow: -2px 2px 2px @color-flyout-box-shadow;
+    --bubble-right-box-shadow: 2px -2px 2px @color-flyout-box-shadow;
+    --bubble-bottom-box-shadow: 2px 2px 2px @color-flyout-box-shadow;
+    --bubble-top-box-shadow: -2px -2px 2px @color-flyout-box-shadow;
+}
 
-    .page-notice {
-        --page-notice-color: @color-text-default;
-        --page-notice-general-background-color: @color-background-default;
-        --page-notice-attention-background-color: @color-background-default;
-        --page-notice-confirmation-background-color: @color-background-default;
-        --page-notice-information-background-color: @color-background-default;
-        --page-notice-attention-icon-color: @color-status-attention;
-        --page-notice-confirmation-icon-color: @color-status-confirmation;
-        --page-notice-information-icon-color: @color-status-information;
-    }
+.page-notice {
+    --page-notice-color: @color-text-default;
+    --page-notice-general-background-color: @color-background-default;
+    --page-notice-attention-background-color: @color-background-default;
+    --page-notice-confirmation-background-color: @color-background-default;
+    --page-notice-information-background-color: @color-background-default;
+    --page-notice-attention-icon-color: @color-status-attention;
+    --page-notice-confirmation-icon-color: @color-status-confirmation;
+    --page-notice-information-icon-color: @color-status-information;
+}
 
-    .progress-spinner {
-        --progress-spinner-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
-        --progress-spinner-large-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
-    }
+.progress-spinner {
+    --progress-spinner-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
+    --progress-spinner-large-image-url: url("https://ir.ebaystatic.com/cr/v/c1/skin/svg/spinner/v1/ds4/spinner.svg");
+}
 
-    .section-notice {
-        --section-notice-border-radius: @border-radius-none;
-    }
+.section-notice {
+    --section-notice-border-radius: @border-radius-none;
+}
 
-    .select {
-        --select-background-color: @color-background-default;
-        --select-border-color: @color-grey3;
-        --select-border-radius: @border-radius-extra-small;
-        --select-disabled-foregound-color: @color-grey3;
-        --select-invalid-background-color: @color-background-default;
-        --select-invalid-foreground-color: @color-text-default;
-        --select-borderless-disabled-background-color: @color-background-default;
-    }
+.select {
+    --select-background-color: @color-background-default;
+    --select-border-color: @color-grey3;
+    --select-border-radius: @border-radius-extra-small;
+    --select-disabled-foregound-color: @color-grey3;
+    --select-invalid-background-color: @color-background-default;
+    --select-invalid-foreground-color: @color-text-default;
+    --select-borderless-disabled-background-color: @color-background-default;
+}
 
-    .textbox {
-        --textbox-background-color: @color-background-default;
-        --textbox-border-color: @color-grey3;
-        --textbox-foreground-color: #555;
-        --textbox-focus-background-color: @color-background-default;
-        --textbox-readonly-foreground-color: @color-grey6;
-        --textbox-disabled-border-color: @color-disabled;
-        --textbox-disabled-foreground-color: @color-disabled;
-        --textbox-disabled-placeholder-color: @color-action-disabled;
-        --textbox-invalid-background-color: @color-form-control-background;
-        --textbox-border-radius: @border-radius-extra-small;
-    }
+.textbox {
+    --textbox-background-color: @color-background-default;
+    --textbox-border-color: @color-grey3;
+    --textbox-foreground-color: #555;
+    --textbox-focus-background-color: @color-background-default;
+    --textbox-readonly-foreground-color: @color-grey6;
+    --textbox-disabled-border-color: @color-disabled;
+    --textbox-disabled-foreground-color: @color-disabled;
+    --textbox-disabled-placeholder-color: @color-action-disabled;
+    --textbox-invalid-background-color: @color-form-control-background;
+    --textbox-border-radius: @border-radius-extra-small;
 }


### PR DESCRIPTION
## Description
When theme on ds4 switches to dark-mode, styles are not being applied. The issue was due to the `prefers-color-scheme: light`.
Removed that query and have styles apply at all times.

## References
https://github.com/eBay/skin/issues/1661

