### PR TITLE
fix(progress-spinner): made progress spinner work in loading button

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -96,6 +96,10 @@ button.btn svg.icon:last-child,
 a.fake-btn svg.icon:last-child {
   margin-left: 8px;
 }
+button.btn svg.icon:only-child,
+a.fake-btn svg.icon:only-child {
+  margin: 0;
+}
 button.btn__cell--fixed-height svg.icon,
 a.fake-btn__cell--fixed-height svg.icon {
   align-self: center;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -96,6 +96,10 @@ button.btn svg.icon:last-child,
 a.fake-btn svg.icon:last-child {
   margin-left: 8px;
 }
+button.btn svg.icon:only-child,
+a.fake-btn svg.icon:only-child {
+  margin: 0;
+}
 button.btn__cell--fixed-height svg.icon,
 a.fake-btn__cell--fixed-height svg.icon {
   align-self: center;

--- a/dist/cta-button/ds4/cta-button.css
+++ b/dist/cta-button/ds4/cta-button.css
@@ -85,6 +85,9 @@ a.cta-btn svg.icon:first-child {
 a.cta-btn svg.icon:last-child {
   margin-left: 8px;
 }
+a.cta-btn svg.icon:only-child {
+  margin: 0;
+}
 span.cta-btn__cell--fixed-height svg.icon {
   align-self: center;
   height: 1rem;

--- a/dist/cta-button/ds6/cta-button.css
+++ b/dist/cta-button/ds6/cta-button.css
@@ -85,6 +85,9 @@ a.cta-btn svg.icon:first-child {
 a.cta-btn svg.icon:last-child {
   margin-left: 8px;
 }
+a.cta-btn svg.icon:only-child {
+  margin: 0;
+}
 span.cta-btn__cell--fixed-height svg.icon {
   align-self: center;
   height: 1rem;

--- a/dist/expand-button/ds4/expand-button.css
+++ b/dist/expand-button/ds4/expand-button.css
@@ -46,6 +46,9 @@ button.expand-btn svg.icon:first-child {
 button.expand-btn svg.icon:last-child {
   margin-left: 8px;
 }
+button.expand-btn svg.icon:only-child {
+  margin: 0;
+}
 button.expand-btn--wide {
   padding-left: 48px;
   padding-right: 48px;

--- a/dist/expand-button/ds6/expand-button.css
+++ b/dist/expand-button/ds6/expand-button.css
@@ -46,6 +46,9 @@ button.expand-btn svg.icon:first-child {
 button.expand-btn svg.icon:last-child {
   margin-left: 8px;
 }
+button.expand-btn svg.icon:only-child {
+  margin: 0;
+}
 button.expand-btn--wide {
   padding-left: 48px;
   padding-right: 48px;

--- a/dist/mixins/button/base/button-mixins.less
+++ b/dist/mixins/button/base/button-mixins.less
@@ -33,6 +33,10 @@
     &:last-child {
         margin-left: 8px; // when icon is placed after button text
     }
+
+    &:only-child {
+        margin: 0;
+    }
 }
 
 .btn-fixed-height() {

--- a/dist/progress-spinner/ds4/progress-spinner.css
+++ b/dist/progress-spinner/ds4/progress-spinner.css
@@ -12,6 +12,13 @@
     transform: rotate(360deg);
   }
 }
+.progress-spinner > svg.icon.icon--spinner {
+  height: inherit;
+  margin: 0;
+  max-height: inherit;
+  max-width: inherit;
+  width: inherit;
+}
 .progress-spinner--large {
   height: 60px;
   width: 60px;

--- a/dist/progress-spinner/ds6/progress-spinner.css
+++ b/dist/progress-spinner/ds6/progress-spinner.css
@@ -12,6 +12,13 @@
     transform: rotate(360deg);
   }
 }
+.progress-spinner > svg.icon.icon--spinner {
+  height: inherit;
+  margin: 0;
+  max-height: inherit;
+  max-width: inherit;
+  width: inherit;
+}
 .progress-spinner--large {
   height: 60px;
   width: 60px;

--- a/docs/_includes/button.html
+++ b/docs/_includes/button.html
@@ -183,17 +183,29 @@
             <div class="demo__inner">
                 <button class="btn btn--primary" aria-label="Loading..." aria-disabled="true" aria-live="polite">
                     <span class="btn__cell">
-                        <span class="progress-spinner"></span>
+                        <span class="progress-spinner">
+                            <svg aria-hidden="true" class="icon icon--spinner" focusable="false" height="24" width="24">
+                                {% include symbol.html name="spinner" %}
+                            </svg>
+                        </span>
                     </span>
                 </button>
                 <button class="btn btn--secondary" aria-label="Loading..." aria-disabled="true" aria-live="polite">
                     <span class="btn__cell">
-                        <span class="progress-spinner"></span>
+                        <span class="progress-spinner">
+                            <svg aria-hidden="true" class="icon icon--spinner" focusable="false" height="24" width="24">
+                                {% include symbol.html name="spinner" %}
+                            </svg>
+                        </span>
                     </span>
                 </button>
                 <button class="btn btn--tertiary" aria-label="Loading..." aria-disabled="true" aria-live="polite">
                     <span class="btn__cell">
-                        <span class="progress-spinner"></span>
+                        <span class="progress-spinner">
+                            <svg aria-hidden="true" class="icon icon--spinner" focusable="false" height="24" width="24">
+                                {% include symbol.html name="spinner" %}
+                            </svg>
+                        </span>
                     </span>
                 </button>
             </div>
@@ -202,17 +214,29 @@
         {% highlight html %}
 <button class="btn btn--primary" aria-label="Loading..." aria-disabled="true" aria-live="polite">
     <span class="btn__cell">
-        <span class="progress-spinner"></span>
+        <span class="progress-spinner">
+            <svg aria-hidden="true" class="icon icon--spinner" focusable="false" height="24" width="24">
+                <use xlink:href="#icon-spinner"></use>
+            </svg>
+        </span>
     </span>
 </button>
 <button class="btn btn--secondary" aria-label="Loading..." aria-disabled="true" aria-live="polite">
     <span class="btn__cell">
-        <span class="progress-spinner"></span>
+        <span class="progress-spinner">
+            <svg aria-hidden="true" class="icon icon--spinner" focusable="false" height="24" width="24">
+                <use xlink:href="#icon-spinner"></use>
+            </svg>
+        </span>
     </span>
 </button>
 <button class="btn btn--tertiary" aria-label="Loading..." aria-disabled="true" aria-live="polite">
     <span class="btn__cell">
-        <span class="progress-spinner"></span>
+        <span class="progress-spinner">
+            <svg aria-hidden="true" class="icon icon--spinner" focusable="false" height="24" width="24">
+                <use xlink:href="#icon-spinner"></use>
+            </svg>
+        </span>
     </span>
 </button>
         {% endhighlight %}

--- a/src/less/mixins/button/base/button-mixins.less
+++ b/src/less/mixins/button/base/button-mixins.less
@@ -33,6 +33,10 @@
     &:last-child {
         margin-left: 8px; // when icon is placed after button text
     }
+
+    &:only-child {
+        margin: 0;
+    }
 }
 
 .btn-fixed-height() {

--- a/src/less/progress-spinner/base/progress-spinner.less
+++ b/src/less/progress-spinner/base/progress-spinner.less
@@ -17,6 +17,15 @@
     }
 }
 
+// fixes wobble
+.progress-spinner > svg.icon.icon--spinner {
+    height: inherit;
+    margin: 0;
+    max-height: inherit;
+    max-width: inherit;
+    width: inherit;
+}
+
 .progress-spinner--large {
     height: 60px;
     width: 60px;


### PR DESCRIPTION
## Description
When we changed the progress spinner syntax last minor version, we forgot to check loading button. Seems like there was a major wobble with that.

## Context
* Thanks to @ArtBlue , added the CSS styles for SVG to force the width to make it not wobble.
* I had to change some margin on the button mixin when it's an `only-child` (so the negative margins don't get applied)
* Also updated docs 

## References
https://github.com/eBay/skin/issues/1665

## Screenshots
![spinner](https://user-images.githubusercontent.com/1755269/153461911-ed7030de-26b0-4b3f-9ebe-5bf540f3b051.gif)

