### PR TITLE
feat(split-button): added new split-button to skin

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -398,6 +398,20 @@ a.fake-btn--large-truncated span {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+button.btn--split-start {
+  border-radius: 24px 0 0 24px;
+}
+button.btn--split-end {
+  border-left-color: currentColor;
+  border-radius: 0 24px 24px 0;
+  margin-left: -5px;
+  min-width: 40px;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+button.btn--tertiary.btn--split-end {
+  border-left-color: var(--tertiary-border-left-color, var(--color-separator, #eee));
+}
 [dir="rtl"] button.btn svg.icon--dropdown:first-child,
 [dir="rtl"] a.fake-btn svg.icon--dropdown:first-child {
   margin-left: 8px;

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -398,6 +398,20 @@ a.fake-btn--large-truncated span {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+button.btn--split-start {
+  border-radius: 24px 0 0 24px;
+}
+button.btn--split-end {
+  border-left-color: currentColor;
+  border-radius: 0 24px 24px 0;
+  margin-left: -5px;
+  min-width: 40px;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+button.btn--tertiary.btn--split-end {
+  border-left-color: var(--tertiary-border-left-color, var(--color-separator, #e5e5e5));
+}
 [dir="rtl"] button.btn svg.icon--dropdown:first-child,
 [dir="rtl"] a.fake-btn svg.icon--dropdown:first-child {
   margin-left: 8px;

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -118,6 +118,10 @@
     .customPropertyToken(border-color, @component-token, @product-token);
 }
 
+.border-left-color-token(@component-token, @product-token) {
+    .customPropertyToken(border-left-color, @component-token, @product-token);
+}
+
 .box-shadow-token(@token) {
     .customPropertyToken(box-shadow, @token);
 }

--- a/docs/_includes/main.html
+++ b/docs/_includes/main.html
@@ -12,7 +12,8 @@
 <img class="skin-graphic" src="{{ page.static_dir }}/common/skin-graphic.png" alt="" />
 {% include animation.html %}
 
-{% assign modules = "alert-dialog, badge, breadcrumbs, button, carousel, checkbox, color, combobox, confirm-dialog, cta-button, dark-mode, details, drawer-dialog, fullscreen-dialog, eek, expand-button, field, filter-button, filter-menu, filter-menu-button, floating-label, global, icon, icon-button, infotip, inline-notice, less, lightbox-dialog, link, listbox, listbox-button, marketsans, menu, menu-button, page-grid, page-notice, pagination, panel-dialog, program-badge, progress-bar, progress-spinner, progress-stepper, radio, section-notice, section-title, select, signal, snackbar-dialog, star-rating, svg, switch, tabs, textbox, toast-dialog, tooltip, tourtip, typography, utility" | split: ", " %}
+{% assign modules = "alert-dialog, badge, breadcrumbs, button, carousel, checkbox, color, combobox, confirm-dialog, cta-button, dark-mode, details, drawer-dialog, fullscreen-dialog, eek, expand-button, field, filter-button, filter-menu, filter-menu-button, floating-label, global, icon, icon-button, infotip, inline-notice, less, lightbox-dialog, link, listbox, listbox-button, marketsans, menu, menu-button, page-grid, page-notice, pagination, panel-dialog, program-badge, progress-bar, progress-spinner, progress-stepper, radio, section-notice, section-title, select, signal, snackbar-dialog, split-button, star-rating, svg, switch, tabs, textbox, toast-dialog, tooltip, tourtip, typography, utility" | split: ", " %}
+
 
 {% for moduleName in modules %}
 <img class="skin-graphic" src="{{ page.static_dir }}/common/skin-graphic.png" alt="" />

--- a/docs/_includes/module-list.html
+++ b/docs/_includes/module-list.html
@@ -47,6 +47,7 @@
 <li><a href="#signal">Signal</a></li>
 <li><a href="#snackbar-dialog">Snackbar Dialog</a></li>
 <li><a href="#star-rating">Star Rating</a></li>
+<li><a href="#split-button">Split Button</a></li>
 <li><a href="#svg">SVG</a></li>
 <li><a href="#switch">Switch</a></li>
 <li><a href="#tabs">Tabs</a></li>

--- a/docs/_includes/split-button.html
+++ b/docs/_includes/split-button.html
@@ -1,0 +1,241 @@
+<div id="split-button">
+    {% include section-header.html name="split-button" version=page.versions.split-button %}
+
+    <p>Split button is a button with a menu-button squished together.<p>
+    <p>Note: In future versions, a middle element may be included, and will use the class "btn--split-middle"</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary btn--split-start" aria-haspopup="true" type="button">
+                <span class="btn__cell">
+                    <span class="btn__text">Button</span>
+                </span>
+            </button>
+            <span class="menu-button">
+                <button class="btn btn--primary btn--split-end " aria-haspopup="true" type="button">
+                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                        {% include symbol.html name="dropdown" %}
+                    </svg>
+                </button>
+                <div class="menu-button__menu">
+                    <div class="menu-button__items" role="menu">
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 10000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 20000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 30000</span>
+                        </div>
+                    </div>
+                </div>
+            </span>
+        </div>
+    </div>
+    {% highlight html %}
+<button class="btn btn--primary btn--split-start" aria-haspopup="true" type="button">
+    <span class="btn__cell">
+        <span class="btn__text">Button</span>
+    </span>
+</button>
+<span class="menu-button">
+    <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </button>
+    <div class="menu-button__menu">
+        <div class="menu-button__items" role="menu">
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 10000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 20000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 30000</span>
+            </div>
+        </div>
+    </div>
+</span>
+    {% endhighlight %}
+
+    <p>Secondary Variant<p>
+
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--secondary btn--split-start" aria-haspopup="true" type="button">
+                <span class="btn__cell">
+                    <span class="btn__text">Button</span>
+                </span>
+            </button>
+            <span class="menu-button">
+                <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
+                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                        {% include symbol.html name="dropdown" %}
+                    </svg>
+                </button>
+                <div class="menu-button__menu">
+                    <div class="menu-button__items" role="menu">
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 10000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 20000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 30000</span>
+                        </div>
+                    </div>
+                </div>
+            </span>
+        </div>
+    </div>
+    {% highlight html %}
+<button class="btn btn--secondary btn--split-start" aria-haspopup="true" type="button">
+    <span class="btn__cell">
+        <span class="btn__text">Button</span>
+    </span>
+</button>
+<span class="menu-button">
+    <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
+        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </button>
+    <div class="menu-button__menu">
+        <div class="menu-button__items" role="menu">
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 10000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 20000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 30000</span>
+            </div>
+        </div>
+    </div>
+</span>
+    {% endhighlight %}
+
+    <p>Tertiary Variant<p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--tertiary btn--split-start" aria-haspopup="true" type="button">
+                <span class="btn__cell">
+                    <span class="btn__text">Button</span>
+                </span>
+            </button>
+            <span class="menu-button">
+                <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
+                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                        {% include symbol.html name="dropdown" %}
+                    </svg>
+                </button>
+                <div class="menu-button__menu">
+                    <div class="menu-button__items" role="menu">
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 10000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 20000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 30000</span>
+                        </div>
+                    </div>
+                </div>
+            </span>
+        </div>
+    </div>
+    {% highlight html %}
+<button class="btn btn--tertiary btn--split-start" aria-haspopup="true" type="button">
+    <span class="btn__cell">
+        <span class="btn__text">Button</span>
+    </span>
+</button>
+<span class="menu-button">
+    <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
+        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </button>
+    <div class="menu-button__menu">
+        <div class="menu-button__items" role="menu">
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 10000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 20000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 30000</span>
+            </div>
+        </div>
+    </div>
+</span>
+    {% endhighlight %}
+
+    <p>Lots of Text</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary btn--split-start btn--truncated" aria-haspopup="true" type="button">
+                <span class="btn__cell">
+                    <span class="btn__text">Longest Button Text Example Lorem Ipsum Dolor</span>
+                </span>
+            </button>
+            <span class="menu-button">
+                <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                        {% include symbol.html name="dropdown" %}
+                    </svg>
+                </button>
+                <div class="menu-button__menu">
+                    <div class="menu-button__items" role="menu">
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 10000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 20000</span>
+                        </div>
+                        <div class="menu-button__item" role="menuitem">
+                            <span>Item 30000</span>
+                        </div>
+                    </div>
+                </div>
+            </span>
+        </div>
+    </div>
+    {% highlight html %}
+<button class="btn btn--primary btn--split-start" aria-haspopup="true" type="button">
+    <span class="btn__cell">
+        <span class="btn__text">Button</span>
+    </span>
+</button>
+<span class="menu-button">
+    <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </button>
+    <div class="menu-button__menu">
+        <div class="menu-button__items" role="menu">
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 10000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 20000</span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <span>Item 30000</span>
+            </div>
+        </div>
+    </div>
+</span>
+    {% endhighlight %}
+</div>

--- a/docs/_includes/split-button.html
+++ b/docs/_includes/split-button.html
@@ -1,241 +1,197 @@
 <div id="split-button">
     {% include section-header.html name="split-button" version=page.versions.split-button %}
 
-    <p>Split button is a button with a menu-button squished together.<p>
-    <p>Note: In future versions, a middle element may be included, and will use the class "btn--split-middle"</p>
+    <p>A split button is a button broken into two seperately actionable portions: a common action (a <a href="#button">button</a>) at the start, and supplemental actions (a <a href="#menu-button">menu button</a>) at the end.</p>
+    <p>Split buttons are for actions only, and should not be used for site navigation.<p>
 
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--primary btn--split-start" aria-haspopup="true" type="button">
-                <span class="btn__cell">
-                    <span class="btn__text">Button</span>
-                </span>
-            </button>
-            <span class="menu-button">
-                <button class="btn btn--primary btn--split-end " aria-haspopup="true" type="button">
-                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                        {% include symbol.html name="dropdown" %}
-                    </svg>
+            <span class="split-button">
+                <button class="btn btn--primary btn--split-start" type="button">
+                    <span class="btn__cell">
+                        <span class="btn__text">Button</span>
+                    </span>
                 </button>
-                <div class="menu-button__menu">
-                    <div class="menu-button__items" role="menu">
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 10000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 20000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 30000</span>
+                <span class="menu-button">
+                    <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+                        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                            {% include symbol.html name="dropdown" %}
+                        </svg>
+                    </button>
+                    <div class="menu-button__menu">
+                        <div class="menu-button__items" role="menu">
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 10000</span>
+                            </div>
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 20000</span>
+                            </div>
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 30000</span>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </span>
             </span>
         </div>
     </div>
     {% highlight html %}
-<button class="btn btn--primary btn--split-start" aria-haspopup="true" type="button">
-    <span class="btn__cell">
-        <span class="btn__text">Button</span>
-    </span>
-</button>
-<span class="menu-button">
-    <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
-        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-            <use xlink:href="#icon-dropdown"></use>
-        </svg>
+<span class="split-button">
+    <button class="btn btn--primary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
     </button>
-    <div class="menu-button__menu">
-        <div class="menu-button__items" role="menu">
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 10000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 20000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 30000</span>
+    <span class="menu-button">
+        <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
             </div>
         </div>
-    </div>
+    </span>
 </span>
     {% endhighlight %}
+        <p>Note the usage of <span class="highlight">btn--split-start</span> to denote the start of a split button sequence, and <span class="highlight">btn--split-end</span> to denote its end.</p>
 
-    <p>Secondary Variant<p>
-
+    <h3 id="split-button-secondary">Secondary Split Button</h3>
+    <p>Use the secondary modifiers to create a secondary split button style.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--secondary btn--split-start" aria-haspopup="true" type="button">
-                <span class="btn__cell">
-                    <span class="btn__text">Button</span>
-                </span>
-            </button>
-            <span class="menu-button">
-                <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
-                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                        {% include symbol.html name="dropdown" %}
-                    </svg>
+            <span class="split-button">
+                <button class="btn btn--secondary btn--split-start" type="button">
+                    <span class="btn__cell">
+                        <span class="btn__text">Button</span>
+                    </span>
                 </button>
-                <div class="menu-button__menu">
-                    <div class="menu-button__items" role="menu">
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 10000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 20000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 30000</span>
+                <span class="menu-button">
+                    <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
+                        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                            {% include symbol.html name="dropdown" %}
+                        </svg>
+                    </button>
+                    <div class="menu-button__menu">
+                        <div class="menu-button__items" role="menu">
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 10000</span>
+                            </div>
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 20000</span>
+                            </div>
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 30000</span>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </span>
             </span>
         </div>
     </div>
     {% highlight html %}
-<button class="btn btn--secondary btn--split-start" aria-haspopup="true" type="button">
-    <span class="btn__cell">
-        <span class="btn__text">Button</span>
-    </span>
-</button>
-<span class="menu-button">
-    <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
-        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-            <use xlink:href="#icon-dropdown"></use>
-        </svg>
+<span class="split-button">
+    <button class="btn btn--secondary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
     </button>
-    <div class="menu-button__menu">
-        <div class="menu-button__items" role="menu">
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 10000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 20000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 30000</span>
+    <span class="menu-button">
+        <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
             </div>
         </div>
-    </div>
+    </span>
 </span>
     {% endhighlight %}
 
-    <p>Tertiary Variant<p>
+    <h3 id="split-button-tertirary">Tertiary Split Button</h3>
+    <p>Use the tertiary modifiers to create a tertiary split button style.</p>
 
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--tertiary btn--split-start" aria-haspopup="true" type="button">
-                <span class="btn__cell">
-                    <span class="btn__text">Button</span>
-                </span>
-            </button>
-            <span class="menu-button">
-                <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
-                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                        {% include symbol.html name="dropdown" %}
-                    </svg>
+            <span class="split-button">
+                <button class="btn btn--tertiary btn--split-start" type="button">
+                    <span class="btn__cell">
+                        <span class="btn__text">Button</span>
+                    </span>
                 </button>
-                <div class="menu-button__menu">
-                    <div class="menu-button__items" role="menu">
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 10000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 20000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 30000</span>
+                <span class="menu-button">
+                    <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
+                        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                            {% include symbol.html name="dropdown" %}
+                        </svg>
+                    </button>
+                    <div class="menu-button__menu">
+                        <div class="menu-button__items" role="menu">
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 10000</span>
+                            </div>
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 20000</span>
+                            </div>
+                            <div class="menu-button__item" role="menuitem">
+                                <span>Item 30000</span>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </span>
             </span>
         </div>
     </div>
     {% highlight html %}
-<button class="btn btn--tertiary btn--split-start" aria-haspopup="true" type="button">
-    <span class="btn__cell">
-        <span class="btn__text">Button</span>
-    </span>
-</button>
-<span class="menu-button">
-    <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
-        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-            <use xlink:href="#icon-dropdown"></use>
-        </svg>
+<span class="split-button">
+    <button class="btn btn--tertiary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
     </button>
-    <div class="menu-button__menu">
-        <div class="menu-button__items" role="menu">
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 10000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 20000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 30000</span>
-            </div>
-        </div>
-    </div>
-</span>
-    {% endhighlight %}
-
-    <p>Lots of Text</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <button class="btn btn--primary btn--split-start btn--truncated" aria-haspopup="true" type="button">
-                <span class="btn__cell">
-                    <span class="btn__text">Longest Button Text Example Lorem Ipsum Dolor</span>
-                </span>
-            </button>
-            <span class="menu-button">
-                <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
-                    <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                        {% include symbol.html name="dropdown" %}
-                    </svg>
-                </button>
-                <div class="menu-button__menu">
-                    <div class="menu-button__items" role="menu">
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 10000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 20000</span>
-                        </div>
-                        <div class="menu-button__item" role="menuitem">
-                            <span>Item 30000</span>
-                        </div>
-                    </div>
+    <span class="menu-button">
+        <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
                 </div>
-            </span>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
         </div>
-    </div>
-    {% highlight html %}
-<button class="btn btn--primary btn--split-start" aria-haspopup="true" type="button">
-    <span class="btn__cell">
-        <span class="btn__text">Button</span>
     </span>
-</button>
-<span class="menu-button">
-    <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
-        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-            <use xlink:href="#icon-dropdown"></use>
-        </svg>
-    </button>
-    <div class="menu-button__menu">
-        <div class="menu-button__items" role="menu">
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 10000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 20000</span>
-            </div>
-            <div class="menu-button__item" role="menuitem">
-                <span>Item 30000</span>
-            </div>
-        </div>
-    </div>
 </span>
     {% endhighlight %}
+
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@ versions:
     select: 1.2.0
     signal: 1.0.0
     snackbar-dialog: 1.0.0
+    split-button: 1.6.0
     star-rating: 1.0.0
     switch: 1.2.0
     tabs: 2.1.0

--- a/scripts/generate-imports/config.json
+++ b/scripts/generate-imports/config.json
@@ -2,7 +2,8 @@
     "modules": {
         "core": ["global", "utility"],
         "combo": ["core", "lightbox-dialog", "form", "progress-spinner"],
-        "form": ["button", "checkbox", "field", "radio", "select", "switch", "textbox"]
+        "form": ["button", "checkbox", "field", "radio", "select", "switch", "textbox"],
+        "split-button": ["button", "menu-button"]
     },
     "skip": ["mixins", "primitives", "tokens", "svg"],
     "skipIndex": [

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -392,6 +392,23 @@ a.fake-btn--large-truncated {
     padding: @padding-vertical-button-large @padding-horizontal-button;
 }
 
+button.btn--split-start {
+    border-radius: 24px 0 0 24px;
+}
+
+button.btn--split-end {
+    border-left-color: currentColor;
+    border-radius: 0 24px 24px 0;
+    margin-left: -5px;
+    min-width: 40px;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+button.btn--tertiary.btn--split-end {
+    .border-left-color-token(tertiary-border-left-color, color-separator);
+}
+
 [dir="rtl"] button.btn svg.icon--dropdown,
 [dir="rtl"] a.fake-btn svg.icon--dropdown {
     &:first-child {

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -118,6 +118,10 @@
     .customPropertyToken(border-color, @component-token, @product-token);
 }
 
+.border-left-color-token(@component-token, @product-token) {
+    .customPropertyToken(border-left-color, @component-token, @product-token);
+}
+
 .box-shadow-token(@token) {
     .customPropertyToken(box-shadow, @token);
 }


### PR DESCRIPTION
## Description
Adds the split button module to skin - it is a squashed together button with a menu button. 

## Context
Followed design spec as closely as possible

## References
closes #1567 

## Screenshots
<img width="188" alt="Screen Shot 2022-02-12 at 2 25 22 PM" src="https://user-images.githubusercontent.com/25092249/153730715-6650c7d8-9b21-49ac-8701-785ac5ce5bc5.png">
<img width="190" alt="Screen Shot 2022-02-12 at 2 25 26 PM" src="https://user-images.githubusercontent.com/25092249/153730717-40b579d9-4251-4fc6-9a2c-1ac8f1e0c26e.png">
<img width="197" alt="Screen Shot 2022-02-12 at 2 25 31 PM" src="https://user-images.githubusercontent.com/25092249/153730718-f17fb881-e10a-48f8-b097-2b979a4c6d82.png">
<img width="426" alt="Screen Shot 2022-02-12 at 2 25 36 PM" src="https://user-images.githubusercontent.com/25092249/153730719-bba331cd-fe3f-42ac-bcf9-ae1abd2e6c6b.png">
<img width="195" alt="Screen Shot 2022-02-12 at 2 25 53 PM" src="https://user-images.githubusercontent.com/25092249/153730720-c4471f86-d255-44f3-a0c7-76e0bc2b200d.png">
<img width="201" alt="Screen Shot 2022-02-12 at 2 25 59 PM" src="https://user-images.githubusercontent.com/25092249/153730721-1266a48c-9bdd-449e-b53d-c45890acdcc1.png">
<img width="195" alt="Screen Shot 2022-02-12 at 2 26 07 PM" src="https://user-images.githubusercontent.com/25092249/153730722-eb91b90f-3465-4f19-a635-bfbc9ce4f112.png">
<img width="432" alt="Screen Shot 2022-02-12 at 2 26 24 PM" src="https://user-images.githubusercontent.com/25092249/153730723-f1f4b451-c9ae-4a37-9dda-09fb49f4ff9e.png">

![split-button-actions](https://user-images.githubusercontent.com/25092249/153730727-8115204c-b40c-4315-8e79-f91afbb011de.gif)

