### PR TITLE
fix(textbox): changed border-color to be black on all inputs

### DIFF
--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -175,7 +175,7 @@ span.combobox {
 }
 .combobox__control > input:focus {
   background-color: var(--combobox-textbox-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--combobox-textbox-focus-border-color, var(--color-black, #000));
+  border-color: var(--combobox-focus-border-color, var(--color-form-control-focus-border, #000));
   outline: 0;
 }
 .combobox__control--borderless > input:focus {

--- a/dist/combobox/ds4/combobox.css
+++ b/dist/combobox/ds4/combobox.css
@@ -175,7 +175,7 @@ span.combobox {
 }
 .combobox__control > input:focus {
   background-color: var(--combobox-textbox-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--combobox-textbox-focus-border-color, var(--color-action-primary, #0654ba));
+  border-color: var(--combobox-textbox-focus-border-color, var(--color-black, #000));
   outline: 0;
 }
 .combobox__control--borderless > input:focus {

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -175,7 +175,7 @@ span.combobox {
 }
 .combobox__control > input:focus {
   background-color: var(--combobox-textbox-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--combobox-textbox-focus-border-color, var(--color-black, #000));
+  border-color: var(--combobox-focus-border-color, var(--color-form-control-focus-border, #000));
   outline: 0;
 }
 .combobox__control--borderless > input:focus {

--- a/dist/combobox/ds6/combobox.css
+++ b/dist/combobox/ds6/combobox.css
@@ -175,7 +175,7 @@ span.combobox {
 }
 .combobox__control > input:focus {
   background-color: var(--combobox-textbox-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--combobox-textbox-focus-border-color, var(--color-action-primary, #3665f3));
+  border-color: var(--combobox-textbox-focus-border-color, var(--color-black, #000));
   outline: 0;
 }
 .combobox__control--borderless > input:focus {

--- a/dist/select/ds4/select.css
+++ b/dist/select/ds4/select.css
@@ -50,7 +50,7 @@ span.select {
 }
 .select select:focus {
   background-color: var(--select-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--select-focus-border-color, var(--color-action-primary, #0654ba));
+  border-color: var(--select-focus-border-color, var(--color-black, #000));
   outline: 0;
   text-decoration: underline;
 }

--- a/dist/select/ds4/select.css
+++ b/dist/select/ds4/select.css
@@ -50,7 +50,7 @@ span.select {
 }
 .select select:focus {
   background-color: var(--select-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--select-focus-border-color, var(--color-black, #000));
+  border-color: var(--select-focus-border-color, var(--color-form-control-focus-border, #000));
   outline: 0;
   text-decoration: underline;
 }

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -50,7 +50,7 @@ span.select {
 }
 .select select:focus {
   background-color: var(--select-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--select-focus-border-color, var(--color-action-primary, #3665f3));
+  border-color: var(--select-focus-border-color, var(--color-black, #000));
   outline: 0;
   text-decoration: underline;
 }

--- a/dist/select/ds6/select.css
+++ b/dist/select/ds6/select.css
@@ -50,7 +50,7 @@ span.select {
 }
 .select select:focus {
   background-color: var(--select-focus-background-color, var(--color-background-default, #fff));
-  border-color: var(--select-focus-border-color, var(--color-black, #000));
+  border-color: var(--select-focus-border-color, var(--color-form-control-focus-border, #000));
   outline: 0;
   text-decoration: underline;
 }

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -74,7 +74,7 @@ textarea.textbox__control[aria-invalid="true"] {
 }
 input.textbox__control:focus,
 textarea.textbox__control:focus {
-  border-color: var(--textbox-focus-border-color, var(--color-black, #000));
+  border-color: var(--textbox-focus-border-color, var(--color-form-control-focus-border, #000));
   background-color: var(--textbox-focus-background-color, var(--color-background-default, #fff));
   outline: 0;
 }

--- a/dist/textbox/ds4/textbox.css
+++ b/dist/textbox/ds4/textbox.css
@@ -74,7 +74,7 @@ textarea.textbox__control[aria-invalid="true"] {
 }
 input.textbox__control:focus,
 textarea.textbox__control:focus {
-  border-color: var(--textbox-focus-border-color, var(--color-action-primary, #0654ba));
+  border-color: var(--textbox-focus-border-color, var(--color-black, #000));
   background-color: var(--textbox-focus-background-color, var(--color-background-default, #fff));
   outline: 0;
 }

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -74,7 +74,7 @@ textarea.textbox__control[aria-invalid="true"] {
 }
 input.textbox__control:focus,
 textarea.textbox__control:focus {
-  border-color: var(--textbox-focus-border-color, var(--color-action-primary, #3665f3));
+  border-color: var(--textbox-focus-border-color, var(--color-black, #000));
   background-color: var(--textbox-focus-background-color, var(--color-background-default, #fff));
   outline: 0;
 }

--- a/dist/textbox/ds6/textbox.css
+++ b/dist/textbox/ds6/textbox.css
@@ -74,7 +74,7 @@ textarea.textbox__control[aria-invalid="true"] {
 }
 input.textbox__control:focus,
 textarea.textbox__control:focus {
-  border-color: var(--textbox-focus-border-color, var(--color-black, #000));
+  border-color: var(--textbox-focus-border-color, var(--color-form-control-focus-border, #000));
   background-color: var(--textbox-focus-background-color, var(--color-background-default, #fff));
   outline: 0;
 }

--- a/dist/tokens/base/tokens.less
+++ b/dist/tokens/base/tokens.less
@@ -59,6 +59,7 @@
 // form controls
 @color-form-control-background: @color-grey1;
 @color-form-control-border: #949494; // non-palette colour
+@color-form-control-focus-border: @color-black; // non-palette colour
 @color-form-control-underline: @color-grey5;
 @color-form-control-foreground: @color-text-default;
 @color-form-control-disabled-placeholder: @color-grey4;

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -149,7 +149,7 @@ span.combobox {
 
 .combobox__control > input:focus {
     .background-color-token(combobox-textbox-focus-background-color, color-background-default);
-    .border-color-token(combobox-textbox-focus-border-color, color-black);
+    .border-color-token(combobox-focus-border-color, color-form-control-focus-border);
     outline: 0;
 }
 

--- a/src/less/combobox/base/combobox.less
+++ b/src/less/combobox/base/combobox.less
@@ -149,7 +149,7 @@ span.combobox {
 
 .combobox__control > input:focus {
     .background-color-token(combobox-textbox-focus-background-color, color-background-default);
-    .border-color-token(combobox-textbox-focus-border-color, color-action-primary);
+    .border-color-token(combobox-textbox-focus-border-color, color-black);
     outline: 0;
 }
 

--- a/src/less/select/base/select.less
+++ b/src/less/select/base/select.less
@@ -59,7 +59,7 @@ span.select {
 
 .select select:focus {
     .background-color-token(select-focus-background-color, color-background-default);
-    .border-color-token(select-focus-border-color, color-black);
+    .border-color-token(select-focus-border-color, color-form-control-focus-border);
     outline: 0;
     text-decoration: underline;
 }

--- a/src/less/select/base/select.less
+++ b/src/less/select/base/select.less
@@ -59,7 +59,7 @@ span.select {
 
 .select select:focus {
     .background-color-token(select-focus-background-color, color-background-default);
-    .border-color-token(select-focus-border-color, color-action-primary);
+    .border-color-token(select-focus-border-color, color-black);
     outline: 0;
     text-decoration: underline;
 }

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -79,7 +79,7 @@ textarea.textbox__control {
     }
 
     &:focus {
-        .border-color-token(textbox-focus-border-color, color-black);
+        .border-color-token(textbox-focus-border-color, color-form-control-focus-border);
         .background-color-token(textbox-focus-background-color, color-background-default);
         outline: 0;
     }

--- a/src/less/textbox/base/textbox.less
+++ b/src/less/textbox/base/textbox.less
@@ -79,7 +79,7 @@ textarea.textbox__control {
     }
 
     &:focus {
-        .border-color-token(textbox-focus-border-color, color-action-primary);
+        .border-color-token(textbox-focus-border-color, color-black);
         .background-color-token(textbox-focus-background-color, color-background-default);
         outline: 0;
     }

--- a/src/less/tokens/base/tokens.less
+++ b/src/less/tokens/base/tokens.less
@@ -59,6 +59,7 @@
 // form controls
 @color-form-control-background: @color-grey1;
 @color-form-control-border: #949494; // non-palette colour
+@color-form-control-focus-border: @color-black; // non-palette colour
 @color-form-control-underline: @color-grey5;
 @color-form-control-foreground: @color-text-default;
 @color-form-control-disabled-placeholder: @color-grey4;


### PR DESCRIPTION
## Description
* Fixed textbox, select, and combobox to all have black focus borders

## References
https://github.com/eBay/skin/issues/1655

## Screenshots
<img width="311" alt="Screen Shot 2022-02-16 at 10 56 53 AM" src="https://user-images.githubusercontent.com/1755269/154336644-93d3b63e-e340-4fa8-837f-34c937c3d3e5.png">
<img width="264" alt="Screen Shot 2022-02-16 at 10 57 02 AM" src="https://user-images.githubusercontent.com/1755269/154336650-4d3944a8-4a7b-418f-b6f6-97e19d68c2a9.png">
<img width="177" alt="Screen Shot 2022-02-16 at 10 56 46 AM" src="https://user-images.githubusercontent.com/1755269/154336678-ea21786b-3f14-4178-bd24-c8d20007dc92.png">

