### PR TITLE
fix(icon-button): added min-width so it does not shrink

### DIFF
--- a/dist/icon-button/ds4/icon-button.css
+++ b/dist/icon-button/ds4/icon-button.css
@@ -14,6 +14,7 @@ a.icon-link {
   font-family: inherit;
   height: 40px;
   margin: 0;
+  min-width: 40px;
   padding: 0;
   vertical-align: text-bottom;
   width: 40px;

--- a/dist/icon-button/ds6/icon-button.css
+++ b/dist/icon-button/ds6/icon-button.css
@@ -14,6 +14,7 @@ a.icon-link {
   font-family: inherit;
   height: 40px;
   margin: 0;
+  min-width: 40px;
   padding: 0;
   vertical-align: text-bottom;
   width: 40px;

--- a/src/less/icon-button/base/icon-button.less
+++ b/src/less/icon-button/base/icon-button.less
@@ -18,6 +18,7 @@ a.icon-link {
     font-family: inherit;
     height: 40px;
     margin: 0;
+    min-width: 40px;
     padding: 0;
     vertical-align: text-bottom;
     width: 40px;


### PR DESCRIPTION
## Description
* Added `min-width` to icon-button

## References
https://github.com/eBay/skin/issues/1632

## Screenshots
<img width="762" alt="Screen Shot 2022-02-18 at 10 52 09 AM" src="https://user-images.githubusercontent.com/1755269/154745150-25e0f48e-a19d-4013-b64f-a7e188e5067c.png">
<img width="634" alt="Screen Shot 2022-02-18 at 10 52 20 AM" src="https://user-images.githubusercontent.com/1755269/154745155-34279e2d-ed7a-4c47-87af-30477b375e1c.png">


