### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,28 @@
 <!-- Insert GitHub issue number below -->
 Fixes #
 
+<!-- Select which type of PR this is -->
+- [ ] This PR contains CSS changes
+- [ ] This PR does not contain CSS changes
+
 ## Description
 <!-- Briefly describe the proposed changes -->
 
 ## Notes
 <!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
 
-## Checklist
-<!-- Acknowledge the general checklist below -->
-- [ ] I verify the build is in a non-broken state
-- [ ] I verify all changes are within scope of the linked issue
-
-<!-- Acknowledge which type of PR this is -->
-- [ ] This PR contains CSS changes
-- [ ] This PR does not contain CSS changes
-
-<!-- Acknowledge or delete all steps below based on type of PR -->
-- [ ] I re-generated all CSS files under dist folder
-- [ ] I tested the UI in all supported browsers
-- [ ] I tested the UI in dark mode and RTL mode
-- [ ] I added/updated/removed Storybook coverage as appropriate
-
 ## Screenshots
 <!-- Upload screenshots of UI before & after these changes -->
 
+## Checklist
+<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->
+
+<!-- For all PR types -->
+- [ ] I verify the build is in a non-broken state
+- [ ] I verify all changes are within scope of the linked issue
+
+<!-- For CSS changes -->
+- [ ] I tested the local build is working and all CSS files under dist folder were re-generated
+- [ ] I tested the UI in all supported browsers
+- [ ] I tested the UI in dark mode and RTL mode
+- [ ] I added/updated/removed Storybook coverage as appropriate

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,27 @@
-<!--  Delete any sections below that are not relevant to this PR -->
+<!-- Insert GitHub issue number below -->
+Fixes #
 
 ## Description
-<!--- What are the changes? -->
+<!-- Briefly describe the proposed changes -->
 
-## Context
-<!--- Why did you make these changes, and why in this particular way? -->
+## Notes
+<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
 
-## References
-<!-- Include links to JIRA, Github, etc. if appropriate -->
+## Checklist
+<!-- Acknowledge the general checklist below -->
+- [ ] I verify the build is in a non-broken state
+- [ ] I verify all changes are within scope of the linked issue
+
+<!-- Acknowledge which type of PR this is -->
+- [ ] This PR contains CSS changes
+- [ ] This PR does not contain CSS changes
+
+<!-- Acknowledge or delete all steps below based on type of PR -->
+- [ ] I re-generated all CSS files under dist folder
+- [ ] I tested the UI in all supported browsers
+- [ ] I tested the UI in dark mode and RTL mode
+- [ ] I added/updated/removed Storybook coverage as appropriate
 
 ## Screenshots
-<!-- Upload screenshots if appropriate-->
+<!-- Upload screenshots of UI before & after these changes -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Fixes #
 - [ ] I verify all changes are within scope of the linked issue
 
 <!-- For CSS changes -->
-- [ ] I tested the local build is working and all CSS files under dist folder were re-generated
+- [ ] I regenerated all CSS files under dist folder
 - [ ] I tested the UI in all supported browsers
 - [ ] I tested the UI in dark mode and RTL mode
 - [ ] I added/updated/removed Storybook coverage as appropriate


### PR DESCRIPTION
Fixes #1492

A new PR template based on a checklist approach.

We can use this as a starting point, but I'm open to exploring different ideas.

We can, if we like, use different templates based on PR type (i.e. documentation change only, new feature, bugfix, etc) but for now I'm seeing if a single global template could work.