### PR TITLE
chore: added stories for split button

### DIFF
--- a/dist/button/ds4/button.css
+++ b/dist/button/ds4/button.css
@@ -402,15 +402,17 @@ button.btn--split-start {
   border-radius: 24px 0 0 24px;
 }
 button.btn--split-end {
-  border-left-color: currentColor;
   border-radius: 0 24px 24px 0;
   margin-left: -5px;
   min-width: 40px;
   padding-left: 8px;
   padding-right: 8px;
 }
+button.btn--primary.btn--split-end {
+  border-left-color: var(--primary-border-split-color, var(--color-white, #fff));
+}
 button.btn--tertiary.btn--split-end {
-  border-left-color: var(--tertiary-border-left-color, var(--color-separator, #eee));
+  border-left-color: var(--tertiary-border-split-color, var(--color-separator, #eee));
 }
 [dir="rtl"] button.btn svg.icon--dropdown:first-child,
 [dir="rtl"] a.fake-btn svg.icon--dropdown:first-child {
@@ -421,4 +423,24 @@ button.btn--tertiary.btn--split-end {
 [dir="rtl"] a.fake-btn svg.icon--dropdown:last-child {
   margin-left: 0;
   margin-right: 8px;
+}
+[dir="rtl"] button.btn svg.icon--dropdown:only-child,
+[dir="rtl"] a.fake-btn svg.icon--dropdown:only-child {
+  margin-left: 0;
+  margin-right: 0;
+}
+[dir="rtl"] button.btn--split-start {
+  border-radius: 0 24px 24px 0;
+}
+[dir="rtl"] button.btn--split-end {
+  border-radius: 24px 0 0 24px;
+  margin-right: -5px;
+}
+[dir="rtl"] button.btn--primary.btn--split-end {
+  border-left-color: var(--btn-primary-border-color, var(--color-action-primary, #0654ba));
+  border-right-color: var(--primary-border-split-color, var(--color-separator, #eee));
+}
+[dir="rtl"] button.btn--tertiary.btn--split-end {
+  border-left-color: var(--btn-tertiary-border-color, var(--color-grey1, #eee));
+  border-right-color: var(--tertiary-border-split-color, var(--color-separator, #eee));
 }

--- a/dist/button/ds6/button.css
+++ b/dist/button/ds6/button.css
@@ -402,15 +402,17 @@ button.btn--split-start {
   border-radius: 24px 0 0 24px;
 }
 button.btn--split-end {
-  border-left-color: currentColor;
   border-radius: 0 24px 24px 0;
   margin-left: -5px;
   min-width: 40px;
   padding-left: 8px;
   padding-right: 8px;
 }
+button.btn--primary.btn--split-end {
+  border-left-color: var(--primary-border-split-color, var(--color-white, #fff));
+}
 button.btn--tertiary.btn--split-end {
-  border-left-color: var(--tertiary-border-left-color, var(--color-separator, #e5e5e5));
+  border-left-color: var(--tertiary-border-split-color, var(--color-separator, #e5e5e5));
 }
 [dir="rtl"] button.btn svg.icon--dropdown:first-child,
 [dir="rtl"] a.fake-btn svg.icon--dropdown:first-child {
@@ -421,4 +423,24 @@ button.btn--tertiary.btn--split-end {
 [dir="rtl"] a.fake-btn svg.icon--dropdown:last-child {
   margin-left: 0;
   margin-right: 8px;
+}
+[dir="rtl"] button.btn svg.icon--dropdown:only-child,
+[dir="rtl"] a.fake-btn svg.icon--dropdown:only-child {
+  margin-left: 0;
+  margin-right: 0;
+}
+[dir="rtl"] button.btn--split-start {
+  border-radius: 0 24px 24px 0;
+}
+[dir="rtl"] button.btn--split-end {
+  border-radius: 24px 0 0 24px;
+  margin-right: -5px;
+}
+[dir="rtl"] button.btn--primary.btn--split-end {
+  border-left-color: var(--btn-primary-border-color, var(--color-action-primary, #3665f3));
+  border-right-color: var(--primary-border-split-color, var(--color-separator, #e5e5e5));
+}
+[dir="rtl"] button.btn--tertiary.btn--split-end {
+  border-left-color: var(--btn-tertiary-border-color, var(--color-grey1, #f7f7f7));
+  border-right-color: var(--tertiary-border-split-color, var(--color-separator, #e5e5e5));
 }

--- a/dist/mixins/utility/utility-mixins.less
+++ b/dist/mixins/utility/utility-mixins.less
@@ -122,6 +122,10 @@
     .customPropertyToken(border-left-color, @component-token, @product-token);
 }
 
+.border-right-color-token(@component-token, @product-token) {
+    .customPropertyToken(border-right-color, @component-token, @product-token);
+}
+
 .box-shadow-token(@token) {
     .customPropertyToken(box-shadow, @token);
 }

--- a/src/less/button/base/button.less
+++ b/src/less/button/base/button.less
@@ -397,7 +397,6 @@ button.btn--split-start {
 }
 
 button.btn--split-end {
-    border-left-color: currentColor;
     border-radius: 0 24px 24px 0;
     margin-left: -5px;
     min-width: 40px;
@@ -405,8 +404,12 @@ button.btn--split-end {
     padding-right: 8px;
 }
 
+button.btn--primary.btn--split-end {
+    .border-left-color-token(primary-border-split-color, color-white);
+}
+
 button.btn--tertiary.btn--split-end {
-    .border-left-color-token(tertiary-border-left-color, color-separator);
+    .border-left-color-token(tertiary-border-split-color, color-separator);
 }
 
 [dir="rtl"] button.btn svg.icon--dropdown,
@@ -420,4 +423,28 @@ button.btn--tertiary.btn--split-end {
         margin-left: 0;
         margin-right: 8px;
     }
+
+    &:only-child {
+        margin-left: 0;
+        margin-right: 0;
+    }
+}
+
+[dir="rtl"] button.btn--split-start {
+    border-radius: 0 24px 24px 0;
+}
+
+[dir="rtl"] button.btn--split-end {
+    border-radius: 24px 0 0 24px;
+    margin-right: -5px;
+}
+
+[dir="rtl"] button.btn--primary.btn--split-end {
+    .border-left-color-token(btn-primary-border-color, color-action-primary);
+    .border-right-color-token(primary-border-split-color, color-separator);
+}
+
+[dir="rtl"] button.btn--tertiary.btn--split-end {
+    .border-left-color-token(btn-tertiary-border-color, color-grey1);
+    .border-right-color-token(tertiary-border-split-color, color-separator);
 }

--- a/src/less/mixins/utility/utility-mixins.less
+++ b/src/less/mixins/utility/utility-mixins.less
@@ -122,6 +122,10 @@
     .customPropertyToken(border-left-color, @component-token, @product-token);
 }
 
+.border-right-color-token(@component-token, @product-token) {
+    .customPropertyToken(border-right-color, @component-token, @product-token);
+}
+
 .box-shadow-token(@token) {
     .customPropertyToken(box-shadow, @token);
 }

--- a/src/less/split-button/stories/base.stories.js
+++ b/src/less/split-button/stories/base.stories.js
@@ -1,0 +1,180 @@
+export default { title: 'Split Button/Split Button/Base' };
+export const primaryCollapsed = () => `
+<span class="split-button">
+    <button class="btn btn--primary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;
+
+export const primaryExpanded = () => `
+<span class="split-button">
+    <button class="btn btn--primary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--primary btn--split-end" aria-haspopup="true" aria-expanded="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;
+
+export const secondaryCollapsed = () => `
+<span class="split-button">
+    <button class="btn btn--secondary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;
+
+export const secondaryExpanded = () => `
+<span class="split-button">
+    <button class="btn btn--secondary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--secondary btn--split-end" aria-expanded="true" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;
+
+export const tertiaryCollapsed = () => `
+<span class="split-button">
+    <button class="btn btn--tertiary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;
+
+export const tertiaryExpanded = () => `
+<span class="split-button">
+    <button class="btn btn--tertiary btn--split-start" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Button</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--tertiary btn--split-end" aria-expanded="true" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;

--- a/src/less/split-button/stories/rtl.stories.js
+++ b/src/less/split-button/stories/rtl.stories.js
@@ -1,0 +1,193 @@
+export default { title: 'Split Button/Split Button/RTL' };
+
+export const primaryCollapsed = () => `
+<div dir="rtl">
+    <span class="split-button">
+        <button class="btn btn--primary btn--split-start" type="button">
+            <span class="btn__cell">
+                <span class="btn__text">Button</span>
+            </span>
+        </button>
+        <span class="menu-button">
+            <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+                <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </button>
+            <div class="menu-button__menu">
+                <div class="menu-button__items" role="menu">
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 10000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 20000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 30000</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </span>
+</div>
+`;
+
+export const primaryExpanded = () => `
+<div dir="rtl">
+    <span class="split-button">
+        <button class="btn btn--primary btn--split-start" type="button">
+            <span class="btn__cell">
+                <span class="btn__text">Button</span>
+            </span>
+        </button>
+        <span class="menu-button">
+            <button class="btn btn--primary btn--split-end" aria-haspopup="true" aria-expanded="true" type="button">
+                <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </button>
+            <div class="menu-button__menu">
+                <div class="menu-button__items" role="menu">
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 10000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 20000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 30000</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </span>
+</div>
+`;
+
+export const secondaryCollapsed = () => `
+<div dir="rtl">
+    <span class="split-button">
+        <button class="btn btn--secondary btn--split-start" type="button">
+            <span class="btn__cell">
+                <span class="btn__text">Button</span>
+            </span>
+        </button>
+        <span class="menu-button">
+            <button class="btn btn--secondary btn--split-end" aria-haspopup="true" type="button">
+                <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </button>
+            <div class="menu-button__menu">
+                <div class="menu-button__items" role="menu">
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 10000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 20000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 30000</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </span>
+</div>
+`;
+
+export const secondaryExpanded = () => `
+<div dir="rtl">
+    <span class="split-button">
+        <button class="btn btn--secondary btn--split-start" type="button">
+            <span class="btn__cell">
+                <span class="btn__text">Button</span>
+            </span>
+        </button>
+        <span class="menu-button">
+            <button class="btn btn--secondary btn--split-end" aria-expanded="true" aria-haspopup="true" type="button">
+                <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </button>
+            <div class="menu-button__menu">
+                <div class="menu-button__items" role="menu">
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 10000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 20000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 30000</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </span>
+</div>
+`;
+
+export const tertiaryCollapsed = () => `
+<div dir="rtl">
+    <span class="split-button">
+        <button class="btn btn--tertiary btn--split-start" type="button">
+            <span class="btn__cell">
+                <span class="btn__text">Button</span>
+            </span>
+        </button>
+        <span class="menu-button">
+            <button class="btn btn--tertiary btn--split-end" aria-haspopup="true" type="button">
+                <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </button>
+            <div class="menu-button__menu">
+                <div class="menu-button__items" role="menu">
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 10000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 20000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 30000</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </span>
+</div>
+`;
+
+export const tertiaryExpanded = () => `
+<div dir="rtl">
+    <span class="split-button">
+        <button class="btn btn--tertiary btn--split-start" type="button">
+            <span class="btn__cell">
+                <span class="btn__text">Button</span>
+            </span>
+        </button>
+        <span class="menu-button">
+            <button class="btn btn--tertiary btn--split-end" aria-expanded="true" aria-haspopup="true" type="button">
+                <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                    <use xlink:href="#icon-dropdown"></use>
+                </svg>
+            </button>
+            <div class="menu-button__menu">
+                <div class="menu-button__items" role="menu">
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 10000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 20000</span>
+                    </div>
+                    <div class="menu-button__item" role="menuitem">
+                        <span>Item 30000</span>
+                    </div>
+                </div>
+            </div>
+        </span>
+    </span>
+</div>
+`;

--- a/src/less/split-button/stories/size.stories.js
+++ b/src/less/split-button/stories/size.stories.js
@@ -1,0 +1,60 @@
+export default { title: 'Split Button/Split Button/Size' };
+export const longTextCollapsed = () => `
+<span class="split-button">
+    <button class="btn btn--primary btn--split-start btn--truncated" aria-haspopup="true" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Longest Button Text Example Lorem Ipsum Dolor</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--primary btn--split-end" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;
+
+export const longTextExpanded = () => `
+<span class="split-button">
+    <button class="btn btn--primary btn--split-start btn--truncated" aria-haspopup="true" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Longest Button Text Example Lorem Ipsum Dolor</span>
+        </span>
+    </button>
+    <span class="menu-button">
+        <button class="btn btn--primary btn--split-end" aria-expanded="true" aria-haspopup="true" type="button">
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </button>
+        <div class="menu-button__menu">
+            <div class="menu-button__items" role="menu">
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 10000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 20000</span>
+                </div>
+                <div class="menu-button__item" role="menuitem">
+                    <span>Item 30000</span>
+                </div>
+            </div>
+        </div>
+    </span>
+</span>
+`;


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added stories for split button
* Had to rework some split button to get it to work for RTL

## Screenshots
<img width="658" alt="Screen Shot 2022-03-01 at 5 21 34 PM" src="https://user-images.githubusercontent.com/1755269/156276793-a5d65773-57f0-4b8e-a870-b510dfc167e9.png">
<img width="774" alt="Screen Shot 2022-03-01 at 5 21 38 PM" src="https://user-images.githubusercontent.com/1755269/156276795-11fe8b60-ee4f-4954-8d45-891227a71538.png">
<img width="483" alt="Screen Shot 2022-03-01 at 5 21 53 PM" src="https://user-images.githubusercontent.com/1755269/156276797-5b0994ac-1543-46e0-bb74-ea594ad4b759.png">


## Checklist

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
