### PR TITLE
fix(drawer-dialog): color contrast on handle

### DIFF
--- a/dist/drawer-dialog/ds4/drawer-dialog.css
+++ b/dist/drawer-dialog/ds4/drawer-dialog.css
@@ -49,7 +49,7 @@
   z-index: 2;
 }
 .drawer-dialog__handle::after {
-  background-color: var(--dialog-handle-color, var(--color-grey4, #999));
+  background-color: var(--dialog-handle-color, var(--color-grey4, #707070));
   border-radius: 5px;
   content: "";
   display: block;

--- a/dist/drawer-dialog/ds4/drawer-dialog.css
+++ b/dist/drawer-dialog/ds4/drawer-dialog.css
@@ -49,7 +49,7 @@
   z-index: 2;
 }
 .drawer-dialog__handle::after {
-  background-color: var(--dialog-handle-color, var(--color-grey4, #707070));
+  background-color: var(--dialog-handle-color, var(--color-grey5, #707070));
   border-radius: 5px;
   content: "";
   display: block;

--- a/dist/drawer-dialog/ds6/drawer-dialog.css
+++ b/dist/drawer-dialog/ds6/drawer-dialog.css
@@ -49,7 +49,7 @@
   z-index: 2;
 }
 .drawer-dialog__handle::after {
-  background-color: var(--dialog-handle-color, var(--color-grey4, #a2a2a2));
+  background-color: var(--dialog-handle-color, var(--color-grey4, #707070));
   border-radius: 5px;
   content: "";
   display: block;

--- a/dist/drawer-dialog/ds6/drawer-dialog.css
+++ b/dist/drawer-dialog/ds6/drawer-dialog.css
@@ -49,7 +49,7 @@
   z-index: 2;
 }
 .drawer-dialog__handle::after {
-  background-color: var(--dialog-handle-color, var(--color-grey4, #707070));
+  background-color: var(--dialog-handle-color, var(--color-grey5, #707070));
   border-radius: 5px;
   content: "";
   display: block;

--- a/src/less/drawer-dialog/base/drawer-dialog.less
+++ b/src/less/drawer-dialog/base/drawer-dialog.less
@@ -28,7 +28,7 @@
 
 // Added :after class in order to increase parent hit box
 .drawer-dialog__handle::after {
-    .background-color-token(dialog-handle-color, color-grey4); // todo: needs product token
+    .background-color-token(dialog-handle-color, color-grey5); // todo: needs product token
     border-radius: 5px;
     content: "";
     display: block;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes [url redacted]PIEACC-547

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes

## Description
Fixes the color contrast issue for PIEACC-547

## Screenshots
<img width="380" alt="After screenshot" src="https://user-images.githubusercontent.com/64549036/158256570-c14b1102-1f10-4d01-82f6-e77f19dd59cd.png">
<img width="397" alt="Before screenshot" src="https://user-images.githubusercontent.com/64549036/158256577-5187db37-8e2a-4058-9335-afd1c76c0630.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [* ] I verify the build is in a non-broken state
- [ *] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [* ] I tested the UI in all supported browsers
- [ *] I tested the UI in dark mode and RTL mode
- [ *] I added/updated/removed Storybook coverage as appropriate
