### PR TITLE
fix(infotip): added min-width of 20px to button

### DIFF
--- a/dist/infotip/ds4/infotip.css
+++ b/dist/infotip/ds4/infotip.css
@@ -137,6 +137,7 @@ span.infotip__heading {
 .infotip .icon-btn {
   flex-shrink: 0;
   height: 20px;
+  min-width: 20px;
   outline-offset: 2px;
   overflow: visible;
   width: 20px;

--- a/dist/infotip/ds6/infotip.css
+++ b/dist/infotip/ds6/infotip.css
@@ -137,6 +137,7 @@ span.infotip__heading {
 .infotip .icon-btn {
   flex-shrink: 0;
   height: 20px;
+  min-width: 20px;
   outline-offset: 2px;
   overflow: visible;
   width: 20px;

--- a/src/less/infotip/base/infotip.less
+++ b/src/less/infotip/base/infotip.less
@@ -110,6 +110,7 @@ span.infotip__heading {
 .infotip .icon-btn {
     flex-shrink: 0; // todo: Should move to icon-btn in next major
     height: 20px;
+    min-width: 20px;
     outline-offset: 2px;
     overflow: visible;
     width: 20px;


### PR DESCRIPTION
Fixes #1693

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed infotip min-width to be 20px

## Screenshots
<img width="464" alt="Screen Shot 2022-03-14 at 2 51 19 PM" src="https://user-images.githubusercontent.com/1755269/158267579-6a195d20-e002-4442-ac63-a2df0034fc83.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
