### PR TITLE
fix(snackbar): changed mobile border radius to 0

### DIFF
--- a/dist/snackbar-dialog/ds4/snackbar-dialog.css
+++ b/dist/snackbar-dialog/ds4/snackbar-dialog.css
@@ -1,7 +1,7 @@
 /* large screens */
 .snackbar-dialog {
   background-color: var(--snackbar-dialog-background-color, var(--color-action-tertiary, #eee));
-  border-radius: var(--snackbar-dialog-border-radius, var(--border-radius-dialog, 0));
+  border-radius: var(--snackbar-dialog-border-radius, var(--border-radius-none, 0));
   bottom: 0;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
   color: var(--snackbar-dialog-foreground-color, var(--color-text-default, #333));

--- a/dist/snackbar-dialog/ds6/snackbar-dialog.css
+++ b/dist/snackbar-dialog/ds6/snackbar-dialog.css
@@ -1,7 +1,7 @@
 /* large screens */
 .snackbar-dialog {
   background-color: var(--snackbar-dialog-background-color, var(--color-action-tertiary, #f7f7f7));
-  border-radius: var(--snackbar-dialog-border-radius, var(--border-radius-dialog, 16px));
+  border-radius: var(--snackbar-dialog-border-radius, var(--border-radius-none, 0));
   bottom: 0;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
   color: var(--snackbar-dialog-foreground-color, var(--color-text-default, #111820));

--- a/src/less/snackbar-dialog/base/snackbar-dialog.less
+++ b/src/less/snackbar-dialog/base/snackbar-dialog.less
@@ -2,7 +2,7 @@
 
 .snackbar-dialog {
     .background-color-token(snackbar-dialog-background-color, color-action-tertiary);
-    .border-radius-token(snackbar-dialog-border-radius, border-radius-dialog);
+    .border-radius-token(snackbar-dialog-border-radius, border-radius-none);
     bottom: 0;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.28);
     .color-token(snackbar-dialog-foreground-color, color-text-default);


### PR DESCRIPTION
Fixes #1710 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
According to figma the border radius for snackbar on mobile should be none. Changed it to be 0 for mobile (but kept it as curved for desktop)

## Screenshots
_FYI_ The dot on the bottom left is due to the screenshot on mac. You can see it's also present on the desktop one too. 
<img width="400" alt="Screen Shot 2022-04-05 at 8 45 18 AM" src="https://user-images.githubusercontent.com/1755269/161794160-1ed7af65-87da-4851-9394-5ca31df0ea95.png">
<img width="1211" alt="Screen Shot 2022-04-05 at 8 45 35 AM" src="https://user-images.githubusercontent.com/1755269/161794163-f9c509b6-b48f-4398-9984-694bb88932d4.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
