### PR TITLE
fix: made menu button status to only target tick-small

### DIFF
--- a/dist/menu-button/ds4/menu-button.css
+++ b/dist/menu-button/ds4/menu-button.css
@@ -72,8 +72,8 @@ div.menu-button__item[role^="menuitem"]:last-child {
   border-bottom-left-radius: var(--border-radius-dropdown, 0);
   border-bottom-right-radius: var(--border-radius-dropdown, 0);
 }
-.menu-button__item svg.icon,
-.fake-menu-button__item svg.icon {
+.menu-button__item svg.icon--tick-small,
+.fake-menu-button__item svg.icon--tick-small {
   align-self: center;
   fill: currentColor;
   height: 10px;
@@ -83,8 +83,8 @@ div.menu-button__item[role^="menuitem"]:last-child {
   stroke-width: 0;
   width: 14px;
 }
-.menu-button__item svg.icon:last-child,
-.fake-menu-button__item svg.icon:last-child {
+.menu-button__item svg.icon--tick-small:last-child,
+.fake-menu-button__item svg.icon--tick-small:last-child {
   margin-left: 8px;
 }
 a.fake-menu-button__item {
@@ -105,8 +105,8 @@ button.fake-menu-button__item {
   font-size: 1em;
   text-align: left;
 }
-button.fake-menu-button__item:active svg.icon,
-a.fake-menu-button__item:active svg.icon {
+button.fake-menu-button__item:active svg.icon--tick-small,
+a.fake-menu-button__item:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #ccc));
 }
 a.fake-menu-button__item:not([href]),
@@ -114,14 +114,14 @@ button.fake-menu-button__item[disabled],
 div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
   color: var(--menu-button-menuitem-disabled-foreground-color, var(--color-text-disabled, #999));
 }
-a.fake-menu-button__item[aria-current="page"] svg.icon,
-button.fake-menu-button__item[aria-current="page"] svg.icon {
+a.fake-menu-button__item[aria-current="page"] svg.icon--tick-small,
+button.fake-menu-button__item[aria-current="page"] svg.icon--tick-small {
   opacity: 1;
 }
-div.menu-button__item[role^="menuitem"]:active svg.icon {
+div.menu-button__item[role^="menuitem"]:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #ccc));
 }
-div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
+div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-small {
   opacity: 1;
 }
 .fake-menu-button__menu a.fake-menu-button__item,

--- a/dist/menu-button/ds6/menu-button.css
+++ b/dist/menu-button/ds6/menu-button.css
@@ -72,8 +72,8 @@ div.menu-button__item[role^="menuitem"]:last-child {
   border-bottom-left-radius: var(--border-radius-dropdown, 8px);
   border-bottom-right-radius: var(--border-radius-dropdown, 8px);
 }
-.menu-button__item svg.icon,
-.fake-menu-button__item svg.icon {
+.menu-button__item svg.icon--tick-small,
+.fake-menu-button__item svg.icon--tick-small {
   align-self: center;
   fill: currentColor;
   height: 10px;
@@ -83,8 +83,8 @@ div.menu-button__item[role^="menuitem"]:last-child {
   stroke-width: 0;
   width: 14px;
 }
-.menu-button__item svg.icon:last-child,
-.fake-menu-button__item svg.icon:last-child {
+.menu-button__item svg.icon--tick-small:last-child,
+.fake-menu-button__item svg.icon--tick-small:last-child {
   margin-left: 8px;
 }
 a.fake-menu-button__item {
@@ -105,8 +105,8 @@ button.fake-menu-button__item {
   font-size: 1em;
   text-align: left;
 }
-button.fake-menu-button__item:active svg.icon,
-a.fake-menu-button__item:active svg.icon {
+button.fake-menu-button__item:active svg.icon--tick-small,
+a.fake-menu-button__item:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #fff));
 }
 a.fake-menu-button__item:not([href]),
@@ -114,14 +114,14 @@ button.fake-menu-button__item[disabled],
 div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
   color: var(--menu-button-menuitem-disabled-foreground-color, var(--color-text-disabled, #c7c7c7));
 }
-a.fake-menu-button__item[aria-current="page"] svg.icon,
-button.fake-menu-button__item[aria-current="page"] svg.icon {
+a.fake-menu-button__item[aria-current="page"] svg.icon--tick-small,
+button.fake-menu-button__item[aria-current="page"] svg.icon--tick-small {
   opacity: 1;
 }
-div.menu-button__item[role^="menuitem"]:active svg.icon {
+div.menu-button__item[role^="menuitem"]:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #fff));
 }
-div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
+div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-small {
   opacity: 1;
 }
 .fake-menu-button__menu a.fake-menu-button__item,

--- a/dist/menu/ds4/menu.css
+++ b/dist/menu/ds4/menu.css
@@ -17,8 +17,8 @@ span.fake-menu__items {
   margin: 0;
   padding: 0;
 }
-.menu__item > svg.icon,
-.fake-menu__item > svg.icon {
+.menu__item > svg.icon--tick-small,
+.fake-menu__item > svg.icon--tick-small {
   align-self: center;
   fill: currentColor;
   height: 10px;
@@ -28,8 +28,8 @@ span.fake-menu__items {
   stroke-width: 0;
   width: 14px;
 }
-.menu__item > svg.icon:last-child,
-.fake-menu__item > svg.icon:last-child,
+.menu__item > svg.icon--tick-small:last-child,
+.fake-menu__item > svg.icon--tick-small:last-child,
 .menu__item .badge {
   margin-left: 8px;
   margin-right: 8px;
@@ -80,12 +80,12 @@ div.menu__item[role^="menuitem"]:active {
 a.fake-menu__item:focus {
   text-decoration: underline;
 }
-button.fake-menu__item:active svg.icon,
-a.fake-menu__item:active svg.icon {
+button.fake-menu__item:active svg.icon--tick-small,
+a.fake-menu__item:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #ccc));
 }
-a.fake-menu__item[aria-current="page"] svg.icon,
-button.fake-menu__item[aria-current="page"] svg.icon {
+a.fake-menu__item[aria-current="page"] svg.icon--tick-small,
+button.fake-menu__item[aria-current="page"] svg.icon--tick-small {
   opacity: 1;
 }
 a.fake-menu__item:not([href]),
@@ -93,10 +93,10 @@ button.fake-menu__item[disabled],
 div.menu__item[role^="menuitem"][aria-disabled="true"] {
   color: var(--menu-menuitem-disabled-foreground-color, var(--color-text-disabled, #999));
 }
-div.menu__item[role^="menuitem"]:active svg.icon {
+div.menu__item[role^="menuitem"]:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #ccc));
 }
-div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
+div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-small {
   opacity: 1;
 }
 a.fake-menu__item > span,

--- a/dist/menu/ds6/menu.css
+++ b/dist/menu/ds6/menu.css
@@ -17,8 +17,8 @@ span.fake-menu__items {
   margin: 0;
   padding: 0;
 }
-.menu__item > svg.icon,
-.fake-menu__item > svg.icon {
+.menu__item > svg.icon--tick-small,
+.fake-menu__item > svg.icon--tick-small {
   align-self: center;
   fill: currentColor;
   height: 10px;
@@ -28,8 +28,8 @@ span.fake-menu__items {
   stroke-width: 0;
   width: 14px;
 }
-.menu__item > svg.icon:last-child,
-.fake-menu__item > svg.icon:last-child,
+.menu__item > svg.icon--tick-small:last-child,
+.fake-menu__item > svg.icon--tick-small:last-child,
 .menu__item .badge {
   margin-left: 8px;
   margin-right: 8px;
@@ -80,12 +80,12 @@ div.menu__item[role^="menuitem"]:active {
 a.fake-menu__item:focus {
   text-decoration: underline;
 }
-button.fake-menu__item:active svg.icon,
-a.fake-menu__item:active svg.icon {
+button.fake-menu__item:active svg.icon--tick-small,
+a.fake-menu__item:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #fff));
 }
-a.fake-menu__item[aria-current="page"] svg.icon,
-button.fake-menu__item[aria-current="page"] svg.icon {
+a.fake-menu__item[aria-current="page"] svg.icon--tick-small,
+button.fake-menu__item[aria-current="page"] svg.icon--tick-small {
   opacity: 1;
 }
 a.fake-menu__item:not([href]),
@@ -93,10 +93,10 @@ button.fake-menu__item[disabled],
 div.menu__item[role^="menuitem"][aria-disabled="true"] {
   color: var(--menu-menuitem-disabled-foreground-color, var(--color-text-disabled, #c7c7c7));
 }
-div.menu__item[role^="menuitem"]:active svg.icon {
+div.menu__item[role^="menuitem"]:active svg.icon--tick-small {
   color: var(--menu-menuitem-active-status-color, var(--color-selection-list-item-active-status, #fff));
 }
-div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
+div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-small {
   opacity: 1;
 }
 a.fake-menu__item > span,

--- a/src/less/menu-button/base/menu-button.less
+++ b/src/less/menu-button/base/menu-button.less
@@ -38,13 +38,13 @@ div.menu-button__item[role^="menuitem"] {
     cursor: default; // needed to override text cursor
 }
 
-.menu-button__item svg.icon,
-.fake-menu-button__item svg.icon {
+.menu-button__item svg.icon--tick-small,
+.fake-menu-button__item svg.icon--tick-small {
     .menu-menuitem-status();
 }
 
-.menu-button__item svg.icon:last-child,
-.fake-menu-button__item svg.icon:last-child {
+.menu-button__item svg.icon--tick-small:last-child,
+.fake-menu-button__item svg.icon--tick-small:last-child {
     margin-left: 8px;
 }
 
@@ -72,8 +72,8 @@ button.fake-menu-button__item {
     text-align: left;
 }
 
-button.fake-menu-button__item:active svg.icon,
-a.fake-menu-button__item:active svg.icon {
+button.fake-menu-button__item:active svg.icon--tick-small,
+a.fake-menu-button__item:active svg.icon--tick-small {
     .color-token(menu-menuitem-active-status-color, color-selection-list-item-active-status);
 }
 
@@ -83,16 +83,16 @@ div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
     .color-token(menu-button-menuitem-disabled-foreground-color, color-text-disabled);
 }
 
-a.fake-menu-button__item[aria-current="page"] svg.icon,
-button.fake-menu-button__item[aria-current="page"] svg.icon {
+a.fake-menu-button__item[aria-current="page"] svg.icon--tick-small,
+button.fake-menu-button__item[aria-current="page"] svg.icon--tick-small {
     opacity: 1;
 }
 
-div.menu-button__item[role^="menuitem"]:active svg.icon {
+div.menu-button__item[role^="menuitem"]:active svg.icon--tick-small {
     .color-token(menu-menuitem-active-status-color, color-selection-list-item-active-status);
 }
 
-div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon {
+div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-small {
     opacity: 1;
 }
 

--- a/src/less/menu-button/stories/menu-button.stories.js
+++ b/src/less/menu-button/stories/menu-button.stories.js
@@ -404,6 +404,47 @@ export const menuFixWidth = () => `
 </span>
 `;
 
+export const menuIcons = () => `
+<span class="menu-button">
+    <button class="expand-btn" aria-expanded="true" aria-haspopup="true" type="button">
+        <span class="expand-btn__cell">
+            <span class="expand-btn__text">Button</span>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use xlink:href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="menu-button__menu">
+        <div class="menu-button__items" role="menu">
+            <div class="menu-button__item" role="menuitem">
+                <svg class="icon icon--settings" focusable="false" aria-label="Settings" role="icon">
+                    <use xlink:href="#icon-settings"></use>
+                </svg>
+                <span style="margin: auto 5px;">
+                    Profile
+                </span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <svg class="icon icon--calendar" focusable="false" aria-label="Calendar" role="icon">
+                    <use xlink:href="#icon-calendar"></use>
+                </svg>
+                <span style="margin: auto 5px;">
+                    Calendar
+                </span>
+            </div>
+            <div class="menu-button__item" role="menuitem">
+                <svg class="icon icon--profile" focusable="false" aria-label="Profile" role="icon">
+                    <use xlink:href="#icon-profile"></use>
+                </svg>
+                <span style="margin: auto 5px;">
+                    Profile
+                </span>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
 export const separator = () => `
 <span class="menu-button">
     <button class="expand-btn" type="button" aria-expanded="true" aria-haspopup="true">

--- a/src/less/menu/base/menu.less
+++ b/src/less/menu/base/menu.less
@@ -23,13 +23,13 @@ span.fake-menu__items {
     padding: 0;
 }
 
-.menu__item > svg.icon,
-.fake-menu__item > svg.icon {
+.menu__item > svg.icon--tick-small,
+.fake-menu__item > svg.icon--tick-small {
     .menu-menuitem-status();
 }
 
-.menu__item > svg.icon:last-child,
-.fake-menu__item > svg.icon:last-child,
+.menu__item > svg.icon--tick-small:last-child,
+.fake-menu__item > svg.icon--tick-small:last-child,
 .menu__item .badge {
     margin-left: 8px;
     margin-right: 8px;
@@ -54,13 +54,13 @@ a.fake-menu__item:focus {
     text-decoration: underline;
 }
 
-button.fake-menu__item:active svg.icon,
-a.fake-menu__item:active svg.icon {
+button.fake-menu__item:active svg.icon--tick-small,
+a.fake-menu__item:active svg.icon--tick-small {
     .color-token(menu-menuitem-active-status-color, color-selection-list-item-active-status);
 }
 
-a.fake-menu__item[aria-current="page"] svg.icon,
-button.fake-menu__item[aria-current="page"] svg.icon {
+a.fake-menu__item[aria-current="page"] svg.icon--tick-small,
+button.fake-menu__item[aria-current="page"] svg.icon--tick-small {
     opacity: 1;
 }
 
@@ -70,11 +70,11 @@ div.menu__item[role^="menuitem"][aria-disabled="true"] {
     .color-token(menu-menuitem-disabled-foreground-color, color-text-disabled);
 }
 
-div.menu__item[role^="menuitem"]:active svg.icon {
+div.menu__item[role^="menuitem"]:active svg.icon--tick-small {
     .color-token(menu-menuitem-active-status-color, color-selection-list-item-active-status);
 }
 
-div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon {
+div.menu__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-small {
     opacity: 1;
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1717

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed selector for menu/fake-menu/menu-button/fake-menu-button to target svg with tick-small so that other SVGs do not get overriden

## Notes
Added a storybook example for icons

## Screenshots
<img width="178" alt="Screen Shot 2022-04-08 at 11 09 28 AM" src="https://user-images.githubusercontent.com/1755269/162498727-ddc7961b-300f-4333-ae17-4db3a8fac224.png">
<img width="168" alt="Screen Shot 2022-04-08 at 11 09 39 AM" src="https://user-images.githubusercontent.com/1755269/162498728-073d3064-59aa-4695-8cd8-25d0d7e0891b.png">

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
