### PR TITLE
fix(docs): add aria-hidden to checkbox & radio SVG #1730

### DIFF
--- a/docs/_includes/checkbox.html
+++ b/docs/_includes/checkbox.html
@@ -14,10 +14,10 @@
             <span class="checkbox">
                 <input aria-label="Default checkbox example" class="checkbox__control" type="checkbox" name="checkbox-default" checked />
                 <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="checkbox-unchecked" %}
                     </svg>
-                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="checkbox-checked" %}
                     </svg>
                 </span>
@@ -28,10 +28,10 @@
 <span class="checkbox">
     <input class="checkbox__control" type="checkbox" checked />
     <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-checkbox-unchecked"></use>
         </svg>
-        <svg class="checkbox__checked" focusable="false" height="18" width="18">
+        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-checkbox-checked"></use>
         </svg>
     </span>
@@ -47,10 +47,10 @@
             <span class="checkbox">
                 <input aria-label="Mixed checkbox example" aria-checked="mixed" class="checkbox__control" type="checkbox" name="checkbox-default" checked />
                 <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="checkbox-unchecked-large" %}
                     </svg>
-                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="checkbox-mixed" %}
                     </svg>
                 </span>
@@ -61,10 +61,10 @@
 <span class="checkbox">
     <input aria-checked="mixed" class="checkbox__control" type="checkbox" checked />
     <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-checkbox-unchecked"></use>
         </svg>
-        <svg class="checkbox__checked" focusable="false" height="18" width="18">
+        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-checkbox-mixed"></use>
         </svg>
     </span>
@@ -79,10 +79,10 @@
             <span class="checkbox checkbox--large">
                 <input aria-label="Large checkbox example" class="checkbox__control" type="checkbox" name="checkbox-large" checked />
                 <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="24" width="24">
+                    <svg class="checkbox__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include symbol.html name="checkbox-unchecked-large" %}
                     </svg>
-                    <svg class="checkbox__checked" focusable="false" height="24" width="24">
+                    <svg class="checkbox__checked" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include symbol.html name="checkbox-checked-large" %}
                     </svg>
                 </span>
@@ -93,10 +93,10 @@
 <span class="checkbox checkbox--large">
     <input class="checkbox__control" type="checkbox" checked />
     <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="24" width="24">
+        <svg class="checkbox__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-checkbox-unchecked-large"></use>
         </svg>
-        <svg class="checkbox__checked" focusable="false" height="24" width="24">
+        <svg class="checkbox__checked" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-checkbox-checked-large"></use>
         </svg>
     </span>
@@ -111,10 +111,10 @@
             <span class="checkbox">
                 <input aria-label="Disabled checkbox example" class="checkbox__control" type="checkbox" name="checkbox-svg" aria-label="SVG checkbox example" checked disabled />
                 <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="checkbox-unchecked" %}
                     </svg>
-                    <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="checkbox-checked" %}
                     </svg>
                 </span>
@@ -125,10 +125,10 @@
 <span class="checkbox">
     <input class="checkbox__control" type="checkbox" checked disabled />
     <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-checkbox-unchecked"></use>
         </svg>
-        <svg class="checkbox__checked" focusable="false" height="18" width="18">
+        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-checkbox-checked"></use>
         </svg>
     </span>
@@ -148,10 +148,10 @@
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-1" type="checkbox" value="1" name="checkbox-group" checked />
                         <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-unchecked" %}
                             </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-checked" %}
                             </svg>
                         </span>
@@ -162,10 +162,10 @@
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-2" type="checkbox" value="2" name="checkbox-group" />
                         <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-unchecked" %}
                             </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-checked" %}
                             </svg>
                         </span>
@@ -176,10 +176,10 @@
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-3" type="checkbox" value="3" name="checkbox-group" />
                         <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-unchecked" %}
                             </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-checked" %}
                             </svg>
                         </span>
@@ -197,10 +197,10 @@
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-1" type="checkbox" value="1" name="checkbox-group" checked />
             <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-unchecked"></use>
                 </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-checked"></use>
                 </svg>
             </span>
@@ -211,10 +211,10 @@
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-2" type="checkbox" value="2" name="checkbox-group" />
             <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-unchecked"></use>
                 </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-checked"></use>
                 </svg>
             </span>
@@ -225,10 +225,10 @@
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-3" type="checkbox" value="3" name="checkbox-group" />
             <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-unchecked"></use>
                 </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-checked"></use>
                 </svg>
             </span>
@@ -249,10 +249,10 @@
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-4" type="checkbox" value="1" name="checkbox-group" checked />
                         <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-unchecked" %}
                             </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-checked" %}
                             </svg>
                         </span>
@@ -263,10 +263,10 @@
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-5" type="checkbox" value="2" name="checkbox-group" />
                         <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-unchecked" %}
                             </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-checked" %}
                             </svg>
                         </span>
@@ -277,10 +277,10 @@
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-6" type="checkbox" value="3" name="checkbox-group" />
                         <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-unchecked" %}
                             </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="checkbox-checked" %}
                             </svg>
                         </span>
@@ -298,10 +298,10 @@
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-4" type="checkbox" value="1" name="checkbox-group" checked />
             <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-unchecked"></use>
                 </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-checked"></use>
                 </svg>
             </span>
@@ -312,10 +312,10 @@
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-5" type="checkbox" value="2" name="checkbox-group" />
             <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-unchecked"></use>
                 </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-checked"></use>
                 </svg>
             </span>
@@ -326,10 +326,10 @@
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-6" type="checkbox" value="3" name="checkbox-group" />
             <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18">
+                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-unchecked"></use>
                 </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18">
+                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-checkbox-checked"></use>
                 </svg>
             </span>

--- a/docs/_includes/radio.html
+++ b/docs/_includes/radio.html
@@ -14,10 +14,10 @@
             <span class="radio">
                 <input aria-label="Default radio example" class="radio__control" type="radio" name="radio-default"/>
                 <span class="radio__icon" hidden>
-                    <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="radio-unchecked" %}
                     </svg>
-                    <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="radio-checked" %}
                     </svg>
                 </span>
@@ -28,10 +28,10 @@
 <span class="radio">
     <input class="radio__control" type="radio" />
     <span class="radio__icon" hidden>
-        <svg class="radio__unchecked" focusable="false" height="18" width="18">
+        <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-radio-unchecked"></use>
         </svg>
-        <svg class="radio__checked" focusable="false" height="18" width="18">
+        <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-radio-checked"></use>
         </svg>
     </span>
@@ -46,10 +46,10 @@
             <span class="radio radio--large">
                 <input aria-label="Large radio example" class="radio__control" type="radio" name="radio-large"/>
                 <span class="radio__icon" hidden>
-                    <svg class="radio__unchecked" focusable="false" height="24" width="24">
+                    <svg class="radio__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include symbol.html name="radio-unchecked-large" %}
                     </svg>
-                    <svg class="radio__checked" focusable="false" height="24" width="24">
+                    <svg class="radio__checked" focusable="false" height="24" width="24" aria-hidden="true">
                         {% include symbol.html name="radio-checked-large" %}
                     </svg>
                 </span>
@@ -60,10 +60,10 @@
 <span class="radio radio--large">
     <input class="radio__control" type="radio" />
     <span class="radio__icon" hidden>
-        <svg class="radio__unchecked" focusable="false" height="24" width="24">
+        <svg class="radio__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-radio-unchecked-large"></use>
         </svg>
-        <svg class="radio__checked" focusable="false" height="24" width="24">
+        <svg class="radio__checked" focusable="false" height="24" width="24" aria-hidden="true">
             <use xlink:href="#icon-radio-checked-large"></use>
         </svg>
     </span>
@@ -77,10 +77,10 @@
             <span class="radio">
                 <input aria-label="Disabled radio example" class="radio__control" name="radio-disabled" type="radio" checked disabled />
                 <span class="radio__icon" hidden>
-                    <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="radio-unchecked" %}
                     </svg>
-                    <svg class="radio__checked" focusable="false" height="18" width="18">
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                         {% include symbol.html name="radio-checked" %}
                     </svg>
                 </span>
@@ -92,10 +92,10 @@
 <span class="radio">
     <input class="radio__control" type="radio" checked disabled />
     <span class="radio__icon" hidden>
-        <svg class="radio__unchecked" focusable="false" height="18" width="18">
+        <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-radio-unchecked"></use>
         </svg>
-        <svg class="radio__checked" focusable="false" height="18" width="18">
+        <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
             <use xlink:href="#icon-radio-checked"></use>
         </svg>
     </span>
@@ -114,10 +114,10 @@
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-1" type="radio" value="1" name="radio-group" />
                         <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-unchecked" %}
                             </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-checked" %}
                             </svg>
                         </span>
@@ -128,10 +128,10 @@
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-2" type="radio" value="3" name="radio-group" />
                         <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-unchecked" %}
                             </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-checked" %}
                             </svg>
                         </span>
@@ -142,10 +142,10 @@
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-3" type="radio" value="3" name="radio-group" />
                         <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-unchecked" %}
                             </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-checked" %}
                             </svg>
                         </span>
@@ -163,10 +163,10 @@
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-1" type="radio" value="1" name="radio-group" />
             <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-unchecked"></use>
                 </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18">
+                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-checked"></use>
                 </svg>
             </span>
@@ -177,10 +177,10 @@
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-2" type="radio" value="2" name="radio-group" />
             <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-unchecked"></use>
                 </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18">
+                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-checked"></use>
                 </svg>
             </span>
@@ -191,10 +191,10 @@
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-3" type="radio" value="3" name="radio-group" />
             <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-unchecked"></use>
                 </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18">
+                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-checked"></use>
                 </svg>
             </span>
@@ -215,10 +215,10 @@
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-4" type="radio" value="1" name="radio-group" />
                         <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-unchecked" %}
                             </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-checked" %}
                             </svg>
                         </span>
@@ -229,10 +229,10 @@
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-5" type="radio" value="3" name="radio-group" />
                         <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-unchecked" %}
                             </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-checked" %}
                             </svg>
                         </span>
@@ -243,10 +243,10 @@
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-6" type="radio" value="3" name="radio-group" />
                         <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-unchecked" %}
                             </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18">
+                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                                 {% include symbol.html name="radio-checked" %}
                             </svg>
                         </span>
@@ -264,10 +264,10 @@
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-4" type="radio" value="1" name="radio-group" />
             <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-unchecked"></use>
                 </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18">
+                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-checked"></use>
                 </svg>
             </span>
@@ -278,10 +278,10 @@
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-5" type="radio" value="2" name="radio-group" />
             <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-unchecked"></use>
                 </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18">
+                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-checked"></use>
                 </svg>
             </span>
@@ -292,10 +292,10 @@
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-6" type="radio" value="3" name="radio-group" />
             <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18">
+                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-unchecked"></use>
                 </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18">
+                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
                     <use xlink:href="#icon-radio-checked"></use>
                 </svg>
             </span>

--- a/docs/_includes/star-rating-select.html
+++ b/docs/_includes/star-rating-select.html
@@ -9,7 +9,7 @@
 
     <h3>Star Rating Select with Visual Semantic Grouping</h3>
     <p>This instance of star rating select uses visible HTML <code>fieldset</code> and <code>legend</code> for semantic grouping.</p>
- 
+
     <div class="demo">
         <div class="demo__inner">
             <div role="radiogroup" aria-label="Rate this product" class="star-rating-select">
@@ -18,7 +18,7 @@
                     <span class="star-rating-select__radio">
                        <input class="star-rating-select__control" aria-label="1 Star" type="radio" name="radio-star-rating-select" value="1">
                         <span class="star-rating-select__radio-icon">
-                            <svg focusable="false">
+                            <svg focusable="false" height="12" width="12" aria-hidden="true">
                                 {% include symbol.html name="star-dynamic" %}
                             </svg>
                         </span>
@@ -27,7 +27,7 @@
                     <span class="star-rating-select__radio">
                        <input class="star-rating-select__control" aria-label="2 Stars" type="radio" name="radio-star-rating-select" value="2">
                         <span class="star-rating-select__radio-icon">
-                            <svg focusable="false">
+                            <svg focusable="false" height="12" width="12" aria-hidden="true">
                                 {% include symbol.html name="star-dynamic" %}
                             </svg>
                         </span>
@@ -36,7 +36,7 @@
                     <span class="star-rating-select__radio">
                        <input class="star-rating-select__control" aria-label="3 Stars" type="radio" name="radio-star-rating-select" value="3">
                         <span class="star-rating-select__radio-icon">
-                            <svg focusable="false">
+                            <svg focusable="false" height="12" width="12" aria-hidden="true">
                                 {% include symbol.html name="star-dynamic" %}
                             </svg>
                         </span>
@@ -45,7 +45,7 @@
                     <span class="star-rating-select__radio">
                        <input class="star-rating-select__control" aria-label="4 Stars" type="radio" name="radio-star-rating-select" value="4">
                         <span class="star-rating-select__radio-icon">
-                            <svg focusable="false">
+                            <svg focusable="false" height="12" width="12" aria-hidden="true">
                                 {% include symbol.html name="star-dynamic" %}
                             </svg>
                         </span>
@@ -54,7 +54,7 @@
                     <span class="star-rating-select__radio">
                        <input class="star-rating-select__control" aria-label="5 Stars" type="radio" name="radio-star-rating-select" value="5">
                         <span class="star-rating-select__radio-icon">
-                            <svg focusable="false">
+                            <svg focusable="false" height="12" width="12" aria-hidden="true">
                                 {% include symbol.html name="star-dynamic" %}
                             </svg>
                         </span>
@@ -71,7 +71,7 @@
         <span class="star-rating-select__radio">
            <input class="star-rating-select__control" aria-label="1 Star" type="radio" name="radio-star-rating-select" value="1">
             <span class="star-rating-select__radio-icon">
-                <svg focusable="false">
+                <svg focusable="false" height="12" width="12" aria-hidden="true">
                     <use xlink:href="#icon-star-dynamic"></use>
                 </svg>
             </span>
@@ -80,7 +80,7 @@
         <span class="star-rating-select__radio">
            <input class="star-rating-select__control" aria-label="2 Stars" type="radio" name="radio-star-rating-select" value="2">
             <span class="star-rating-select__radio-icon">
-                <svg focusable="false">
+                <svg focusable="false" height="12" width="12" aria-hidden="true">
                     <use xlink:href="#icon-star-dynamic"></use>
                 </svg>
             </span>
@@ -89,7 +89,7 @@
         <span class="star-rating-select__radio">
            <input class="star-rating-select__control" aria-label="3 Stars" type="radio" name="radio-star-rating-select" value="3">
             <span class="star-rating-select__radio-icon">
-                <svg focusable="false">
+                <svg focusable="false" height="12" width="12" aria-hidden="true">
                     <use xlink:href="#icon-star-dynamic"></use>
                 </svg>
             </span>
@@ -98,7 +98,7 @@
         <span class="star-rating-select__radio">
            <input class="star-rating-select__control" aria-label="4 Stars" type="radio" name="radio-star-rating-select" value="4">
             <span class="star-rating-select__radio-icon">
-                <svg focusable="false">
+                <svg focusable="false" height="12" width="12" aria-hidden="true">
                     <use xlink:href="#icon-star-dynamic"></use>
                 </svg>
             </span>
@@ -107,7 +107,7 @@
         <span class="star-rating-select__radio">
            <input class="star-rating-select__control" aria-label="5 Stars" type="radio" name="radio-star-rating-select" value="5">
             <span class="star-rating-select__radio-icon">
-                <svg focusable="false">
+                <svg focusable="false" height="12" width="12" aria-hidden="true">
                     <use xlink:href="#icon-star-dynamic"></use>
                 </svg>
             </span>
@@ -124,7 +124,7 @@
                 <span class="star-rating-select__radio">
                    <input class="star-rating-select__control" aria-label="1 Star" type="radio" name="radio-star-rating-select" value="1">
                     <span class="star-rating-select__radio-icon">
-                        <svg focusable="false">
+                        <svg focusable="false" height="12" width="12" aria-hidden="true">
                             {% include symbol.html name="star-dynamic" %}
                         </svg>
                     </span>
@@ -133,7 +133,7 @@
                 <span class="star-rating-select__radio">
                    <input class="star-rating-select__control" aria-label="2 Stars" type="radio" name="radio-star-rating-select" value="2">
                     <span class="star-rating-select__radio-icon">
-                        <svg focusable="false">
+                        <svg focusable="false" height="12" width="12" aria-hidden="true">
                             {% include symbol.html name="star-dynamic" %}
                         </svg>
                     </span>
@@ -142,7 +142,7 @@
                 <span class="star-rating-select__radio">
                    <input class="star-rating-select__control" aria-label="3 Stars" type="radio" name="radio-star-rating-select" value="3">
                     <span class="star-rating-select__radio-icon">
-                        <svg focusable="false">
+                        <svg focusable="false" height="12" width="12" aria-hidden="true">
                             {% include symbol.html name="star-dynamic" %}
                         </svg>
                     </span>
@@ -151,7 +151,7 @@
                 <span class="star-rating-select__radio">
                    <input class="star-rating-select__control" aria-label="4 Stars" type="radio" name="radio-star-rating-select" value="4">
                     <span class="star-rating-select__radio-icon">
-                        <svg focusable="false">
+                        <svg focusable="false" height="12" width="12" aria-hidden="true">
                             {% include symbol.html name="star-dynamic" %}
                         </svg>
                     </span>
@@ -160,7 +160,7 @@
                 <span class="star-rating-select__radio">
                    <input class="star-rating-select__control" aria-label="5 Stars" type="radio" name="radio-star-rating-select" value="5">
                     <span class="star-rating-select__radio-icon">
-                        <svg focusable="false">
+                        <svg focusable="false" height="12" width="12" aria-hidden="true">
                             {% include symbol.html name="star-dynamic" %}
                         </svg>
                     </span>
@@ -174,7 +174,7 @@
     <span class="star-rating-select__radio">
        <input class="star-rating-select__control" aria-label="1 Star" type="radio" name="radio-star-rating-select" value="1">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -183,7 +183,7 @@
     <span class="star-rating-select__radio">
        <input class="star-rating-select__control" aria-label="2 Stars" type="radio" name="radio-star-rating-select" value="2">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -192,7 +192,7 @@
     <span class="star-rating-select__radio">
        <input class="star-rating-select__control" aria-label="3 Stars" type="radio" name="radio-star-rating-select" value="3">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -201,7 +201,7 @@
     <span class="star-rating-select__radio">
        <input class="star-rating-select__control" aria-label="4 Stars" type="radio" name="radio-star-rating-select" value="4">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -210,7 +210,7 @@
     <span class="star-rating-select__radio">
        <input class="star-rating-select__control" aria-label="5 Stars" type="radio" name="radio-star-rating-select" value="5">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>

--- a/docs/_includes/star-rating.html
+++ b/docs/_includes/star-rating.html
@@ -36,23 +36,23 @@
             <li>
                 <span>{{ rating }}</span>
                 <div role="img" aria-label="Rating: 2.5/5" class="star-rating" data-stars="{{ rating }}">
-                    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+                    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
                         {% include symbol.html name="star-dynamic" %}
                     </svg>
 
-                    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+                    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
                         {% include symbol.html name="star-dynamic" %}
                     </svg>
 
-                    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+                    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
                         {% include symbol.html name="star-dynamic" %}
                     </svg>
 
-                    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+                    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
                         {% include symbol.html name="star-dynamic" %}
                     </svg>
 
-                    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+                    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
                         {% include symbol.html name="star-dynamic" %}
                     </svg>
                 </div>
@@ -63,23 +63,23 @@
 
     {% highlight html %}
 <div role="img" aria-label="Rating: 2.5/5" class="star-rating" data-stars="2-5">
-    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
         <use xlink:href="static/common/icons.svg#icon-star-dynamic"></use>
     </svg>
 
-    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
         <use xlink:href="static/common/icons.svg#icon-star-dynamic"></use>
     </svg>
 
-    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
         <use xlink:href="static/common/icons.svg#icon-star-dynamic"></use>
     </svg>
 
-    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
         <use xlink:href="static/common/icons.svg#icon-star-dynamic"></use>
     </svg>
 
-    <svg class="star-rating__icon" aria-hidden="true" focusable="false">
+    <svg class="star-rating__icon" focusable="false" height="12" width="12" aria-hidden="true">
         <use xlink:href="static/common/icons.svg#icon-star-dynamic"></use>
     </svg>
 </div>

--- a/docs/_includes/textbox.html
+++ b/docs/_includes/textbox.html
@@ -158,7 +158,7 @@
         <div class="demo__inner">
             <span class="textbox textbox--icon-end">
                 <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
-                <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
+                <button class="icon-btn icon-btn--transparent" type="button" aria-label="Clear text">
                     <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
                         {% include symbol.html name="clear" %}
                     </svg>
@@ -170,7 +170,7 @@
     {% highlight html %}
 <span class="textbox textbox--icon-end">
     <input class="textbox__control" type="text" placeholder="placeholder text" />
-    <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
+    <button class="icon-btn icon-btn--transparent" type="button" aria-label="Clear text">
         <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
             <use xlink:href="#icon-clear"></use>
         </svg>
@@ -187,7 +187,7 @@
                     {% include symbol.html name="search" %}
                 </svg>
                 <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
-                <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
+                <button class="icon-btn icon-btn--transparent" type="button" aria-label="Clear text">
                     <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
                         {% include symbol.html name="clear" %}
                     </svg>
@@ -202,7 +202,7 @@
         <use xlink:href="#icon-search"></use>
     </svg>
     <input aria-label="Textbox demo" class="textbox__control" type="text" placeholder="placeholder text" />
-    <button class="icon-btn icon-btn--transparent" type="button" aria-label="Choose Contact">
+    <button class="icon-btn icon-btn--transparent" type="button" aria-label="Clear text">
         <svg aria-hidden="true" class="icon icon--clear" focusable="false" width="16" height="16">
             <use xlink:href="#icon-clear"></use>
         </svg>

--- a/src/less/star-rating-select/star-rating-select.stories.js
+++ b/src/less/star-rating-select/star-rating-select.stories.js
@@ -5,7 +5,7 @@ export const base = () => `
     <span class="star-rating-select__radio">
         <input class="star-rating-select__control" aria-label="1 Star" type="radio" name="radio-star-rating-select" value="1">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -14,7 +14,7 @@ export const base = () => `
     <span class="star-rating-select__radio">
         <input class="star-rating-select__control" aria-label="2 Stars" type="radio" name="radio-star-rating-select" value="2">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -23,7 +23,7 @@ export const base = () => `
     <span class="star-rating-select__radio">
         <input class="star-rating-select__control" aria-label="3 Stars" type="radio" name="radio-star-rating-select" value="3">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -32,7 +32,7 @@ export const base = () => `
     <span class="star-rating-select__radio">
         <input class="star-rating-select__control" aria-label="4 Stars" type="radio" name="radio-star-rating-select" value="4">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>
@@ -41,7 +41,7 @@ export const base = () => `
     <span class="star-rating-select__radio">
         <input class="star-rating-select__control" aria-label="5 Stars" type="radio" name="radio-star-rating-select" value="5">
         <span class="star-rating-select__radio-icon">
-            <svg focusable="false">
+            <svg focusable="false" height="12" width="12" aria-hidden="true">
                 <use xlink:href="#icon-star-dynamic"></use>
             </svg>
         </span>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1730

<!-- Select which type of PR this is -->
- [X] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->

Somewhere along the line, `aria-hidden` attribute got lost from the checkbox and radio SVG tags. This PR reinstates those and adds them for star rating and star-rating-select too.

I also added a default width and height for star-rating and star-rating-select so that we don't get giant SVGs while in an unstyled state. See screenshots below.

### Before

![Screen Shot 2022-04-21 at 2 36 25 PM](https://user-images.githubusercontent.com/38065/164557218-ea655e46-6eed-414e-aefc-fb22dca9b71e.png)

### After

![Screen Shot 2022-04-21 at 2 39 14 PM](https://user-images.githubusercontent.com/38065/164557205-8508da62-0d6f-483d-a300-36523f339f56.png)

### Before

![Screen Shot 2022-04-21 at 2 40 14 PM](https://user-images.githubusercontent.com/38065/164557200-be52e244-1885-4ab2-8328-5d838fdb012a.png)

### After

![Screen Shot 2022-04-21 at 2 40 48 PM](https://user-images.githubusercontent.com/38065/164557198-1cd24dfe-bcfe-4c64-8cb9-f1ff4cce5de1.png)


## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

While making these changes I notice that stars SVGs are showing up alongside browser native radio button while in an unstyled state. Not a huge deal, but we should probably use the same trick we do on checkbox and radio to avoid that. Can be done as a separate PR.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue (see above - I added width and height attrs too)

