### PR TITLE
fix(token): changed color neutral 7

### DIFF
--- a/dist/legacy-tokens/ds4-light.css
+++ b/dist/legacy-tokens/ds4-light.css
@@ -30,7 +30,7 @@
     --color-stroke-confirmation: var(--color-green-6);
     --color-stroke-information: var(--color-blue-4);
     --color-stroke-disabled: var(--color-neutral-3);
-    --color-stroke-strong: #191919;
+    --color-stroke-strong: var(--color-neutral-7);
     --color-stroke-subtle: var(--color-neutral-2);
     --color-state-visited: var(--color-magenta-4);
     --color-state-primary-hover: #f5f5f5;

--- a/dist/tokens/evo-light.css
+++ b/dist/tokens/evo-light.css
@@ -30,7 +30,7 @@
     --color-stroke-confirmation: var(--color-green-6);
     --color-stroke-information: var(--color-blue-4);
     --color-stroke-disabled: var(--color-neutral-3);
-    --color-stroke-strong: #191919;
+    --color-stroke-strong: var(--color-neutral-7);
     --color-stroke-subtle: var(--color-neutral-2);
     --color-state-visited: var(--color-magenta-4);
     --color-state-primary-hover: #f5f5f5;

--- a/docs/static/evo-core.css
+++ b/docs/static/evo-core.css
@@ -8,7 +8,7 @@
     --color-neutral-4: #8f8f8f;
     --color-neutral-5: #707070;
     --color-neutral-6: #363636;
-    --color-neutral-7: #111820;
+    --color-neutral-7: #191919;
     --color-neutral-8: #000;
     --color-orange-1: #ffdec7;
     --color-orange-2: #feb786;

--- a/docs/static/evo-light.css
+++ b/docs/static/evo-light.css
@@ -30,7 +30,7 @@
     --color-stroke-confirmation: var(--color-green-6);
     --color-stroke-information: var(--color-blue-4);
     --color-stroke-disabled: var(--color-neutral-3);
-    --color-stroke-strong: #191919;
+    --color-stroke-strong: var(--color-neutral-7);
     --color-stroke-subtle: var(--color-neutral-2);
     --color-state-visited: var(--color-magenta-4);
     --color-state-primary-hover: #f5f5f5;

--- a/src/tokens/evo-core.css
+++ b/src/tokens/evo-core.css
@@ -8,7 +8,7 @@
     --color-neutral-4: #8f8f8f;
     --color-neutral-5: #707070;
     --color-neutral-6: #363636;
-    --color-neutral-7: #111820;
+    --color-neutral-7: #191919;
     --color-neutral-8: #000;
     --color-orange-1: #ffdec7;
     --color-orange-2: #feb786;

--- a/src/tokens/evo-light.css
+++ b/src/tokens/evo-light.css
@@ -30,7 +30,7 @@
     --color-stroke-confirmation: var(--color-green-6);
     --color-stroke-information: var(--color-blue-4);
     --color-stroke-disabled: var(--color-neutral-3);
-    --color-stroke-strong: #191919;
+    --color-stroke-strong: var(--color-neutral-7);
     --color-stroke-subtle: var(--color-neutral-2);
     --color-state-visited: var(--color-magenta-4);
     --color-state-primary-hover: #f5f5f5;


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Changed color neutral 7 for light mode and use the token instead of custom color.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
