### PR TITLE
fix: added variables to ignore list in gen imports

### DIFF
--- a/scripts/generate-imports/config.json
+++ b/scripts/generate-imports/config.json
@@ -4,14 +4,15 @@
         "combo": ["core", "lightbox-dialog", "form", "progress-spinner"],
         "form": ["button", "checkbox", "field", "radio", "select", "switch", "textbox"]
     },
-    "skip": ["mixins", "legacy-tokens", "tokens", "svg", "icon-large"],
+    "skip": ["mixins", "legacy-tokens", "tokens", "svg", "icon-large", "variables"],
     "skipIndex": [
         "dark-mode",
         "legacy-textbox",
         "legacy-theme",
         "legacy-tokens",
         "rounded-off",
-        "square-corner-theme"
+        "square-corner-theme",
+        "variables"
     ],
     "dsVersions": ["6", "4"],
     "defaultDS": "6",


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1788

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
Added variables to ignore list in gen imports.
Please verify there are no other modules to ignore in import and that index.js works fine. 

## Checklist
- [X] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue
