### PR TITLE
feat(notice): added dismiss icon

### DIFF
--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -29,6 +29,12 @@ span[role="region"].page-notice {
   font-size: 0.875rem;
   font-weight: bold;
 }
+.page-notice__cta a {
+  white-space: nowrap;
+}
+.page-notice__dismiss {
+  cursor: pointer;
+}
 .page-notice a:hover {
   color: var(--page-notice-color, var(--color-foreground-on-inverse));
 }
@@ -65,7 +71,7 @@ span[role="region"].page-notice {
   background-color: var(--page-notice-general-background-color, var(--color-background-inverse));
 }
 .page-notice__header {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   justify-content: center;
   padding-right: 16px;
@@ -74,7 +80,7 @@ span[role="region"].page-notice {
 .page-notice__footer {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
 }
 .page-notice__footer {
   flex-shrink: 0;
@@ -87,11 +93,34 @@ span[role="region"].page-notice {
   font-size: 0.875rem;
   margin: 4px 0 0;
 }
+.page-notice__main p.page-notice__cta {
+  margin-top: 16px;
+}
 @media (min-width: 601px) {
   section.page-notice,
   div[role="region"].page-notice {
     flex-wrap: nowrap;
     margin: 16px 0;
+  }
+  .page-notice__main {
+    display: grid;
+    justify-content: initial;
+    width: 100%;
+  }
+  .page-notice__title {
+    grid-column: 1 / 2;
+    grid-row: 1;
+    margin-top: 4px;
+  }
+  .page-notice__main p {
+    grid-column: 1 / 2;
+    grid-row: 2;
+  }
+  .page-notice__main p.page-notice__cta {
+    grid-column: 2 / 2;
+    grid-row: 1;
+    justify-self: end;
+    margin-top: 0;
   }
   .page-notice__footer {
     margin-top: 0;

--- a/docs/_includes/page-notice.html
+++ b/docs/_includes/page-notice.html
@@ -103,6 +103,50 @@
 </section>
     {% endhighlight %}
 
+    <h3 id="page-notice-dismissable-title">Dismissable Page Notice With Title</h3>
+    <section class="page-notice page-notice--information" role="region" aria-label="Information">
+        <div class="page-notice__header">
+            <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
+                {% include symbol.html name="information-filled" %}
+            </svg>
+        </div>
+        <div class="page-notice__main">
+            <h3 class="page-notice__title">Notice Title</h3>
+            <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+            <p class="page-notice__cta" tabindex="0"><a href="https://www.ebay.com">Opt in</a></p>
+        </div>
+        <div class="page-notice__footer">
+            <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
+                 <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
+                    {% include symbol.html name="close" %}
+                 </svg>
+            </a>
+        </div>
+    </section>
+
+{% highlight html %}
+<h3 id="page-notice-dismissable-title">Dismissable Page Notice With Title</h3>
+<section class="page-notice page-notice--information" role="region" aria-label="Information">
+    <div class="page-notice__header">
+        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
+            <use xlink:href="#icon-information-filled"></use>
+        </svg>
+    </div>
+    <div class="page-notice__main">
+        <h3 class="page-notice__title">Notice Title</h3>
+        <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+        <p class="page-notice__cta" tabindex="0"><a href="https://www.ebay.com">Opt in</a></p>
+    </div>
+    <div class="page-notice__footer">
+        <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
+            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
+                <use xlink:href="#icon-close"></use>
+            </svg>
+        </a>
+    </div>
+</section>
+{% endhighlight %}
+
     <h3 id="page-notice-form-error">Form Error Page Notice</h3>
 
     <section class="page-notice page-notice--attention" role="region" aria-label="Attention">

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -38,6 +38,15 @@ span[role="region"].page-notice {
     font-weight: bold;
 }
 
+// force links with text having more than one word to remain on same line
+.page-notice__cta a {
+    white-space: nowrap;
+}
+
+.page-notice__dismiss {
+    cursor: pointer;
+}
+
 .page-notice a:hover {
     .color-token(page-notice-color, color-foreground-on-inverse);
 }
@@ -84,7 +93,7 @@ span[role="region"].page-notice {
 }
 
 .page-notice__header {
-    align-items: center;
+    align-items: flex-start;
     display: flex;
     justify-content: center;
     padding-right: @spacing-200;
@@ -94,7 +103,7 @@ span[role="region"].page-notice {
 .page-notice__footer {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
 }
 
 .page-notice__footer {
@@ -110,11 +119,40 @@ span[role="region"].page-notice {
     margin: @spacing-50 0 0;
 }
 
+.page-notice__main p.page-notice__cta {
+    margin-top: 16px;
+}
+
 @media (min-width: 601px) {
     section.page-notice,
     div[role="region"].page-notice {
         flex-wrap: nowrap;
         margin: @spacing-200 0;
+    }
+
+    // for wider viewport widths, use grid layout to more easily move/place elements
+    .page-notice__main {
+        display: grid;
+        justify-content: initial;
+        width: 100%;
+    }
+
+    .page-notice__title {
+        grid-column: 1 / 2;
+        grid-row: 1;
+        margin-top: 4px;
+    }
+
+    .page-notice__main p {
+        grid-column: 1 / 2;
+        grid-row: 2;
+    }
+
+    .page-notice__main p.page-notice__cta {
+        grid-column: 2 / 2;
+        grid-row: 1;
+        justify-self: end;
+        margin-top: 0;
     }
 
     .page-notice__footer {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1656 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Adds a dismiss icon to the page notice.

## Screenshots
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/1675667/176922106-fdc7bee6-7ef2-485d-b044-91083b5d0a6a.png">

## Notes
The suggestion for top alignment of the icon on the left and the dismiss icon(cta link) on the right is still being considered by the design team. There is a chance (if design does not prefer it), that we may still need to rework the alignment.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
