### PR TITLE
fix: added top level css files for nested modules

### DIFF
--- a/scripts/generate-imports/config.json
+++ b/scripts/generate-imports/config.json
@@ -37,10 +37,12 @@
     },
     "nested": {
         "tokens": {
-            "index": ["evo-core", "evo-light"]
+            "index": ["evo-core", "evo-light"],
+            "tokens": ["tokens/evo-core", "tokens/evo-light"]
         },
         "legacy-tokens": {
-            "index": ["ds4-core", "ds4-light"]
+            "index": ["ds4-core", "ds4-light"],
+            "legacy-tokens": ["legacy-tokens/ds4-core", "legacy-tokens/ds4-light"]
         }
     }
 }

--- a/scripts/generate-imports/module-builder.js
+++ b/scripts/generate-imports/module-builder.js
@@ -85,6 +85,9 @@ class ModuleBuilder {
         if (this.options.isNested) {
             try {
                 await fs.promises.rm(this.moduleName, { recursive: true });
+                await removeFile(getMJSFileName(this.moduleName));
+                await removeFile(getFileName(this.moduleName, 'js'));
+                await removeFile(getFileName(this.moduleName, 'css'));
             } catch (e) {
                 return;
             }
@@ -122,14 +125,24 @@ class ModuleBuilder {
 
             if (this.options.addIndexModules) {
                 for (const file of Object.keys(this.options.addIndexModules)) {
-                    await this.overrideData(
-                        { hasBaseModule: false },
-                        this.options.addIndexModules[file],
-                        async () => {
-                            await this.writeBrowserJSON(file);
-                            await this.writeModuleFiles(file);
-                        }
-                    );
+                    if (file === this.moduleName) {
+                        await this.overrideData(
+                            { hasBaseModule: false, isNested: false },
+                            this.options.addIndexModules[file],
+                            async () => {
+                                await this.writeModuleFiles(file);
+                            }
+                        );
+                    } else {
+                        await this.overrideData(
+                            { hasBaseModule: false },
+                            this.options.addIndexModules[file],
+                            async () => {
+                                await this.writeBrowserJSON(file);
+                                await this.writeModuleFiles(file);
+                            }
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION

Fixes #1793

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
When someone would require `@ebay/skin/tokens` in webpack, they would need to add the `.css` extension. That does not work currently, so I added top level token files as well. (This might need some minor cleanup next major version though).

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
