### PR TITLE
fix(select): updated colors for disabled

### DIFF
--- a/dist/select/select.css
+++ b/dist/select/select.css
@@ -58,16 +58,16 @@ span.select {
   display: none;
 }
 .select select[disabled] {
-  background-color: var(--select-disabled-background-color, var(--color-background-secondary));
-  color: var(--select-disabled-foregound-color, var(--color-foreground-ghost));
+  background-color: var(--select-disabled-background-color, var(--color-background-disabled));
+  color: var(--select-disabled-foregound-color, var(--color-foreground-on-disabled));
 }
 .select--borderless select[disabled] {
-  background-color: var(--select-borderless-disabled-background-color, var(--color-background-secondary));
-  color: var(--select-borderless-disabled-foregound-color, var(--color-foreground-disabled));
+  background-color: var(--select-borderless-disabled-background-color, var(--color-background-disabled));
+  color: var(--select-borderless-disabled-foregound-color, var(--color-foreground-on-disabled));
 }
 .select select[readonly] {
-  background-color: var(--select-disabled-background-color, var(--color-background-secondary));
-  color: var(--select-readonly-foregound-color, var(--color-foreground-ghost));
+  background-color: var(--select-disabled-background-color, var(--color-background-disabled));
+  color: var(--select-readonly-foregound-color, var(--color-foreground-on-disabled));
 }
 .select select[aria-invalid="true"] {
   background-color: var(--select-invalid-background-color, var(--color-red-1));

--- a/dist/select/select.css
+++ b/dist/select/select.css
@@ -57,18 +57,19 @@ span.select {
 .select select::-ms-expand {
   display: none;
 }
-.select select[disabled],
-.select--borderless select[disabled],
-.select select[readonly],
-.select--borderless select[readonly] {
+.select select[disabled] {
   background-color: var(--select-disabled-background-color, var(--color-background-disabled));
   color: var(--select-disabled-foregound-color, var(--color-foreground-on-disabled));
   opacity: 1;
 }
-.select select[disabled] + svg,
-.select--borderless select[disabled] + svg,
-.select select[readonly] + svg,
-.select--borderless select[readonly] + svg {
+.select select[disabled] + svg {
+  color: var(--select-disabled-foregound-color, var(--color-foreground-on-disabled));
+}
+.select select[readonly] {
+  background-color: var(--select-disabled-background-color, var(--color-background-disabled));
+  color: var(--select-disabled-foregound-color, var(--color-foreground-on-disabled));
+}
+.select select[readonly] + svg {
   color: var(--select-disabled-foregound-color, var(--color-foreground-on-disabled));
 }
 .select select[aria-invalid="true"] {

--- a/dist/select/select.css
+++ b/dist/select/select.css
@@ -57,17 +57,19 @@ span.select {
 .select select::-ms-expand {
   display: none;
 }
-.select select[disabled] {
+.select select[disabled],
+.select--borderless select[disabled],
+.select select[readonly],
+.select--borderless select[readonly] {
   background-color: var(--select-disabled-background-color, var(--color-background-disabled));
   color: var(--select-disabled-foregound-color, var(--color-foreground-on-disabled));
+  opacity: 1;
 }
-.select--borderless select[disabled] {
-  background-color: var(--select-borderless-disabled-background-color, var(--color-background-disabled));
-  color: var(--select-borderless-disabled-foregound-color, var(--color-foreground-on-disabled));
-}
-.select select[readonly] {
-  background-color: var(--select-disabled-background-color, var(--color-background-disabled));
-  color: var(--select-readonly-foregound-color, var(--color-foreground-on-disabled));
+.select select[disabled] + svg,
+.select--borderless select[disabled] + svg,
+.select select[readonly] + svg,
+.select--borderless select[readonly] + svg {
+  color: var(--select-disabled-foregound-color, var(--color-foreground-on-disabled));
 }
 .select select[aria-invalid="true"] {
   background-color: var(--select-invalid-background-color, var(--color-red-1));
@@ -82,9 +84,6 @@ span.select {
 }
 .select select[aria-invalid="true"] + svg {
   color: var(--select-invalid-foreground-color, var(--color-foreground-primary));
-}
-.select select[disabled] + svg {
-  color: var(--select-disabled-foregound-color, var(--color-foreground-ghost));
 }
 [dir="rtl"] .select > select {
   padding-left: 30px;

--- a/src/less/select/select.less
+++ b/src/less/select/select.less
@@ -71,18 +71,18 @@ span.select {
 }
 
 .select select[disabled] {
-    .background-color-token(select-disabled-background-color, color-background-secondary);
-    .color-token(select-disabled-foregound-color, color-foreground-ghost);
+    .background-color-token(select-disabled-background-color, color-background-disabled);
+    .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
 }
 
 .select--borderless select[disabled] {
-    .background-color-token(select-borderless-disabled-background-color, color-background-secondary);
-    .color-token(select-borderless-disabled-foregound-color, color-foreground-disabled);
+    .background-color-token(select-borderless-disabled-background-color, color-background-disabled);
+    .color-token(select-borderless-disabled-foregound-color, color-foreground-on-disabled);
 }
 
 .select select[readonly] {
-    .background-color-token(select-disabled-background-color, color-background-secondary);
-    .color-token(select-readonly-foregound-color, color-foreground-ghost);
+    .background-color-token(select-disabled-background-color, color-background-disabled);
+    .color-token(select-readonly-foregound-color, color-foreground-on-disabled);
 }
 
 .select select[aria-invalid="true"] {

--- a/src/less/select/select.less
+++ b/src/less/select/select.less
@@ -70,19 +70,18 @@ span.select {
     display: none;
 }
 
-.select select[disabled] {
-    .background-color-token(select-disabled-background-color, color-background-disabled);
-    .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
-}
+.select,
+.select--borderless {
+    select[disabled],
+    select[readonly] {
+        .background-color-token(select-disabled-background-color, color-background-disabled);
+        .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
+        opacity: 1;
 
-.select--borderless select[disabled] {
-    .background-color-token(select-borderless-disabled-background-color, color-background-disabled);
-    .color-token(select-borderless-disabled-foregound-color, color-foreground-on-disabled);
-}
-
-.select select[readonly] {
-    .background-color-token(select-disabled-background-color, color-background-disabled);
-    .color-token(select-readonly-foregound-color, color-foreground-on-disabled);
+        + svg {
+            .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
+        }
+    }
 }
 
 .select select[aria-invalid="true"] {
@@ -100,10 +99,6 @@ span.select {
 
 .select select[aria-invalid="true"] + svg {
     .color-token(select-invalid-foreground-color, color-foreground-primary);
-}
-
-.select select[disabled] + svg {
-    .color-token(select-disabled-foregound-color, color-foreground-ghost);
 }
 
 // stylelint-disable no-descending-specificity

--- a/src/less/select/select.less
+++ b/src/less/select/select.less
@@ -70,18 +70,23 @@ span.select {
     display: none;
 }
 
-.select,
-.select--borderless {
-    select[disabled],
-    select[readonly] {
-        .background-color-token(select-disabled-background-color, color-background-disabled);
-        .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
-        opacity: 1;
+.select select[disabled] {
+    .background-color-token(select-disabled-background-color, color-background-disabled);
+    .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
+    opacity: 1;
+}
 
-        + svg {
-            .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
-        }
-    }
+.select select[disabled] + svg {
+    .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
+}
+
+.select select[readonly] {
+    .background-color-token(select-disabled-background-color, color-background-disabled);
+    .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
+}
+
+.select select[readonly] + svg {
+    .color-token(select-disabled-foregound-color, color-foreground-on-disabled);
 }
 
 .select select[aria-invalid="true"] {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1787 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Updated the colors for the disabled select component to add differentiation.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
Right now, Safari and Chrome are displaying different colors even though they share CSS variables in developer view. This may be worth looking into. Screenshots of each (in dark mode) are attached. 

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
Chrome: 
<img width="130" alt="image" src="https://user-images.githubusercontent.com/26027232/177657407-d72035c4-f11e-4ef9-8ebb-9cbe449d5f96.png">
Safari:
<img width="126" alt="image" src="https://user-images.githubusercontent.com/26027232/177657454-134a26f0-074f-4772-9c8c-701636a5915a.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
