### PR TITLE
fix: consistent hover color for disabled fake button

### DIFF
--- a/dist/link/link.css
+++ b/dist/link/link.css
@@ -21,6 +21,6 @@ button.fake-link {
 button.fake-link[disabled] {
   color: var(--fake-link-foreground-disabled-color, var(--color-foreground-disabled));
 }
-button.fake-link:hover {
+button.fake-link:hover:not(:disabled) {
   color: var(--color-state-accent-hover);
 }

--- a/src/less/link/link.less
+++ b/src/less/link/link.less
@@ -29,7 +29,7 @@ button.fake-link {
         .color-token(fake-link-foreground-disabled-color, color-foreground-disabled);
     }
 
-    &:hover {
+    &:hover:not(:disabled) {
         color: var(--color-state-accent-hover);
     }
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1799 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Buttons with the `fake-link` class and the `disabled` attribute were still changing color when hovered.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
I did not add an example to the Skin site for this specific case, as it did not seem necessary.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
