### PR TITLE
feat(dialogs): updated panel, fullscreen, and lightbox with new spec

### DIFF
--- a/dist/drawer-dialog/drawer-dialog.css
+++ b/dist/drawer-dialog/drawer-dialog.css
@@ -20,7 +20,7 @@
 .drawer-dialog__header {
   display: flex;
   flex-shrink: 0;
-  margin: 16px 8px 0;
+  margin: 16px 16px 0;
   position: relative;
 }
 .drawer-dialog__header h1,
@@ -31,7 +31,7 @@
 .drawer-dialog__header h6 {
   align-self: center;
   flex: 1 1 auto;
-  margin: 0 8px;
+  margin: 0;
 }
 .drawer-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;

--- a/dist/fullscreen-dialog/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/fullscreen-dialog.css
@@ -30,7 +30,7 @@
 .fullscreen-dialog__header {
   display: flex;
   flex-shrink: 0;
-  margin: 16px 8px 0;
+  margin: 16px 16px 0;
   position: relative;
 }
 .fullscreen-dialog__header h1,
@@ -41,7 +41,7 @@
 .fullscreen-dialog__header h6 {
   align-self: center;
   flex: 1 1 auto;
-  margin: 0 8px;
+  margin: 0;
 }
 .fullscreen-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
@@ -73,11 +73,15 @@
 .fullscreen-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
+button.icon-btn.fullscreen-dialog__close {
+  height: 32px;
+  min-width: 32px;
+  width: 32px;
+}
 button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
   align-self: center;
   border: 0;
-  outline-offset: -8px;
   padding: 0;
   position: relative;
   z-index: 1;
@@ -95,7 +99,9 @@ button.fullscreen-dialog__back {
   transition: opacity 0.16s ease-out;
 }
 .fullscreen-dialog--show .fullscreen-dialog__window--slide,
-.fullscreen-dialog--hide .fullscreen-dialog__window--slide {
+.fullscreen-dialog--hide .fullscreen-dialog__window--slide,
+.fullscreen-dialog--show .fullscreen-dialog__window--slide-end,
+.fullscreen-dialog--hide .fullscreen-dialog__window--slide-end {
   transition: transform 0.32s ease-out;
 }
 .fullscreen-dialog--hide.fullscreen-dialog--hide,
@@ -118,6 +124,10 @@ button.fullscreen-dialog__back {
 .fullscreen-dialog--show-init .fullscreen-dialog__window--slide {
   transform: translateY(100%);
 }
+.fullscreen-dialog--hide .fullscreen-dialog__window--slide-end,
+.fullscreen-dialog--show-init .fullscreen-dialog__window--slide-end {
+  transform: translateX(100%);
+}
 .fullscreen-dialog--show.fullscreen-dialog--show,
 .fullscreen-dialog--show.fullscreen-dialog--hide-init,
 .fullscreen-dialog--hide-init.fullscreen-dialog--show,
@@ -138,20 +148,7 @@ button.fullscreen-dialog__back {
 .fullscreen-dialog--hide-init .fullscreen-dialog__window--slide {
   transform: translateX(0);
 }
-@media (min-width: 601px) {
-  .fullscreen-dialog__header {
-    margin: 16px 16px 0;
-  }
-  .fullscreen-dialog__main {
-    margin: 16px 24px 24px;
-  }
-  .fullscreen-dialog__footer {
-    flex-direction: row;
-    justify-content: flex-end;
-    padding: 24px;
-  }
-  .fullscreen-dialog__footer > :not(:first-child) {
-    margin-left: 24px;
-    margin-top: initial;
-  }
+.fullscreen-dialog--show .fullscreen-dialog__window--slide-end,
+.fullscreen-dialog--hide-init .fullscreen-dialog__window--slide-end {
+  transform: translateX(0);
 }

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -38,7 +38,7 @@
 .lightbox-dialog__header {
   display: flex;
   flex-shrink: 0;
-  margin: 16px 8px 0;
+  margin: 16px 16px 0;
   position: relative;
 }
 .lightbox-dialog__header h1,
@@ -49,7 +49,7 @@
 .lightbox-dialog__header h6 {
   align-self: center;
   flex: 1 1 auto;
-  margin: 0 8px;
+  margin: 0;
 }
 .lightbox-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
@@ -80,10 +80,13 @@
 .lightbox-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-button.lightbox-dialog__close {
+button.icon-btn.lightbox-dialog__close {
   align-self: center;
   border: 0;
+  height: 32px;
+  min-width: 32px;
   position: relative;
+  width: 32px;
   z-index: 1;
 }
 .lightbox-dialog__title:not(:first-child) {
@@ -147,19 +150,13 @@ button.lightbox-dialog__close {
   }
 }
 @media (min-width: 601px) {
-  .lightbox-dialog__window .lightbox-dialog__header {
-    margin: 16px 16px 0;
-  }
-  .lightbox-dialog__window .lightbox-dialog__main {
-    margin: 16px 24px 24px;
-  }
   .lightbox-dialog__window .lightbox-dialog__footer {
     flex-direction: row;
     justify-content: flex-end;
-    padding: 24px;
+    padding: 0 16px 16px;
   }
   .lightbox-dialog__window .lightbox-dialog__footer > :not(:first-child) {
-    margin-left: 24px;
+    margin-left: 8px;
     margin-top: initial;
   }
 }

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -24,7 +24,7 @@
   border-right: 1px solid rgba(153, 153, 153, 0.18);
   -webkit-overflow-scrolling: touch;
   overflow-y: auto;
-  width: calc(100% - 32px);
+  width: 100%;
 }
 .panel-dialog__window--end {
   align-self: flex-end;
@@ -33,7 +33,7 @@
 .panel-dialog__header {
   display: flex;
   flex-shrink: 0;
-  margin: 16px 8px 0;
+  margin: 16px 16px 0;
   position: relative;
 }
 .panel-dialog__header h1,
@@ -44,7 +44,7 @@
 .panel-dialog__header h6 {
   align-self: center;
   flex: 1 1 auto;
-  margin: 0 8px;
+  margin: 0;
 }
 .panel-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
@@ -75,12 +75,14 @@
 .panel-dialog__footer > :not(:first-child) {
   margin-top: 16px;
 }
-button.panel-dialog__close {
+button.icon-btn.panel-dialog__close {
   align-self: center;
   border: 0;
-  outline-offset: -8px;
+  height: 32px;
+  min-width: 32px;
   padding: 0;
   position: relative;
+  width: 32px;
   z-index: 1;
 }
 .panel-dialog__title:not(:first-child) {
@@ -147,21 +149,6 @@ button.panel-dialog__close {
 }
 @media (min-width: 601px) {
   .panel-dialog__window {
-    width: calc(88% - 32px);
-  }
-  .panel-dialog__header {
-    margin: 16px 16px 0;
-  }
-  .panel-dialog__main {
-    margin: 16px 24px 24px;
-  }
-  .panel-dialog__footer {
-    flex-direction: row;
-    justify-content: flex-end;
-    padding: 24px;
-  }
-  .panel-dialog__footer > :not(:first-child) {
-    margin-left: 24px;
-    margin-top: initial;
+    width: 384px;
   }
 }

--- a/docs/_includes/fullscreen-dialog.html
+++ b/docs/_includes/fullscreen-dialog.html
@@ -10,12 +10,12 @@
             <div class="fullscreen-dialog" id="fullscreen-dialog-1" role="dialog" hidden aria-labelledby="fullscreen-dialog-1-title" aria-modal="true">
                 <div class="fullscreen-dialog__window">
                     <div class="fullscreen-dialog__header">
+                        <h2 id="fullscreen-dialog-1-title" class="large-text-1 bold-text">Fullscreen Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
-                        <h2 id="fullscreen-dialog-1-title" class="large-text-1 bold-text">Fullscreen Dialog</h2>
                     </div>
                     <div class="fullscreen-dialog__main">
                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -33,12 +33,12 @@
 <div class="fullscreen-dialog" role="dialog" aria-labelledby="dialog-title" aria-modal="true" hidden>
     <div class="fullscreen-dialog__window">
         <div id="dialog-title-fade-1" class="fullscreen-dialog__header">
+            <h2 class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
-            <h2 class="large-text-1 bold-text">Heading</h2>
         </div>
         <div class="fullscreen-dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -51,21 +51,100 @@
 </div>
     {% endhighlight %}
 
-    <h3 id="fullscreen-dialog-sliding">Sliding Fullscreen Dialog</h3>
-    <p>The fullscreen dialog should slide in and out, using the <span class="highlight">fullscreen-dialog__window--slide</span> modifier.</p>
+    <h3 id="fullscreen-dialog-sliding">Fullscreen Dialog with footer</h3>
 
     <div class="demo">
         <div class="demo__inner">
-            <button class="btn btn--primary dialog-button" data-makeup-for="fullscreen-dialog-2" type="button">Slide Open Fullscreen Dialog</button>
-            <div class="fullscreen-dialog fullscreen-dialog--transition" id="fullscreen-dialog-2" role="dialog" aria-labelledby="dialog-title-slide-0" aria-modal="true" hidden>
-                <div class="fullscreen-dialog__window fullscreen-dialog__window--slide">
+            <button class="btn btn--primary dialog-button" data-makeup-for="fullscreen-dialog-footer-1" type="button">Open Fullscreen Dialog</button>
+            <div class="fullscreen-dialog" id="fullscreen-dialog-footer-1" role="dialog" hidden aria-labelledby="fullscreen-dialog-1-title" aria-modal="true">
+                <div class="fullscreen-dialog__window">
                     <div class="fullscreen-dialog__header">
+                        <h2 id="fullscreen-dialog-1-title" class="large-text-1 bold-text">Fullscreen Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
+                    </div>
+                    <div class="fullscreen-dialog__main">
+                       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                    <div class="fullscreen-dialog__footer">
+                        <button class="btn btn--primary">Submit</button>
+                        <button class="btn">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="fullscreen-dialog" role="dialog" aria-labelledby="dialog-title" aria-modal="true" hidden>
+    <div class="fullscreen-dialog__window">
+        <div id="dialog-title-fade-1" class="fullscreen-dialog__header">
+            <h2 class="large-text-1 bold-text">Heading</h2>
+            <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="fullscreen-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+        <div class="fullscreen-dialog__footer">
+            <button class="btn btn--primary">Submit</button>
+            <button class="btn">Cancel</button>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+    <h3 id="fullscreen-dialog-sliding">Sliding Fullscreen Dialog</h3>
+    <p>The fullscreen dialog should slide in and out, using the <span class="highlight">fullscreen-dialog__window--slide</span> modifier.</p>
+    <p>You can use <span class="highlight">fullscreen-dialog__window--slide-end</span> modifier, to slide in from the right side of the screen.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-button" data-makeup-for="fullscreen-dialog-2" type="button">Slide Bottom Fullscreen Dialog</button>
+            <div class="fullscreen-dialog fullscreen-dialog--transition" id="fullscreen-dialog-2" role="dialog" aria-labelledby="dialog-title-slide-0" aria-modal="true" hidden>
+                <div class="fullscreen-dialog__window fullscreen-dialog__window--slide">
+                    <div class="fullscreen-dialog__header">
                         <h2 class="large-text-1 bold-text">Fullscreen Dialog</h2>
+                        <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                                {% include symbol.html name="close" %}
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="fullscreen-dialog__main">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                </div>
+            </div>
+
+        <button class="btn btn--primary dialog-button" data-makeup-for="fullscreen-dialog-3" type="button">Slide End Fullscreen Dialog</button>
+            <div class="fullscreen-dialog fullscreen-dialog--transition" id="fullscreen-dialog-3" role="dialog" aria-labelledby="dialog-title-slide-1" aria-modal="true" hidden>
+                <div class="fullscreen-dialog__window fullscreen-dialog__window--slide-end">
+                    <div class="fullscreen-dialog__header">
+                        <h2 class="large-text-1 bold-text">Fullscreen Dialog</h2>
+                        <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                                {% include symbol.html name="close" %}
+                            </svg>
+                        </button>
                     </div>
                     <div class="fullscreen-dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -85,8 +164,28 @@
         <div class="fullscreen-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="fullscreen-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+
+<div class="fullscreen-dialog" role="dialog" aria-labelledby="dialog-title" aria-modal="true" hidden>
+    <div class="fullscreen-dialog__window dialog__window--slide-end">
+        <div class="fullscreen-dialog__header">
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
+            <button aria-label="Close dialog" class="icon-btn fullscreen-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -11,7 +11,7 @@
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-default" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
@@ -34,8 +34,8 @@
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -61,7 +61,7 @@
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-scrolling">Scrolling Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
@@ -84,8 +84,8 @@
         <div class="lightbox-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -116,7 +116,7 @@
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-fade-title" class="large-text-1 bold-text">Transitioned Lightbox</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
@@ -141,8 +141,8 @@
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -170,7 +170,7 @@
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-footer-title" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
@@ -197,8 +197,8 @@
         <div class="large-text-1 lightbox-dialog__header">
             <h2 class="large-text-1 bold-text" id="lightbox-dialog-title">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -227,7 +227,7 @@
                 <div class="lightbox-dialog__window lightbox-dialog__window--mini lightbox-dialog__window--fade">
                     <div class="lightbox-dialog__header">
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
@@ -245,8 +245,8 @@
     <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
         <div class="lightbox-dialog__header">
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>

--- a/docs/_includes/panel-dialog.html
+++ b/docs/_includes/panel-dialog.html
@@ -12,7 +12,7 @@
                     <div class="panel-dialog__header">
                         <h2 id="panel-dialog-default-title" class="large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
@@ -35,8 +35,8 @@
         <div class="panel-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -46,6 +46,63 @@
                 consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
                 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+    <h3 id="panel-dialog-footer">Panel dialog with footer</h3>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-button" data-makeup-for="dialog-w-footer-panel-0" type="button">Open Panel</button>
+            <div aria-labelledby="panel-dialog-default-title" aria-modal="true" class="panel-dialog" hidden id="dialog-w-footer-panel-0" role="dialog">
+                <div class="panel-dialog__window">
+                    <div class="panel-dialog__header">
+                        <h2 id="panel-dialog-default-title" class="large-text-1 bold-text">Heading</h2>
+                        <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                                {% include symbol.html name="close" %}
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="panel-dialog__main">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                    <div class="panel-dialog__footer">
+                        <button class="btn btn--primary">Submit</button>
+                        <button class="btn">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div aria-labelledby="dialog-title" aria-modal="true" class="panel-dialog" hidden role="dialog">
+    <div class="panel-dialog__window">
+        <div class="panel-dialog__header">
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
+            <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="panel-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+        <div class="panel-dialog__footer">
+            <button class="btn btn--primary">Submit</button>
+            <button class="btn">Cancel</button>
         </div>
     </div>
 </div>
@@ -61,13 +118,8 @@
             <div aria-labelledby="panel-dialog-end-title" aria-modal="true" class="panel-dialog" hidden id="dialog-right-panel-1" role="dialog">
                 <div class="panel-dialog__window panel-dialog__window--end">
                     <div class="panel-dialog__header">
-                        <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                                {% include symbol.html name="close" %}
-                            </svg>
-                        </button>
-                        <h2 id="panel-dialog-end-title" class="panel-dialog__title panel-dialog__title--center large-text-1 bold-text">Heading</h2>
-                        <button class="fake-link panel-dialog__reset" type="button">Reset</button>
+                        <h2 id="panel-dialog-end-title" class="panel-dialog__title large-text-1 bold-text">Heading</h2>
+                        <button class="fake-link panel-dialog__reset" type="button">Done</button>
                     </div>
                     <div class="panel-dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -85,13 +137,8 @@
 <div aria-labelledby="dialog-title" aria-modal="true" class="panel-dialog" hidden id="dialog-right-panel-1" role="dialog">
     <div class="panel-dialog__window panel-dialog__window--end">
         <div class="panel-dialog__header">
-            <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
-                </svg>
-            </button>
-            <h2 id="dialog-title" class="panel-dialog__title panel-dialog__title--center large-text-1 bold-text">Heading</h2>
-            <button class="fake-link panel-dialog__reset" type="button">Reset</button>
+            <h2 id="dialog-title" class="panel-dialog__title large-text-1 bold-text">Heading</h2>
+            <button class="fake-link panel-dialog__reset" type="button">Done</button>
         </div>
         <div class="panel-dialog__main">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -116,7 +163,7 @@
                     <div class="panel-dialog__header">
                         <h2 id="panel-dialog-title-slide-1" class="panel-dialog__title large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
@@ -135,12 +182,12 @@
             <div aria-labelledby="panel-dialog-title-slide-2" aria-modal="true" class="panel-dialog panel-dialog--mask-fade-slow" hidden id="dialog-slide-right-panel-0" role="dialog">
                 <div class="panel-dialog__window panel-dialog__window--end panel-dialog__window--slide">
                     <div class="panel-dialog__header">
+                        <h2 id="panel-dialog-title-slide-2" class="panel-dialog__title large-text-1 bold-text">Heading</h2>
                         <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close" %}
                             </svg>
                         </button>
-                        <h2 id="panel-dialog-title-slide-2" class="panel-dialog__title panel-dialog__title--center large-text-1 bold-text">Heading</h2>
                     </div>
                     <div class="panel-dialog__main">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -159,8 +206,8 @@
         <div class="panel-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn panel-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>

--- a/src/less/fullscreen-dialog/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/fullscreen-dialog.less
@@ -37,12 +37,17 @@
     .dialog-footer-content();
 }
 
+button.icon-btn.fullscreen-dialog__close {
+    height: 32px;
+    min-width: 32px;
+    width: 32px;
+}
+
 // inherits from .icon-btn
 button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
     align-self: center;
     border: 0;
-    outline-offset: -8px;
     padding: 0;
     position: relative;
     z-index: 1;
@@ -62,7 +67,8 @@ button.fullscreen-dialog__back {
         transition: opacity 0.16s ease-out;
     }
 
-    .fullscreen-dialog__window--slide {
+    .fullscreen-dialog__window--slide,
+    .fullscreen-dialog__window--slide-end {
         transition: transform 0.32s ease-out;
     }
 }
@@ -85,6 +91,10 @@ button.fullscreen-dialog__back {
     .fullscreen-dialog__window--slide {
         transform: translateY(100%);
     }
+
+    .fullscreen-dialog__window--slide-end {
+        transform: translateX(100%);
+    }
 }
 
 .fullscreen-dialog--show,
@@ -105,18 +115,8 @@ button.fullscreen-dialog__back {
     .fullscreen-dialog__window--slide {
         transform: translateX(0);
     }
-}
 
-@media (min-width: 601px) {
-    .fullscreen-dialog__header {
-        .dialog-header-content-large();
-    }
-
-    .fullscreen-dialog__main {
-        .dialog-body-content-large();
-    }
-
-    .fullscreen-dialog__footer {
-        .dialog-footer-content-large();
+    .fullscreen-dialog__window--slide-end {
+        transform: translateX(0);
     }
 }

--- a/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
+++ b/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
@@ -4,12 +4,12 @@ export const closeButton = () => `
 <div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
     <div class="fullscreen-dialog__window">
         <div class="fullscreen-dialog__header">
+            <h2 id="fullscreen-dialog-title">Dialog Full</h2>
             <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
-                <svg class="icon icon--close" aria-hidden="true">
-                    <use xlink:href="#icon-close"></use>
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
-            <h2 id="fullscreen-dialog-title">Dialog Full</h2>
         </div>
         <div class="fullscreen-dialog__main">
             <h3>Heading</h3>
@@ -23,17 +23,44 @@ export const closeButton = () => `
 </div>
 `;
 
+export const withFooter = () => `
+<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
+    <div class="fullscreen-dialog__window">
+        <div class="fullscreen-dialog__header">
+            <h2 id="fullscreen-dialog-title">Dialog Full</h2>
+            <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="fullscreen-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+        <div class="fullscreen-dialog__footer">
+            <button class="btn btn--primary">Submit</button>
+            <button class="btn">Cancel</button>
+        </div>
+    </div>
+</div>
+`;
+
 export const RTL = () => `
 <div dir="rtl">
     <div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
         <div class="fullscreen-dialog__window">
             <div class="fullscreen-dialog__header">
+                <h2 id="fullscreen-dialog-title">Dialog Full</h2>
                 <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
-                    <svg class="icon icon--close" aria-hidden="true">
-                        <use xlink:href="#icon-close"></use>
+                    <svg class="icon icon--close-small" aria-hidden="true">
+                        <use xlink:href="#icon-close-small"></use>
                     </svg>
                 </button>
-                <h2 id="fullscreen-dialog-title">Dialog Full</h2>
             </div>
             <div class="fullscreen-dialog__main">
                 <h3>Heading</h3>
@@ -52,12 +79,12 @@ export const backButton = () => `
 <div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
     <div class="fullscreen-dialog__window">
         <div class="fullscreen-dialog__header">
+            <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>
             <button class="icon-btn fullscreen-dialog__back" type="button" aria-label="Back">
                 <svg class="icon icon--back" aria-hidden="true">
                     <use xlink:href="#icon-back"></use>
                 </svg>
             </button>
-            <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>
         </div>
         <div class="fullscreen-dialog__main">
             <h3>Heading</h3>
@@ -75,11 +102,6 @@ export const secondaryButton = () => `
 <div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
     <div class="fullscreen-dialog__window">
         <div class="fullscreen-dialog__header">
-            <button class="icon-btn fullscreen-dialog__back" type="button" aria-label="Back">
-                <svg class="icon icon--back" aria-hidden="true">
-                    <use xlink:href="#icon-back"></use>
-                </svg>
-            </button>
             <h2 id="fullscreen-dialog-title">Fullscreen Dialog</h2>
             <button class="fake-link fullscreen-dialog__close" type="button">Reset</button>
         </div>

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -39,10 +39,14 @@
 }
 
 // inherits from .icon-btn
-button.lightbox-dialog__close {
+// Might need to see if icon-btn can support a small version
+button.icon-btn.lightbox-dialog__close {
     align-self: center;
     border: 0;
+    height: 32px;
+    min-width: 32px;
     position: relative;
+    width: 32px;
     z-index: 1;
 }
 
@@ -117,17 +121,7 @@ button.lightbox-dialog__close {
 }
 
 @media (min-width: 601px) {
-    .lightbox-dialog__window {
-        .lightbox-dialog__header {
-            .dialog-header-content-large();
-        }
-
-        .lightbox-dialog__main {
-            .dialog-body-content-large();
-        }
-
-        .lightbox-dialog__footer {
-            .dialog-footer-content-large();
-        }
+    .lightbox-dialog__window .lightbox-dialog__footer {
+        .dialog-footer-content-large();
     }
 }

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -6,8 +6,8 @@ export const base = () => `
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
-                <svg class="icon icon--close" aria-hidden="true">
-                    <use xlink:href="#icon-close"></use>
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -23,13 +23,41 @@ export const base = () => `
 </div>
 `;
 
+export const baseWithFooter = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window">
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+        <div class="lightbox-dialog__footer">
+            <button class="btn btn--primary">Submit</button>
+            <button class="btn">Cancel</button>
+        </div>
+
+    </div>
+</div>
+`;
+
 export const mini = () => `
 <div aria-label="mini Example" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" role="dialog">
     <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
         <div class="lightbox-dialog__header">
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -45,8 +73,8 @@ export const miniMinHeight = () => `
     <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
         <div class="lightbox-dialog__header">
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -64,8 +92,8 @@ export const baseRTL = () => `
             <div class="lightbox-dialog__header">
                 <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
                 <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
-                    <svg class="icon icon--close" aria-hidden="true">
-                        <use xlink:href="#icon-close"></use>
+                    <svg class="icon icon--close-small" aria-hidden="true">
+                        <use xlink:href="#icon-close-small"></use>
                     </svg>
                 </button>
             </div>
@@ -88,8 +116,8 @@ export const miniRTL = () => `
         <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
             <div class="lightbox-dialog__header">
                 <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                    <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                        <use xlink:href="#icon-close"></use>
+                    <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                        <use xlink:href="#icon-close-small"></use>
                     </svg>
                 </button>
             </div>

--- a/src/less/mixins/private/dialog-mixins.less
+++ b/src/less/mixins/private/dialog-mixins.less
@@ -1,5 +1,6 @@
 @import "../public/utility-mixins.less";
 
+// Deprecated, remove the gutter sizes next major
 @dialog-small-gutter-size: 16px;
 @dialog-large-gutter-size: 24px;
 @dialog-scrim-color-hide: rgba(17, 24, 32, 0);
@@ -52,7 +53,7 @@
     display: flex;
     // Fix for Safari not honoring min-height
     flex-shrink: 0;
-    margin: @dialog-small-gutter-size (@dialog-small-gutter-size - 8) 0;
+    margin: @spacing-200 @spacing-200 0;
     position: relative;
 
     h1,
@@ -63,18 +64,18 @@
     h6 {
         align-self: center;
         flex: 1 1 auto;
-        margin: 0 8px;
+        margin: 0;
     }
 
     & > :last-child:not(:only-child) {
-        margin-left: 16px;
+        margin-left: @spacing-200;
     }
 }
 
 .dialog-body-content() {
     box-sizing: border-box;
     flex: 1 1 auto;
-    margin: @dialog-small-gutter-size;
+    margin: @spacing-200;
     position: relative;
 
     & > :first-child {
@@ -90,29 +91,31 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 16px;
+    padding: @spacing-200;
     position: relative;
 
     & > :not(:first-child) {
-        margin-top: 16px;
+        margin-top: @spacing-200;
     }
 }
 
+// Unused, small and large are the same now
 .dialog-header-content-large() {
-    margin: (@dialog-large-gutter-size - 8px) (@dialog-large-gutter-size - 8px) 0;
+    margin: @spacing-200 @spacing-200 0;
 }
 
+// Unused, small and large are the same now
 .dialog-body-content-large() {
-    margin: (@dialog-large-gutter-size - 8px) @dialog-large-gutter-size @dialog-large-gutter-size;
+    margin: @spacing-200;
 }
 
 .dialog-footer-content-large() {
     flex-direction: row;
     justify-content: flex-end;
-    padding: @dialog-large-gutter-size;
+    padding: 0 @spacing-200 @spacing-200;
 
     & > :not(:first-child) {
-        margin-left: @dialog-large-gutter-size;
+        margin-left: @spacing-100;
         margin-top: initial;
     }
 }

--- a/src/less/panel-dialog/panel-dialog.less
+++ b/src/less/panel-dialog/panel-dialog.less
@@ -14,7 +14,7 @@
     border-right: 1px solid rgba(153, 153, 153, 0.18);
     -webkit-overflow-scrolling: touch;
     overflow-y: auto;
-    width: calc(100% - @spacing-400);
+    width: 100%;
 }
 
 .panel-dialog__window--end {
@@ -35,18 +35,20 @@
     .dialog-body-content();
 }
 
-// deprecated & undocumented, but still used by teams
 .panel-dialog__footer {
     .dialog-footer-content();
 }
 
 // inherits from .icon-btn
-button.panel-dialog__close {
+// Might need to see to add a small icon btn
+button.icon-btn.panel-dialog__close {
     align-self: center;
     border: 0;
-    outline-offset: -@spacing-100;
+    height: 32px;
+    min-width: 32px;
     padding: 0;
     position: relative;
+    width: 32px;
     z-index: 1;
 }
 
@@ -56,6 +58,7 @@ button.panel-dialog__close {
     }
 }
 
+// Deprecated
 .panel-dialog__title--center {
     text-align: center;
 }
@@ -126,19 +129,6 @@ button.panel-dialog__close {
 
 @media (min-width: 601px) {
     .panel-dialog__window {
-        width: calc(88% - @spacing-400);
-    }
-
-    .panel-dialog__header {
-        .dialog-header-content-large();
-    }
-
-    .panel-dialog__main {
-        .dialog-body-content-large();
-    }
-
-    // deprecated & undocumented, but still used by teams
-    .panel-dialog__footer {
-        .dialog-footer-content-large();
+        width: 384px;
     }
 }

--- a/src/less/panel-dialog/stories/panel-dialog.stories.js
+++ b/src/less/panel-dialog/stories/panel-dialog.stories.js
@@ -6,8 +6,8 @@ export const panelStart = () => `
         <div class="panel-dialog__header">
             <h2 id="panel-title">Left Panel</h2>
             <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
-                <svg class="icon icon--close" aria-hidden="true">
-                    <use xlink:href="#icon-close"></use>
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
@@ -30,8 +30,8 @@ export const RTL = () => `
             <div class="panel-dialog__header">
                 <h2 id="panel-title">Left Panel</h2>
                 <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
-                    <svg class="icon icon--close" aria-hidden="true">
-                        <use xlink:href="#icon-close"></use>
+                    <svg class="icon icon--close-small" aria-hidden="true">
+                        <use xlink:href="#icon-close-small"></use>
                     </svg>
                 </button>
             </div>
@@ -52,12 +52,12 @@ export const panelEnd = () => `
 <div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
     <div class="panel-dialog__window panel-dialog__window--end">
         <div class="panel-dialog__header">
+            <h2 id="panel-title">Right Panel</h2>
             <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
-                <svg class="icon icon--close" aria-hidden="true">
-                    <use xlink:href="#icon-close"></use>
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
-            <h2 id="panel-title">Right Panel</h2>
         </div>
         <div class="panel-dialog__main">
             <h3>Heading</h3>
@@ -71,15 +71,37 @@ export const panelEnd = () => `
 </div>
 `;
 
+export const panelEndWithFooter = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window panel-dialog__window--end">
+        <div class="panel-dialog__header">
+            <h2 id="panel-title">Right Panel</h2>
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="panel-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+        <div class="panel-dialog__footer">
+            <button class="btn btn--primary">Submit</button>
+            <button class="btn">Cancel</button>
+        </div>
+    </div>
+</div>
+`;
+
 export const panelEndSecondaryButton = () => `
 <div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
     <div class="panel-dialog__window panel-dialog__window--end">
         <div class="panel-dialog__header">
-            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
-                <svg class="icon icon--close" aria-hidden="true">
-                    <use xlink:href="#icon-close"></use>
-                </svg>
-            </button>
             <h2 id="panel-title">Right Panel</h2>
             <button class="fake-link panel-dialog__close" type="button">Reset</button>
         </div>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1734 and #1708

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Updated panel-dialog to have a max-width. Made fullscreen panel dialog to take up the whole space.
* Updated full-screen dialog to have an animation from right to left. 
* Updated all dialogs (lightbox, fullscreen, and panel) to be 16px padding. Fixed spacing for all headings. All close buttons are now on right side. (kept backwards compatibility)
* Fixed close button to be 32x32 as per spec. Switched out icon to be close-small
* Added footer support to all dialogs and cleaned up footer code.
* A lot of old code is deprecated and unused. We should remove next major

## Screenshots
<img width="607" alt="Screen Shot 2022-07-11 at 4 30 31 PM" src="https://user-images.githubusercontent.com/1755269/178376753-1ecc3fe6-0113-47ec-8860-1585c6f52c8a.png">
<img width="396" alt="Screen Shot 2022-07-11 at 4 41 44 PM" src="https://user-images.githubusercontent.com/1755269/178376729-1822d848-a40c-46a5-8532-204080408888.png">
<img width="930" alt="Screen Shot 2022-07-11 at 4 42 03 PM" src="https://user-images.githubusercontent.com/1755269/178376737-f10a086f-e71a-4042-b10f-5a3a9f1725db.png">

![sliding-dialog](https://user-images.githubusercontent.com/1755269/178376831-133f958c-48df-4f2a-a64d-3553dfa840c4.gif)

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
