### PR TITLE
fix(floating-label): added mask and spacing changes

### DIFF
--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -13,9 +13,11 @@ label.floating-label__label {
   display: inline-block;
   left: 16px;
   overflow: hidden;
+  padding-top: 3px;
   pointer-events: none;
   position: absolute;
   text-overflow: ellipsis;
+  top: -3px;
   transform: scale(0.75, 0.75) translate(0, 2px);
   transform-origin: left;
   white-space: nowrap;

--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -8,6 +8,7 @@ div.floating-label {
   display: block;
 }
 label.floating-label__label {
+  background-color: var(--floating-label-background-color, var(--color-background-secondary));
   color: var(--floating-label-color, var(--color-foreground-primary));
   display: inline-block;
   left: 16px;
@@ -18,10 +19,11 @@ label.floating-label__label {
   transform: scale(0.75, 0.75) translate(0, 2px);
   transform-origin: left;
   white-space: nowrap;
-  width: calc(100% - 24px);
+  width: calc(100% - 40px);
   z-index: 1;
 }
 label.floating-label__label--focus {
+  background-color: var(--floating-label-focus-background-color, var(--color-background-primary));
   color: var(--color-background-inverse);
 }
 .floating-label--large label.floating-label__label {
@@ -38,10 +40,12 @@ label.floating-label__label--animate {
   transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), bottom 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 label.floating-label__label--disabled {
+  background-color: var(--floating-label-disabled-background-color, var(--color-background-secondary));
   color: var(--floating-label-disabled-color, var(--color-foreground-disabled));
 }
 label.floating-label__label--invalid {
   color: var(--floating-label-invalid-color, var(--color-foreground-attention));
+  background-color: var(--color-red-1);
 }
 .floating-label .textbox__control,
 .floating-label .combobox__control > input {
@@ -53,16 +57,9 @@ label.floating-label__label--invalid {
   padding-bottom: 5px;
   padding-top: 23px;
 }
-.floating-label .select {
-  margin-right: -24px;
-}
 .floating-label .select select {
   line-height: 52px;
 }
 .floating-label .select--large select {
   line-height: 60px;
-}
-[dir="rtl"] .floating-label .select {
-  margin-left: -24px;
-  margin-right: 0;
 }

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -19,9 +19,11 @@ label.floating-label__label {
     display: inline-block;
     left: 16px;
     overflow: hidden;
+    padding-top: 3px;
     pointer-events: none;
     position: absolute;
     text-overflow: ellipsis;
+    top: -3px;
     transform: scale(0.75, 0.75) translate(0, 2px);
     transform-origin: left;
     white-space: nowrap;

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -14,6 +14,7 @@ div.floating-label {
 }
 
 label.floating-label__label {
+    .background-color-token(floating-label-background-color, color-background-secondary);
     .color-token(floating-label-color, color-foreground-primary);
     display: inline-block;
     left: 16px;
@@ -24,11 +25,12 @@ label.floating-label__label {
     transform: scale(0.75, 0.75) translate(0, 2px);
     transform-origin: left;
     white-space: nowrap;
-    width: calc(100% - 24px);
+    width: calc(100% - 40px);
     z-index: 1;
 }
 
 label.floating-label__label--focus {
+    .background-color-token(floating-label-focus-background-color, color-background-primary);
     color: var(--color-background-inverse);
 }
 
@@ -51,11 +53,14 @@ label.floating-label__label--animate {
 }
 
 label.floating-label__label--disabled {
+    .background-color-token(floating-label-disabled-background-color, color-background-secondary);
     .color-token(floating-label-disabled-color, color-foreground-disabled);
 }
 
 label.floating-label__label--invalid {
     .color-token(floating-label-invalid-color, color-foreground-attention);
+
+    background-color: var(--color-red-1);
 }
 
 .floating-label .textbox__control,
@@ -72,21 +77,10 @@ label.floating-label__label--invalid {
     padding-top: 23px;
 }
 
-// For select floating label
-.floating-label .select {
-    // Reduce space given for floating-label so that it doesn't cover the chevron
-    margin-right: -24px;
-}
-
 .floating-label .select select {
     line-height: 52px;
 }
 
 .floating-label .select--large select {
     line-height: 60px;
-}
-
-[dir="rtl"] .floating-label .select {
-    margin-left: -24px;
-    margin-right: 0;
 }

--- a/src/less/floating-label/stories/floating-label.stories.js
+++ b/src/less/floating-label/stories/floating-label.stories.js
@@ -108,6 +108,38 @@ export const selectInline = () => `
 </span>
 `;
 
+export const selectInlineDoubled = () => `
+<span class="floating-label">
+    <label class="floating-label__label floating-label__label--inline">Select Option long text with ellipsis</label>
+    <span class="select">
+        <select aria-label="Select demo" name="options">
+            <option value=""></option>
+            <option value="item1">Pick Option 1 (default)</option>
+            <option value="item2">Pick Option 2</option>
+            <option value="item3">Pick Option 3</option>
+        </select>
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</span>
+<span class="floating-label">
+    <label class="floating-label__label floating-label__label--inline">Select Option long text</label>
+    <span class="select">
+        <select aria-label="Select demo" name="options">
+            <option value=""></option>
+            <option value="item1">Pick Option 1 (default)</option>
+            <option value="item2">Pick Option 2</option>
+            <option value="item3">Pick Option 3</option>
+        </select>
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</span>
+
+`;
+
 export const RTLSelectInline = () => `
 <div dir="rtl">
     <span class="floating-label">
@@ -125,4 +157,13 @@ export const RTLSelectInline = () => `
         </span>
     </span>
 </div>
+`;
+
+export const TextArea = () => `
+<span class="floating-label">
+    <label class="floating-label__label" for="first-name">Enter list of users</label>
+    <span class="textbox">
+        <textarea aria-label="Textbox demo" class="textbox__control"></textarea>
+    </span>
+</span>
 `;


### PR DESCRIPTION
Fixes #1722 #1698

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Removed negative margin. Added a smaller size to floating label. This makes it so that it doesn't overlap with any icons (this also affects normal textbox, but in case there's an icon it won't overlap). We might need to revisit floating label to see if we can add a "with-icon" modifier. But that should be for future 
* Added a background-color to match textbox background for floating-label. This is so that textarea's text does not overlap with label when scrolling

## Screenshots
<img width="447" alt="Screen Shot 2022-07-15 at 8 51 53 AM" src="https://user-images.githubusercontent.com/1755269/179270169-0ff8dbf2-2a44-468b-9fa3-87db719d13f9.png">
<img width="260" alt="Screen Shot 2022-07-15 at 9 50 02 AM" src="https://user-images.githubusercontent.com/1755269/179270545-4cee3d35-3239-4ced-a44c-779532773ff3.png">



## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
