### PR TITLE
fix(textbox): changed variables to be the correct naming

### DIFF
--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -64,7 +64,7 @@ textarea.textbox__control[disabled]:-ms-input-placeholder {
 }
 input.textbox__control[readonly],
 textarea.textbox__control[readonly] {
-  color: var(--textbox-readonly-color, var(--color-foreground-ghost));
+  color: var(--textbox-readonly-color, var(--color-foreground-on-secondary));
 }
 input.textbox__control[aria-invalid="true"],
 textarea.textbox__control[aria-invalid="true"] {
@@ -75,17 +75,17 @@ input.textbox__control:focus,
 textarea.textbox__control:focus {
   border-color: var(--textbox-focus-border-color, var(--color-stroke-default));
   background-color: var(--textbox-focus-background-color, var(--color-background-primary));
-  color: var(--textbox-focus-foreground-color, var(--color-foreground-secondary));
+  color: var(--textbox-focus-foreground-color, var(--color-foreground-on-secondary));
   outline: 0;
 }
 input.textbox__control::-webkit-input-placeholder,
 textarea.textbox__control::-webkit-input-placeholder {
-  color: var(--textbox-placeholder-color, var(--color-foreground-secondary));
+  color: var(--textbox-placeholder-color, var(--color-foreground-on-secondary));
   font-weight: 200;
 }
 input.textbox__control:-ms-input-placeholder,
 textarea.textbox__control:-ms-input-placeholder {
-  color: var(--textbox-placeholder-color, var(--color-foreground-secondary));
+  color: var(--textbox-placeholder-color, var(--color-foreground-on-secondary));
   font-weight: 200;
 }
 input.textbox__control::-ms-input-placeholder,

--- a/src/less/textbox/textbox.less
+++ b/src/less/textbox/textbox.less
@@ -69,7 +69,7 @@ textarea.textbox__control {
     }
 
     &[readonly] {
-        .color-token(textbox-readonly-color, color-foreground-ghost);
+        .color-token(textbox-readonly-color, color-foreground-on-secondary);
     }
 
     &[aria-invalid="true"] {
@@ -80,22 +80,22 @@ textarea.textbox__control {
     &:focus {
         .border-color-token(textbox-focus-border-color, color-stroke-default);
         .background-color-token(textbox-focus-background-color, color-background-primary);
-        .color-token(textbox-focus-foreground-color, color-foreground-secondary);
+        .color-token(textbox-focus-foreground-color, color-foreground-on-secondary);
         outline: 0;
     }
 
     &::-webkit-input-placeholder {
-        .color-token(textbox-placeholder-color, color-foreground-secondary);
+        .color-token(textbox-placeholder-color, color-foreground-on-secondary);
         font-weight: 200;
     }
 
     &::-moz-placeholder {
-        .color-token(textbox-placeholder-color, color-foreground-secondary);
+        .color-token(textbox-placeholder-color, color-foreground-on-secondary);
         font-weight: 200;
     }
 
     &:-ms-input-placeholder {
-        .color-token(textbox-placeholder-color, color-foreground-secondary);
+        .color-token(textbox-placeholder-color, color-foreground-on-secondary);
         font-weight: 200;
     }
 


### PR DESCRIPTION
Fixes #1775

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Fixed typo of  `color-foreground-secondary`, which should be `color-foreground-on-secondary`
* Set readonly text as the same color, instead of ghost color.

## Screenshots
<img width="936" alt="Screen Shot 2022-07-15 at 10 16 47 AM" src="https://user-images.githubusercontent.com/1755269/179275628-6dd7d7eb-a2fc-44b8-9011-a4a2bac5f8b2.png">
<img width="328" alt="Screen Shot 2022-07-15 at 10 16 50 AM" src="https://user-images.githubusercontent.com/1755269/179275632-b87ff573-f81f-4f92-8faa-ddb2d0ec92da.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
