### PR TITLE
fix(filter): added font-family:inherit to mixin

### DIFF
--- a/dist/filter-button/filter-button.css
+++ b/dist/filter-button/filter-button.css
@@ -12,6 +12,7 @@ a.filter-link {
   display: inline-flex;
   flex: 0 1 auto;
   flex-direction: column;
+  font-family: inherit;
   font-size: 0.875rem;
   height: 32px;
   justify-content: center;

--- a/dist/filter-menu-button/filter-menu-button.css
+++ b/dist/filter-menu-button/filter-menu-button.css
@@ -18,6 +18,7 @@ button.filter-menu-button__button {
   display: inline-flex;
   flex: 0 1 auto;
   flex-direction: column;
+  font-family: inherit;
   font-size: 0.875rem;
   height: 32px;
   justify-content: center;

--- a/src/less/mixins/private/filter-button-mixins.less
+++ b/src/less/mixins/private/filter-button-mixins.less
@@ -7,6 +7,7 @@
     display: inline-flex;
     flex: 0 1 auto;
     flex-direction: column;
+    font-family: inherit;
     font-size: @font-size-14;
     height: 32px;
     justify-content: center;


### PR DESCRIPTION
Fixes #1813 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added `font-family: inherit` to filter mixins

## Screenshots
<img width="1485" alt="Screen Shot 2022-07-21 at 10 35 00 AM" src="https://user-images.githubusercontent.com/1755269/180277605-2e230d01-16ef-4f71-b28c-b2c04bc763d3.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
