### PR TITLE
fix(page-notice): changed confirm color to green 6

### DIFF
--- a/dist/legacy-tokens/ds4-light.css
+++ b/dist/legacy-tokens/ds4-light.css
@@ -4,7 +4,7 @@
     --color-background-disabled: var(--color-neutral-3);
     --color-background-inverse: var(--color-neutral-6);
     --color-background-attention: var(--color-red-4);
-    --color-background-confirmation: var(--color-green-4);
+    --color-background-confirmation: var(--color-green-6);
     --color-background-information: var(--color-blue-4);
     --color-background-accent: var(--color-blue-4);
     --color-background-invalid: var(--color-red-1);

--- a/dist/tokens/evo-light.css
+++ b/dist/tokens/evo-light.css
@@ -4,7 +4,7 @@
     --color-background-disabled: var(--color-neutral-3);
     --color-background-inverse: var(--color-neutral-6);
     --color-background-attention: var(--color-red-4);
-    --color-background-confirmation: var(--color-green-4);
+    --color-background-confirmation: var(--color-green-6);
     --color-background-information: var(--color-blue-4);
     --color-background-accent: var(--color-blue-4);
     --color-background-invalid: var(--color-red-1);

--- a/src/tokens/evo-light.css
+++ b/src/tokens/evo-light.css
@@ -4,7 +4,7 @@
     --color-background-disabled: var(--color-neutral-3);
     --color-background-inverse: var(--color-neutral-6);
     --color-background-attention: var(--color-red-4);
-    --color-background-confirmation: var(--color-green-4);
+    --color-background-confirmation: var(--color-green-6);
     --color-background-information: var(--color-blue-4);
     --color-background-accent: var(--color-blue-4);
     --color-background-invalid: var(--color-red-1);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1818

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Changed page notice color to be green 6

## Screenshots
<img width="1074" alt="Screen Shot 2022-07-27 at 11 40 05 AM" src="https://user-images.githubusercontent.com/1755269/181347840-5042edef-26bd-4cca-a366-1b068fcfdb6f.png">

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue


- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
