### PR TITLE
fix(floating-label): changed select background to white on focus

### DIFF
--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -13,11 +13,10 @@ label.floating-label__label {
   display: inline-block;
   left: 16px;
   overflow: hidden;
-  padding-top: 3px;
   pointer-events: none;
   position: absolute;
   text-overflow: ellipsis;
-  top: -3px;
+  top: 0;
   transform: scale(0.75, 0.75) translate(0, 2px);
   transform-origin: left;
   white-space: nowrap;

--- a/dist/select/select.css
+++ b/dist/select/select.css
@@ -46,7 +46,11 @@ span.select {
   width: auto;
 }
 .select--borderless select:focus {
+  background-color: transparent;
   text-decoration: underline;
+}
+.select select:focus {
+  background-color: var(--select-focus-background-color, var(--color-background-primary));
 }
 .select select:focus:not(:read-only) {
   background-color: var(--select-focus-background-color, var(--color-background-primary));

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -19,11 +19,10 @@ label.floating-label__label {
     display: inline-block;
     left: 16px;
     overflow: hidden;
-    padding-top: 3px;
     pointer-events: none;
     position: absolute;
     text-overflow: ellipsis;
-    top: -3px;
+    top: 0;
     transform: scale(0.75, 0.75) translate(0, 2px);
     transform-origin: left;
     white-space: nowrap;

--- a/src/less/select/select.less
+++ b/src/less/select/select.less
@@ -54,8 +54,13 @@ span.select {
     width: auto;
 
     &:focus {
+        background-color: transparent;
         text-decoration: underline;
     }
+}
+
+.select select:focus {
+    .background-color-token(select-focus-background-color, color-background-primary);
 }
 
 .select select:focus:not(:read-only) {

--- a/src/less/select/stories/floating-label.stories.js
+++ b/src/less/select/stories/floating-label.stories.js
@@ -1,0 +1,66 @@
+export default { title: 'Select/Select/Floating Label' };
+
+export const defaultLabel = () => `
+<span class="floating-label">
+    <label class="floating-label__label" for="select-01">Choose Option</label>
+    <span class="select">
+        <select id="select-01">
+            <option value="1">Option 1 with long text</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+        </select>
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</span>
+`;
+
+export const selectedOption = () => `
+<span class="floating-label">
+    <label class="floating-label__label floating-label__label--inline" for="select-01">Here are your options</label>
+    <span class="select">
+        <select id="select-01">
+            <option value=""></option>
+            <option value="1">Option 1 with long text</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+        </select>
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</span>
+`;
+
+export const errorState = () => `
+<span class="floating-label">
+    <label class="floating-label__label floating-label__label--invalid" for="select-03">Choose Option</label>
+    <span class="select">
+        <select id="select-03" aria-invalid="true">
+            <option value="1">Option 1 with long text</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+        </select>
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</span>
+`;
+
+export const disabled = () => `
+<span class="floating-label">
+    <label class="floating-label__label" for="select-03">Choose Option</label>
+    <span class="select">
+        <select disabled>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2 can't pick</option>
+            <option value="3">Option 3</option>
+        </select>
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</span>
+`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1819

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Select did not have a white background when focused. I changed that focus color background. This fixes the issue with floating label changing color on focus
* I also remove the padding from the top. This caused the focus ring to be off. This will make a bit of the text bleed through on textarea on the top a bit, but it is better to fix this and have the textarea bleed text through the top (it isn't as bad as before though)
* Added floating label test cases to select. Unfortunately there is no JS on storybook, so won't simulate it correctly on focus/unfocus. 

## Screenshots
<img width="340" alt="Screen Shot 2022-07-27 at 11 44 31 AM" src="https://user-images.githubusercontent.com/1755269/181348608-c496191e-699d-4231-aa62-b24ee1095018.png">
<img width="317" alt="Screen Shot 2022-07-27 at 11 44 47 AM" src="https://user-images.githubusercontent.com/1755269/181348617-abf409c4-fe18-4289-85da-b583f797052a.png">
<img width="285" alt="Screen Shot 2022-07-27 at 11 47 45 AM" src="https://user-images.githubusercontent.com/1755269/181349115-3a944ea7-111f-4d4a-81c3-88d4f5e49cdb.png">

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
