### PR TITLE
fix(textbox): removed padding from readonly

### DIFF
--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -62,10 +62,12 @@ input.textbox__control[disabled]:-ms-input-placeholder,
 textarea.textbox__control[disabled]:-ms-input-placeholder {
   color: var(--textbox-disabled-placeholder-color, var(--color-foreground-ghost));
 }
-input.textbox__control[readonly],
-textarea.textbox__control[readonly] {
+input.textbox__control:read-only,
+textarea.textbox__control:read-only {
   background-color: transparent;
   border: none;
+  padding-left: 0;
+  padding-right: 0;
 }
 input.textbox__control[aria-invalid="true"],
 textarea.textbox__control[aria-invalid="true"] {
@@ -119,6 +121,11 @@ textarea.textbox__control:not(:read-only):focus {
   border-color: var(--textbox-focus-border-color, var(--color-stroke-default));
   background-color: var(--textbox-focus-background-color, var(--color-background-primary));
   outline: 0;
+}
+input.textbox__control:read-only:focus,
+textarea.textbox__control:read-only:focus {
+  outline: 0;
+  text-decoration: underline;
 }
 .textbox > svg:first-child {
   left: 16px;

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -62,8 +62,8 @@ input.textbox__control[disabled]:-ms-input-placeholder,
 textarea.textbox__control[disabled]:-ms-input-placeholder {
   color: var(--textbox-disabled-placeholder-color, var(--color-foreground-ghost));
 }
-input.textbox__control:read-only,
-textarea.textbox__control:read-only {
+input.textbox__control[readonly],
+textarea.textbox__control[readonly] {
   background-color: transparent;
   border: none;
   padding-left: 0;
@@ -122,8 +122,8 @@ textarea.textbox__control:not(:read-only):focus {
   background-color: var(--textbox-focus-background-color, var(--color-background-primary));
   outline: 0;
 }
-input.textbox__control:read-only:focus,
-textarea.textbox__control:read-only:focus {
+input.textbox__control[readonly]:focus,
+textarea.textbox__control[readonly]:focus {
   outline: 0;
   text-decoration: underline;
 }

--- a/src/less/textbox/textbox.less
+++ b/src/less/textbox/textbox.less
@@ -68,7 +68,7 @@ textarea.textbox__control {
         }
     }
 
-    &:read-only {
+    &[readonly] {
         background-color: transparent;
         border: none;
         padding-left: 0;
@@ -135,8 +135,8 @@ textarea.textbox__control:not(:read-only):focus {
     outline: 0;
 }
 
-input.textbox__control:read-only:focus,
-textarea.textbox__control:read-only:focus {
+input.textbox__control[readonly]:focus,
+textarea.textbox__control[readonly]:focus {
     outline: 0;
     text-decoration: underline;
 }

--- a/src/less/textbox/textbox.less
+++ b/src/less/textbox/textbox.less
@@ -68,9 +68,11 @@ textarea.textbox__control {
         }
     }
 
-    &[readonly] {
+    &:read-only {
         background-color: transparent;
         border: none;
+        padding-left: 0;
+        padding-right: 0;
     }
 
     &[aria-invalid="true"] {
@@ -131,6 +133,12 @@ textarea.textbox__control:not(:read-only):focus {
     .border-color-token(textbox-focus-border-color, color-stroke-default);
     .background-color-token(textbox-focus-background-color, color-background-primary);
     outline: 0;
+}
+
+input.textbox__control:read-only:focus,
+textarea.textbox__control:read-only:focus {
+    outline: 0;
+    text-decoration: underline;
 }
 
 .textbox > svg:first-child {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1820 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Removed the padding from textbox

## Notes
So the focus rings were looking odd without padding. I changed it to be underline text like we have for select borderless. 

## Screenshots

<img width="699" alt="Screen Shot 2022-07-27 at 3 01 04 PM" src="https://user-images.githubusercontent.com/1755269/181380178-5e67161e-6c9b-4e41-beb8-0c550e55c028.png">
<img width="703" alt="Screen Shot 2022-07-27 at 3 01 10 PM" src="https://user-images.githubusercontent.com/1755269/181380182-44d8f1f1-6af5-425f-b5f6-87700adcee1f.png">

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
