### PR TITLE
fix: reverted floating-label to be transparent again

### DIFF
--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -8,8 +8,8 @@ div.floating-label {
   display: block;
 }
 label.floating-label__label {
-  background-color: var(--floating-label-background-color, var(--color-background-secondary));
   color: var(--floating-label-color, var(--color-foreground-primary));
+  background-color: transparent;
   display: inline-block;
   left: 16px;
   overflow: hidden;
@@ -24,7 +24,6 @@ label.floating-label__label {
   z-index: 1;
 }
 label.floating-label__label--focus {
-  background-color: var(--floating-label-focus-background-color, var(--color-background-primary));
   color: var(--color-background-inverse);
 }
 .floating-label--large label.floating-label__label {
@@ -41,7 +40,6 @@ label.floating-label__label--animate {
   transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), bottom 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 label.floating-label__label--disabled {
-  background-color: var(--floating-label-disabled-background-color, var(--color-background-secondary));
   color: var(--floating-label-disabled-color, var(--color-foreground-disabled));
 }
 label.floating-label__label--invalid {

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -14,8 +14,9 @@ div.floating-label {
 }
 
 label.floating-label__label {
-    .background-color-token(floating-label-background-color, color-background-secondary);
     .color-token(floating-label-color, color-foreground-primary);
+
+    background-color: transparent;
     display: inline-block;
     left: 16px;
     overflow: hidden;
@@ -31,7 +32,6 @@ label.floating-label__label {
 }
 
 label.floating-label__label--focus {
-    .background-color-token(floating-label-focus-background-color, color-background-primary);
     color: var(--color-background-inverse);
 }
 
@@ -54,7 +54,6 @@ label.floating-label__label--animate {
 }
 
 label.floating-label__label--disabled {
-    .background-color-token(floating-label-disabled-background-color, color-background-secondary);
     .color-token(floating-label-disabled-color, color-foreground-disabled);
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Reverts #1698

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* We added a background color to floating label to obscure text behind it. However this is causing a lot of issues especially in the case where chrome adds autocomplete to a field. There is no way to resolve that issue on our end since it's a browser problem. To resolve this, this reverts the background color and makes it transparent again.
* Next minor we should add a feature which obscures the background which can be used on textarea (although if textarea has autocomplete on it too it could cause the same issue).


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
