### PR TITLE
feat(notice): updated notice to use new styles

### DIFF
--- a/dist/infotip/infotip.css
+++ b/dist/infotip/infotip.css
@@ -4,6 +4,7 @@
   --bubble-right-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
   --bubble-bottom-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
   --bubble-top-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
+  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
 }
 .infotip {
   position: relative;
@@ -13,7 +14,7 @@ span.infotip {
 }
 .infotip__overlay {
   border-radius: var(--bubble-border-radius, var(--border-radius-50));
-  box-shadow: var(--bubble-base-box-shadow);
+  filter: var(--bubble-filter);
   font-size: 14px;
   max-width: 344px;
   width: -webkit-max-content;
@@ -22,7 +23,7 @@ span.infotip {
   background-color: var(--infotip-background-color, var(--color-background-primary));
   color: var(--infotip-foreground-color, var(--color-foreground-primary));
   display: none;
-  left: -10px;
+  left: -6px;
   margin-top: 16px;
   position: absolute;
 }
@@ -38,7 +39,7 @@ span.infotip__mask {
 }
 .infotip__cell {
   display: flex;
-  padding: 16px;
+  padding: 8px 16px;
   word-break: break-word;
 }
 .infotip__content {
@@ -52,82 +53,70 @@ span.infotip__mask {
 }
 .infotip__pointer {
   background-color: var(--infotip-background-color, var(--color-background-primary));
-  height: 16px;
+  height: 8px;
   position: absolute;
   transform: rotate(45deg);
-  width: 16px;
+  width: 8px;
   z-index: 0;
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
-  left: calc(50% - 8px);
+  top: -4px;
+  left: calc(50% - 4px);
 }
 .infotip__pointer--top-left {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
+  top: -4px;
   left: 12px;
 }
 .infotip__pointer--top {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
-  left: calc(50% - 8px);
+  top: -4px;
+  left: calc(50% - 4px);
 }
 .infotip__pointer--top-right {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
+  top: -4px;
   left: auto;
   right: 12px;
 }
 .infotip__pointer--bottom-left {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
   left: 12px;
 }
 .infotip__pointer--bottom {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
-  left: calc(50% - 8px);
+  left: calc(50% - 4px);
 }
 .infotip__pointer--bottom-right {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
   left: auto;
   right: 12px;
 }
 .infotip__pointer--left {
-  top: calc(50% - 8px);
-  left: -7px;
+  top: calc(50% - 4px);
+  left: -4px;
 }
 .infotip__pointer--left-bottom {
   bottom: 12px;
-  box-shadow: var(--bubble-left-box-shadow);
-  left: -7px;
+  left: -4px;
   top: auto;
 }
 .infotip__pointer--left-top {
-  box-shadow: var(--bubble-left-box-shadow);
-  left: -7px;
+  left: -4px;
   top: 12px;
 }
 .infotip__pointer--right {
-  top: calc(50% - 8px);
-  box-shadow: var(--bubble-right-box-shadow);
+  top: calc(50% - 4px);
   left: auto;
-  right: -7px;
+  right: -4px;
 }
 .infotip__pointer--right-bottom {
   bottom: 12px;
-  box-shadow: var(--bubble-right-box-shadow);
   left: auto;
-  right: -7px;
+  right: -4px;
   top: auto;
 }
 .infotip__pointer--right-top {
-  box-shadow: var(--bubble-right-box-shadow);
   left: auto;
-  right: -7px;
+  right: -4px;
   top: 12px;
 }
 .infotip__heading {

--- a/dist/tooltip/tooltip.css
+++ b/dist/tooltip/tooltip.css
@@ -4,6 +4,7 @@
   --bubble-right-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
   --bubble-bottom-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
   --bubble-top-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
+  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
 }
 .tooltip {
   position: relative;
@@ -13,7 +14,7 @@ span.tooltip {
 }
 .tooltip__overlay {
   border-radius: var(--bubble-border-radius, var(--border-radius-50));
-  box-shadow: var(--bubble-base-box-shadow);
+  filter: var(--bubble-filter);
   font-size: 14px;
   max-width: 344px;
   width: -webkit-max-content;
@@ -28,19 +29,19 @@ span.tooltip {
   border-radius: var(--bubble-border-radius, var(--border-radius-50));
   position: relative;
   z-index: 1;
-  background-color: var(--tooltip-background-color, var(--color-background-information));
-  color: var(--tooltip-foreground-color, var(--color-foreground-on-information));
+  background-color: var(--tooltip-background-color, var(--color-background-primary));
+  color: var(--tooltip-foreground-color, var(--color-foreground-primary));
 }
 span.tooltip__mask {
   display: block;
 }
 .tooltip__cell {
   display: flex;
-  padding: 16px;
+  padding: 8px 16px;
   word-break: break-word;
 }
 .tooltip__cell a {
-  color: var(--tooltip-foreground-color, var(--color-foreground-on-information));
+  color: var(--tooltip-foreground-color, var(--color-foreground-primary));
 }
 .tooltip__cell a:focus {
   outline: 1px dashed currentColor;
@@ -66,83 +67,71 @@ button.tooltip__close {
   width: 32px;
 }
 .tooltip__pointer {
-  height: 16px;
+  height: 8px;
   position: absolute;
   transform: rotate(45deg);
-  width: 16px;
+  width: 8px;
   z-index: 0;
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
-  left: calc(50% - 8px);
-  background-color: var(--tooltip-background-color, var(--color-background-information));
+  top: -4px;
+  left: calc(50% - 4px);
+  background-color: var(--tooltip-background-color, var(--color-background-primary));
 }
 .tooltip__pointer--top-left {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
+  top: -4px;
   left: 12px;
 }
 .tooltip__pointer--top {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
-  left: calc(50% - 8px);
+  top: -4px;
+  left: calc(50% - 4px);
 }
 .tooltip__pointer--top-right {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
+  top: -4px;
   left: auto;
   right: 12px;
 }
 .tooltip__pointer--bottom-left {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
   left: 12px;
 }
 .tooltip__pointer--bottom {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
-  left: calc(50% - 8px);
+  left: calc(50% - 4px);
 }
 .tooltip__pointer--bottom-right {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
   left: auto;
   right: 12px;
 }
 .tooltip__pointer--left {
-  top: calc(50% - 8px);
-  left: -7px;
+  top: calc(50% - 4px);
+  left: -4px;
 }
 .tooltip__pointer--left-bottom {
   bottom: 12px;
-  box-shadow: var(--bubble-left-box-shadow);
-  left: -7px;
+  left: -4px;
   top: auto;
 }
 .tooltip__pointer--left-top {
-  box-shadow: var(--bubble-left-box-shadow);
-  left: -7px;
+  left: -4px;
   top: 12px;
 }
 .tooltip__pointer--right {
-  top: calc(50% - 8px);
-  box-shadow: var(--bubble-right-box-shadow);
+  top: calc(50% - 4px);
   left: auto;
-  right: -7px;
+  right: -4px;
 }
 .tooltip__pointer--right-bottom {
   bottom: 12px;
-  box-shadow: var(--bubble-right-box-shadow);
   left: auto;
-  right: -7px;
+  right: -4px;
   top: auto;
 }
 .tooltip__pointer--right-top {
-  box-shadow: var(--bubble-right-box-shadow);
   left: auto;
-  right: -7px;
+  right: -4px;
   top: 12px;
 }
 .tooltip--expanded .tooltip__overlay,

--- a/dist/tourtip/tourtip.css
+++ b/dist/tourtip/tourtip.css
@@ -4,6 +4,7 @@
   --bubble-right-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
   --bubble-bottom-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
   --bubble-top-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
+  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
 }
 .tourtip {
   position: relative;
@@ -13,7 +14,7 @@ span.tourtip {
 }
 .tourtip__overlay {
   border-radius: var(--bubble-border-radius, var(--border-radius-50));
-  box-shadow: var(--bubble-base-box-shadow);
+  filter: var(--bubble-filter);
   font-size: 14px;
   max-width: 344px;
   width: -webkit-max-content;
@@ -26,19 +27,19 @@ span.tourtip {
   border-radius: var(--bubble-border-radius, var(--border-radius-50));
   position: relative;
   z-index: 1;
-  background-color: var(--tourtip-background-color, var(--color-background-information));
-  color: var(--tourtip-foreground-color, var(--color-foreground-on-information));
+  background-color: var(--tourtip-background-color, var(--color-background-primary));
+  color: var(--tourtip-foreground-color, var(--color-foreground-primary));
 }
 span.tourtip__mask {
   display: block;
 }
 .tourtip__cell {
   display: flex;
-  padding: 16px;
+  padding: 8px 16px;
   word-break: break-word;
 }
 .tourtip__cell a {
-  color: var(--tourtip-foreground-color, var(--color-foreground-on-information));
+  color: var(--tourtip-foreground-color, var(--color-foreground-primary));
 }
 .tourtip__cell a:focus {
   outline: 1px dashed currentColor;
@@ -62,7 +63,7 @@ button.tourtip__close {
   padding: 0;
   white-space: nowrap;
   width: 32px;
-  color: var(--tourtip-foreground-color, var(--color-foreground-on-information));
+  color: var(--tourtip-foreground-color, var(--color-foreground-primary));
 }
 button.tourtip__close:focus,
 button.tourtip__close:hover {
@@ -77,83 +78,71 @@ button.tourtip__close > svg {
   width: 14px;
 }
 .tourtip__pointer {
-  height: 16px;
+  height: 8px;
   position: absolute;
   transform: rotate(45deg);
-  width: 16px;
+  width: 8px;
   z-index: 0;
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
-  left: calc(50% - 8px);
-  background-color: var(--tourtip-background-color, var(--color-background-information));
+  top: -4px;
+  left: calc(50% - 4px);
+  background-color: var(--tourtip-background-color, var(--color-background-primary));
 }
 .tourtip__pointer--top-left {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
+  top: -4px;
   left: 12px;
 }
 .tourtip__pointer--top {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
-  left: calc(50% - 8px);
+  top: -4px;
+  left: calc(50% - 4px);
 }
 .tourtip__pointer--top-right {
-  box-shadow: var(--bubble-top-box-shadow);
-  top: -7px;
+  top: -4px;
   left: auto;
   right: 12px;
 }
 .tourtip__pointer--bottom-left {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
   left: 12px;
 }
 .tourtip__pointer--bottom {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
-  left: calc(50% - 8px);
+  left: calc(50% - 4px);
 }
 .tourtip__pointer--bottom-right {
-  bottom: -7px;
-  box-shadow: var(--bubble-bottom-box-shadow);
+  bottom: -4px;
   top: auto;
   left: auto;
   right: 12px;
 }
 .tourtip__pointer--left {
-  top: calc(50% - 8px);
-  left: -7px;
+  top: calc(50% - 4px);
+  left: -4px;
 }
 .tourtip__pointer--left-bottom {
   bottom: 12px;
-  box-shadow: var(--bubble-left-box-shadow);
-  left: -7px;
+  left: -4px;
   top: auto;
 }
 .tourtip__pointer--left-top {
-  box-shadow: var(--bubble-left-box-shadow);
-  left: -7px;
+  left: -4px;
   top: 12px;
 }
 .tourtip__pointer--right {
-  top: calc(50% - 8px);
-  box-shadow: var(--bubble-right-box-shadow);
+  top: calc(50% - 4px);
   left: auto;
-  right: -7px;
+  right: -4px;
 }
 .tourtip__pointer--right-bottom {
   bottom: 12px;
-  box-shadow: var(--bubble-right-box-shadow);
   left: auto;
-  right: -7px;
+  right: -4px;
   top: auto;
 }
 .tourtip__pointer--right-top {
-  box-shadow: var(--bubble-right-box-shadow);
   left: auto;
-  right: -7px;
+  right: -4px;
   top: 12px;
 }
 .tourtip__heading {

--- a/dist/tourtip/tourtip.css
+++ b/dist/tourtip/tourtip.css
@@ -63,18 +63,9 @@ button.tourtip__close {
   padding: 0;
   white-space: nowrap;
   width: 32px;
-  color: var(--tourtip-foreground-color, var(--color-foreground-primary));
-}
-button.tourtip__close:focus,
-button.tourtip__close:hover {
-  color: var(--color-state-primary-hover);
-}
-button.tourtip__close:focus {
-  outline: 1px dashed currentColor;
 }
 button.tourtip__close > svg {
   fill: currentColor;
-  height: 14px;
   width: 14px;
 }
 .tourtip__pointer {

--- a/docs/_includes/infotip.html
+++ b/docs/_includes/infotip.html
@@ -21,8 +21,8 @@
                                 <p>Here's a tip to help you be successful at your task.</p>
                             </span>
                             <button class="icon-btn icon-btn--transparent infotip__close" type="button" aria-label="Dismiss infotip">
-                                <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                    {% include symbol.html name="close" %}
+                                <svg class="icon icon--close-small" focusable="false" height="24" width="24" aria-hidden="true">
+                                    {% include symbol.html name="close-small" %}
                                 </svg>
                             </button>
                         </div>
@@ -47,8 +47,8 @@
                     <p>Here's a tip to help you be successful at your task.</p>
                 </span>
                 <button class="icon-btn icon-btn--transparent infotip__close" type="button" aria-label="Dismiss infotip">
-                    <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                        <use xlink:href="#icon-close"></use>
+                    <svg class="icon icon--close-small" focusable="false" height="24" width="24" aria-hidden="true">
+                        <use xlink:href="#icon-close-small"></use>
                     </svg>
                 </button>
             </div>
@@ -78,8 +78,8 @@
                                     <span>Here's a tip to help you be successful at your task.</span>
                                 </span>
                                 <button class="icon-btn icon-btn--transparent infotip__close" type="button" aria-label="Dismiss infotip">
-                                    <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                        {% include symbol.html name="close" %}
+                                    <svg class="icon icon--close-small" focusable="false" height="24" width="24" aria-hidden="true">
+                                        {% include symbol.html name="close-small" %}
                                     </svg>
                                 </button>
                             </span>
@@ -107,8 +107,8 @@
                         <span>Here's a tip to help you be successful at your task.</span>
                     </span>
                     <button class="icon-btn icon-btn--transparent infotip__close" type="button" aria-label="Dismiss infotip">
-                        <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                            <use xlink:href="#icon-close"></use>
+                        <svg class="icon icon--close-small" focusable="false" height="24" width="24" aria-hidden="true">
+                            <use xlink:href="#icon-close-small"></use>
                         </svg>
                     </button>
                 </span>
@@ -119,27 +119,29 @@
     {% endhighlight %}
 
     <h3 id="infotip-modal">Modal Infotip</h3>
-    <p>On small screens, the infotip should launch a modal dialog.</p>
+    <p>On small screens, the infotip should launch a modal drawer-dialog.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="infotip infotip--modal">
-                <button class="icon-btn icon-btn--transparent dialog-button" type="button" data-makeup-for="lightbox-dialog-mini-infotip-0" aria-expanded="false" aria-label="Help">
+                <button class="icon-btn icon-btn--transparent dialog-button" type="button" data-makeup-for="drawer-dialog-mini-infotip-0" aria-expanded="false" aria-label="Help">
                     <svg class="icon icon--information-small" focusable="false" width="16" height="16" aria-hidden="true">
                         {% include symbol.html name="information-small" %}
                     </svg>
                 </button>
             </span>
-            <div aria-labelledby="mini-dialog-title" aria-modal="true" hidden class="lightbox-dialog lightbox-dialog--mini" id="lightbox-dialog-mini-infotip-0" role="dialog">
-                <div class="lightbox-dialog__window lightbox-dialog__window--mini">
-                    <div class="lightbox-dialog__header">
-                        <button aria-label="Close dialog" class="icon-btn icon-btn--transparent lightbox-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                                {% include symbol.html name="close" %}
+            <div aria-labelledby="mini-dialog-title" aria-modal="true" hidden class="drawer-dialog" id="drawer-dialog-mini-infotip-0" role="dialog">
+                <div class="drawer-dialog__window">
+                    <button class="drawer-dialog__handle" type="button"></button>
+                    <div class="drawer-dialog__header">
+                        <h2>Info</h2>
+                        <button aria-label="Close dialog" class="icon-btn icon-btn--transparent drawer-dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                                {% include symbol.html name="close-small" %}
                             </svg>
                         </button>
                     </div>
-                    <div class="lightbox-dialog__main" id="mini-dialog-title">
+                    <div class="drawer-dialog__main" id="mini-dialog-title">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                     </div>
                 </div>
@@ -155,16 +157,18 @@
         </svg>
     </button>
 </span>
-<div aria-labelledby="lightbox-dialog-title" aria-modal="true" hidden class="lightbox-dialog lightbox-dialog--mini" id="lightbox-dialog-mini-default-0" role="dialog">
-    <div class="lightbox-dialog__window lightbox-dialog__window--mini">
-        <div class="lightbox-dialog__header">
-            <button aria-label="Close dialog" class="icon-btn icon-btn--transparent lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
+<div aria-labelledby="drawer-dialog-title" aria-modal="true" hidden class="drawer-dialog" role="dialog">
+    <div class="drawer-dialog__window">
+        <button class="drawer-dialog__handle" type="button"></button>
+        <div class="drawer-dialog__header">
+            <h2>Info</h2>
+            <button aria-label="Close dialog" class="icon-btn icon-btn--transparent drawer-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
+                    <use xlink:href="#icon-close-small"></use>
                 </svg>
             </button>
         </div>
-        <div class="lightbox-dialog__main" id="lightbox-dialog-title">
+        <div class="drawer-dialog__main" id="drawer-dialog-title">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </div>

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -217,44 +217,4 @@
 </div>
     {% endhighlight %}
 
-    <h3 id="lightbox-mini">Mini Lightbox</h3>
-    <p>A mini lightbox is used primarily as an infotip for small devices. The dialog must be labelled using aria-label.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-mini-0" type="button">Open Mini Lightbox Dialog</button>
-            <div aria-label="Mini Lightbox Example" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-mini-0" role="dialog">
-                <div class="lightbox-dialog__window lightbox-dialog__window--mini lightbox-dialog__window--fade">
-                    <div class="lightbox-dialog__header">
-                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
-                                {% include symbol.html name="close" %}
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="lightbox-dialog__main">
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {% highlight html %}
-<div aria-label="Mini Lightbox Example" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden role="dialog">
-    <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
-        <div class="lightbox-dialog__header">
-            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close-small"></use>
-                </svg>
-            </button>
-        </div>
-        <div class="lightbox-dialog__main">
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-        </div>
-    </div>
-</div>
-    {% endhighlight %}
-
 </div>

--- a/docs/_includes/tooltip.html
+++ b/docs/_includes/tooltip.html
@@ -13,7 +13,7 @@
                         {% include symbol.html name="settings" %}
                     </svg>
                 </button>
-                <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="bottom: calc(100% + 12px); left: 0">
+                <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="bottom: calc(100% + 8px); left: 4px">
                     <span class="tooltip__pointer tooltip__pointer--bottom-left"></span>
                     <div class="tooltip__mask">
                         <div class="tooltip__cell">
@@ -33,7 +33,7 @@
             <use xlink:href="#icon-settings"></use>
         </svg>
     </button>
-    <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="bottom: calc(100% + 12px); left: 0">
+    <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="bottom: calc(100% + 8px); left: 4px">
         <span class="tooltip__pointer tooltip__pointer--bottom-left"></span>
         <div class="tooltip__mask">
             <div class="tooltip__cell">
@@ -56,7 +56,7 @@
                         {% include symbol.html name="settings" %}
                     </svg>
                 </button>
-                <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="bottom: -4px; left: calc(100% + 12px)">
+                <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="bottom: 4px; left: calc(100% + 12px)">
                     <span class="tooltip__pointer tooltip__pointer--left"></span>
                     <div class="tooltip__mask">
                         <div class="tooltip__cell">
@@ -76,7 +76,7 @@
             <use xlink:href="#icon-settings"></use>
         </svg>
     </button>
-    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="bottom: -4px; left: calc(100% + 12px)">
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="bottom: 4px; left: calc(100% + 12px)">
         <span class="tooltip__pointer tooltip__pointer--left"></span>
         <div class="tooltip__mask">
             <div class="tooltip__cell">

--- a/docs/_includes/tourtip.html
+++ b/docs/_includes/tourtip.html
@@ -17,8 +17,8 @@
                                 <p>Here's something new to help you be successful at your task.</p>
                             </span>
                             <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
-                                <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                    {% include symbol.html name="close" %}
+                                <svg class="icon icon--close-small" focusable="false" height="16" width="16" aria-hidden="true">
+                                    {% include symbol.html name="close-small" %}
                                 </svg>
                             </button>
                         </div>
@@ -39,8 +39,8 @@
                     <p>Here's something new to help you be successful at your task.</p>
                 </span>
                 <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
-                    <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                        <use xlink:href="#icon-close"></use>
+                    <svg class="icon icon--close-small" focusable="false" height="16" width="16" aria-hidden="true">
+                        <use xlink:href="#icon-close-small"></use>
                     </svg>
                 </button>
             </div>

--- a/src/less/infotip/infotip.less
+++ b/src/less/infotip/infotip.less
@@ -15,7 +15,7 @@ span.infotip {
     .background-color-token(infotip-background-color, color-background-primary);
     .color-token(infotip-foreground-color, color-foreground-primary);
     display: none;
-    left: 0 - 10px;
+    left: 0 - 6px;
     margin-top: @spacing-200;
     position: absolute;
 }

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -10,6 +10,7 @@
     .lightbox-dialog-window();
 }
 
+// Deprecated --mini dilaog in favor of drawer, remove next major
 .lightbox-dialog__window--mini {
     align-items: flex-start;
     align-self: center;

--- a/src/less/mixins/private/bubble-mixins.less
+++ b/src/less/mixins/private/bubble-mixins.less
@@ -1,18 +1,25 @@
 // this mixin is used by infotip, tooltip, tourtip
 
+// Deprecated
 @bubble-base-box-shadow: 0 0 3px rgba(17, 24, 32, 0.499);
 
 :root {
+    // Deprecated variables, remove next version
     --bubble-base-box-shadow: @bubble-base-box-shadow;
     --bubble-left-box-shadow: @bubble-base-box-shadow;
     --bubble-right-box-shadow: @bubble-base-box-shadow;
     --bubble-bottom-box-shadow: @bubble-base-box-shadow;
     --bubble-top-box-shadow: @bubble-base-box-shadow;
+    // End deprecated
+
+    --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15))
+        drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
 }
 
 .bubble() {
     .border-radius-token(bubble-border-radius, border-radius-50);
-    .box-shadow-token(bubble-base-box-shadow);
+
+    filter: var(--bubble-filter);
     font-size: 14px;
     max-width: 344px;
     width: max-content;
@@ -32,7 +39,7 @@
 // creates basic layout
 .bubble-cell() {
     display: flex;
-    padding: @spacing-200;
+    padding: @spacing-100 @spacing-200;
     word-break: break-word;
 }
 
@@ -62,30 +69,28 @@
 
 // styles common to all pointers
 .pointer-base() {
-    height: 16px;
+    height: 8px;
     position: absolute;
     transform: rotate(45deg);
-    width: 16px;
+    width: 8px;
     z-index: 0;
 }
 
 .pointer-bottom() {
-    bottom: -7px;
-    .box-shadow-token(bubble-bottom-box-shadow);
+    bottom: -4px;
     top: auto;
 }
 
 .pointer-side-middle() {
-    top: calc(50% - 8px);
+    top: calc(50% - 4px);
 }
 
 .pointer-top() {
-    .box-shadow-token(bubble-top-box-shadow);
-    top: -7px;
+    top: -4px;
 }
 
 .pointer-center() {
-    left: calc(50% - 8px);
+    left: calc(50% - 4px);
 }
 
 .pointer-top-center() {
@@ -127,40 +132,35 @@
 .pointer-left() {
     .pointer-side-middle();
 
-    left: -7px;
+    left: -4px;
 }
 
 .pointer-left-top() {
-    .box-shadow-token(bubble-left-box-shadow);
-    left: -7px;
+    left: -4px;
     top: 12px;
 }
 
 .pointer-left-bottom() {
     bottom: 12px;
-    .box-shadow-token(bubble-left-box-shadow);
-    left: -7px;
+    left: -4px;
     top: auto;
 }
 
 .pointer-right() {
     .pointer-side-middle();
-    .box-shadow-token(bubble-right-box-shadow);
     left: auto;
-    right: -7px;
+    right: -4px;
 }
 
 .pointer-right-top() {
-    .box-shadow-token(bubble-right-box-shadow);
     left: auto;
-    right: -7px;
+    right: -4px;
     top: 12px;
 }
 
 .pointer-right-bottom() {
     bottom: 12px;
-    .box-shadow-token(bubble-right-box-shadow);
     left: auto;
-    right: -7px;
+    right: -4px;
     top: auto;
 }

--- a/src/less/tooltip/stories/pointer.stories.js
+++ b/src/less/tooltip/stories/pointer.stories.js
@@ -1,18 +1,348 @@
 export default { title: 'Tooltip/Pointer' };
 
-export const left = () => `
-<span class="tooltip">
+const pointerStyles = {
+    left: {
+        transform: 'translateX(16px) translateY(-50%)',
+        left: '100%',
+        right: 'auto',
+        top: '0',
+        bottom: 'auto',
+    },
+    'left-top': {
+        transform: 'translateX(16px)',
+        left: '100%',
+        right: 'auto',
+        top: '-25%',
+        bottom: 'auto',
+    },
+    'left-bottom': {
+        transform: 'translateX(16px)',
+        left: '100%',
+        right: 'auto',
+        top: 'auto',
+        bottom: '8px',
+    },
+    right: {
+        transform: 'translateX(-16px) translateY(-50%)',
+        left: 'auto',
+        right: '100%',
+        top: '0',
+        bottom: 'auto',
+    },
+    'right-top': {
+        transform: 'translateX(-16px)',
+        left: 'auto',
+        right: '100%',
+        top: '-25%',
+        bottom: 'auto',
+    },
+    'right-bottom': {
+        transform: 'translateX(-16px)',
+        left: 'auto',
+        right: '100%',
+        top: 'auto',
+        bottom: '4px',
+    },
+    top: {
+        transform: 'translateX(-50%)',
+        left: '50%',
+        right: 'auto',
+        top: 'calc(100% + 2px)',
+        bottom: 'auto',
+    },
+    'top-left': {
+        left: '4px',
+        right: 'auto',
+        top: 'calc(100% + 2px)',
+        bottom: 'auto',
+    },
+    'top-right': {
+        left: 'auto',
+        right: '4px',
+        top: 'calc(100% + 2px)',
+        bottom: 'auto',
+    },
+    'bottom-right': {
+        left: 'auto',
+        right: '4px',
+        top: 'auto',
+        bottom: 'calc(100% + 12px)',
+    },
+    'bottom-left': {
+        left: '4px',
+        right: 'auto',
+        top: 'auto',
+        bottom: 'calc(100% + 12px)',
+    },
+    bottom: {
+        transform: 'translateX(-50%)',
+        left: '50%',
+        right: 'auto',
+        top: 'auto',
+        bottom: 'calc(100% + 12px)',
+    },
+};
+
+function getPointerStyle(key) {
+    const ret = [];
+    for (const pointerKey of Object.keys(pointerStyles[key])) {
+        ret.push(`${pointerKey}: ${pointerStyles[key][pointerKey]}`);
+    }
+    return ret.join('; ');
+}
+
+export const top = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
     <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
         <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
             <use xlink:href="#icon-settings"></use>
         </svg>
     </button>
-    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="bottom: -4px; left: calc(100% + 12px)">
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle('top')}">
+        <span class="tooltip__pointer tooltip__pointer--top"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const topLeft = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'top-left'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--top-left"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const leftTop = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'left-top'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--left-top"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+               </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const left = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle('left')}">
         <span class="tooltip__pointer tooltip__pointer--left"></span>
         <div class="tooltip__mask">
             <div class="tooltip__cell">
                 <div class="tooltip__content">
-                    <p>Pointer Left</p>
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const leftBottom = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'left-bottom'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--left-bottom"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const bottomLeft = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'bottom-left'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--bottom-left"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const bottom = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'bottom'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--bottom"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const bottomRight = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'bottom-right'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--bottom-right"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const rightBottom = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'right-bottom'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--right-bottom"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const right = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle('right')}">
+        <span class="tooltip__pointer tooltip__pointer--right"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const rightTop = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'right-top'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--right-top"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>`;
+
+export const topRight = () => `
+<span class="tooltip" style="margin-left: 100px; margin-top: 100px;">
+    <button class="icon-btn tooltip__host" aria-describedby="tooltip-1" aria-expanded="true" aria-label="Info">
+        <svg class="icon icon--settings" focusable="false" height="16" width="16" aria-hidden="true">
+            <use xlink:href="#icon-settings"></use>
+        </svg>
+    </button>
+    <div class="tooltip__overlay" id="tooltip-1" role="tooltip" style="${getPointerStyle(
+        'top-right'
+    )}">
+        <span class="tooltip__pointer tooltip__pointer--top-right"></span>
+        <div class="tooltip__mask">
+            <div class="tooltip__cell">
+                <div class="tooltip__content">
+                    <p>Pointer</p>
+                    <p>Item</p>
                 </div>
             </div>
         </div>

--- a/src/less/tooltip/stories/tooltip.stories.js
+++ b/src/less/tooltip/stories/tooltip.stories.js
@@ -26,7 +26,7 @@ export const expanded = () => `
             <use xlink:href="#icon-settings"></use>
         </svg>
     </button>
-    <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="bottom: calc(100% - 100px); left: 0">
+    <div class="tooltip__overlay" id="tooltip-0" role="tooltip" style="bottom: calc(100% - 90px); left: 4px">
         <span class="tooltip__pointer tooltip__pointer--top-left"></span>
         <div class="tooltip__mask">
             <div class="tooltip__cell">

--- a/src/less/tooltip/tooltip.less
+++ b/src/less/tooltip/tooltip.less
@@ -21,8 +21,8 @@ span.tooltip {
 
 .tooltip__mask {
     .bubble-mask();
-    .background-color-token(tooltip-background-color, color-background-information);
-    .color-token(tooltip-foreground-color, color-foreground-on-information);
+    .background-color-token(tooltip-background-color, color-background-primary);
+    .color-token(tooltip-foreground-color, color-foreground-primary);
 }
 
 span.tooltip__mask {
@@ -33,7 +33,7 @@ span.tooltip__mask {
     .bubble-cell();
 
     a {
-        .color-token(tooltip-foreground-color, color-foreground-on-information);
+        .color-token(tooltip-foreground-color, color-foreground-primary);
 
         &:focus {
             outline: 1px dashed currentColor;
@@ -53,7 +53,7 @@ button.tooltip__close {
     .pointer-base();
     .pointer-top();
     .pointer-center();
-    .background-color-token(tooltip-background-color, color-background-information);
+    .background-color-token(tooltip-background-color, color-background-primary);
 }
 
 .tooltip__pointer--top-left {

--- a/src/less/tourtip/tourtip.less
+++ b/src/less/tourtip/tourtip.less
@@ -45,21 +45,10 @@ span.tourtip__mask {
 
 button.tourtip__close {
     .bubble-close();
-    .color-token(tourtip-foreground-color, color-foreground-primary);
-
-    &:focus,
-    &:hover {
-        color: var(--color-state-primary-hover);
-    }
-
-    &:focus {
-        outline: 1px dashed currentColor;
-    }
 }
 
 button.tourtip__close > svg {
     fill: currentColor;
-    height: 14px;
     width: 14px;
 }
 

--- a/src/less/tourtip/tourtip.less
+++ b/src/less/tourtip/tourtip.less
@@ -19,8 +19,8 @@ span.tourtip {
 
 .tourtip__mask {
     .bubble-mask();
-    .background-color-token(tourtip-background-color, color-background-information);
-    .color-token(tourtip-foreground-color, color-foreground-on-information);
+    .background-color-token(tourtip-background-color, color-background-primary);
+    .color-token(tourtip-foreground-color, color-foreground-primary);
 }
 
 span.tourtip__mask {
@@ -31,7 +31,7 @@ span.tourtip__mask {
     .bubble-cell();
 
     a {
-        .color-token(tourtip-foreground-color, color-foreground-on-information);
+        .color-token(tourtip-foreground-color, color-foreground-primary);
 
         &:focus {
             outline: 1px dashed currentColor;
@@ -45,7 +45,7 @@ span.tourtip__mask {
 
 button.tourtip__close {
     .bubble-close();
-    .color-token(tourtip-foreground-color, color-foreground-on-information);
+    .color-token(tourtip-foreground-color, color-foreground-primary);
 
     &:focus,
     &:hover {
@@ -67,7 +67,7 @@ button.tourtip__close > svg {
     .pointer-base();
     .pointer-top();
     .pointer-center();
-    .background-color-token(tourtip-background-color, color-background-information);
+    .background-color-token(tourtip-background-color, color-background-primary);
 }
 
 .tourtip__pointer--top-left {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1745

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Changed tooltip to match new designs (this includes, tooltip tourtip and infotip)
* Added stories for these

## Screenshots
<img width="391" alt="Screen Shot 2022-08-11 at 10 59 36 AM" src="https://user-images.githubusercontent.com/1755269/184211644-61eb6ee6-6678-4af6-ad55-8cb4299909fb.png">
<img width="280" alt="Screen Shot 2022-08-11 at 10 59 42 AM" src="https://user-images.githubusercontent.com/1755269/184211646-0a5b94a5-9e4c-4d86-ae3f-146ec96463a1.png">
<img width="478" alt="Screen Shot 2022-08-11 at 10 59 49 AM" src="https://user-images.githubusercontent.com/1755269/184211649-291ee4eb-649b-4dc8-99ef-32e50ea119ff.png">
<img width="616" alt="Screen Shot 2022-08-11 at 11 00 09 AM" src="https://user-images.githubusercontent.com/1755269/184211656-099d2994-5823-47d9-b6aa-2861d68703e5.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
