### PR TITLE
feat(page-notice): updated icon sizes, adjusted spacing

### DIFF
--- a/dist/icon/icon.css
+++ b/dist/icon/icon.css
@@ -19,17 +19,17 @@ svg.icon--arrow-left-medium {
   height: 20px;
   width: 20px;
 }
-svg.icon--arrow-left-small {
-  height: 14px;
-  width: 14px;
+svg.icon--arrow-left {
+  height: 18px;
+  width: 20px;
 }
 svg.icon--arrow-move-small {
   height: 11px;
   width: 11px;
 }
-svg.icon--arrow-left {
-  height: 18px;
-  width: 20px;
+svg.icon--arrow-left-small {
+  height: 14px;
+  width: 14px;
 }
 svg.icon--arrow-move {
   height: 15px;
@@ -43,6 +43,10 @@ svg.icon--arrow-right-extra-small {
   height: 10px;
   width: 10px;
 }
+svg.icon--arrow-right-small {
+  height: 14px;
+  width: 14px;
+}
 svg.icon--arrow-right-group-titles {
   height: 14px;
   width: 14px;
@@ -51,65 +55,61 @@ svg.icon--arrow-right {
   height: 18px;
   width: 20px;
 }
-svg.icon--arrow-right-small {
-  height: 14px;
-  width: 14px;
-}
 svg.icon--attention-filled-small {
   height: 16px;
   width: 16px;
-}
-svg.icon--attention-small {
-  height: 16px;
-  width: 16px;
-}
-svg.icon--avatar-dark {
-  height: 22px;
-  width: 22px;
-}
-svg.icon--attention {
-  height: 24px;
-  width: 24px;
-}
-svg.icon--avatar-light {
-  height: 40px;
-  width: 40px;
-}
-svg.icon--avatar-filled {
-  height: 22px;
-  width: 22px;
-}
-svg.icon--back {
-  height: 24px;
-  width: 24px;
 }
 svg.icon--attention-filled {
   height: 24px;
   width: 24px;
 }
+svg.icon--attention-small {
+  height: 16px;
+  width: 16px;
+}
+svg.icon--attention {
+  height: 24px;
+  width: 24px;
+}
+svg.icon--avatar-filled {
+  height: 22px;
+  width: 22px;
+}
+svg.icon--avatar-dark {
+  height: 22px;
+  width: 22px;
+}
 svg.icon--avatar {
   height: 22px;
   width: 22px;
+}
+svg.icon--avatar-light {
+  height: 40px;
+  width: 40px;
+}
+svg.icon--back {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--bag {
   height: 24px;
   width: 24px;
 }
-svg.icon--bank-large {
-  height: 58px;
-  width: 58px;
-}
 svg.icon--bank {
   height: 22px;
   width: 22px;
 }
-svg.icon--bids-large {
-  height: 64px;
-  width: 64px;
+svg.icon--bank-large {
+  height: 58px;
+  width: 58px;
 }
 svg.icon--bids {
   height: 23px;
   width: 23px;
+}
+svg.icon--bids-large {
+  height: 64px;
+  width: 64px;
 }
 svg.icon--calendar-large {
   height: 60px;
@@ -135,10 +135,6 @@ svg.icon--carousel-next {
   height: 24px;
   width: 24px;
 }
-svg.icon--carousel-prev {
-  height: 24px;
-  width: 24px;
-}
 svg.icon--cart-large {
   height: 64px;
   width: 64px;
@@ -148,6 +144,10 @@ svg.icon--cart-small {
   width: 16px;
 }
 svg.icon--cart {
+  height: 24px;
+  width: 24px;
+}
+svg.icon--carousel-prev {
   height: 24px;
   width: 24px;
 }
@@ -167,15 +167,7 @@ svg.icon--chat-large {
   height: 53px;
   width: 58px;
 }
-svg.icon--checkbox-checked {
-  height: 18px;
-  width: 18px;
-}
 svg.icon--checkbox-checked-large {
-  height: 24px;
-  width: 24px;
-}
-svg.icon--checkbox-mixed-large {
   height: 24px;
   width: 24px;
 }
@@ -183,21 +175,29 @@ svg.icon--checkbox-mixed {
   height: 18px;
   width: 18px;
 }
-svg.icon--checkbox-square-checked {
-  height: 18px;
-  width: 18px;
-}
-svg.icon--checkbox-square-unchecked-large {
+svg.icon--checkbox-mixed-large {
   height: 24px;
   width: 24px;
 }
-svg.icon--checkbox-square-unchecked {
+svg.icon--checkbox-checked {
   height: 18px;
   width: 18px;
 }
 svg.icon--checkbox-square-checked-large {
   height: 24px;
   width: 24px;
+}
+svg.icon--checkbox-square-unchecked-large {
+  height: 24px;
+  width: 24px;
+}
+svg.icon--checkbox-square-checked {
+  height: 18px;
+  width: 18px;
+}
+svg.icon--checkbox-square-unchecked {
+  height: 18px;
+  width: 18px;
 }
 svg.icon--checkbox-unchecked-large {
   height: 24px;
@@ -207,17 +207,21 @@ svg.icon--checkbox-unchecked {
   height: 18px;
   width: 18px;
 }
-svg.icon--chevron-down-bold {
-  height: 12.58px;
-  width: 21.6px;
-}
 svg.icon--chevron-down-extra-small {
   height: 16px;
   width: 16px;
 }
+svg.icon--chevron-down-bold {
+  height: 12.58px;
+  width: 21.6px;
+}
 svg.icon--chevron-down-small {
   height: 16px;
   width: 16px;
+}
+svg.icon--chevron-down {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--chevron-left-extra-small {
   height: 16px;
@@ -227,21 +231,21 @@ svg.icon--chevron-left-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--chevron-right-extra-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--chevron-left {
   height: 24px;
   width: 24px;
 }
-svg.icon--chevron-right-small {
+svg.icon--chevron-right-extra-small {
   height: 16px;
   width: 16px;
 }
 svg.icon--chevron-right {
   height: 24px;
   width: 24px;
+}
+svg.icon--chevron-right-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--chevron-up-bold {
   height: 12.58px;
@@ -251,23 +255,15 @@ svg.icon--chevron-up-extra-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--chevron-up {
-  height: 24px;
-  width: 24px;
-}
-svg.icon--chevron-up-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--circle {
   height: 24px;
   width: 24px;
 }
-svg.icon--chevron-down {
-  height: 24px;
-  width: 24px;
-}
 svg.icon--clear-small {
+  height: 16px;
+  width: 16px;
+}
+svg.icon--chevron-up-small {
   height: 16px;
   width: 16px;
 }
@@ -282,6 +278,14 @@ svg.icon--clear {
 svg.icon--close-small {
   height: 14px;
   width: 14px;
+}
+svg.icon--clock {
+  height: 22px;
+  width: 22px;
+}
+svg.icon--chevron-up {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--close {
   height: 18px;
@@ -299,25 +303,21 @@ svg.icon--confirmation-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--confirmation {
-  height: 24px;
-  width: 24px;
-}
 svg.icon--credit-card-large {
   height: 46px;
   width: 58px;
 }
-svg.icon--clock {
-  height: 22px;
-  width: 22px;
+svg.icon--credit-card-small {
+  height: 12px;
+  width: 16px;
+}
+svg.icon--confirmation {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--cta {
   height: 18px;
   width: 20px;
-}
-svg.icon--credit-card-small {
-  height: 12px;
-  width: 16px;
 }
 svg.icon--credit-card {
   height: 16px;
@@ -327,41 +327,37 @@ svg.icon--customize-small {
   height: 16px;
   width: 16px;
 }
+svg.icon--customize {
+  height: 24px;
+  width: 24px;
+}
 svg.icon--deals {
   height: 24px;
   width: 18px;
-}
-svg.icon--delete {
-  height: 22px;
-  width: 23px;
-}
-svg.icon--download-small {
-  height: 16px;
-  width: 16px;
 }
 svg.icon--delete-small {
   height: 16px;
   width: 16px;
 }
+svg.icon--delete {
+  height: 22px;
+  width: 23px;
+}
 svg.icon--download {
   height: 22px;
   width: 22px;
-}
-svg.icon--customize {
-  height: 24px;
-  width: 24px;
 }
 svg.icon--edit-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--edit {
-  height: 22px;
-  width: 22px;
-}
 svg.icon--eek-arrow {
   height: 28px;
   width: 11px;
+}
+svg.icon--edit {
+  height: 22px;
+  width: 22px;
 }
 svg.icon--eek-range-arrow {
   height: 6px;
@@ -371,10 +367,6 @@ svg.icon--envelope {
   height: 24px;
   width: 24px;
 }
-svg.icon--event-large {
-  height: 58px;
-  width: 58px;
-}
 svg.icon--event {
   height: 22px;
   width: 22px;
@@ -383,13 +375,25 @@ svg.icon--fast-n-free-small {
   height: 13px;
   width: 18px;
 }
-svg.icon--fast-n-free {
-  height: 17px;
-  width: 22px;
+svg.icon--download-small {
+  height: 16px;
+  width: 16px;
+}
+svg.icon--event-large {
+  height: 58px;
+  width: 58px;
 }
 svg.icon--filter-gallery-small {
   height: 14px;
   width: 15.75px;
+}
+svg.icon--filter-list-small {
+  height: 14px;
+  width: 15.75px;
+}
+svg.icon--fast-n-free {
+  height: 17px;
+  width: 22px;
 }
 svg.icon--filter-gallery {
   height: 18px;
@@ -403,17 +407,13 @@ svg.icon--filter-single-selected {
   height: 18px;
   width: 22px;
 }
-svg.icon--filter-single-small {
-  height: 14px;
-  width: 16px;
-}
-svg.icon--filter-list-small {
-  height: 14px;
-  width: 15.75px;
-}
 svg.icon--filter-single {
   height: 18px;
   width: 22px;
+}
+svg.icon--filter-single-small {
+  height: 14px;
+  width: 16px;
 }
 svg.icon--filter-small {
   height: 16px;
@@ -422,6 +422,10 @@ svg.icon--filter-small {
 svg.icon--filter {
   height: 24px;
   width: 24px;
+}
+svg.icon--flag-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--fingerprint-large {
   height: 64px;
@@ -435,28 +439,24 @@ svg.icon--folder-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--folder {
-  height: 24px;
-  width: 24px;
-}
-svg.icon--flag-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--following-small {
   height: 16px;
   width: 12px;
 }
-svg.icon--gift-small {
-  height: 16px;
+svg.icon--folder {
+  height: 24px;
+  width: 24px;
+}
+svg.icon--following {
+  height: 22px;
   width: 16px;
 }
 svg.icon--gift-large {
   height: 58px;
   width: 58px;
 }
-svg.icon--following {
-  height: 22px;
+svg.icon--gift-small {
+  height: 16px;
   width: 16px;
 }
 svg.icon--gift {
@@ -503,6 +503,10 @@ svg.icon--information-filled {
   height: 24px;
   width: 24px;
 }
+svg.icon--information-small {
+  height: 16px;
+  width: 16px;
+}
 svg.icon--information {
   height: 24px;
   width: 24px;
@@ -511,17 +515,9 @@ svg.icon--key {
   height: 13.5px;
   width: 22.5px;
 }
-svg.icon--information-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--large-box {
   height: 16px;
   width: 22px;
-}
-svg.icon--lightbulb {
-  height: 24px;
-  width: 24px;
 }
 svg.icon--large-case {
   height: 24px;
@@ -530,6 +526,10 @@ svg.icon--large-case {
 svg.icon--lightbulb-small {
   height: 16px;
   width: 16px;
+}
+svg.icon--lightbulb {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--live-eye-small {
   height: 16px;
@@ -551,13 +551,13 @@ svg.icon--locked-small {
   height: 14px;
   width: 12px;
 }
-svg.icon--mail-move-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--mail-move {
   height: 24px;
   width: 24px;
+}
+svg.icon--mail-move-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--locked {
   height: 22px;
@@ -567,21 +567,21 @@ svg.icon--mail-open-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--mail-unread-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--mail-open {
   height: 24px;
   width: 24px;
 }
-svg.icon--mail-unread {
-  height: 24px;
-  width: 24px;
+svg.icon--mail-unread-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--medium-box {
   height: 16px;
   width: 18px;
+}
+svg.icon--mail-unread {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--menu {
   height: 18px;
@@ -599,17 +599,25 @@ svg.icon--messages {
   height: 24px;
   width: 24px;
 }
-svg.icon--mic-small {
-  height: 16px;
-  width: 12px;
-}
 svg.icon--mic {
   height: 22px;
   width: 16px;
 }
+svg.icon--mic-small {
+  height: 16px;
+  width: 12px;
+}
 svg.icon--mobile-signal {
   height: 22px;
   width: 22px;
+}
+svg.icon--mobile {
+  height: 22px;
+  width: 14px;
+}
+svg.icon--money-back-guarantee-us-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--money-back-guarantee-us {
   height: 24px;
@@ -619,14 +627,6 @@ svg.icon--notification {
   height: 24px;
   width: 22px;
 }
-svg.icon--money-back-guarantee-us-small {
-  height: 16px;
-  width: 16px;
-}
-svg.icon--mobile {
-  height: 22px;
-  width: 14px;
-}
 svg.icon--overflow-small {
   height: 13px;
   width: 3px;
@@ -635,15 +635,15 @@ svg.icon--overflow {
   height: 18px;
   width: 4px;
 }
-svg.icon--pagination-next {
-  height: 14px;
-  width: 14px;
-}
 svg.icon--package {
   height: 20px;
   width: 22px;
 }
 svg.icon--pagination-prev {
+  height: 14px;
+  width: 14px;
+}
+svg.icon--pagination-next {
   height: 14px;
   width: 14px;
 }
@@ -655,13 +655,13 @@ svg.icon--pause-filled {
   height: 24px;
   width: 24px;
 }
-svg.icon--pause-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--pause-large {
   height: 60px;
   width: 60px;
+}
+svg.icon--pause-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--pause {
   height: 24px;
@@ -691,20 +691,24 @@ svg.icon--photo-gallery-more {
   height: 24px;
   width: 24px;
 }
+svg.icon--photo-gallery-small {
+  height: 16px;
+  width: 16px;
+}
 svg.icon--photo-gallery {
   height: 24px;
   width: 24px;
 }
-svg.icon--photo-gallery-small {
-  height: 16px;
-  width: 16px;
+svg.icon--photo-image {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--photo-image-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--photo-image {
-  height: 24px;
+svg.icon--photo-rotate {
+  height: 21px;
   width: 24px;
 }
 svg.icon--photo-select-all {
@@ -715,45 +719,41 @@ svg.icon--photo-select-none {
   height: 23px;
   width: 23px;
 }
+svg.icon--photo-sharpen {
+  height: 20px;
+  width: 21px;
+}
 svg.icon--play-filled-large {
   height: 60px;
   width: 60px;
-}
-svg.icon--photo-rotate {
-  height: 21px;
-  width: 24px;
 }
 svg.icon--play-filled {
   height: 24px;
   width: 24px;
 }
-svg.icon--photo-sharpen {
-  height: 20px;
-  width: 21px;
-}
 svg.icon--play-large {
   height: 60px;
   width: 60px;
-}
-svg.icon--play {
-  height: 24px;
-  width: 24px;
 }
 svg.icon--play-small {
   height: 16px;
   width: 16px;
 }
+svg.icon--play {
+  height: 24px;
+  width: 24px;
+}
 svg.icon--print {
   height: 24px;
   width: 24px;
 }
-svg.icon--profile {
-  height: 24px;
-  width: 22px;
-}
 svg.icon--purchases-large {
   height: 56px;
   width: 60px;
+}
+svg.icon--profile {
+  height: 24px;
+  width: 22px;
 }
 svg.icon--purchases {
   height: 20px;
@@ -775,17 +775,21 @@ svg.icon--radio-unchecked {
   height: 18px;
   width: 18px;
 }
+svg.icon--red-laser-small {
+  height: 12px;
+  width: 14px;
+}
 svg.icon--red-laser {
   height: 18px;
   width: 22px;
 }
-svg.icon--remove {
-  height: 2px;
-  width: 20px;
-}
 svg.icon--refresh {
   height: 18px;
   width: 18px;
+}
+svg.icon--remove {
+  height: 2px;
+  width: 20px;
 }
 svg.icon--reply-small {
   height: 16px;
@@ -795,10 +799,6 @@ svg.icon--reply {
   height: 24px;
   width: 24px;
 }
-svg.icon--red-laser-small {
-  height: 12px;
-  width: 14px;
-}
 svg.icon--report-flag-small {
   height: 16px;
   width: 16px;
@@ -807,23 +807,19 @@ svg.icon--report-flag {
   height: 24px;
   width: 24px;
 }
-svg.icon--return {
-  height: 24px;
-  width: 24px;
+svg.icon--return-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--save-bold {
   height: 14px;
   width: 16px;
 }
-svg.icon--return-small {
-  height: 16px;
-  width: 16px;
+svg.icon--return {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--save-selected-small {
-  height: 16px;
-  width: 16px;
-}
-svg.icon--save-small {
   height: 16px;
   width: 16px;
 }
@@ -839,33 +835,41 @@ svg.icon--save {
   height: 24px;
   width: 24px;
 }
+svg.icon--save-small {
+  height: 16px;
+  width: 16px;
+}
 svg.icon--scan {
   height: 24px;
   width: 24px;
-}
-svg.icon--search-active {
-  height: 24px;
-  width: 24px;
-}
-svg.icon--search-small {
-  height: 14px;
-  width: 14px;
-}
-svg.icon--search-large {
-  height: 57px;
-  width: 57px;
 }
 svg.icon--search-bold {
   height: 21.6px;
   width: 21.6px;
 }
-svg.icon--security-key {
+svg.icon--search-active {
   height: 24px;
   width: 24px;
+}
+svg.icon--search-large {
+  height: 57px;
+  width: 57px;
+}
+svg.icon--search-small {
+  height: 14px;
+  width: 14px;
 }
 svg.icon--search {
   height: 22px;
   width: 22px;
+}
+svg.icon--security-key {
+  height: 24px;
+  width: 24px;
+}
+svg.icon--selling-medium {
+  height: 20px;
+  width: 20px;
 }
 svg.icon--selling {
   height: 22px;
@@ -879,11 +883,11 @@ svg.icon--settings-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--selling-medium {
-  height: 20px;
-  width: 20px;
-}
 svg.icon--settings {
+  height: 24px;
+  width: 24px;
+}
+svg.icon--share {
   height: 24px;
   width: 24px;
 }
@@ -891,23 +895,23 @@ svg.icon--share-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--share {
-  height: 24px;
-  width: 24px;
+svg.icon--show-secret-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--shoe-box {
   height: 24px;
   width: 24px;
 }
-svg.icon--show-secret-small {
-  height: 16px;
-  width: 16px;
+svg.icon--show-secret {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--small-box {
   height: 12px;
   width: 18px;
 }
-svg.icon--show-secret {
+svg.icon--small-case {
   height: 24px;
   width: 24px;
 }
@@ -915,7 +919,7 @@ svg.icon--small-letter {
   height: 24px;
   width: 24px;
 }
-svg.icon--small-case {
+svg.icon--social-facebook {
   height: 24px;
   width: 24px;
 }
@@ -924,10 +928,6 @@ svg.icon--social-discord {
   width: 24px;
 }
 svg.icon--social-instagram {
-  height: 24px;
-  width: 24px;
-}
-svg.icon--social-facebook {
   height: 24px;
   width: 24px;
 }
@@ -947,29 +947,29 @@ svg.icon--social-pinterest {
   height: 24px;
   width: 24px;
 }
+svg.icon--social-reddit {
+  height: 24px;
+  width: 24px;
+}
 svg.icon--social-twitter {
   height: 24px;
   width: 24px;
 }
-svg.icon--social-reddit {
-  height: 24px;
-  width: 24px;
+svg.icon--sort-down-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--social-whatsapp {
   height: 24px;
   width: 24px;
 }
-svg.icon--sort-up-small {
-  height: 16px;
-  width: 16px;
-}
 svg.icon--sort-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--star-dynamic {
-  height: 22px;
-  width: 22px;
+svg.icon--sort-up-small {
+  height: 16px;
+  width: 16px;
 }
 svg.icon--spinner {
   height: 24px;
@@ -979,15 +979,11 @@ svg.icon--star-empty-small {
   height: 22px;
   width: 22px;
 }
-svg.icon--sort-down-small {
-  height: 16px;
-  width: 16px;
-}
-svg.icon--star-empty {
+svg.icon--star-dynamic {
   height: 22px;
   width: 22px;
 }
-svg.icon--star-full-small {
+svg.icon--star-empty {
   height: 22px;
   width: 22px;
 }
@@ -995,7 +991,11 @@ svg.icon--star-full {
   height: 22px;
   width: 22px;
 }
-svg.icon--star-undefined-small {
+svg.icon--star-full-small {
+  height: 22px;
+  width: 22px;
+}
+svg.icon--star-half-small {
   height: 22px;
   width: 22px;
 }
@@ -1003,7 +1003,11 @@ svg.icon--star-half {
   height: 22px;
   width: 22px;
 }
-svg.icon--star-half-small {
+svg.icon--star-undefined-small {
+  height: 22px;
+  width: 22px;
+}
+svg.icon--star-undefined {
   height: 22px;
   width: 22px;
 }
@@ -1015,21 +1019,17 @@ svg.icon--stepper-confirmation {
   height: 24px;
   width: 24px;
 }
-svg.icon--star-undefined {
-  height: 22px;
-  width: 22px;
-}
 svg.icon--stepper-current {
-  height: 24px;
-  width: 24px;
-}
-svg.icon--stepper-information {
   height: 24px;
   width: 24px;
 }
 svg.icon--store-large {
   height: 58px;
   width: 57px;
+}
+svg.icon--stepper-information {
+  height: 24px;
+  width: 24px;
 }
 svg.icon--store {
   height: 22px;
@@ -1039,13 +1039,13 @@ svg.icon--suitcase {
   height: 24px;
   width: 24px;
 }
-svg.icon--tablet-condensed-grid-filled {
-  height: 22px;
-  width: 22px;
-}
 svg.icon--support {
   height: 21px;
   width: 23px;
+}
+svg.icon--tablet-condensed-grid-filled {
+  height: 22px;
+  width: 22px;
 }
 svg.icon--tablet-condensed-grid {
   height: 22px;
@@ -1055,11 +1055,11 @@ svg.icon--tablet-relaxed-grid-filled {
   height: 22px;
   width: 22px;
 }
-svg.icon--tablet-vertical-split-filled {
+svg.icon--tablet-relaxed-grid {
   height: 22px;
   width: 22px;
 }
-svg.icon--tablet-relaxed-grid {
+svg.icon--tablet-vertical-split-filled {
   height: 22px;
   width: 22px;
 }
@@ -1067,11 +1067,19 @@ svg.icon--tablet-vertical-split {
   height: 22px;
   width: 22px;
 }
+svg.icon--text-messaging-large {
+  height: 53px;
+  width: 58px;
+}
 svg.icon--thumbs-down-selected-small {
   height: 16px;
   width: 16px;
 }
 svg.icon--thumbs-down-selected {
+  height: 24px;
+  width: 24px;
+}
+svg.icon--thumbs-down {
   height: 24px;
   width: 24px;
 }
@@ -1083,7 +1091,7 @@ svg.icon--thumbs-up-selected-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--thumbs-down {
+svg.icon--thumbs-up-selected {
   height: 24px;
   width: 24px;
 }
@@ -1091,21 +1099,17 @@ svg.icon--thumbs-up-small {
   height: 16px;
   width: 16px;
 }
-svg.icon--thumbs-up-selected {
-  height: 24px;
-  width: 24px;
-}
 svg.icon--thumbs-up {
   height: 24px;
   width: 24px;
 }
-svg.icon--text-messaging-large {
-  height: 53px;
-  width: 58px;
-}
 svg.icon--tick-small {
   height: 9px;
   width: 12px;
+}
+svg.icon--tick {
+  height: 10px;
+  width: 14px;
 }
 svg.icon--top-seller {
   height: 19.96px;
@@ -1119,25 +1123,21 @@ svg.icon--truck {
   height: 17px;
   width: 22px;
 }
-svg.icon--unlocked-small {
-  height: 14px;
-  width: 12px;
-}
-svg.icon--user-profile {
-  height: 22px;
-  width: 22px;
-}
-svg.icon--tick {
-  height: 10px;
-  width: 14px;
-}
 svg.icon--undo {
   height: 25px;
   width: 24px;
 }
+svg.icon--unlocked-small {
+  height: 14px;
+  width: 12px;
+}
 svg.icon--unlocked {
   height: 22px;
   width: 18px;
+}
+svg.icon--user-profile {
+  height: 22px;
+  width: 22px;
 }
 svg.icon--vault-small {
   height: 16px;
@@ -1159,43 +1159,43 @@ svg.icon--visa-large {
   height: 33px;
   width: 51px;
 }
-svg.icon--visa-small {
-  height: 19px;
-  width: 31px;
-}
 svg.icon--visa-xsmall {
   height: 13px;
   width: 21px;
+}
+svg.icon--visa-small {
+  height: 19px;
+  width: 31px;
 }
 svg.icon--visa {
   height: 25px;
   width: 39px;
 }
-svg.icon--watch {
-  height: 18px;
-  width: 24px;
-}
 svg.icon--watch-large {
   height: 43px;
   width: 61px;
+}
+svg.icon--watch {
+  height: 18px;
+  width: 24px;
 }
 svg.icon--window {
   height: 25px;
   width: 28px;
 }
-svg.icon--zoom-out {
-  height: 24px;
-  width: 24px;
-}
 svg.icon--zoom-in {
   height: 24px;
   width: 24px;
 }
-svg.program-badge--authenticity-guaranteed {
+svg.icon--zoom-out {
+  height: 24px;
+  width: 24px;
+}
+svg.program-badge--click-to-call {
   height: 48px;
   width: 48px;
 }
-svg.program-badge--click-to-call {
+svg.program-badge--authenticity-guaranteed {
   height: 48px;
   width: 48px;
 }
@@ -1223,11 +1223,11 @@ svg.program-badge--money-back-guarantee-uk {
   height: 48px;
   width: 48px;
 }
-svg.program-badge--money-back-guarantee-us {
+svg.program-badge--money-back-guarantee-zl {
   height: 48px;
   width: 48px;
 }
-svg.program-badge--money-back-guarantee-zl {
+svg.program-badge--money-back-guarantee-us {
   height: 48px;
   width: 48px;
 }
@@ -1239,15 +1239,15 @@ svg.program-badge--vault {
   height: 48px;
   width: 48px;
 }
-svg.star-rating--0 {
-  height: 12px;
-  width: 64px;
-}
 svg.star-rating--0-5 {
   height: 12px;
   width: 64px;
 }
-svg.star-rating--2-5 {
+svg.star-rating--0 {
+  height: 12px;
+  width: 64px;
+}
+svg.star-rating--1-5 {
   height: 12px;
   width: 64px;
 }
@@ -1255,7 +1255,7 @@ svg.star-rating--1 {
   height: 12px;
   width: 64px;
 }
-svg.star-rating--1-5 {
+svg.star-rating--2-5 {
   height: 12px;
   width: 64px;
 }
@@ -1271,15 +1271,93 @@ svg.star-rating--3 {
   height: 12px;
   width: 64px;
 }
-svg.star-rating--4 {
+svg.star-rating--4-5 {
   height: 12px;
   width: 64px;
 }
-svg.star-rating--4-5 {
+svg.star-rating--4 {
   height: 12px;
   width: 64px;
 }
 svg.star-rating--5 {
   height: 12px;
   width: 64px;
+}
+svg.icon {
+  display: inline-block;
+  fill: currentColor;
+  pointer-events: none;
+  stroke: currentColor;
+  stroke-width: 0;
+  vertical-align: middle;
+}
+svg.icon--disabled {
+  color: var(--color-foreground-disabled);
+  fill: currentColor;
+}
+svg.icon--attention-filled {
+  color: var(--color-foreground-attention);
+}
+svg.icon--confirmation-filled {
+  color: var(--color-foreground-confirmation);
+}
+svg.icon--information-filled {
+  color: var(--color-foreground-information);
+}
+svg.icon--star-empty {
+  color: var(--color-foreground-disabled);
+}
+svg.icon--attention-filled-small {
+  color: var(--color-foreground-attention);
+}
+svg.icon--confirmation-filled-small {
+  color: var(--color-foreground-confirmation);
+}
+svg.icon--information-filled-small {
+  color: var(--color-foreground-information);
+}
+svg.icon--star-empty-small {
+  color: var(--color-foreground-disabled);
+}
+svg.icon--social-link {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-discord {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-facebook {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-messenger {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-pinterest {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-reddit {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-twitter {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-whatsapp {
+  color: var(--color-social-icons-background);
+}
+svg.icon--social-linkedin {
+  color: var(--color-social-icons-background);
+}
+svg.icon--spinner-large {
+  height: 60px;
+  width: 60px;
+}
+[dir="rtl"] svg.icon--back,
+[dir="rtl"] svg.icon--breadcrumb,
+[dir="rtl"] svg.icon--carousel-next,
+[dir="rtl"] svg.icon--carousel-prev,
+[dir="rtl"] svg.icon--chevron-left,
+[dir="rtl"] svg.icon--chevron-right,
+[dir="rtl"] svg.icon--cta,
+[dir="rtl"] svg.icon--pagination-next,
+[dir="rtl"] svg.icon--pagination-prev {
+  transform: rotate(180deg);
 }

--- a/dist/inline-notice/inline-notice.css
+++ b/dist/inline-notice/inline-notice.css
@@ -8,9 +8,9 @@ span.inline-notice {
   display: inline-flex;
 }
 .inline-notice__header {
-  align-items: center;
   display: flex;
   margin-right: 8px;
+  margin-top: 4px;
 }
 .inline-notice p {
   margin: 4px 0;
@@ -19,6 +19,6 @@ span.inline-notice {
 .inline-notice button.fake-link {
   color: var(--color-foreground-primary);
 }
-[dir="rtl"] .inline-notice__header .icon.icon--confirmation-filled {
+[dir="rtl"] .inline-notice__header .icon.icon--confirmation-filled-small {
   margin-left: 8px;
 }

--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -124,6 +124,9 @@ p.page-notice__cta {
   padding-left: 16px;
   padding-right: 0;
 }
+[dir="rtl"] .page-notice__main {
+  padding-right: 0;
+}
 [dir="rtl"] .page-notice__footer {
   margin-left: initial;
   margin-right: auto;

--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -6,12 +6,12 @@
   color: var(--page-notice-color, var(--color-foreground-on-inverse));
   font-size: 0.875rem;
   margin: 8px 0;
-  padding: 24px 16px;
+  padding: 16px;
 }
 div[role="region"].page-notice,
 section.page-notice {
   display: grid;
-  grid-template-columns: 40px auto auto auto;
+  grid-template-columns: 32px auto auto auto;
 }
 span[role="region"].page-notice {
   display: grid;
@@ -19,7 +19,7 @@ span[role="region"].page-notice {
 .page-notice__title {
   font-size: 0.875rem;
   font-weight: normal;
-  margin: 0;
+  margin: 4px 0 0;
 }
 /* legacy version with separate bold heading */
 .page-notice__title:not(:only-child) {
@@ -84,6 +84,7 @@ span[role="region"].page-notice {
 .page-notice__footer {
   grid-column: 4;
   grid-row: 1;
+  text-align: right;
 }
 /* support legacy 6.5 notice with heading + paragaphs */
 .page-notice__main p {
@@ -104,12 +105,13 @@ p.page-notice__cta {
     margin: 16px 0;
   }
   .page-notice__title {
-    margin-top: 4px;
+    margin-top: 2px;
   }
   p.page-notice__cta {
     grid-column: 4;
     grid-row: 1;
     justify-self: end;
+    margin-bottom: 0;
     margin-top: 0;
     padding-right: 16px;
   }

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -42,7 +42,7 @@ span[role="region"].section-notice {
   align-items: center;
   display: flex;
   justify-content: center;
-  padding-right: 16px;
+  padding-right: 12px;
 }
 .section-notice__main,
 .section-notice__footer {

--- a/dist/variables/variables.less
+++ b/dist/variables/variables.less
@@ -33,6 +33,7 @@
 @spacing-25: @spacing-100 * 0.25;
 @spacing-50: @spacing-100 * 0.5;
 @spacing-100: 8px;
+@spacing-150: @spacing-100 * 1.5;
 @spacing-200: @spacing-100 * 2;
 @spacing-300: @spacing-100 * 3;
 @spacing-400: @spacing-100 * 4;

--- a/docs/_includes/inline-notice.html
+++ b/docs/_includes/inline-notice.html
@@ -15,8 +15,8 @@
 
             <div class="inline-notice inline-notice--confirmation">
                 <span class="inline-notice__header">
-                    <svg focusable="false" class="icon icon--confirmation-filled" height="24" width="24" role="img" aria-label="Confirmation">
-                        {% include symbol.html name="confirmation-filled" %}
+                    <svg focusable="false" class="icon icon--confirmation-filled-small" height="16" width="16" role="img" aria-label="Confirmation">
+                        {% include symbol.html name="confirmation-filled-small" %}
                     </svg>
                 </span>
                 <span class="inline-notice__main">
@@ -26,8 +26,8 @@
 
             <div class="inline-notice inline-notice--information">
                 <span class="inline-notice__header">
-                    <svg focusable="false" class="icon icon--information-filled" height="24" width="24" role="img" aria-label="Information">
-                        {% include symbol.html name="information-filled" %}
+                    <svg focusable="false" class="icon icon--information-filled-small" height="16" width="16" role="img" aria-label="Information">
+                        {% include symbol.html name="information-filled-small" %}
                     </svg>
                 </span>
                 <span class="inline-notice__main">
@@ -37,8 +37,8 @@
 
             <div class="inline-notice inline-notice--attention">
                 <span class="inline-notice__header">
-                    <svg focusable="false" class="icon icon--attention-filled" height="24" width="24" role="img" aria-label="Attention">
-                        {% include symbol.html name="attention-filled" %}
+                    <svg focusable="false" class="icon icon--attention-filled-small" height="16" width="16" role="img" aria-label="Attention">
+                        {% include symbol.html name="attention-filled-small" %}
                     </svg>
                 </span>
                 <span class="inline-notice__main">
@@ -56,8 +56,8 @@
 
 <div class="inline-notice inline-notice--confirmation">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--confirmation-filled" height="24" width="24" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg focusable="false" class="icon icon--confirmation-filled-small" height="16" width="16" role="img" aria-label="Confirmation">
+            <use xlink:href="#icon-confirmation-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -67,8 +67,8 @@
 
 <div class="inline-notice inline-notice--information">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--information-filled" height="24" width="24" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg focusable="false" class="icon icon--information-filled-small" height="16" width="16" role="img" aria-label="Information">
+            <use xlink:href="#icon-information-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -78,8 +78,8 @@
 
 <div class="inline-notice inline-notice--attention">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--attention-filled" height="24" width="24" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg focusable="false" class="icon icon--attention-filled-small" height="16" width="16" role="img" aria-label="Attention">
+            <use xlink:href="#icon-attention-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">

--- a/docs/_includes/page-notice.html
+++ b/docs/_includes/page-notice.html
@@ -14,8 +14,8 @@
             </section>
             <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
                 <div class="page-notice__header">
-                    <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-                        {% include symbol.html name="confirmation-filled" %}
+                    <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
+                        {% include symbol.html name="confirmation-filled-small" %}
                     </svg>
                 </div>
                 <div class="page-notice__main">
@@ -27,8 +27,8 @@
             </section>
             <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
                 <div class="page-notice__header">
-                    <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" role="img" aria-label="Attention">
-                        {% include symbol.html name="attention-filled" %}
+                    <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
+                        {% include symbol.html name="attention-filled-small" %}
                     </svg>
                 </div>
                 <div class="page-notice__main">
@@ -40,8 +40,8 @@
             </section>
             <section class="page-notice page-notice--information" role="region" aria-label="Information">
                 <div class="page-notice__header">
-                    <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-                        {% include symbol.html name="information-filled" %}
+                    <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+                        {% include symbol.html name="information-filled-small" %}
                     </svg>
                 </div>
                 <div class="page-notice__main">
@@ -62,8 +62,8 @@
 
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
     <div class="page-notice__header">
-        <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -76,8 +76,8 @@
 
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
-        <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -90,8 +90,8 @@
 
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
-        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -106,8 +106,8 @@
     <h3 id="page-notice-dismissable-title">Dismissable Page Notice With Title</h3>
     <section class="page-notice page-notice--information" role="region" aria-label="Information">
         <div class="page-notice__header">
-            <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-                {% include symbol.html name="information-filled" %}
+            <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+                {% include symbol.html name="information-filled-small" %}
             </svg>
         </div>
         <div class="page-notice__main">
@@ -128,8 +128,8 @@
 <h3 id="page-notice-dismissable-title">Dismissable Page Notice With Title</h3>
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
-        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -140,7 +140,7 @@
     <div class="page-notice__footer">
         <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
             <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
-                <use xlink:href="#icon-close"></use>
+                <use href="#icon-close"></use>
             </svg>
         </a>
     </div>
@@ -151,8 +151,8 @@
 
     <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
         <div class="page-notice__header">
-            <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" role="img" aria-label="Attention">
-                {% include symbol.html name="attention-filled" %}
+            <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
+                {% include symbol.html name="attention-filled-small" %}
             </svg>
         </div>
         <div class="page-notice__main">
@@ -164,8 +164,8 @@
     {% highlight html %}
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
-        <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">

--- a/docs/_includes/section-notice.html
+++ b/docs/_includes/section-notice.html
@@ -18,8 +18,8 @@
 
             <section class="section-notice section-notice--confirmation" role="region" aria-label="Confirmation" aria-roledescription="Notice">
                 <div class="section-notice__header" id="section-notice-confirmation">
-                    <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-                        {% include symbol.html name="confirmation-filled" %}
+                    <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
+                        {% include symbol.html name="confirmation-filled-small" %}
                     </svg>
                 </div>
                 <div class="section-notice__main">
@@ -32,8 +32,8 @@
 
             <section class="section-notice section-notice--attention" role="region" aria-label="Attention" aria-roledescription="Notice">
                 <div class="section-notice__header" id="section-notice-attention">
-                    <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" aria-label="Attention">
-                        {% include symbol.html name="attention-filled" %}
+                    <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" aria-label="Attention">
+                        {% include symbol.html name="attention-filled-small" %}
                     </svg>
                 </div>
                 <div class="section-notice__main">
@@ -46,8 +46,8 @@
 
             <section class="section-notice section-notice--information" role="region" aria-label="Information" aria-roledescription="Notice">
                 <div class="section-notice__header" id="section-notice-information">
-                    <svg class="icon icon--information-filled" focusable="false" height="24" width="24" aria-label="Information">
-                        {% include symbol.html name="information-filled" %}
+                    <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" aria-label="Information">
+                        {% include symbol.html name="information-filled-small" %}
                     </svg>
                 </div>
                 <div class="section-notice__main">
@@ -72,8 +72,8 @@
 
 <section class="section-notice section-notice--confirmation" role="region" aria-label="Confirmation" aria-roledescription="Notice">
     <div class="section-notice__header" id="section-notice-confirmation">
-        <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -86,8 +86,8 @@
 
 <section class="section-notice section-notice--attention" role="region" aria-label="Attention" aria-roledescription="Notice">
     <div class="section-notice__header" id="section-notice-attention">
-        <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" aria-label="Attention">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -100,8 +100,8 @@
 
 <section class="section-notice section-notice--information" role="region" aria-label="Information" aria-roledescription="Notice">
     <div class="section-notice__header" id="section-notice-information">
-        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" aria-label="Information">
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">

--- a/src/less/icon/icon.less
+++ b/src/less/icon/icon.less
@@ -1,12 +1,81 @@
 @import "./generated/icon.less";
+@import "../mixins/private/icon-mixins.less";
+@import "../mixins/private/token-mixins.less";
 
 svg {
     &.icon {
         .icon-base-mixin();
     }
-
     &.icon--disabled {
         .color-token(color-foreground-disabled);
         fill: currentColor;
+    }
+    &.icon--attention-filled {
+        .color-token(color-foreground-attention);
+    }
+    &.icon--confirmation-filled {
+        .color-token(color-foreground-confirmation);
+    }
+    &.icon--information-filled {
+        .color-token(color-foreground-information);
+    }
+    &.icon--star-empty {
+        .color-token(color-foreground-disabled);
+    }
+    &.icon--attention-filled-small {
+        .color-token(color-foreground-attention);
+    }
+    &.icon--confirmation-filled-small {
+        .color-token(color-foreground-confirmation);
+    }
+    &.icon--information-filled-small {
+        .color-token(color-foreground-information);
+    }
+    &.icon--star-empty-small {
+        .color-token(color-foreground-disabled);
+    }
+    // todo: these should be .color-token(icon-foreground-color, color-foreground-primary) ?
+    &.icon--social-link {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-discord {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-facebook {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-messenger {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-pinterest {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-reddit {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-twitter {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-whatsapp {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--social-linkedin {
+        .color-token(color-social-icons-background);
+    }
+    &.icon--spinner-large {
+        .icon-image-mixin("spinner-large");
+    }
+}
+[dir="rtl"] svg {
+    &.icon--back,
+    &.icon--breadcrumb,
+    &.icon--carousel-next,
+    &.icon--carousel-prev,
+    &.icon--chevron-left,
+    &.icon--chevron-right,
+    &.icon--cta,
+    &.icon--pagination-next,
+    &.icon--pagination-prev {
+        transform: rotate(180deg);
     }
 }

--- a/src/less/inline-notice/inline-notice.less
+++ b/src/less/inline-notice/inline-notice.less
@@ -14,9 +14,9 @@ span.inline-notice {
 }
 
 .inline-notice__header {
-    align-items: center;
     display: flex;
     margin-right: @spacing-100;
+    margin-top: @spacing-50;
 }
 
 .inline-notice p {
@@ -29,7 +29,7 @@ span.inline-notice {
 }
 
 [dir="rtl"] {
-    .inline-notice__header .icon.icon--confirmation-filled {
+    .inline-notice__header .icon.icon--confirmation-filled-small {
         margin-left: @spacing-100;
     }
 }

--- a/src/less/inline-notice/stories/inline.stories.js
+++ b/src/less/inline-notice/stories/inline.stories.js
@@ -3,8 +3,8 @@ export default { title: 'Inline Notice' };
 export const confirmation = () => `
 <div class="inline-notice inline-notice--confirmation">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--confirmation-filled" role="img">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg focusable="false" class="icon icon--confirmation-filled-small" role="img">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -17,8 +17,8 @@ export const RTL = () => `
 <div dir="rtl">
     <div class="inline-notice inline-notice--confirmation">
         <span class="inline-notice__header">
-            <svg focusable="false" class="icon icon--confirmation-filled" role="img">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg focusable="false" class="icon icon--confirmation-filled-small" role="img">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </span>
         <span class="inline-notice__main">
@@ -31,8 +31,8 @@ export const RTL = () => `
 export const attention = () => `
 <div class="inline-notice inline-notice--attention">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--attention-filled" role="img">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg focusable="false" class="icon icon--attention-filled-small" role="img">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -44,8 +44,8 @@ export const attention = () => `
 export const information = () => `
 <div class="inline-notice inline-notice--information">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--information-filled" role="img">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg focusable="false" class="icon icon--information-filled-small" role="img">
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -65,8 +65,8 @@ export const general = () => `
 export const paragraphAndLink = () => `
 <div class="inline-notice inline-notice--attention">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--attention-filled" role="img">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg focusable="false" class="icon icon--attention-filled-small" role="img">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -79,8 +79,8 @@ export const paragraphAndLink = () => `
 export const longParagraph = () => `
 <div class="inline-notice inline-notice--attention">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--attention-filled" role="img">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg focusable="false" class="icon icon--attention-filled-small" role="img">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -92,8 +92,8 @@ export const longParagraph = () => `
 export const longParagraphAndLink = () => `
 <div class="inline-notice inline-notice--attention">
     <span class="inline-notice__header" role="img">
-        <svg focusable="false" class="icon icon--attention-filled">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg focusable="false" class="icon icon--attention-filled-small">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -106,8 +106,8 @@ export const longParagraphAndLink = () => `
 export const multiParagraph = () => `
 <div class="inline-notice inline-notice--attention">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--attention-filled" role="img">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg focusable="false" class="icon icon--attention-filled-small" role="img">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -120,8 +120,8 @@ export const multiParagraph = () => `
 export const multiParagraphAndLink = () => `
 <div class="inline-notice inline-notice--attention">
     <span class="inline-notice__header">
-        <svg focusable="false" class="icon icon--attention-filled" role="img">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg focusable="false" class="icon icon--attention-filled-small" role="img">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </span>
     <span class="inline-notice__main">
@@ -136,8 +136,8 @@ export const longWordInConstrainedWidth = () => `
 <div style="width:300px;">
     <div class="inline-notice inline-notice--confirmation">
         <span class="inline-notice__header">
-            <svg focusable="false" class="icon icon--confirmation-filled" role="img">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg focusable="false" class="icon icon--confirmation-filled-small" role="img">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </span>
         <span class="inline-notice__main">

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -158,6 +158,10 @@ p.page-notice__cta {
         padding-right: 0;
     }
 
+    .page-notice__main {
+        padding-right: 0;
+    }
+
     .page-notice__footer {
         margin-left: initial;
         margin-right: auto;

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -9,14 +9,14 @@
     .color-token(page-notice-color, color-foreground-on-inverse);
     font-size: @font-size-regular;
     margin: @spacing-100 0;
-    padding: @spacing-300 @spacing-200;
+    padding: @spacing-200;
 }
 
 div[role="region"].page-notice,
 section.page-notice {
     display: grid;
     // provide explicit structure up front, create loose markup model
-    grid-template-columns: 40px auto auto auto;
+    grid-template-columns: 32px auto auto auto;
 }
 
 span[role="region"].page-notice {
@@ -26,7 +26,7 @@ span[role="region"].page-notice {
 .page-notice__title {
     font-size: @font-size-regular;
     font-weight: normal;
-    margin: 0;
+    margin: 4px 0 0;
 }
 
 /* legacy version with separate bold heading */
@@ -109,6 +109,7 @@ span[role="region"].page-notice {
 .page-notice__footer {
     grid-column: 4;
     grid-row: 1;
+    text-align: right;
 }
 
 /* support legacy 6.5 notice with heading + paragaphs */
@@ -133,13 +134,14 @@ p.page-notice__cta {
     }
 
     .page-notice__title {
-        margin-top: 4px;
+        margin-top: 2px;
     }
 
     p.page-notice__cta {
         grid-column: 4;
         grid-row: 1;
         justify-self: end;
+        margin-bottom: 0;
         margin-top: 0;
         padding-right: @spacing-200;
     }

--- a/src/less/page-notice/stories/page-notice.stories.js
+++ b/src/less/page-notice/stories/page-notice.stories.js
@@ -33,8 +33,8 @@ export const generalWithLink = () => `
 export const confirmationWithButton = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
     <div class="page-notice__header">
-        <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
+            <use xlink:href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -49,8 +49,8 @@ export const confirmationWithButton = () => `
 export const confirmationWithLink = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
     <div class="page-notice__header">
-        <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
+            <use xlink:href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -65,8 +65,8 @@ export const confirmationWithLink = () => `
 export const attentionWithButton = () => `
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
-        <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
+            <use xlink:href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -81,8 +81,8 @@ export const attentionWithButton = () => `
 export const attentionWithLink = () => `
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
-        <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
+            <use xlink:href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -97,8 +97,8 @@ export const attentionWithLink = () => `
 export const informationWithButton = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
-        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use xlink:href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -113,8 +113,8 @@ export const informationWithButton = () => `
 export const informationWithLink = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
-        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use xlink:href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -129,8 +129,8 @@ export const informationWithLink = () => `
 export const dismissableWithTitle = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
-        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use xlink:href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -151,8 +151,8 @@ export const dismissableWithTitle = () => `
 export const dismissableWithoutTitle = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
-        <svg class="icon icon--information-filled" focusable="false" height="24" width="24" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use xlink:href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -172,8 +172,8 @@ export const dismissableWithoutTitle = () => `
 export const formErrors = () => `
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
-        <svg class="icon icon--attention-filled" focusable="false" height="24" width="24" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
+            <use xlink:href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">

--- a/src/less/page-notice/stories/page-notice.stories.js
+++ b/src/less/page-notice/stories/page-notice.stories.js
@@ -34,7 +34,7 @@ export const confirmationWithButton = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
     <div class="page-notice__header">
         <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled-small"></use>
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -50,7 +50,7 @@ export const confirmationWithLink = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
     <div class="page-notice__header">
         <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled-small"></use>
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -66,7 +66,7 @@ export const attentionWithButton = () => `
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
         <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled-small"></use>
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -82,7 +82,7 @@ export const attentionWithLink = () => `
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
         <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled-small"></use>
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -98,7 +98,7 @@ export const informationWithButton = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
         <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled-small"></use>
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -114,7 +114,7 @@ export const informationWithLink = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
         <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled-small"></use>
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -130,7 +130,7 @@ export const dismissableWithTitle = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
         <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled-small"></use>
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -140,8 +140,8 @@ export const dismissableWithTitle = () => `
     <p class="page-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
     <div class="page-notice__footer">
         <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
-            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
-                <use xlink:href="#icon-close"></use>
+            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="14" width="14">
+                <use href="#icon-close-small"></use>
             </svg>
         </a>
     </div>
@@ -152,7 +152,7 @@ export const dismissableWithoutTitle = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">
         <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
-            <use xlink:href="#icon-information-filled-small"></use>
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -161,8 +161,8 @@ export const dismissableWithoutTitle = () => `
     <p class="page-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
     <div class="page-notice__footer">
         <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
-            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
-                <use xlink:href="#icon-close"></use>
+            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="14" width="14">
+                <use href="#icon-close-small"></use>
             </svg>
         </a>
     </div>
@@ -173,7 +173,7 @@ export const formErrors = () => `
 <section class="page-notice page-notice--attention" role="region" aria-label="Attention">
     <div class="page-notice__header">
         <svg class="icon icon--attention-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Attention">
-            <use xlink:href="#icon-attention-filled-small"></use>
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">

--- a/src/less/page-notice/stories/test.stories.js
+++ b/src/less/page-notice/stories/test.stories.js
@@ -4,8 +4,8 @@ export const RTL = () => `
 <div dir="rtl">
     <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
         <div class="page-notice__header">
-            <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg class="icon icon--confirmation-filled-small" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </div>
         <div class="page-notice__main">
@@ -22,8 +22,8 @@ export const RTL = () => `
 export const longText = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
     <div class="page-notice__header">
-        <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg class="icon icon--confirmation-filled-small" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -38,8 +38,8 @@ export const longText = () => `
 export const legacy = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
     <div class="page-notice__header">
-        <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg class="icon icon--confirmation-filled-small" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="page-notice__main">
@@ -52,8 +52,8 @@ export const legacy = () => `
 export const legacyLongText = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
         <div class="page-notice__header">
-            <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg class="icon icon--confirmation-filled-small" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </div>
         <div class="page-notice__main">
@@ -66,8 +66,8 @@ export const legacyLongText = () => `
 export const legacyLongTextAndCTA = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
         <div class="page-notice__header">
-            <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg class="icon icon--confirmation-filled-small" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </div>
         <div class="page-notice__main">
@@ -83,8 +83,8 @@ export const legacyLongTextAndCTA = () => `
 export const legacyMultiParagraph = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
         <div class="page-notice__header">
-            <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg class="icon icon--confirmation-filled-small" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </div>
         <div class="page-notice__main">
@@ -98,8 +98,8 @@ export const legacyMultiParagraph = () => `
 export const legacyMultiParagraphWithCTA = () => `
 <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
         <div class="page-notice__header">
-            <svg class="icon icon--confirmation-filled" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg class="icon icon--confirmation-filled-small" focusable="false" height="24" width="24" role="img" aria-label="Confirmation">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </div>
         <div class="page-notice__main">

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -54,7 +54,7 @@ span[role="region"].section-notice {
     align-items: center;
     display: flex;
     justify-content: center;
-    padding-right: @spacing-200;
+    padding-right: @spacing-150;
 }
 
 .section-notice__main,

--- a/src/less/section-notice/stories/section-notice.stories.js
+++ b/src/less/section-notice/stories/section-notice.stories.js
@@ -33,8 +33,8 @@ export const generalWithLink = () => `
 export const confirmationWithButton = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -49,8 +49,8 @@ export const confirmationWithButton = () => `
 export const confirmationWithLink = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -65,8 +65,8 @@ export const confirmationWithLink = () => `
 export const attentionWithButton = () => `
 <div class="section-notice section-notice--attention" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--attention-filled-small">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -81,8 +81,8 @@ export const attentionWithButton = () => `
 export const attentionWithLink = () => `
 <div class="section-notice section-notice--attention" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--attention-filled">
-            <use xlink:href="#icon-attention-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--attention-filled-small">
+            <use href="#icon-attention-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -97,8 +97,8 @@ export const attentionWithLink = () => `
 export const informationWithButton = () => `
 <div class="section-notice section-notice--information" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--information-filled">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--information-filled-small">
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -113,8 +113,8 @@ export const informationWithButton = () => `
 export const informationWithLink = () => `
 <div class="section-notice section-notice--information" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--information-filled">
-            <use xlink:href="#icon-information-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--information-filled-small">
+            <use href="#icon-information-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">

--- a/src/less/section-notice/stories/test.stories.js
+++ b/src/less/section-notice/stories/test.stories.js
@@ -4,8 +4,8 @@ export const RTL = () => `
 <div dir="rtl">
     <div class="section-notice section-notice--confirmation" role="region">
         <div class="section-notice__header" role="region" aria-roledescription="Notice">
-            <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
-                <use xlink:href="#icon-confirmation-filled"></use>
+            <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+                <use href="#icon-confirmation-filled-small"></use>
             </svg>
         </div>
         <div class="section-notice__main">
@@ -21,8 +21,8 @@ export const RTL = () => `
 export const longText = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -34,8 +34,8 @@ export const longText = () => `
 export const longTextWithCTA = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -50,8 +50,8 @@ export const longTextWithCTA = () => `
 export const legacy = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -64,8 +64,8 @@ export const legacy = () => `
 export const legacyWithCTA = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled">
-            <use xlink:href="#icon-confirmation-filled"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+            <use href="#icon-confirmation-filled-small"></use>
         </svg>
     </div>
     <div class="section-notice__main">

--- a/src/less/variables/variables.less
+++ b/src/less/variables/variables.less
@@ -33,6 +33,7 @@
 @spacing-25: @spacing-100 * 0.25;
 @spacing-50: @spacing-100 * 0.5;
 @spacing-100: 8px;
+@spacing-150: @spacing-100 * 1.5;
 @spacing-200: @spacing-100 * 2;
 @spacing-300: @spacing-100 * 3;
 @spacing-400: @spacing-100 * 4;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1806 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Reduced icon dimensions and made spacing adjustments.

## Notes
* Inline notice and Section notice components were modified as well to match the icon sizes and spacing.
* Percy's still on the blink. Even though I ran the snapshots, the diffs are missing for now. 

## Screenshots

### Page Notice
Before:
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/1675667/184721132-dd1e218c-3275-43db-af58-a280a6ec0075.png">

After:
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/1675667/184721771-c598f9d2-a7ba-47d9-ad03-20214ef7ec4b.png">

### Inline Notice
Before:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/1675667/184945531-0521a097-7a38-472f-9577-a25c53d870f0.png">

After:
<img width="307" alt="image" src="https://user-images.githubusercontent.com/1675667/184945562-1f23826a-dc70-4c10-8f05-da37bdd7f90e.png">

### Section Notice
Before:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/1675667/184945652-6a9f8029-6edf-4732-a692-a2b2f4b771c0.png">

After:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/1675667/184945691-02d258f4-3b20-4760-812b-e18e11f82161.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
