### PR TITLE
fix(font): change swap loading strategy for fonts

### DIFF
--- a/dist/marketsans/marketsans.css
+++ b/dist/marketsans/marketsans.css
@@ -1,5 +1,5 @@
 @font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: "Market Sans";
   font-style: normal;
   font-weight: normal;
@@ -7,7 +7,7 @@
   src: url("https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.eot?#iefix") format("embedded-opentype"), url("https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff2") format("woff2"), url("https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.woff") format("woff"), url("https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.ttf") format("truetype"), url("https://ir.ebaystatic.com/cr/v/c1/market-sans/v1.0/MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS") format("svg");
 }
 @font-face {
-  font-display: optional;
+  font-display: swap;
   font-family: "Market Sans";
   font-style: normal;
   font-weight: bold;

--- a/src/fonts/marketsans/MarketSans-Regular-WebS.css
+++ b/src/fonts/marketsans/MarketSans-Regular-WebS.css
@@ -7,7 +7,8 @@
         /* Pretty Modern Browsers */ url("MarketSans-Regular-WebS.ttf") format("truetype"),
         /* Safari, Android, iOS */ url("MarketSans-Regular-WebS.svg#MarketSans-Regular-WebS")
             format("svg"); /* Legacy iOS */
+
     font-weight: normal;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }

--- a/src/fonts/marketsans/MarketSans-SemiBold-WebS.css
+++ b/src/fonts/marketsans/MarketSans-SemiBold-WebS.css
@@ -7,7 +7,8 @@
         /* Pretty Modern Browsers */ url("MarketSans-SemiBold-WebS.ttf") format("truetype"),
         /* Safari, Android, iOS */ url("MarketSans-SemiBold-WebS.svg#MarketSans-SemiBold-WebS")
             format("svg"); /* Legacy iOS */
+
     font-weight: bold;
     font-style: normal;
-    font-display: optional;
+    font-display: swap;
 }

--- a/src/less/marketsans/marketsans.less
+++ b/src/less/marketsans/marketsans.less
@@ -8,7 +8,7 @@
 // svg: Legacy iOS
 
 @font-face {
-    font-display: optional;
+    font-display: swap;
     font-family: @marketsans-fontname;
     font-style: normal;
     font-weight: normal;
@@ -23,7 +23,7 @@
 }
 
 @font-face {
-    font-display: optional;
+    font-display: swap;
     font-family: @marketsans-fontname;
     font-style: normal;
     font-weight: bold;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1699 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Switching to using swap font loading strategy to ensure font consistency.

## Notes
Adding on to the missing changes in PR #1845 . See more details in that PR.
