### PR TITLE
1827 multiple menu buttons

### DIFF
--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -28,6 +28,7 @@ span.combobox {
   box-shadow: var(--combobox-listbox-box-shadow, var(--dropdown-box-shadow));
   box-sizing: border-box;
   display: none;
+  left: 0;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;

--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -16,9 +16,6 @@ span.combobox {
 .combobox__options--fix-width[role="listbox"] {
   width: 100%;
 }
-.combobox__options--reverse[role="listbox"] {
-  right: 0;
-}
 .combobox__listbox {
   background-color: var(--combobox-listbox-background-color, var(--color-background-primary));
   border-color: var(--combobox-listbox-border-color, var(--color-stroke-default));
@@ -36,6 +33,18 @@ span.combobox {
   top: calc(100% + 4px);
   width: auto;
   z-index: 2;
+}
+[dir="rtl"] .combobox__listbox {
+  left: unset;
+  right: 0;
+}
+.combobox__listbox--reverse {
+  left: unset;
+  right: 0;
+}
+[dir="rtl"] .combobox__listbox--reverse {
+  left: 0;
+  right: unset;
 }
 .combobox__option[role^="option"] {
   background-color: transparent;

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -29,6 +29,10 @@ div.listbox-button__listbox {
   width: auto;
   z-index: 2;
 }
+[dir="rtl"] div.listbox-button__listbox {
+  left: unset;
+  right: 0;
+}
 button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 .listbox-button button.btn[aria-expanded="true"] ~ div.listbox-button__listbox {
   display: block;

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -20,6 +20,7 @@ div.listbox-button__listbox {
   box-shadow: var(--listbox-button-listbox-box-shadow, var(--dropdown-box-shadow));
   box-sizing: border-box;
   display: none;
+  left: 0;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;

--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -23,6 +23,11 @@
   z-index: 2;
   outline: 0;
 }
+[dir="rtl"] .menu-button__menu,
+[dir="rtl"] .fake-menu-button__menu {
+  left: unset;
+  right: 0;
+}
 span.menu-button__button,
 span.fake-menu-button__button {
   display: inline-block;
@@ -190,12 +195,13 @@ div.menu-button__item--badged[role^="menuitem"] .badge {
 }
 .menu-button__menu--reverse,
 .fake-menu-button__menu--reverse {
+  left: unset;
   right: 0;
 }
 [dir="rtl"] .menu-button__menu--reverse,
 [dir="rtl"] .fake-menu-button__menu--reverse {
   left: 0;
-  right: inherit;
+  right: unset;
 }
 .menu-button__button[aria-expanded="true"] ~ .menu-button__menu,
 .fake-menu-button__button[aria-expanded="true"] ~ .fake-menu-button__menu,

--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -13,6 +13,7 @@
   box-shadow: var(--menu-button-menu-box-shadow, var(--dropdown-box-shadow));
   box-sizing: border-box;
   display: none;
+  left: 0;
   max-height: 400px;
   min-width: 100%;
   overflow-y: auto;

--- a/src/less/combobox/combobox.less
+++ b/src/less/combobox/combobox.less
@@ -27,12 +27,12 @@ span.combobox {
     width: 100%;
 }
 
-.combobox__options--reverse[role="listbox"] {
-    right: 0;
-}
-
 .combobox__listbox {
     .dropdown-base(combobox-listbox);
+}
+
+.combobox__listbox--reverse {
+    .dropdown-reverse(combobox-listbox-reverse);
 }
 
 .combobox__option[role^="option"] {

--- a/src/less/menu-button/menu-button.less
+++ b/src/less/menu-button/menu-button.less
@@ -146,13 +146,7 @@ div.menu-button__item--badged[role^="menuitem"] .badge {
 
 .menu-button__menu--reverse,
 .fake-menu-button__menu--reverse {
-    right: 0;
-}
-
-[dir="rtl"] .menu-button__menu--reverse,
-[dir="rtl"] .fake-menu-button__menu--reverse {
-    left: 0;
-    right: inherit;
+    .dropdown-reverse(menu-button-menu-reverse);
 }
 
 .menu-button__button[aria-expanded="true"] ~ .menu-button__menu,

--- a/src/less/mixins/private/dropdown-mixins.less
+++ b/src/less/mixins/private/dropdown-mixins.less
@@ -24,7 +24,7 @@
     }
 }
 
-.dropdown-reverse(@component) {
+.dropdown-reverse() {
     left: unset;
     right: 0;
 

--- a/src/less/mixins/private/dropdown-mixins.less
+++ b/src/less/mixins/private/dropdown-mixins.less
@@ -9,6 +9,7 @@
     .box-shadow-token(~"@{component}-box-shadow", dropdown-box-shadow);
     box-sizing: border-box;
     display: none;
+    left: 0;
     max-height: 400px;
     min-width: 100%;
     overflow-y: auto;

--- a/src/less/mixins/private/dropdown-mixins.less
+++ b/src/less/mixins/private/dropdown-mixins.less
@@ -17,6 +17,21 @@
     top: calc(100% + 4px);
     width: auto;
     z-index: 2;
+
+    [dir="rtl"] & {
+        left: unset;
+        right: 0;
+    }
+}
+
+.dropdown-reverse(@component) {
+    left: unset;
+    right: 0;
+
+    [dir="rtl"] & {
+        left: 0;
+        right: unset;
+    }
 }
 
 .dropdown-item-border-radius(@component) {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
- Fixes #1827 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Dropdown menu spanned whole set of buttons when multiple were placed next to each other.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
- I modified `dropdown-base` instead of just `menu-button` for expandability, it did not break anything as far as my testing is concerned, so I think it is preferable.

## Checklist

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
