### PR TITLE
fix(button): removed min-width on borderless variant

### DIFF
--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -13,6 +13,7 @@ a.fake-btn {
   display: inline-block;
   font-size: 0.875rem;
   min-height: 40px;
+  min-width: 88px;
   padding: 9.5px 20px;
 }
 button.btn--fixed-height,
@@ -35,10 +36,6 @@ a.fake-btn--truncated span {
 button.btn:focus:not(:focus-visible),
 a.fake-btn:focus:not(:focus-visible) {
   outline: none;
-}
-button.btn:not(.btn--borderless),
-a.fake-btn:not(.fake-btn--borderless) {
-  min-width: 88px;
 }
 button.btn--form,
 a.fake-btn--form {
@@ -64,6 +61,7 @@ button.btn[aria-disabled="true"] {
 button.btn--borderless,
 a.fake-btn--borderless {
   border-color: transparent;
+  min-width: auto;
   padding-left: 0;
   vertical-align: initial;
 }

--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -13,7 +13,6 @@ a.fake-btn {
   display: inline-block;
   font-size: 0.875rem;
   min-height: 40px;
-  min-width: 88px;
   padding: 9.5px 20px;
 }
 button.btn--fixed-height,
@@ -36,6 +35,10 @@ a.fake-btn--truncated span {
 button.btn:focus:not(:focus-visible),
 a.fake-btn:focus:not(:focus-visible) {
   outline: none;
+}
+button.btn:not(.btn--borderless),
+a.fake-btn:not(.fake-btn--borderless) {
+  min-width: 88px;
 }
 button.btn--form,
 a.fake-btn--form {

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -12,8 +12,12 @@ a.fake-btn {
     display: inline-block;
     font-size: @font-size-regular;
     min-height: @button-height-small;
-    min-width: 88px;
     padding: @button-padding-vertical @button-padding-horizontal;
+}
+
+button.btn:not(.btn--borderless),
+a.fake-btn:not(.fake-btn--borderless) {
+    min-width: 88px;
 }
 
 button.btn--form,

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -12,12 +12,8 @@ a.fake-btn {
     display: inline-block;
     font-size: @font-size-regular;
     min-height: @button-height-small;
-    padding: @button-padding-vertical @button-padding-horizontal;
-}
-
-button.btn:not(.btn--borderless),
-a.fake-btn:not(.fake-btn--borderless) {
     min-width: 88px;
+    padding: @button-padding-vertical @button-padding-horizontal;
 }
 
 button.btn--form,
@@ -45,6 +41,7 @@ button.btn[aria-disabled="true"] {
 button.btn--borderless,
 a.fake-btn--borderless {
     border-color: transparent;
+    min-width: auto;
     padding-left: 0;
     vertical-align: initial;
 

--- a/src/less/button/stories/button/borderless.stories.js
+++ b/src/less/button/stories/button/borderless.stories.js
@@ -26,3 +26,11 @@ export const ariaDisabled = () => `<button class="btn btn--borderless" aria-disa
         </svg>
     </span>
 </button>`;
+
+export const empty = () => `<button class="btn btn--borderless" disabled="true">
+    <span class="btn__cell">
+        <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-dropdown"></use>
+        </svg>
+    </span>
+</button>`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
- Fixes #1824 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
[eBay Figma design system](https://www.figma.com/file/zEBdEhbonrBOGzZ0fXzWvM/eBay-Design-System?node-id=37272%3A40019) states:

> Borderless dropdowns do not have a minimum width since they hug their contents.

Changes have been made to satisfy this statement.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
