### PR TITLE
fix(field label): change color when input is disabled

### DIFF
--- a/dist/checkbox/checkbox.css
+++ b/dist/checkbox/checkbox.css
@@ -52,29 +52,29 @@ input.checkbox__control[type="checkbox"] {
   height: 24px;
   width: 24px;
 }
-input.checkbox__control[type="checkbox"] + span.checkbox__icon svg.checkbox__checked {
+input.checkbox__control[type="checkbox"] + label > span.checkbox__icon svg.checkbox__checked {
   display: none;
 }
-input.checkbox__control[type="checkbox"] + span.checkbox__icon svg.checkbox__unchecked {
+input.checkbox__control[type="checkbox"] + label > span.checkbox__icon svg.checkbox__unchecked {
   display: inline-block;
 }
-input.checkbox__control[type="checkbox"]:checked + span.checkbox__icon svg.checkbox__checked {
+input.checkbox__control[type="checkbox"]:checked + label > span.checkbox__icon svg.checkbox__checked {
   display: inline-block;
 }
-input.checkbox__control[type="checkbox"]:checked + span.checkbox__icon svg.checkbox__unchecked {
+input.checkbox__control[type="checkbox"]:checked + label > span.checkbox__icon svg.checkbox__unchecked {
   display: none;
 }
-input.checkbox__control[type="checkbox"][disabled] + span.checkbox__icon {
+input.checkbox__control[type="checkbox"][disabled] + label > span.checkbox__icon {
   opacity: 1;
 }
-input.checkbox__control[type="checkbox"][disabled] + span.checkbox__icon svg {
+input.checkbox__control[type="checkbox"][disabled] + label > span.checkbox__icon svg {
   fill: var(--checkbox-disabled-color, var(--color-foreground-disabled));
 }
-input.checkbox__control[type="checkbox"]:focus + span.checkbox__icon {
+input.checkbox__control[type="checkbox"]:focus + label > span.checkbox__icon {
   outline: 1px auto;
   outline-color: var(--checkbox-outline, var(--color-foreground-secondary));
   outline-offset: 2px;
 }
-input.checkbox__control[type="checkbox"]:focus:not(:focus-visible) + span.checkbox__icon {
+input.checkbox__control[type="checkbox"]:focus:not(:focus-visible) + label > span.checkbox__icon {
   outline: none;
 }

--- a/dist/field/field.css
+++ b/dist/field/field.css
@@ -101,3 +101,6 @@ div.field__description {
   align-self: start;
   margin-top: 16px;
 }
+input:disabled + label.field__label {
+  color: var(--radio-label, var(--color-foreground-disabled));
+}

--- a/dist/radio/radio.css
+++ b/dist/radio/radio.css
@@ -52,29 +52,29 @@ input.radio__control[type="radio"] {
   height: 24px;
   width: 24px;
 }
-input.radio__control[type="radio"] + span.radio__icon svg.radio__checked {
+input.radio__control[type="radio"] + label > span.radio__icon svg.radio__checked {
   display: none;
 }
-input.radio__control[type="radio"] + span.radio__icon svg.radio__unchecked {
+input.radio__control[type="radio"] + label > span.radio__icon svg.radio__unchecked {
   display: inline-block;
 }
-input.radio__control[type="radio"]:checked + span.radio__icon svg.radio__checked {
+input.radio__control[type="radio"]:checked + label > span.radio__icon svg.radio__checked {
   display: inline-block;
 }
-input.radio__control[type="radio"]:checked + span.radio__icon svg.radio__unchecked {
+input.radio__control[type="radio"]:checked + label > span.radio__icon svg.radio__unchecked {
   display: none;
 }
-input.radio__control[type="radio"][disabled] + span.radio__icon {
+input.radio__control[type="radio"][disabled] + label > span.radio__icon {
   opacity: 1;
 }
-input.radio__control[type="radio"][disabled] + span.radio__icon svg {
+input.radio__control[type="radio"][disabled] + label > span.radio__icon svg {
   fill: var(--radio-disabled-color, var(--color-foreground-disabled));
 }
-input.radio__control[type="radio"]:focus + span.radio__icon {
+input.radio__control[type="radio"]:focus + label > span.radio__icon {
   outline: 1px auto;
   outline-color: var(--radio-outline, var(--color-foreground-secondary));
   outline-offset: 2px;
 }
-input.radio__control[type="radio"]:focus:not(:focus-visible) + span.radio__icon {
+input.radio__control[type="radio"]:focus:not(:focus-visible) + label > span.radio__icon {
   outline: none;
 }

--- a/docs/_includes/checkbox.html
+++ b/docs/_includes/checkbox.html
@@ -13,28 +13,32 @@
         <div class="demo__inner">
             <span class="checkbox">
                 <input aria-label="Default checkbox example" class="checkbox__control" type="checkbox" name="checkbox-default" checked />
-                <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="checkbox-unchecked" %}
-                    </svg>
-                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="checkbox-checked" %}
-                    </svg>
-                </span>
+                <label class="field__label">
+                    <span class="checkbox__icon" hidden>
+                        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="checkbox-unchecked" %}
+                        </svg>
+                        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="checkbox-checked" %}
+                        </svg>
+                    </span>
+                </label>
             </span>
         </div>
     </div>
     {% highlight html %}
 <span class="checkbox">
     <input class="checkbox__control" type="checkbox" checked />
-    <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-unchecked"></use>
-        </svg>
-        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-checked"></use>
-        </svg>
-    </span>
+    <label class="field__label">
+        <span class="checkbox__icon" hidden>
+            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-unchecked"></use>
+            </svg>
+            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-checked"></use>
+            </svg>
+        </span>
+    </label>
 </span>
     {% endhighlight %}
 
@@ -46,28 +50,32 @@
         <div class="demo__inner">
             <span class="checkbox">
                 <input aria-label="Mixed checkbox example" aria-checked="mixed" class="checkbox__control" type="checkbox" name="checkbox-default" checked />
-                <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="checkbox-unchecked-large" %}
-                    </svg>
-                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="checkbox-mixed" %}
-                    </svg>
-                </span>
+                <label class="field__label">
+                    <span class="checkbox__icon" hidden>
+                        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="checkbox-unchecked-large" %}
+                        </svg>
+                        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="checkbox-mixed" %}
+                        </svg>
+                    </span>
+                </label>
             </span>
         </div>
     </div>
     {% highlight html %}
 <span class="checkbox">
     <input aria-checked="mixed" class="checkbox__control" type="checkbox" checked />
-    <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-unchecked"></use>
-        </svg>
-        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-mixed"></use>
-        </svg>
-    </span>
+    <label class="field__label">
+        <span class="checkbox__icon" hidden>
+            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-unchecked"></use>
+            </svg>
+            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-mixed"></use>
+            </svg>
+        </span>
+    </label>
 </span>
     {% endhighlight %}
 
@@ -78,28 +86,32 @@
         <div class="demo__inner">
             <span class="checkbox checkbox--large">
                 <input aria-label="Large checkbox example" class="checkbox__control" type="checkbox" name="checkbox-large" checked />
-                <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
-                        {% include symbol.html name="checkbox-unchecked-large" %}
-                    </svg>
-                    <svg class="checkbox__checked" focusable="false" height="24" width="24" aria-hidden="true">
-                        {% include symbol.html name="checkbox-checked-large" %}
-                    </svg>
-                </span>
+                <label class="field__label">
+                    <span class="checkbox__icon" hidden>
+                        <svg class="checkbox__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
+                            {% include symbol.html name="checkbox-unchecked-large" %}
+                        </svg>
+                        <svg class="checkbox__checked" focusable="false" height="24" width="24" aria-hidden="true">
+                            {% include symbol.html name="checkbox-checked-large" %}
+                        </svg>
+                    </span>
+                </label>
             </span>
         </div>
     </div>
     {% highlight html %}
 <span class="checkbox checkbox--large">
     <input class="checkbox__control" type="checkbox" checked />
-    <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-unchecked-large"></use>
-        </svg>
-        <svg class="checkbox__checked" focusable="false" height="24" width="24" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-checked-large"></use>
-        </svg>
-    </span>
+    <label class="field__label">
+        <span class="checkbox__icon" hidden>
+            <svg class="checkbox__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-unchecked-large"></use>
+            </svg>
+            <svg class="checkbox__checked" focusable="false" height="24" width="24" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-checked-large"></use>
+            </svg>
+        </span>
+    </label>
 </span>
     {% endhighlight %}
 
@@ -110,28 +122,32 @@
         <div class="demo__inner">
             <span class="checkbox">
                 <input aria-label="Disabled checkbox example" class="checkbox__control" type="checkbox" name="checkbox-svg" aria-label="SVG checkbox example" checked disabled />
-                <span class="checkbox__icon" hidden>
-                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="checkbox-unchecked" %}
-                    </svg>
-                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="checkbox-checked" %}
-                    </svg>
-                </span>
+                <label class="field__label">
+                    <span class="checkbox__icon" hidden>
+                        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="checkbox-unchecked" %}
+                        </svg>
+                        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="checkbox-checked" %}
+                        </svg>
+                    </span>
+                </label>
             </span>
         </div>
     </div>
     {% highlight html %}
 <span class="checkbox">
     <input class="checkbox__control" type="checkbox" checked disabled />
-    <span class="checkbox__icon" hidden>
-        <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-unchecked"></use>
-        </svg>
-        <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-checkbox-checked"></use>
-        </svg>
-    </span>
+    <label class="field__label">
+        <span class="checkbox__icon" hidden>
+            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-unchecked"></use>
+            </svg>
+            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-checkbox-checked"></use>
+            </svg>
+        </span>
+    </label>
 </span>
     {% endhighlight %}
 
@@ -147,44 +163,50 @@
                 <span class="field">
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-1" type="checkbox" value="1" name="checkbox-group" checked />
-                        <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-unchecked" %}
-                            </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-checkbox-1">
+                            <span class="checkbox__icon" hidden>
+                                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-unchecked" %}
+                                </svg>
+                                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-checked" %}
+                                </svg>
+                            </span>
+                            Option 1
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-checkbox-1">Option 1</label>
                 </span>
                 <span class="field">
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-2" type="checkbox" value="2" name="checkbox-group" />
-                        <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-unchecked" %}
-                            </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-checkbox-2">
+                            <span class="checkbox__icon" hidden>
+                                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-unchecked" %}
+                                </svg>
+                                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-checked" %}
+                                </svg>
+                            </span>
+                            Option 2
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-checkbox-2">Option 2</label>
                 </span>
                 <span class="field">
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-3" type="checkbox" value="3" name="checkbox-group" />
-                        <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-unchecked" %}
-                            </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-checkbox-3">
+                            <span class="checkbox__icon" hidden>
+                                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-unchecked" %}
+                                </svg>
+                                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-checked" %}
+                                </svg>
+                            </span>
+                            Option 3
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-checkbox-3">Option 3</label>
                 </span>
             </fieldset>
         </div>
@@ -196,44 +218,50 @@
     <span class="field">
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-1" type="checkbox" value="1" name="checkbox-group" checked />
-            <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-checkbox-1">
+                <span class="checkbox__icon" hidden>
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-unchecked"></use>
+                    </svg>
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-checked"></use>
+                    </svg>
+                </span>
+                Option 1
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-checkbox-1">Option 1</label>
     </span>
     <span class="field">
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-2" type="checkbox" value="2" name="checkbox-group" />
-            <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-checkbox-2">
+                <span class="checkbox__icon" hidden>
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-unchecked"></use>
+                    </svg>
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-checked"></use>
+                    </svg>
+                </span>
+                Option 2
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-checkbox-2">Option 2</label>
     </span>
     <span class="field">
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-3" type="checkbox" value="3" name="checkbox-group" />
-            <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-checkbox-3">
+                <span class="checkbox__icon" hidden>
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-unchecked"></use>
+                    </svg>
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-checked"></use>
+                    </svg>
+                </span>
+                Option 3
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-checkbox-3">Option 3</label>
     </span>
 </fieldset>
     {% endhighlight %}
@@ -248,44 +276,50 @@
                 <div class="field">
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-4" type="checkbox" value="1" name="checkbox-group" checked />
-                        <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-unchecked" %}
-                            </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-checkbox-4">
+                            <span class="checkbox__icon" hidden>
+                                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-unchecked" %}
+                                </svg>
+                                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-checked" %}
+                                </svg>
+                            </span>
+                            Option 1
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-checkbox-4">Option 1</label>
                 </div>
                 <div class="field">
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-5" type="checkbox" value="2" name="checkbox-group" />
-                        <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-unchecked" %}
-                            </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-checkbox-5">
+                            <span class="checkbox__icon" hidden>
+                                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-unchecked" %}
+                                </svg>
+                                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-checked" %}
+                                </svg>
+                            </span>
+                            Option 2
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-checkbox-5">Option 2</label>
                 </div>
                 <div class="field">
                     <span class="checkbox field__control">
                         <input class="checkbox__control" id="group-checkbox-6" type="checkbox" value="3" name="checkbox-group" />
-                        <span class="checkbox__icon" hidden>
-                            <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-unchecked" %}
-                            </svg>
-                            <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="checkbox-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-checkbox-6">
+                            <span class="checkbox__icon" hidden>
+                                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-unchecked" %}
+                                </svg>
+                                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="checkbox-checked" %}
+                                </svg>
+                            </span>
+                            Option 3
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-checkbox-6">Option 3</label>
                 </div>
             </fieldset>
         </div>
@@ -297,44 +331,50 @@
     <div class="field">
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-4" type="checkbox" value="1" name="checkbox-group" checked />
-            <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-checkbox-4">
+                <span class="checkbox__icon" hidden>
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-unchecked"></use>
+                    </svg>
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-checked"></use>
+                    </svg>
+                </span>
+                Option 1
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-checkbox-4">Option 1</label>
     </div>
     <div class="field">
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-5" type="checkbox" value="2" name="checkbox-group" />
-            <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-checkbox-5">
+                <span class="checkbox__icon" hidden>
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-unchecked"></use>
+                    </svg>
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-checked"></use>
+                    </svg>
+                </span>
+                Option 2
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-checkbox-5">Option 2</label>
     </div>
     <div class="field">
         <span class="checkbox field__control">
             <input class="checkbox__control" id="group-checkbox-6" type="checkbox" value="3" name="checkbox-group" />
-            <span class="checkbox__icon" hidden>
-                <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-unchecked"></use>
-                </svg>
-                <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-checkbox-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-checkbox-6">
+                <span class="checkbox__icon" hidden>
+                    <svg class="checkbox__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-unchecked"></use>
+                    </svg>
+                    <svg class="checkbox__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-checkbox-checked"></use>
+                    </svg>
+                </span>
+                Option 3
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-checkbox-6">Option 3</label>
     </div>
 </fieldset>
     {% endhighlight %}

--- a/docs/_includes/radio.html
+++ b/docs/_includes/radio.html
@@ -13,28 +13,32 @@
         <div class="demo__inner">
             <span class="radio">
                 <input aria-label="Default radio example" class="radio__control" type="radio" name="radio-default"/>
-                <span class="radio__icon" hidden>
-                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="radio-unchecked" %}
-                    </svg>
-                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="radio-checked" %}
-                    </svg>
-                </span>
+                <label class="field__label">
+                    <span class="radio__icon" hidden>
+                        <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="radio-unchecked" %}
+                        </svg>
+                        <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="radio-checked" %}
+                        </svg>
+                    </span>
+                </label>
             </span>
         </div>
     </div>
     {% highlight html %}
 <span class="radio">
     <input class="radio__control" type="radio" />
-    <span class="radio__icon" hidden>
-        <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-radio-unchecked"></use>
-        </svg>
-        <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-radio-checked"></use>
-        </svg>
-    </span>
+    <label class="field__label">
+        <span class="radio__icon" hidden>
+            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-radio-checked"></use>
+            </svg>
+        </span>
+    </label>
 </span>
     {% endhighlight %}
 
@@ -45,28 +49,32 @@
         <div class="demo__inner">
             <span class="radio radio--large">
                 <input aria-label="Large radio example" class="radio__control" type="radio" name="radio-large"/>
-                <span class="radio__icon" hidden>
-                    <svg class="radio__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
-                        {% include symbol.html name="radio-unchecked-large" %}
-                    </svg>
-                    <svg class="radio__checked" focusable="false" height="24" width="24" aria-hidden="true">
-                        {% include symbol.html name="radio-checked-large" %}
-                    </svg>
-                </span>
+                <label class="field__label">
+                    <span class="radio__icon" hidden>
+                        <svg class="radio__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
+                            {% include symbol.html name="radio-unchecked-large" %}
+                        </svg>
+                        <svg class="radio__checked" focusable="false" height="24" width="24" aria-hidden="true">
+                            {% include symbol.html name="radio-checked-large" %}
+                        </svg>
+                    </span>
+                </label>
             </span>
         </div>
     </div>
     {% highlight html %}
 <span class="radio radio--large">
     <input class="radio__control" type="radio" />
-    <span class="radio__icon" hidden>
-        <svg class="radio__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
-            <use xlink:href="#icon-radio-unchecked-large"></use>
-        </svg>
-        <svg class="radio__checked" focusable="false" height="24" width="24" aria-hidden="true">
-            <use xlink:href="#icon-radio-checked-large"></use>
-        </svg>
-    </span>
+    <label class="field__label">
+        <span class="radio__icon" hidden>
+            <svg class="radio__unchecked" focusable="false" height="24" width="24" aria-hidden="true">
+                <use xlink:href="#icon-radio-unchecked-large"></use>
+            </svg>
+            <svg class="radio__checked" focusable="false" height="24" width="24" aria-hidden="true">
+                <use xlink:href="#icon-radio-checked-large"></use>
+            </svg>
+        </span>
+    </label>
 </span>
     {% endhighlight %}
 
@@ -76,14 +84,16 @@
         <div class="demo__inner">
             <span class="radio">
                 <input aria-label="Disabled radio example" class="radio__control" name="radio-disabled" type="radio" checked disabled />
-                <span class="radio__icon" hidden>
-                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="radio-unchecked" %}
-                    </svg>
-                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                        {% include symbol.html name="radio-checked" %}
-                    </svg>
-                </span>
+                <label class="field__label">
+                    <span class="radio__icon" hidden>
+                        <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="radio-unchecked" %}
+                        </svg>
+                        <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                            {% include symbol.html name="radio-checked" %}
+                        </svg>
+                    </span>
+                </label>
             </span>
         </div>
     </div>
@@ -91,14 +101,16 @@
     {% highlight html %}
 <span class="radio">
     <input class="radio__control" type="radio" checked disabled />
-    <span class="radio__icon" hidden>
-        <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-radio-unchecked"></use>
-        </svg>
-        <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-            <use xlink:href="#icon-radio-checked"></use>
-        </svg>
-    </span>
+    <label class="field__label">
+        <span class="radio__icon" hidden>
+            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-radio-unchecked"></use>
+            </svg>
+            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                <use xlink:href="#icon-radio-checked"></use>
+            </svg>
+        </span>
+    </label>
 </span>
     {% endhighlight %}
 
@@ -113,44 +125,50 @@
                 <span class="field">
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-1" type="radio" value="1" name="radio-group" />
-                        <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-unchecked" %}
-                            </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-radio-1">
+                            <span class="radio__icon" hidden>
+                                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-unchecked" %}
+                                </svg>
+                                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-checked" %}
+                                </svg>
+                            </span>
+                            Option 1
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-radio-1">Option 1</label>
                 </span>
                 <span class="field">
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-2" type="radio" value="3" name="radio-group" />
-                        <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-unchecked" %}
-                            </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-radio-2">
+                            <span class="radio__icon" hidden>
+                                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-unchecked" %}
+                                </svg>
+                                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-checked" %}
+                                </svg>
+                            </span>
+                            Option 2
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-radio-2">Option 2</label>
                 </span>
                 <span class="field">
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-3" type="radio" value="3" name="radio-group" />
-                        <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-unchecked" %}
-                            </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-radio-3">
+                            <span class="radio__icon" hidden>
+                                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-unchecked" %}
+                                </svg>
+                                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-checked" %}
+                                </svg>
+                            </span>
+                            Option 3
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-radio-3">Option 3</label>
                 </span>
             </fieldset>
         </div>
@@ -162,44 +180,50 @@
     <span class="field">
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-1" type="radio" value="1" name="radio-group" />
-            <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-unchecked"></use>
-                </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-radio-1">
+                <span class="radio__icon" hidden>
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-unchecked"></use>
+                    </svg>
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-checked"></use>
+                    </svg>
+                </span>
+                Option 1
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-radio-1">Option 1</label>
     </span>
     <span class="field">
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-2" type="radio" value="2" name="radio-group" />
-            <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-unchecked"></use>
-                </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-radio-2">
+                <span class="radio__icon" hidden>
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-unchecked"></use>
+                    </svg>
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-checked"></use>
+                    </svg>
+                </span>
+                Option 2
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-radio-2">Option 2</label>
     </span>
     <span class="field">
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-3" type="radio" value="3" name="radio-group" />
-            <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-unchecked"></use>
-                </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-radio-3">
+                <span class="radio__icon" hidden>
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-unchecked"></use>
+                    </svg>
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-checked"></use>
+                    </svg>
+                </span>
+                Option 3
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-radio-3">Option 3</label>
     </span>
 </fieldset>
     {% endhighlight %}
@@ -214,44 +238,50 @@
                 <div class="field">
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-4" type="radio" value="1" name="radio-group" />
-                        <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-unchecked" %}
-                            </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-radio-4">
+                            <span class="radio__icon" hidden>
+                                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-unchecked" %}
+                                </svg>
+                                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-checked" %}
+                                </svg>
+                            </span>
+                            Option 1
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-radio-4">Option 1</label>
                 </div>
                 <div class="field">
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-5" type="radio" value="3" name="radio-group" />
-                        <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-unchecked" %}
-                            </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-radio-5">
+                            <span class="radio__icon" hidden>
+                                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-unchecked" %}
+                                </svg>
+                                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-checked" %}
+                                </svg>
+                            </span>
+                            Option 2
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-radio-5">Option 2</label>
                 </div>
                 <div class="field">
                     <span class="field__control radio">
                         <input class="radio__control" id="group-radio-6" type="radio" value="3" name="radio-group" />
-                        <span class="radio__icon" hidden>
-                            <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-unchecked" %}
-                            </svg>
-                            <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                                {% include symbol.html name="radio-checked" %}
-                            </svg>
-                        </span>
+                        <label class="field__label field__label--end" for="group-radio-6">
+                            <span class="radio__icon" hidden>
+                                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-unchecked" %}
+                                </svg>
+                                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                                    {% include symbol.html name="radio-checked" %}
+                                </svg>
+                            </span>
+                            Option 3
+                        </label>
                     </span>
-                    <label class="field__label field__label--end" for="group-radio-6">Option 3</label>
                 </div>
             </fieldset>
         </div>
@@ -263,44 +293,50 @@
     <div class="field">
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-4" type="radio" value="1" name="radio-group" />
-            <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-unchecked"></use>
-                </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-radio-4">
+                <span class="radio__icon" hidden>
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-unchecked"></use>
+                    </svg>
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-checked"></use>
+                    </svg>
+                </span>
+                Option 1
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-radio-4">Option 1</label>
     </div>
     <div class="field">
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-5" type="radio" value="2" name="radio-group" />
-            <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-unchecked"></use>
-                </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-radio-5">
+                <span class="radio__icon" hidden>
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-unchecked"></use>
+                    </svg>
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-checked"></use>
+                    </svg>
+                </span>
+                Option 2
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-radio-5">Option 2</label>
     </div>
     <div class="field">
         <span class="field__control radio">
             <input class="radio__control" id="group-radio-6" type="radio" value="3" name="radio-group" />
-            <span class="radio__icon" hidden>
-                <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-unchecked"></use>
-                </svg>
-                <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
-                    <use xlink:href="#icon-radio-checked"></use>
-                </svg>
-            </span>
+            <label class="field__label field__label--end" for="group-radio-6">
+                <span class="radio__icon" hidden>
+                    <svg class="radio__unchecked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-unchecked"></use>
+                    </svg>
+                    <svg class="radio__checked" focusable="false" height="18" width="18" aria-hidden="true">
+                        <use xlink:href="#icon-radio-checked"></use>
+                    </svg>
+                </span>
+                Option 3
+            </label>
         </span>
-        <label class="field__label field__label--end" for="group-radio-6">Option 3</label>
     </div>
 </fieldset>
     {% endhighlight %}

--- a/src/less/checkbox/checkbox.less
+++ b/src/less/checkbox/checkbox.less
@@ -67,23 +67,29 @@ input.checkbox__control[type="checkbox"] {
     width: @dimensions-checkbox-large;
 }
 
-input.checkbox__control[type="checkbox"] + span.checkbox__icon svg.checkbox__checked {
+input.checkbox__control[type="checkbox"] + label > span.checkbox__icon svg.checkbox__checked {
     display: none;
 }
 
-input.checkbox__control[type="checkbox"] + span.checkbox__icon svg.checkbox__unchecked {
+input.checkbox__control[type="checkbox"] + label > span.checkbox__icon svg.checkbox__unchecked {
     display: inline-block;
 }
 
-input.checkbox__control[type="checkbox"]:checked + span.checkbox__icon svg.checkbox__checked {
+input.checkbox__control[type="checkbox"]:checked
+    + label
+    > span.checkbox__icon
+    svg.checkbox__checked {
     display: inline-block;
 }
 
-input.checkbox__control[type="checkbox"]:checked + span.checkbox__icon svg.checkbox__unchecked {
+input.checkbox__control[type="checkbox"]:checked
+    + label
+    > span.checkbox__icon
+    svg.checkbox__unchecked {
     display: none;
 }
 
-input.checkbox__control[type="checkbox"][disabled] + span.checkbox__icon {
+input.checkbox__control[type="checkbox"][disabled] + label > span.checkbox__icon {
     opacity: 1;
 
     svg {
@@ -92,12 +98,12 @@ input.checkbox__control[type="checkbox"][disabled] + span.checkbox__icon {
 }
 
 // https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/
-input.checkbox__control[type="checkbox"]:focus + span.checkbox__icon {
+input.checkbox__control[type="checkbox"]:focus + label > span.checkbox__icon {
     outline: 1px auto;
     .outline-color-token(checkbox-outline, color-foreground-secondary);
     outline-offset: 2px;
 }
 
-input.checkbox__control[type="checkbox"]:focus:not(:focus-visible) + span.checkbox__icon {
+input.checkbox__control[type="checkbox"]:focus:not(:focus-visible) + label > span.checkbox__icon {
     outline: none;
 }

--- a/src/less/field/field.less
+++ b/src/less/field/field.less
@@ -148,3 +148,7 @@ div.field__description {
     align-self: start;
     margin-top: 16px;
 }
+
+input:disabled + label.field__label {
+    .color-token(radio-label, color-foreground-disabled);
+}

--- a/src/less/radio/radio.less
+++ b/src/less/radio/radio.less
@@ -67,23 +67,23 @@ input.radio__control[type="radio"] {
     width: @dimensions-radio-large;
 }
 
-input.radio__control[type="radio"] + span.radio__icon svg.radio__checked {
+input.radio__control[type="radio"] + label > span.radio__icon svg.radio__checked {
     display: none;
 }
 
-input.radio__control[type="radio"] + span.radio__icon svg.radio__unchecked {
+input.radio__control[type="radio"] + label > span.radio__icon svg.radio__unchecked {
     display: inline-block;
 }
 
-input.radio__control[type="radio"]:checked + span.radio__icon svg.radio__checked {
+input.radio__control[type="radio"]:checked + label > span.radio__icon svg.radio__checked {
     display: inline-block;
 }
 
-input.radio__control[type="radio"]:checked + span.radio__icon svg.radio__unchecked {
+input.radio__control[type="radio"]:checked + label > span.radio__icon svg.radio__unchecked {
     display: none;
 }
 
-input.radio__control[type="radio"][disabled] + span.radio__icon {
+input.radio__control[type="radio"][disabled] + label > span.radio__icon {
     opacity: 1;
 
     svg {
@@ -92,12 +92,12 @@ input.radio__control[type="radio"][disabled] + span.radio__icon {
 }
 
 // https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/
-input.radio__control[type="radio"]:focus + span.radio__icon {
+input.radio__control[type="radio"]:focus + label > span.radio__icon {
     outline: 1px auto;
     .outline-color-token(radio-outline, color-foreground-secondary);
     outline-offset: 2px;
 }
 
-input.radio__control[type="radio"]:focus:not(:focus-visible) + span.radio__icon {
+input.radio__control[type="radio"]:focus:not(:focus-visible) + label > span.radio__icon {
     outline: none;
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
- Fixes #1843 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Inputs for disabled checkboxes and radio buttons should be dimmed to the same color as the icon.

## Notes
- Text is not yet properly aligned vertically, should be an easy fix with `line-height` or something but I will wait to fix it until HTML changes have been approved
- Storybook has not yet been modified, again I will update once HTML changes have been approved

### _BREAKING HTML CHANGE_:
- Icon was moved into the label for the input to allow for CSS selectors to work properly

## Screenshots
### Before
<img width="164" alt="image" src="https://user-images.githubusercontent.com/26027232/187771005-d9de48b5-145d-490f-9605-262d7e18f547.png">

### After:
<img width="163" alt="image" src="https://user-images.githubusercontent.com/26027232/187770838-aa3d9b44-d01c-4a48-9998-0e2dc8bbd0b6.png">


## Checklist
- [ ] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
