### PR TITLE
fix(filter-menu-button): fixed color issue

### DIFF
--- a/dist/filter-menu-button/filter-menu-button.css
+++ b/dist/filter-menu-button/filter-menu-button.css
@@ -92,7 +92,7 @@ button.filter-menu-button__button[aria-pressed="true"][aria-disabled="true"]:hov
   background-color: var(--filter-button-selected-background-color, var(--color-background-secondary));
 }
 .filter-menu-button__menu {
-  background-color: var(--filter-menu-item-background-color, var(--color-background-secondary));
+  background-color: var(--filter-menu-item-background-color, var(--color-background-primary));
   border: none;
   border-radius: 16px;
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);

--- a/src/less/filter-menu-button/filter-menu-button.less
+++ b/src/less/filter-menu-button/filter-menu-button.less
@@ -86,7 +86,7 @@ button.filter-menu-button__button[aria-pressed="true"][aria-disabled="true"]:hov
 }
 
 .filter-menu-button__menu {
-    .background-color-token(filter-menu-item-background-color, color-background-secondary);
+    .background-color-token(filter-menu-item-background-color, color-background-primary);
     border: none;
     border-radius: 16px;
     box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1848 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This fixes the mismatched color/pseudo padding visual issue.

## Screenshots
Before:
<img width="184" alt="image" src="https://user-images.githubusercontent.com/1675667/187977655-f07c28d2-918d-4125-960f-d4c464bbea93.png">

After:
<img width="269" alt="image" src="https://user-images.githubusercontent.com/1675667/187976935-15e8d624-5bfb-4a7b-bb3b-372f7b8867e6.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
