### PR TITLE
feat: added old dot syntax to progress-stepper

### DIFF
--- a/dist/icon/icon.css
+++ b/dist/icon/icon.css
@@ -1023,6 +1023,10 @@ svg.icon--stepper-confirmation {
   height: 24px;
   width: 24px;
 }
+svg.icon--stepper-current {
+  height: 24px;
+  width: 24px;
+}
 svg.icon--stepper-upcoming {
   height: 25px;
   width: 24px;

--- a/dist/program-badge/program-badge.css
+++ b/dist/program-badge/program-badge.css
@@ -1023,6 +1023,10 @@ svg.icon--stepper-confirmation {
   height: 24px;
   width: 24px;
 }
+svg.icon--stepper-current {
+  height: 24px;
+  width: 24px;
+}
 svg.icon--stepper-upcoming {
   height: 25px;
   width: 24px;

--- a/dist/progress-stepper/progress-stepper.css
+++ b/dist/progress-stepper/progress-stepper.css
@@ -72,7 +72,8 @@ hr.progress-stepper__separator {
 .progress-stepper__item[aria-current] + hr.progress-stepper__separator {
   background-image: linear-gradient(90deg, var(--progress-stepper-active-color, var(--color-background-information)) 50%, var(--progress-stepper-upcoming-color, var(--color-background-disabled)) 50%);
 }
-.progress-stepper__item--attention[aria-current] ~ hr.progress-stepper__separator {
+.progress-stepper__item--attention[aria-current] ~ hr.progress-stepper__separator,
+.progress-stepper__items--current .progress-stepper__item[aria-current] ~ hr.progress-stepper__separator {
   background-color: var(--progress-stepper-upcoming-color, var(--color-background-disabled));
   background-image: none;
 }
@@ -141,8 +142,16 @@ hr.progress-stepper__separator {
 [dir="rtl"] .progress-stepper__item[aria-current] + hr.progress-stepper__separator {
   background-image: linear-gradient(90deg, var(--progress-stepper-upcoming-color, var(--color-background-disabled)) 50%, var(--progress-stepper-active-color, var(--color-background-information)) 50%);
 }
+[dir="rtl"] .progress-stepper__items--current .progress-stepper__item[aria-current] ~ hr.progress-stepper__separator {
+  background-color: var(--progress-stepper-upcoming-color, var(--color-background-disabled));
+  background-image: none;
+}
 [dir="rtl"] .progress-stepper--vertical .progress-stepper__item[aria-current] + hr.progress-stepper__separator {
   background: linear-gradient(180deg, var(--progress-stepper-active-color, var(--color-background-information)) 50%, var(--progress-stepper-upcoming-color, var(--color-background-disabled)) 50%);
+}
+[dir="rtl"] .progress-stepper--vertical .progress-stepper__items--current .progress-stepper__item[aria-current] ~ hr.progress-stepper__separator {
+  background-color: var(--progress-stepper-upcoming-color, var(--color-background-disabled));
+  background-image: none;
 }
 [dir="rtl"] .progress-stepper__item:last-child .progress-stepper__text {
   margin-left: 4px;

--- a/dist/svg/icon/icon-stepper-current.svg
+++ b/dist/svg/icon/icon-stepper-current.svg
@@ -1,0 +1,8 @@
+<svg viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fill-rule="evenodd"
+    d="M2 12C2 6.476 6.478 2 12 2s10 4.476 10 10c0 5.522-4.478 10-10 10S2 17.522 2 12ZM12 0C5.373 0 0 5.372 0 12c0 6.627 5.373 12 12 12s12-5.373 12-12c0-6.628-5.373-12-12-12Zm0 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"
+    clip-rule="evenodd"
+    fill="var(--progress-stepper-current-icon, var(--color-background-information))"
+  />
+</svg>

--- a/dist/svg/icons.svg
+++ b/dist/svg/icons.svg
@@ -1637,6 +1637,14 @@
       fill="var(--progress-stepper-confirmation-icon, var(--color-background-information))"
     />
   </symbol>
+  <symbol viewBox="0 0 24 24" id="icon-stepper-current">
+    <path
+      fill-rule="evenodd"
+      d="M2 12C2 6.476 6.478 2 12 2s10 4.476 10 10c0 5.522-4.478 10-10 10S2 17.522 2 12ZM12 0C5.373 0 0 5.372 0 12c0 6.627 5.373 12 12 12s12-5.373 12-12c0-6.628-5.373-12-12-12Zm0 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"
+      clip-rule="evenodd"
+      fill="var(--progress-stepper-current-icon, var(--color-background-information))"
+    />
+  </symbol>
   <symbol viewBox="0 0 24 25" fill="none" id="icon-stepper-upcoming">
     <path
       fill-rule="evenodd"

--- a/docs/static/icon/icon-stepper-current.svg
+++ b/docs/static/icon/icon-stepper-current.svg
@@ -1,0 +1,8 @@
+<svg viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fill-rule="evenodd"
+    d="M2 12C2 6.476 6.478 2 12 2s10 4.476 10 10c0 5.522-4.478 10-10 10S2 17.522 2 12ZM12 0C5.373 0 0 5.372 0 12c0 6.627 5.373 12 12 12s12-5.373 12-12c0-6.628-5.373-12-12-12Zm0 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"
+    clip-rule="evenodd"
+    fill="var(--progress-stepper-current-icon, var(--color-background-information))"
+  />
+</svg>

--- a/docs/static/icons.svg
+++ b/docs/static/icons.svg
@@ -1637,6 +1637,14 @@
       fill="var(--progress-stepper-confirmation-icon, var(--color-background-information))"
     />
   </symbol>
+  <symbol viewBox="0 0 24 24" id="icon-stepper-current">
+    <path
+      fill-rule="evenodd"
+      d="M2 12C2 6.476 6.478 2 12 2s10 4.476 10 10c0 5.522-4.478 10-10 10S2 17.522 2 12ZM12 0C5.373 0 0 5.372 0 12c0 6.627 5.373 12 12 12s12-5.373 12-12c0-6.628-5.373-12-12-12Zm0 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"
+      clip-rule="evenodd"
+      fill="var(--progress-stepper-current-icon, var(--color-background-information))"
+    />
+  </symbol>
   <symbol viewBox="0 0 24 25" fill="none" id="icon-stepper-upcoming">
     <path
       fill-rule="evenodd"

--- a/src/less/combobox/combobox.less
+++ b/src/less/combobox/combobox.less
@@ -32,7 +32,7 @@ span.combobox {
 }
 
 .combobox__listbox--reverse {
-    .dropdown-reverse(combobox-listbox-reverse);
+    .dropdown-reverse();
 }
 
 .combobox__option[role^="option"] {

--- a/src/less/icon/generated/icon.less
+++ b/src/less/icon/generated/icon.less
@@ -1023,6 +1023,10 @@ svg.icon--stepper-confirmation {
     height: 24px;
     width: 24px;
 }
+svg.icon--stepper-current {
+    height: 24px;
+    width: 24px;
+}
 svg.icon--stepper-upcoming {
     height: 25px;
     width: 24px;

--- a/src/less/menu-button/menu-button.less
+++ b/src/less/menu-button/menu-button.less
@@ -146,7 +146,7 @@ div.menu-button__item--badged[role^="menuitem"] .badge {
 
 .menu-button__menu--reverse,
 .fake-menu-button__menu--reverse {
-    .dropdown-reverse(menu-button-menu-reverse);
+    .dropdown-reverse();
 }
 
 .menu-button__button[aria-expanded="true"] ~ .menu-button__menu,

--- a/src/less/progress-stepper/progress-stepper.less
+++ b/src/less/progress-stepper/progress-stepper.less
@@ -107,7 +107,11 @@ hr.progress-stepper__separator {
     );
 }
 
-.progress-stepper__item--attention[aria-current] ~ hr.progress-stepper__separator {
+// DEPRECATED remove progress-stepper__item--current in next major version
+.progress-stepper__item--attention[aria-current] ~ hr.progress-stepper__separator,
+.progress-stepper__items--current
+    .progress-stepper__item[aria-current]
+    ~ hr.progress-stepper__separator {
     .background-color-token(progress-stepper-upcoming-color, color-background-disabled);
 
     background-image: none;
@@ -149,8 +153,13 @@ hr.progress-stepper__separator {
     );
 }
 
+// DEPRECATED remove progress-stepper__item--current in next major version
 .progress-stepper--vertical
     .progress-stepper__item--attention[aria-current]
+    ~ hr.progress-stepper__separator,
+.progress-stepper--vertical
+    .progress-stepper__items--current
+    .progress-stepper__item[aria-current]
     ~ hr.progress-stepper__separator {
     .background-color-token(progress-stepper-upcoming-color, color-background-disabled);
 
@@ -195,12 +204,23 @@ hr.progress-stepper__separator {
         text-align: right;
     }
 
+    // stylelint-disable no-descending-specificity
     .progress-stepper__item[aria-current] + hr.progress-stepper__separator {
         background-image: linear-gradient(
             90deg,
             @_progress-stepper-upcoming-gradient,
             @_progress-stepper-active-gradient
         );
+    }
+    // stylelint-enable no-descending-specificity
+
+    // DEPRECATED remove progress-stepper__item--current in next major version
+    .progress-stepper__items--current
+        .progress-stepper__item[aria-current]
+        ~ hr.progress-stepper__separator {
+        .background-color-token(progress-stepper-upcoming-color, color-background-disabled);
+
+        background-image: none;
     }
 
     .progress-stepper--vertical
@@ -211,6 +231,15 @@ hr.progress-stepper__separator {
             @_progress-stepper-active-gradient,
             @_progress-stepper-upcoming-gradient
         );
+    }
+
+    .progress-stepper--vertical
+        .progress-stepper__items--current
+        .progress-stepper__item[aria-current]
+        ~ hr.progress-stepper__separator {
+        .background-color-token(progress-stepper-upcoming-color, color-background-disabled);
+
+        background-image: none;
     }
 
     .progress-stepper__item:last-child .progress-stepper__text {

--- a/src/less/progress-stepper/stories/progress-stepper.stories.js
+++ b/src/less/progress-stepper/stories/progress-stepper.stories.js
@@ -159,6 +159,60 @@ export const allSelected = () => `
 </div>
 `;
 
+export const currentBubble = () => `
+<div class="progress-stepper">
+    <div class="progress-stepper__items  progress-stepper__items--current" role="list">
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-confirmation"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Started</h4>
+                <p>July 3rd</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-confirmation"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Shipped</h4>
+                <p>July 4th</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div aria-current="step" class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-current"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Transit</h4>
+                <p>July 5th</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-label="upcoming" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-upcoming"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Delivered</h4>
+                <p>July 6th</p>
+            </span>
+        </div>
+    </div>
+</div>
+`;
+
 export const noneSelected = () => `
 <div class="progress-stepper">
     <div class="progress-stepper__items  progress-stepper__items--upcoming" role="list">
@@ -266,6 +320,60 @@ export const RTL = () => `
     </div>
 </div>
 
+`;
+
+export const currentBubbleRTL = () => `
+<div class="progress-stepper" dir="rtl">
+    <div class="progress-stepper__items  progress-stepper__items--current" role="list">
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-confirmation"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Started</h4>
+                <p>July 3rd</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-confirmation"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Shipped</h4>
+                <p>July 4th</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div aria-current="step" class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-current"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Transit</h4>
+                <p>July 5th</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-label="upcoming" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-upcoming"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Delivered</h4>
+                <p>July 6th</p>
+            </span>
+        </div>
+    </div>
+</div>
 `;
 
 export const vertical = () => `
@@ -431,6 +539,116 @@ export const verticalRTL = () => `
                 <span class="progress-stepper__text">
                     <h3>Delivered</h3>
                     <p>Guaranteed Wednesday, October 09.</p>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
+export const currentBubbleVertical = () => `
+<div class="progress-stepper progress-stepper--vertical">
+    <div class="progress-stepper__items  progress-stepper__items--current" role="list">
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-confirmation"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Started</h4>
+                <p>July 3rd</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-confirmation"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Shipped</h4>
+                <p>July 4th</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div aria-current="step" class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-current"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Transit</h4>
+                <p>July 5th</p>
+            </span>
+        </div>
+        <hr class="progress-stepper__separator" role="presentation" />
+        <div class="progress-stepper__item" role="listitem">
+            <span class="progress-stepper__icon">
+                <svg role="img" aria-label="upcoming" class="icon" focusable="false" height="24" width="24">
+                    <use href="#icon-stepper-upcoming"></use>
+                </svg>
+            </span>
+            <span class="progress-stepper__text">
+                <h4>Delivered</h4>
+                <p>July 6th</p>
+            </span>
+        </div>
+    </div>
+</div>
+`;
+
+export const currentBubbleVerticalRTL = () => `
+<div dir="rtl">
+    <div class="progress-stepper progress-stepper--vertical">
+        <div class="progress-stepper__items  progress-stepper__items--current" role="list">
+            <div class="progress-stepper__item" role="listitem">
+                <span class="progress-stepper__icon">
+                    <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                        <use href="#icon-stepper-confirmation"></use>
+                    </svg>
+                </span>
+                <span class="progress-stepper__text">
+                    <h4>Started</h4>
+                    <p>July 3rd</p>
+                </span>
+            </div>
+            <hr class="progress-stepper__separator" role="presentation" />
+            <div class="progress-stepper__item" role="listitem">
+                <span class="progress-stepper__icon">
+                    <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                        <use href="#icon-stepper-confirmation"></use>
+                    </svg>
+                </span>
+                <span class="progress-stepper__text">
+                    <h4>Shipped</h4>
+                    <p>July 4th</p>
+                </span>
+            </div>
+            <hr class="progress-stepper__separator" role="presentation" />
+            <div aria-current="step" class="progress-stepper__item" role="listitem">
+                <span class="progress-stepper__icon">
+                    <svg role="img" aria-hidden="true" class="icon" focusable="false" height="24" width="24">
+                        <use href="#icon-stepper-current"></use>
+                    </svg>
+                </span>
+                <span class="progress-stepper__text">
+                    <h4>Transit</h4>
+                    <p>July 5th</p>
+                </span>
+            </div>
+            <hr class="progress-stepper__separator" role="presentation" />
+            <div class="progress-stepper__item" role="listitem">
+                <span class="progress-stepper__icon">
+                    <svg role="img" aria-label="upcoming" class="icon" focusable="false" height="24" width="24">
+                        <use href="#icon-stepper-upcoming"></use>
+                    </svg>
+                </span>
+                <span class="progress-stepper__text">
+                    <h4>Delivered</h4>
+                    <p>July 6th</p>
                 </span>
             </div>
         </div>

--- a/src/svg/icon/icon-stepper-current.svg
+++ b/src/svg/icon/icon-stepper-current.svg
@@ -1,0 +1,8 @@
+<svg viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fill-rule="evenodd"
+    d="M2 12C2 6.476 6.478 2 12 2s10 4.476 10 10c0 5.522-4.478 10-10 10S2 17.522 2 12ZM12 0C5.373 0 0 5.372 0 12c0 6.627 5.373 12 12 12s12-5.373 12-12c0-6.628-5.373-12-12-12Zm0 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"
+    clip-rule="evenodd"
+    fill="var(--progress-stepper-current-icon, var(--color-background-information))"
+  />
+</svg>

--- a/src/svg/icons.svg
+++ b/src/svg/icons.svg
@@ -1637,6 +1637,14 @@
       fill="var(--progress-stepper-confirmation-icon, var(--color-background-information))"
     />
   </symbol>
+  <symbol viewBox="0 0 24 24" id="icon-stepper-current">
+    <path
+      fill-rule="evenodd"
+      d="M2 12C2 6.476 6.478 2 12 2s10 4.476 10 10c0 5.522-4.478 10-10 10S2 17.522 2 12ZM12 0C5.373 0 0 5.372 0 12c0 6.627 5.373 12 12 12s12-5.373 12-12c0-6.628-5.373-12-12-12Zm0 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"
+      clip-rule="evenodd"
+      fill="var(--progress-stepper-current-icon, var(--color-background-information))"
+    />
+  </symbol>
   <symbol viewBox="0 0 24 25" fill="none" id="icon-stepper-upcoming">
     <path
       fill-rule="evenodd"


### PR DESCRIPTION
Fixes #1862

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

__NOTE__
This PR also includes a fix to storybook. There is an issue where there was an argument passed to a mixin in listbox/combobox which was breaking on storybook start

## Description
* As some teams saw the new progress stepper changes, they needed a larger change to support the new syntax. This PR adds the old syntax as an option. We can pass `progress-stepper__items--current` to show the old syntax. This would also be updated in ebayui to add a new `defaultState` as `current` which would show the current item as a bubble and remove the line. 
* Added the old current icon
* I only added storybook examples. I did not show this on docs because we don't want to support this more than a couple of versions

## Notes
* There was some issue with descending specificity which would require a complete restructure of the less file. Since this is temporary, I disabled it for one rule. 

## Screenshots
<img width="869" alt="Screen Shot 2022-09-09 at 11 17 15 AM" src="https://user-images.githubusercontent.com/1755269/189417735-fd348b50-4b02-4f03-8796-4993cd13bd62.png">
<img width="174" alt="Screen Shot 2022-09-09 at 11 17 31 AM" src="https://user-images.githubusercontent.com/1755269/189417739-c8199edf-e451-478e-a0c4-85a81913af3f.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
