### PR TITLE
fix: added stronger selectors to disbled fake-menu-button

### DIFF
--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -108,11 +108,6 @@ button.fake-menu-button__item {
   font-size: 1em;
   text-align: left;
 }
-a.fake-menu-button__item:not([href]),
-button.fake-menu-button__item[disabled],
-div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
-  color: var(--menu-button-menuitem-disabled-foreground-color, var(--color-foreground-disabled));
-}
 a.fake-menu-button__item[aria-current="page"] svg.icon--tick-small,
 button.fake-menu-button__item[aria-current="page"] svg.icon--tick-small {
   opacity: 1;
@@ -150,6 +145,11 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-smal
 .fake-menu-button__menu a.fake-menu-button__item:active,
 .fake-menu-button__menu button.fake-menu-button__item:active {
   font-weight: bold;
+}
+.fake-menu-button__menu a.fake-menu-button__item:not([href]),
+.fake-menu-button__menu button.fake-menu-button__item[disabled],
+.fake-menu-button__menu div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
+  color: var(--menu-button-menuitem-disabled-foreground-color, var(--color-foreground-disabled));
 }
 .fake-menu-button__menu > li:first-child a.fake-menu-button__item {
   border-top-left-radius: var(--menu-button-menu-border-radius, var(--border-radius-50));

--- a/src/less/menu-button/menu-button.less
+++ b/src/less/menu-button/menu-button.less
@@ -76,12 +76,6 @@ button.fake-menu-button__item {
     text-align: left;
 }
 
-a.fake-menu-button__item:not([href]),
-button.fake-menu-button__item[disabled],
-div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
-    .color-token(menu-button-menuitem-disabled-foreground-color, color-foreground-disabled);
-}
-
 a.fake-menu-button__item[aria-current="page"] svg.icon--tick-small,
 button.fake-menu-button__item[aria-current="page"] svg.icon--tick-small {
     opacity: 1;
@@ -94,6 +88,12 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-smal
 .fake-menu-button__menu a.fake-menu-button__item,
 .fake-menu-button__menu button.fake-menu-button__item {
     .menu-menuitem-base(menu-button);
+}
+
+.fake-menu-button__menu a.fake-menu-button__item:not([href]),
+.fake-menu-button__menu button.fake-menu-button__item[disabled],
+.fake-menu-button__menu div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
+    .color-token(menu-button-menuitem-disabled-foreground-color, color-foreground-disabled);
 }
 
 .fake-menu-button__menu > li:first-child a.fake-menu-button__item {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1864

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Disabled styles were being overriden by base styles since those are nested under `fake-menu-button__items`. I added a stronger selector for disabled styles to override.
* We should probably flatten all the styles, but that should be a later PR.

## Screenshots
<img width="161" alt="Screen Shot 2022-09-12 at 9 50 41 AM" src="https://user-images.githubusercontent.com/1755269/189713283-e9b7344b-f6de-4dc5-a4d6-8d043dd92714.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
