### PR TITLE
docs: added class to labels of disabled fields

### DIFF
--- a/docs/_includes/field.html
+++ b/docs/_includes/field.html
@@ -376,13 +376,13 @@
     <div class="demo">
         <div class="demo__inner">
             <span class="field">
-                <label class="field__label" for="field-disabled-1">Field 1</label>
+                <label class="field__label field__label--disabled" for="field-disabled-1">Field 1</label>
                 <span class="field__control textbox">
                     <input class="textbox__control" id="field-disabled-1" type="text" value="placeholder text" disabled />
                 </span>
             </span>
             <span class="field">
-                <label class="field__label" for="field-disabled-2">Field 2</label>
+                <label class="field__label field__label--disabled" for="field-disabled-2">Field 2</label>
                 <span class="field__control">
                     <span class="select">
                         <select name="field-disabled-2" id="field-disabled-2" disabled>
@@ -397,7 +397,7 @@
                 </span>
             </span>
             <span class="field">
-                <label class="field__label" for="field-disabled-3">Field 3</label>
+                <label class="field__label field__label--disabled" for="field-disabled-3">Field 3</label>
                 <span class="field__control switch switch--form">
                     <input disabled aria-label="Switch Demo" class="switch__control" role="switch" type="checkbox" id="field-disabled-3" />
                     <span class="switch__button"></span>
@@ -408,13 +408,13 @@
 
     {% highlight html %}
 <span class="field">
-    <label class="field__label" for="email">Field 1</label>
+    <label class="field__label field__label--disabled" for="email">Field 1</label>
     <span class="field__control textbox">
         <input class="textbox__control" id="field1" type="text" value="placeholder text" disabled />
     </span>
 </span>
 <span class="field">
-    <label class="field__label" for="size">Field 2</label>
+    <label class="field__label field__label--disabled" for="size">Field 2</label>
     <span class="field__control">
         <span class="select">
             <select name="field2" id="field2" disabled>
@@ -429,7 +429,7 @@
     </span>
 </span>
 <span class="field">
-    <label class="field__label" for="field3">Field 3</label>
+    <label class="field__label field__label--disabled" for="field3">Field 3</label>
     <span class="field__control switch">
         <input disabled aria-label="Switch Demo" class="switch__control" role="switch" type="checkbox" id="field3" />
         <span class="switch__button"></span>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
- Fixes #1843 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
Modifier already exists to dim disabled field labels, I added it to the labels of disabled components in documentation.


## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
### Before
<img width="573" alt="image" src="https://user-images.githubusercontent.com/26027232/189745798-c1ff8610-6af6-436d-87d7-204d17c9befc.png">

### After
<img width="571" alt="image" src="https://user-images.githubusercontent.com/26027232/189745895-b2d279a6-ed51-40dd-8039-e4ae80883bfd.png">


## Checklist
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue
