### PR TITLE
feat(section-title): updated section titles to match new specs

### DIFF
--- a/dist/section-title/section-title.css
+++ b/dist/section-title/section-title.css
@@ -1,5 +1,5 @@
 .section-title {
-  align-items: center;
+  align-items: baseline;
   display: flex;
   margin: 30px 0 10px;
 }
@@ -30,29 +30,21 @@
   margin: 0 24px 0 auto;
 }
 .section-title__cta,
-.section-title__info,
 .section-title__overflow {
-  align-items: center;
+  align-items: baseline;
   display: flex;
-  height: 24px;
+  height: 32px;
+  margin-left: auto;
+  margin-right: 0;
 }
 .section-title button.icon-btn,
 .section-title__overflow button.icon-btn {
-  height: 24px;
-  width: 24px;
+  height: 32px;
+  min-width: 32px;
+  width: 32px;
 }
 .section-title__title-container + button.icon-btn {
-  margin-left: 12px;
-}
-.section-title--giant .section-title__title {
-  font-size: 1.5rem;
-  font-weight: 700;
-  line-height: 32px;
-}
-.section-title--giant > .section-title__cta,
-.section-title--giant > .section-title__info,
-.section-title--giant > .section-title__overflow {
-  height: 32px;
+  margin-left: 8px;
 }
 .section-title--large .section-title__title {
   font-size: 1.25rem;
@@ -62,22 +54,23 @@
 .section-title--large > .section-title__cta,
 .section-title--large > .section-title__info,
 .section-title--large > .section-title__overflow {
-  height: 28px;
-}
-.section-title--small .section-title__title {
-  font-size: 0.875rem;
-  line-height: 20px;
-  font-weight: 700;
-}
-.section-title--small > .section-title__cta,
-.section-title--small > .section-title__info,
-.section-title--small > .section-title__overflow {
-  height: 20px;
+  height: 32px;
 }
 [dir="rtl"] .section-title__title svg.icon {
   margin-left: 0;
   margin-right: 8px;
   transform: rotate(180deg);
+}
+[dir="rtl"] .section-title__cta {
+  margin-left: 0;
+  margin-right: auto;
+}
+[dir="rtl"] .section-title__overflow {
+  margin-left: 0;
+  margin-right: auto;
+}
+[dir="rtl"] .section-title__info {
+  margin: 0 8px 0 24px;
 }
 @media (min-width: 601px) {
   .section-title__title {
@@ -88,64 +81,5 @@
   .section-title__subtitle {
     font-size: 1rem;
     line-height: 24px;
-  }
-  .section-title__cta {
-    font-size: 1.5rem;
-    margin: 0 16px;
-  }
-  .section-title__cta > a {
-    border-color: var(--section-title-separator-color, var(--color-stroke-subtle));
-    border-left-style: solid;
-    border-left-width: 2px;
-    line-height: 1.125rem;
-    padding-left: 16px;
-  }
-  .section-title__cta-text {
-    display: inline;
-  }
-  .section-title__cta--no-text {
-    margin: 0;
-  }
-  .section-title__cta--no-text > a {
-    border: 0;
-    padding: 0;
-  }
-  .section-title__cta--no-text .section-title__cta-text {
-    display: none;
-  }
-  .section-title__cta,
-  .section-title__info,
-  .section-title__overflow {
-    height: 28px;
-  }
-  .section-title--giant .section-title__title {
-    font-size: 1.875rem;
-    font-weight: 700;
-    line-height: 40px;
-  }
-  .section-title--giant > .section-title__cta,
-  .section-title--giant > .section-title__info,
-  .section-title--giant > .section-title__overflow {
-    height: 40px;
-  }
-  .section-title--large .section-title__title {
-    font-size: 1.5rem;
-    font-weight: 700;
-    line-height: 32px;
-  }
-  .section-title--large > .section-title__cta,
-  .section-title--large > .section-title__info,
-  .section-title--large > .section-title__overflow {
-    height: 32px;
-  }
-  .section-title--small .section-title__title {
-    font-size: 1rem;
-    line-height: 24px;
-    font-weight: 700;
-  }
-  .section-title--small > .section-title__cta,
-  .section-title--small > .section-title__info,
-  .section-title--small > .section-title__overflow {
-    height: 24px;
   }
 }

--- a/dist/section-title/section-title.css
+++ b/dist/section-title/section-title.css
@@ -24,7 +24,9 @@
   padding: 7px;
 }
 .section-title__info {
+  bottom: -3px;
   margin: 0 24px 0 8px;
+  position: relative;
 }
 .section-title__overflow {
   margin: 0 24px 0 auto;

--- a/dist/tokens/evo-dark.css
+++ b/dist/tokens/evo-dark.css
@@ -1,7 +1,7 @@
 @media (prefers-color-scheme: dark) {
     :root {
         --color-background-primary: var(--color-neutral-8);
-        --color-background-secondary: var(--color-neutral-6);
+        --color-background-secondary: var(--color-neutral-7);
         --color-background-disabled: var(--color-neutral-5);
         --color-background-inverse: var(--color-neutral-2);
         --color-background-attention: var(--color-red-3);

--- a/dist/tokens/evo-dark.css
+++ b/dist/tokens/evo-dark.css
@@ -1,6 +1,6 @@
 @media (prefers-color-scheme: dark) {
     :root {
-        --color-background-primary: var(--color-neutral-7);
+        --color-background-primary: var(--color-neutral-8);
         --color-background-secondary: var(--color-neutral-6);
         --color-background-disabled: var(--color-neutral-5);
         --color-background-inverse: var(--color-neutral-2);
@@ -10,7 +10,7 @@
         --color-background-accent: var(--color-blue-3);
         --color-background-invalid: var(--color-red-1);
         --color-foreground-primary: var(--color-neutral-1);
-        --color-foreground-secondary: var(--color-neutral-3);
+        --color-foreground-secondary: var(--color-neutral-4);
         --color-foreground-disabled: var(--color-neutral-4);
         --color-foreground-attention: var(--color-red-3);
         --color-foreground-confirmation: var(--color-green-4);

--- a/docs/_includes/section-title.html
+++ b/docs/_includes/section-title.html
@@ -10,7 +10,7 @@
         <div class="demo__inner">
             <div class="section-title">
                 <div class="section-title__title-container">
-                    <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+                    <h2 class="section-title__title">Static Section Title</h2>
                 </div>
             </div>
         </div>
@@ -18,7 +18,7 @@
     {% highlight html %}
 <div class="section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+        <h2 class="section-title__title">Static Section Title</h2>
     </div>
 </div>
     {% endhighlight %}
@@ -30,7 +30,7 @@
         <div class="demo__inner">
             <div class="section-title">
                 <div class="section-title__title-container">
-                    <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+                    <h2 class="section-title__title">Subtitled Section Title</h2>
                     <span class="section-title__subtitle">Plus, guaranteed best prices.</span>
                 </div>
             </div>
@@ -39,7 +39,7 @@
     {% highlight html %}
 <div class="section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+        <h2 class="section-title__title">Subtitled Section Title</h2>
         <span class="section-title__subtitle">Plus, guaranteed best prices.</span>
     </div>
 </div>
@@ -52,62 +52,36 @@
         <div class="demo__inner">
             <div class="section-title">
                 <div class="section-title__title-container">
-                    <h2 class="section-title__title">
-                        <a href="https://www.ebay.com">Today’s Deals – All With Free Shipping</a>
-                        <svg class="icon icon--arrow-right-extra-small" focusable="false" height="10" width="10" aria-hidden="true">
-                            {% include symbol.html name="arrow-right-extra-small" %}
-                        </svg>
-                    </h2>
+                    <h2 class="section-title__title">Linked Section Title</h2>
                 </div>
+                <a class="section-title__cta" href="https://www.ebay.com">See all</a>
             </div>
-
         </div>
     </div>
     {% highlight html %}
 <div class="section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title">
-            <a href="https://www.ebay.com">Today’s Deals – All With Free Shipping</a>
-            <svg class="icon icon--arrow-right-extra-small" focusable="false" height="10" width="10" aria-hidden="true">
-                <use xlink:href="icons.svg#icon-arrow-right-extra-small"></use>
-            </svg>
-        </h2>
+        <h2 class="section-title__title">Linked Section Title</h2>
     </div>
+    <a class="section-title__cta" href="https://www.ebay.com">Link</a>
 </div>
     {% endhighlight %}
 
-    <h3 id="section-title-infotip">Infotip Section Title</h3>
-    <p>An <a href="#infotip">infotip</a> supports any required legal text.</p>
+    <h3 id="section-title-infotip">Section Title with Favorite</h3>
 
     <div class="demo">
         <div class="demo__inner">
             <div class="section-title">
                 <div class="section-title__title-container">
-                    <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+                    <h2 class="section-title__title">Section Title with Favorite</h2>
                 </div>
                 <div class="section-title__info">
                     <span class="infotip">
-                        <button class="icon-btn icon-btn--transparent infotip__host" type="button" aria-expanded="false" aria-label="Help">
-                            <svg class="icon icon--information" focusable="false" width="24" height="24" aria-hidden="true">
-                                {% include symbol.html name="information" %}
+                        <button class="icon-btn" type="button" aria-expanded="false" aria-label="Save">
+                            <svg class="icon icon--save-small" focusable="false" width="16" height="14" aria-hidden="true">
+                                {% include symbol.html name="save-small" %}
                             </svg>
                         </button>
-                        <div class="infotip__overlay" style="left: -6px; right: auto; top: calc(100%); bottom: auto">
-                            <span class="infotip__pointer infotip__pointer--top-left"></span>
-                            <div class="infotip__mask">
-                                <div class="infotip__cell">
-                                    <span class="infotip__content">
-                                        <h3 class="infotip__heading">Infotip</h3>
-                                        <p>Here's a tip to help you be successful at your task.</p>
-                                    </span>
-                                    <button class="icon-btn icon-btn--transparent infotip__close" type="button" aria-label="Dismiss infotip">
-                                        <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                            {% include symbol.html name="close" %}
-                                        </svg>
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
                     </span>
                 </div>
             </div>
@@ -116,31 +90,15 @@
     {% highlight html %}
 <div class="section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+        <h2 class="section-title__title">Section Title with Favorite</h2>
     </div>
     <div class="section-title__info">
         <span class="infotip">
-            <button class="icon-btn icon-btn--transparent infotip__host" type="button" aria-expanded="false" aria-label="Help">
-                <svg aria-hidden="true" class="icon icon--information" focusable="false" width="24" height="24">
-                    <use xlink:href="#icon-information"></use>
+            <button class="icon-btn" type="button" aria-expanded="false" aria-label="Help">
+                <svg aria-hidden="true" class="icon icon--save-small" focusable="false" width="16" height="14">
+                    <use href="#icon-save-small"></use>
                 </svg>
             </button>
-            <div class="infotip__overlay" style="left: -6px; right: auto; top: calc(100%); bottom: auto">
-                <span class="infotip__pointer infotip__pointer--top-left"></span>
-                <div class="infotip__mask">
-                    <div class="infotip__cell">
-                        <span class="infotip__content">
-                            <h3 class="infotip__heading">Infotip</h3>
-                            <p>Here's a tip to help you be successful at your task.</p>
-                        </span>
-                        <button class="icon-btn icon-btn--transparent infotip__close" type="button" aria-label="Dismiss infotip">
-                            <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                <use xlink:href="#icon-close"></use>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            </div>
         </span>
     </div>
 </div>
@@ -153,13 +111,13 @@
         <div class="demo__inner">
             <div class="section-title">
                 <div class="section-title__title-container">
-                    <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+                    <h2 class="section-title__title">Overflow Section Title</h2>
                 </div>
                 <div class="section-title__overflow">
                     <span class="menu-button">
                         <button class="menu-button__button icon-btn" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Options" type="button">
-                            <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
-                                {% include symbol.html name="overflow" %}
+                            <svg class="icon icon--overflow-small" focusable="false" width="3" height="13" aria-hidden="true">
+                                {% include symbol.html name="overflow-small" %}
                             </svg>
                         </button>
                         <div class="menu-button__menu menu-button__menu--reverse">
@@ -177,13 +135,13 @@
     {% highlight html %}
 <div class="section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title">Today’s Deals – All With Free Shipping</h2>
+        <h2 class="section-title__title">Overflow Section Title</h2>
     </div>
     <div class="section-title__overflow">
         <span class="menu-button">
             <button class="menu-button__button icon-btn" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Options" type="button">
-                <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
-                    <use xlink:href="#icon-overflow"></use>
+                <svg class="icon icon--overflow-small" focusable="false" width="3" height="13" aria-hidden="true">
+                    <use href="#icon-overflow-small"></use>
                 </svg>
             </button>
             <div class="menu-button__menu menu-button__menu--reverse">

--- a/src/less/section-title/section-title.less
+++ b/src/less/section-title/section-title.less
@@ -31,7 +31,9 @@
 }
 
 .section-title__info {
+    bottom: -3px;
     margin: 0 @spacing-300 0 @spacing-100;
+    position: relative;
 }
 
 .section-title__overflow {

--- a/src/less/section-title/section-title.less
+++ b/src/less/section-title/section-title.less
@@ -3,7 +3,7 @@
 @import "../mixins/private/token-mixins.less";
 
 .section-title {
-    align-items: center;
+    align-items: baseline;
     display: flex;
     margin: 30px 0 10px;
 }
@@ -39,33 +39,23 @@
 }
 
 .section-title__cta,
-.section-title__info,
 .section-title__overflow {
-    align-items: center;
+    align-items: baseline;
     display: flex;
-    height: 24px;
+    height: @spacing-400;
+    margin-left: auto;
+    margin-right: 0;
 }
 
 .section-title button.icon-btn,
 .section-title__overflow button.icon-btn {
-    height: 24px;
-    width: 24px;
+    height: @spacing-400;
+    min-width: @spacing-400;
+    width: @spacing-400;
 }
 
 .section-title__title-container + button.icon-btn {
-    margin-left: 12px;
-}
-
-.section-title--giant {
-    .section-title__title {
-        .typography-large-2();
-    }
-
-    > .section-title__cta,
-    > .section-title__info,
-    > .section-title__overflow {
-        height: 32px;
-    }
+    margin-left: @spacing-100;
 }
 
 .section-title--large {
@@ -76,19 +66,7 @@
     > .section-title__cta,
     > .section-title__info,
     > .section-title__overflow {
-        height: 28px;
-    }
-}
-
-.section-title--small {
-    .section-title__title {
-        .typography-regular-bold();
-    }
-
-    > .section-title__cta,
-    > .section-title__info,
-    > .section-title__overflow {
-        height: 20px;
+        height: @spacing-400;
     }
 }
 
@@ -97,6 +75,20 @@
         margin-left: 0;
         margin-right: @spacing-100;
         transform: rotate(180deg);
+    }
+
+    .section-title__cta {
+        margin-left: 0;
+        margin-right: auto;
+    }
+
+    .section-title__overflow {
+        margin-left: 0;
+        margin-right: auto;
+    }
+
+    .section-title__info {
+        margin: 0 @spacing-100 0 @spacing-300;
     }
 }
 
@@ -107,77 +99,5 @@
 
     .section-title__subtitle {
         .typography-medium();
-    }
-
-    .section-title__cta {
-        font-size: @font-size-large-2;
-        margin: 0 @spacing-200;
-
-        > a {
-            .border-color-token(section-title-separator-color, color-stroke-subtle);
-            border-left-style: solid;
-            border-left-width: 2px;
-            line-height: 1.125rem;
-            padding-left: @spacing-200;
-        }
-    }
-
-    .section-title__cta-text {
-        display: inline;
-    }
-
-    .section-title__cta--no-text {
-        margin: 0;
-
-        > a {
-            border: 0;
-            padding: 0;
-        }
-
-        .section-title__cta-text {
-            display: none;
-        }
-    }
-
-    .section-title__cta,
-    .section-title__info,
-    .section-title__overflow {
-        height: 28px;
-    }
-
-    .section-title--giant {
-        .section-title__title {
-            .typography-giant-1();
-        }
-
-        > .section-title__cta,
-        > .section-title__info,
-        > .section-title__overflow {
-            height: 40px;
-        }
-    }
-
-    .section-title--large {
-        .section-title__title {
-            .typography-large-2();
-        }
-
-        > .section-title__cta,
-        > .section-title__info,
-        > .section-title__overflow {
-            height: 32px;
-        }
-    }
-
-    .section-title--small {
-        .section-title__title {
-            .typography-medium-bold();
-        }
-
-        > .section-title__cta,
-        > .section-title__info,
-        > .section-title__overflow {
-            height: 24px;
-        }
     }
 }

--- a/src/less/section-title/stories/rtl.stories.js
+++ b/src/less/section-title/stories/rtl.stories.js
@@ -23,31 +23,86 @@ export const subheading = () => `
 
 export const linked = () => `
 <div dir="rtl">
-    <div class="section-title">
+    <div class="section-title section-title">
         <div class="section-title__title-container">
-            <h2 class="section-title__title">
-                <a href="https://www.ebay.com">Today’s Deals – All With Free Shipping</a>
-                <svg class="icon icon--arrow-right-extra-small" focusable="false" height="10" width="10" aria-hidden="true">
-                    <use xlink:href="#icon-arrow-right-extra-small"></use>
-                </svg>
-            </h2>
+            <h2 class="section-title__title">Marketing Type Content Title</h2>
         </div>
+        <a class="section-title__cta" href="https://www.ebay.com">See all</a>
     </div>
 </div>
 `;
 
 export const linkedWithSubheading = () => `
 <div dir="rtl">
-    <div class="section-title">
+    <div class="section-title section-title">
         <div class="section-title__title-container">
-            <h2 class="section-title__title">
-                <a href="https://www.ebay.com">Today’s Deals – All With Free Shipping</a>
-                <svg class="icon icon--arrow-right-extra-small" focusable="false" height="10" width="10" aria-hidden="true">
-                    <use xlink:href="#icon-arrow-right-extra-small"></use>
-                </svg>
-            </h2>
+            <h2 class="section-title__title">Marketing Type Content Title</h2>
             <span class="section-title__subtitle">Recommended for you</span>
         </div>
+        <a class="section-title__cta" href="https://www.ebay.com">See all</a>
+    </div>
+</div>
+`;
+
+export const overflow = () => `
+<div dir="rtl">
+    <div class="section-title">
+        <div class="section-title__title-container">
+            <h2 class="section-title__title">Marketing Type Content Title</h2>
+        </div>
+        <div class="section-title__overflow">
+            <span class="menu-button">
+                <button class="menu-button__button icon-btn" type="button" aria-expanded="true" aria-haspopup="true" type="button">
+                    <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
+                        <use href="#icon-overflow"></use>
+                    </svg>
+                </button>
+                <div class="menu-button__menu menu-button__menu--reverse">
+                    <div class="menu-button__items" role="menu">
+                        <div class="menu-button__item" role="menuitem"><span>Item 1</span></div>
+                        <div class="menu-button__item" role="menuitem"><span>Item 2</span></div>
+                        <div class="menu-button__item" role="menuitem"><span>Item 3</span></div>
+                    </div>
+                </div>
+            </span>
+        </div>
+    </div>
+</div>
+`;
+
+export const withFavorite = () => `
+<div dir="rtl">
+    <div class="section-title">
+        <div class="section-title__title-container">
+            <h2 class="section-title__title">Marketing Type Content Title</h2>
+            <span class="section-title__subtitle">Recommended for you</span>
+        </div>
+        <div class="section-title__info">
+            <button class="icon-btn infotip__host" type="button" aria-expanded="false" aria-label="Help">
+                <svg aria-hidden="true" class="icon icon--save-small" focusable="false" width="16" height="14">
+                    <use href="#icon-save-small"></use>
+                </svg>
+            </button>
+        </div>
+    </div>
+</div>
+`;
+
+export const withFavoriteAndLink = () => `
+<div dir="rtl">
+    <div class="section-title">
+        <div class="section-title__title-container">
+            <h2 class="section-title__title">Marketing Type Content Title</h2>
+            <span class="section-title__subtitle">Recommended for you</span>
+        </div>
+        <div class="section-title__info">
+            <button class="icon-btn infotip__host" type="button" aria-expanded="false" aria-label="Help">
+                <svg aria-hidden="true" class="icon icon--save-small" focusable="false" width="16" height="14">
+                    <use href="#icon-save-small"></use>
+                </svg>
+            </button>
+        </div>
+        <a class="section-title__cta" href="https://www.ebay.com">See all</a>
     </div>
 </div>
 `;

--- a/src/less/section-title/stories/section-title.stories.js
+++ b/src/less/section-title/stories/section-title.stories.js
@@ -18,62 +18,21 @@ export const subheading = () => `
 `;
 
 export const linked = () => `
-<div class="section-title">
+<div class="section-title section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title">
-            <a href="https://www.ebay.com">Today’s Deals – All With Free Shipping</a>
-            <svg class="icon icon--arrow-right-extra-small" focusable="false" height="10" width="10" aria-hidden="true">
-                <use xlink:href="#icon-arrow-right-extra-small"></use>
-            </svg>
-        </h2>
+        <h2 class="section-title__title">Marketing Type Content Title</h2>
     </div>
+    <a class="section-title__cta" href="https://www.ebay.com">See all</a>
 </div>
 `;
 
 export const linkedWithSubheading = () => `
-<div class="section-title">
-    <div class="section-title__title-container">
-        <h2 class="section-title__title">
-            <a href="https://www.ebay.com">Today’s Deals – All With Free Shipping</a>
-            <svg class="icon icon--arrow-right-extra-small" focusable="false" height="10" width="10" aria-hidden="true">
-                <use xlink:href="#icon-arrow-right-extra-small"></use>
-            </svg>
-        </h2>
-        <span class="section-title__subtitle">Recommended for you</span>
-    </div>
-</div>
-`;
-
-export const info = () => `
-<div class="section-title">
+<div class="section-title section-title">
     <div class="section-title__title-container">
         <h2 class="section-title__title">Marketing Type Content Title</h2>
+        <span class="section-title__subtitle">Recommended for you</span>
     </div>
-    <div class="section-title__info">
-        <span class="infotip">
-            <button class="icon-btn infotip__host" type="button" aria-expanded="true" aria-label="Help">
-                <svg class="icon icon--information" focusable="false" width="24" height="24" aria-hidden="true">
-                    <use xlink:href="#icon-information"></use>
-                </svg>
-            </button>
-            <div class="infotip__overlay" style="left: -6px; right: auto; top: calc(100%); bottom: auto">
-                <span class="infotip__pointer infotip__pointer--top-left"></span>
-                <div class="infotip__mask">
-                    <div class="infotip__cell">
-                        <span class="infotip__content">
-                            <h3 class="infotip__heading">Infotip</h3>
-                            <p>Here's a tip to help you be successful at your task.</p>
-                        </span>
-                        <button class="infotip__close" type="button" aria-label="Dismiss infotip">
-                            <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                <use xlink:href="#icon-close"></use>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </span>
-    </div>
+    <a class="section-title__cta" href="https://www.ebay.com">See all</a>
 </div>
 `;
 
@@ -86,7 +45,7 @@ export const overflow = () => `
         <span class="menu-button">
             <button class="menu-button__button icon-btn" type="button" aria-expanded="true" aria-haspopup="true" type="button">
                 <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
-                    <use xlink:href="#icon-overflow"></use>
+                    <use href="#icon-overflow"></use>
                 </svg>
             </button>
             <div class="menu-button__menu menu-button__menu--reverse">
@@ -101,234 +60,35 @@ export const overflow = () => `
 </div>
 `;
 
-export const giant = () => `
-<div class="section-title section-title--giant">
+export const withFavorite = () => `
+<div class="section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title"><a href="https://www.ebay.com">Marketing Type Content Title</a></h2>
+        <h2 class="section-title__title">Marketing Type Content Title</h2>
         <span class="section-title__subtitle">Recommended for you</span>
     </div>
-    <div class="section-title__cta">
-        <a href="https://www.ebay.com" tabindex="-1" aria-hidden="true">
-            <span class="section-title__cta-text">See All</span>
-            <svg aria-hidden="true" class="section-title__cta-icon" focusable="false">
-                <use xlink:href="#icon-arrow-right-bold"></use>
-            </svg>
-        </a>
-    </div>
     <div class="section-title__info">
-        <span class="infotip">
-            <button class="icon-btn infotip__host" type="button" aria-expanded="false" aria-label="Help">
-                <svg aria-hidden="true" class="icon icon--information" focusable="false" width="24" height="24">
-                    <use xlink:href="#icon-information"></use>
-                </svg>
-            </button>
-            <div class="infotip__overlay" style="left: -6px; right: auto; top: calc(100%); bottom: auto">
-                <span class="infotip__pointer infotip__pointer--top-left"></span>
-                <div class="infotip__mask">
-                    <div class="infotip__cell">
-                        <span class="infotip__content">
-                            <h3 class="infotip__heading">Infotip</h3>
-                            <p>Here's a tip to help you be successful at your task.</p>
-                        </span>
-                        <button class="infotip__close" type="button" aria-label="Dismiss infotip">
-                            <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                <use xlink:href="#icon-close"></use>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </span>
-    </div>
-    <div class="section-title__overflow">
-        <span class="menu-button">
-            <button class="menu-button__button icon-btn" type="button" aria-expanded="false" aria-haspopup="true" type="button">
-                <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
-                    <use xlink:href="#icon-overflow"></use>
-                </svg>
-            </button>
-            <div class="menu-button__menu menu-button__menu--reverse">
-                <div class="menu-button__items" role="menu">
-                    <div class="menu-button__item" role="menuitem"><span>Item 1</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 2</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 3</span></div>
-                </div>
-            </div>
-        </span>
+        <button class="icon-btn" type="button" aria-expanded="false" aria-label="Help">
+            <svg aria-hidden="true" class="icon icon--save-small" focusable="false" width="16" height="14">
+                <use href="#icon-save-small"></use>
+            </svg>
+        </button>
     </div>
 </div>
 `;
 
-export const large = () => `
-<div class="section-title section-title--large">
+export const withFavoriteAndLink = () => `
+<div class="section-title">
     <div class="section-title__title-container">
-        <h2 class="section-title__title"><a href="https://www.ebay.com">Marketing Type Content Title</a></h2>
+        <h2 class="section-title__title">Marketing Type Content Title</h2>
         <span class="section-title__subtitle">Recommended for you</span>
     </div>
-    <div class="section-title__cta">
-        <a href="https://www.ebay.com" tabindex="-1" aria-hidden="true">
-            <span class="section-title__cta-text">See All</span>
-            <svg aria-hidden="true" class="section-title__cta-icon" focusable="false">
-                <use xlink:href="#icon-arrow-right-bold"></use>
-            </svg>
-        </a>
-    </div>
     <div class="section-title__info">
-        <span class="infotip">
-            <button class="icon-btn infotip__host" type="button" aria-expanded="false" aria-label="Help">
-                <svg aria-hidden="true" class="icon icon--information" focusable="false" width="24" height="24">
-                    <use xlink:href="#icon-information"></use>
-                </svg>
-            </button>
-            <div class="infotip__overlay" style="left: -6px; right: auto; top: calc(100%); bottom: auto">
-                <span class="infotip__pointer infotip__pointer--top-left"></span>
-                <div class="infotip__mask">
-                    <div class="infotip__cell">
-                        <span class="infotip__content">
-                            <h3 class="infotip__heading">Infotip</h3>
-                            <p>Here's a tip to help you be successful at your task.</p>
-                        </span>
-                        <button class="infotip__close" type="button" aria-label="Dismiss infotip">
-                            <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                <use xlink:href="#icon-close"></use>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </span>
-    </div>
-    <div class="section-title__overflow">
-        <span class="menu-button">
-            <button class="menu-button__button icon-btn" type="button" aria-expanded="false" aria-haspopup="true" type="button">
-                <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
-                    <use xlink:href="#icon-overflow"></use>
-                </svg>
-            </button>
-            <div class="menu-button__menu menu-button__menu--reverse">
-                <div class="menu-button__items" role="menu">
-                    <div class="menu-button__item" role="menuitem"><span>Item 1</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 2</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 3</span></div>
-                </div>
-            </div>
-        </span>
-    </div>
-</div>
-`;
-
-export const medium = () => `
-<div class="section-title section-title--medium">
-    <div class="section-title__title-container">
-        <h2 class="section-title__title"><a href="https://www.ebay.com">Marketing Type Content Title</a></h2>
-        <span class="section-title__subtitle">Recommended for you</span>
-    </div>
-    <div class="section-title__cta">
-        <a href="https://www.ebay.com" tabindex="-1" aria-hidden="true">
-            <span class="section-title__cta-text">See All</span>
-            <svg aria-hidden="true" class="section-title__cta-icon" focusable="false">
-                <use xlink:href="#icon-arrow-right-bold"></use>
+        <button class="icon-btn infotip__host" type="button" aria-expanded="false" aria-label="Help">
+            <svg aria-hidden="true" class="icon icon--save-small" focusable="false" width="16" height="14">
+                <use href="#icon-save-small"></use>
             </svg>
-        </a>
+        </button>
     </div>
-    <div class="section-title__info">
-        <span class="infotip">
-            <button class="icon-btn infotip__host" type="button" aria-expanded="false" aria-label="Help">
-                <svg aria-hidden="true" class="icon icon--information" focusable="false" width="24" height="24">
-                    <use xlink:href="#icon-information"></use>
-                </svg>
-            </button>
-            <div class="infotip__overlay" style="left: -6px; right: auto; top: calc(100%); bottom: auto">
-                <span class="infotip__pointer infotip__pointer--top-left"></span>
-                <div class="infotip__mask">
-                    <div class="infotip__cell">
-                        <span class="infotip__content">
-                            <h3 class="infotip__heading">Infotip</h3>
-                            <p>Here's a tip to help you be successful at your task.</p>
-                        </span>
-                        <button class="infotip__close" type="button" aria-label="Dismiss infotip">
-                            <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                <use xlink:href="#icon-close"></use>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </span>
-    </div>
-    <div class="section-title__overflow">
-        <span class="menu-button">
-            <button class="menu-button__button icon-btn" type="button" aria-expanded="false" aria-haspopup="true" type="button">
-                <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
-                    <use xlink:href="#icon-overflow"></use>
-                </svg>
-            </button>
-            <div class="menu-button__menu menu-button__menu--reverse">
-                <div class="menu-button__items" role="menu">
-                    <div class="menu-button__item" role="menuitem"><span>Item 1</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 2</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 3</span></div>
-                </div>
-            </div>
-        </span>
-    </div>
-</div>
-`;
-
-export const small = () => `
-<div class="section-title section-title--small">
-    <div class="section-title__title-container">
-        <h2 class="section-title__title"><a href="https://www.ebay.com">Marketing Type Content Title</a></h2>
-        <span class="section-title__subtitle">Recommended for you</span>
-    </div>
-    <div class="section-title__cta">
-        <a href="https://www.ebay.com" tabindex="-1" aria-hidden="true">
-            <span class="section-title__cta-text">See All</span>
-            <svg aria-hidden="true" class="section-title__cta-icon" focusable="false">
-                <use xlink:href="#icon-arrow-right-bold"></use>
-            </svg>
-        </a>
-    </div>
-    <div class="section-title__info">
-        <span class="infotip">
-            <button class="icon-btn infotip__host" type="button" aria-expanded="false" aria-label="Help">
-                <svg aria-hidden="true" class="icon icon--information" focusable="false" width="24" height="24">
-                    <use xlink:href="#icon-information"></use>
-                </svg>
-            </button>
-            <div class="infotip__overlay" style="left: -6px; right: auto; top: calc(100%); bottom: auto">
-                <span class="infotip__pointer infotip__pointer--top-left"></span>
-                <div class="infotip__mask">
-                    <div class="infotip__cell">
-                        <span class="infotip__content">
-                            <h3 class="infotip__heading">Infotip</h3>
-                            <p>Here's a tip to help you be successful at your task.</p>
-                        </span>
-                        <button class="infotip__close" type="button" aria-label="Dismiss infotip">
-                            <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
-                                <use xlink:href="#icon-close"></use>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </span>
-    </div>
-    <div class="section-title__overflow">
-        <span class="menu-button">
-            <button class="menu-button__button icon-btn" type="button" aria-expanded="false" aria-haspopup="true" type="button">
-                <svg class="icon icon--overflow" focusable="false" width="24" height="24" aria-hidden="true">
-                    <use xlink:href="#icon-overflow"></use>
-                </svg>
-            </button>
-            <div class="menu-button__menu menu-button__menu--reverse">
-                <div class="menu-button__items" role="menu">
-                    <div class="menu-button__item" role="menuitem"><span>Item 1</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 2</span></div>
-                    <div class="menu-button__item" role="menuitem"><span>Item 3</span></div>
-                </div>
-            </div>
-        </span>
-    </div>
+    <a class="section-title__cta" href="https://www.ebay.com">See all</a>
 </div>
 `;

--- a/src/tokens/evo-dark.css
+++ b/src/tokens/evo-dark.css
@@ -1,7 +1,7 @@
 @media (prefers-color-scheme: dark) {
     :root {
         --color-background-primary: var(--color-neutral-8);
-        --color-background-secondary: var(--color-neutral-6);
+        --color-background-secondary: var(--color-neutral-7);
         --color-background-disabled: var(--color-neutral-5);
         --color-background-inverse: var(--color-neutral-2);
         --color-background-attention: var(--color-red-3);

--- a/src/tokens/evo-dark.css
+++ b/src/tokens/evo-dark.css
@@ -1,6 +1,6 @@
 @media (prefers-color-scheme: dark) {
     :root {
-        --color-background-primary: var(--color-neutral-7);
+        --color-background-primary: var(--color-neutral-8);
         --color-background-secondary: var(--color-neutral-6);
         --color-background-disabled: var(--color-neutral-5);
         --color-background-inverse: var(--color-neutral-2);
@@ -10,7 +10,7 @@
         --color-background-accent: var(--color-blue-3);
         --color-background-invalid: var(--color-red-1);
         --color-foreground-primary: var(--color-neutral-1);
-        --color-foreground-secondary: var(--color-neutral-3);
+        --color-foreground-secondary: var(--color-neutral-4);
         --color-foreground-disabled: var(--color-neutral-4);
         --color-foreground-attention: var(--color-red-3);
         --color-foreground-confirmation: var(--color-green-4);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1728 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Updates to the section title component to match new specs.

## Notes
### Breaking Changes

* `<div class="section-title__cta">` that contained an anchor `<a href="https://www.ebay.com" tabindex="-1" aria-hidden="true"><span class="section-title__cta-text">See All</span>` has been simplified to this:

`<a class="section-title__cta" href="https://www.ebay.com">Link</a>`

The link is now an element promoted to a first-level child in the component.

### Additional (necessary) Changes

*Token Reference Changes*
* `--color-foreground-secondary` > `--color-neutral-4` > #8f8f8f
* `--color-background-primary` > `--color-neutral-8` > #000

*Dark Mode Background Change*
* As a result of `--color-background-primary` change, dark mode page background color has now been changed to pure black (`#000`).

## Screenshots
There are many changes across the board on all the variations of the component. This is just one of those changes.

Before:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/1675667/189762243-b9654d71-d9fc-4ba5-b1ab-330e0b315dc3.png">

After:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/1675667/189762444-e5dbb005-26f9-40f1-8632-eadbfba6cd35.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
