### PR TITLE
fix: remove deprecated story and modify CSS selector

### DIFF
--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -148,7 +148,7 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-smal
 }
 .fake-menu-button__menu a.fake-menu-button__item:not([href]),
 .fake-menu-button__menu button.fake-menu-button__item[disabled],
-.fake-menu-button__menu div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
+.menu-button__menu div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
   color: var(--menu-button-menuitem-disabled-foreground-color, var(--color-foreground-disabled));
 }
 .fake-menu-button__menu > li:first-child a.fake-menu-button__item {

--- a/src/less/cta-button/stories/cta-button.stories.js
+++ b/src/less/cta-button/stories/cta-button.stories.js
@@ -10,14 +10,3 @@ export const base = () => `
     </span>
 </a>
 `;
-
-export const wide = () => `
-<a class="cta-btn cta-btn--wide" href="http://www.ebay.com">
-    <span class="cta-btn__cell">
-        <span>Link</span>
-        <svg class="icon icon--cta" focusable="false" height="8" width="8" aria-hidden="true">
-            <use xlink:href="#icon-cta"></use>
-        </svg>
-    </span>
-</a>
-`;

--- a/src/less/menu-button/menu-button.less
+++ b/src/less/menu-button/menu-button.less
@@ -92,7 +92,7 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-smal
 
 .fake-menu-button__menu a.fake-menu-button__item:not([href]),
 .fake-menu-button__menu button.fake-menu-button__item[disabled],
-.fake-menu-button__menu div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
+.menu-button__menu div.menu-button__item[role^="menuitem"][aria-disabled="true"] {
     .color-token(menu-button-menuitem-disabled-foreground-color, color-foreground-disabled);
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes issues found through Percy on September 20, 2022

## Description
- Wide buttons were deprecated but the story was not removed from CTA buttons
- The selector for disabled items in `menu-button` was incorrect
