### PR TITLE
fix(lightbox,global): fixed visual regression issues found by Percy

### DIFF
--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -37,22 +37,6 @@ button.btn:focus:not(:focus-visible),
 a.fake-btn:focus:not(:focus-visible) {
   outline: none;
 }
-button.btn--form,
-a.fake-btn--form {
-  border-color: inherit;
-  border-radius: var(--expand-btn-border-radius, var(--border-radius-50));
-  max-width: 100%;
-}
-button.btn--form:hover,
-a.fake-btn--form:hover,
-button.btn--form:focus,
-a.fake-btn--form:focus {
-  background-color: var(--color-state-primary-hover);
-}
-button.btn--form:active,
-a.fake-btn--form:active {
-  background-color: var(--color-state-primary-active);
-}
 button.btn[disabled],
 button.btn[aria-disabled="true"] {
   border-color: var(--expand-btn-disabled-border-color, var(--color-stroke-disabled));
@@ -335,6 +319,25 @@ a.fake-btn--large {
   border-radius: var(--btn-border-radius, calc(48px / 2));
   font-size: 1rem;
   min-height: 48px;
+  padding: 13px 20px;
+}
+button.btn--form,
+a.fake-btn--form {
+  border-color: inherit;
+  border-radius: var(--expand-btn-border-radius, var(--border-radius-50));
+  max-width: 100%;
+}
+button.btn--form:hover,
+a.fake-btn--form:hover,
+button.btn--form:focus,
+a.fake-btn--form:focus {
+  background-color: var(--color-state-primary-hover);
+}
+button.btn--form:active,
+a.fake-btn--form:active {
+  background-color: var(--color-state-primary-active);
+}
+button.btn--form.btn--large {
   padding: 13px 20px;
 }
 button.btn--transparent,

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -45,9 +45,6 @@
 .lightbox-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
 }
-.lightbox-dialog__window--mini .lightbox-dialog__header {
-  margin-top: 8px;
-}
 .lightbox-dialog__main {
   box-sizing: border-box;
   flex: 1 1 auto;

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -16,22 +16,6 @@ a.fake-btn {
     padding: @button-padding-vertical @button-padding-horizontal;
 }
 
-button.btn--form,
-a.fake-btn--form {
-    border-color: inherit;
-    .border-radius-token(expand-btn-border-radius, border-radius-50);
-    max-width: 100%;
-
-    &:hover,
-    &:focus {
-        background-color: var(--color-state-primary-hover);
-    }
-
-    &:active {
-        background-color: var(--color-state-primary-active);
-    }
-}
-
 button.btn[disabled],
 button.btn[aria-disabled="true"] {
     .border-color-token(expand-btn-disabled-border-color, color-stroke-disabled);
@@ -329,6 +313,26 @@ a.fake-btn--large {
     font-size: @font-size-medium;
     min-height: @button-height-large;
     padding: @button-padding-vertical-large @button-padding-horizontal;
+}
+
+button.btn--form,
+a.fake-btn--form {
+    border-color: inherit;
+    .border-radius-token(expand-btn-border-radius, border-radius-50);
+    max-width: 100%;
+
+    &:hover,
+    &:focus {
+        background-color: var(--color-state-primary-hover);
+    }
+
+    &:active {
+        background-color: var(--color-state-primary-active);
+    }
+}
+
+button.btn--form.btn--large {
+    padding: @button-padding-vertical-large @button-padding-horizontal-large;
 }
 
 button.btn--transparent,

--- a/src/less/global/stories/global.stories.js
+++ b/src/less/global/stories/global.stories.js
@@ -60,9 +60,9 @@ export const alignment = () => `
 </span>
 
 <span class="listbox-button">
-    <button class="expand-btn expand-btn--fixed-height" aria-expanded="false" aria-haspopup="listbox">
-        <span class="expand-btn__cell">
-            <span class="expand-btn__text">Options</span>
+    <button class="btn btn--form btn--fixed-height" aria-expanded="false" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__text">Options</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use xlink:href="#icon-dropdown"></use>
             </svg>
@@ -71,9 +71,9 @@ export const alignment = () => `
 </span>
 
 <span class="menu-button">
-    <button class="expand-btn expand-btn--fixed-height" aria-haspopup="true" type="button">
-        <span class="expand-btn__cell">
-            <span class="expand-btn__text">Menu</span>
+    <button class="btn btn--form btn--fixed-height" aria-haspopup="true" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Menu</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use xlink:href="#icon-dropdown"></use>
             </svg>
@@ -113,9 +113,9 @@ export const RTLAlignment = () => `
     </span>
 
     <span class="listbox-button">
-        <button class="expand-btn expand-btn--fixed-height" aria-expanded="false" aria-haspopup="listbox">
-            <span class="expand-btn__cell">
-                <span class="expand-btn__text">Options</span>
+        <button class="btn btn--fixed-height" aria-expanded="false" aria-haspopup="listbox">
+            <span class="btn__cell">
+                <span class="btn__text">Options</span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                     <use xlink:href="#icon-dropdown"></use>
                 </svg>
@@ -124,9 +124,9 @@ export const RTLAlignment = () => `
     </span>
 
     <span class="menu-button">
-        <button class="expand-btn expand-btn--fixed-height" aria-haspopup="true" type="button">
-            <span class="expand-btn__cell">
-                <span class="expand-btn__text">Menu</span>
+        <button class="btn btn--fixed-height" aria-haspopup="true" type="button">
+            <span class="btn__cell">
+                <span class="btn__text">Menu</span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                     <use xlink:href="#icon-dropdown"></use>
                 </svg>
@@ -166,9 +166,9 @@ export const alignmentLarge = () => `
 </span>
 
 <span class="listbox-button">
-    <button class="expand-btn expand-btn--large expand-btn--large-fixed-height" aria-expanded="false" aria-haspopup="listbox">
-        <span class="expand-btn__cell">
-            <span class="expand-btn__text">Options</span>
+    <button class="btn btn--large btn--form btn--large-fixed-height" aria-expanded="false" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__text">Options</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use xlink:href="#icon-dropdown"></use>
             </svg>
@@ -177,9 +177,9 @@ export const alignmentLarge = () => `
 </span>
 
 <span class="menu-button">
-    <button class="expand-btn expand-btn--large expand-btn--large-fixed-height" aria-haspopup="true" type="button">
-        <span class="expand-btn__cell">
-            <span class="expand-btn__text">Menu</span>
+    <button class="btn btn--large btn--form btn--large-fixed-height" aria-haspopup="true" type="button">
+        <span class="btn__cell">
+            <span class="btn__text">Menu</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use xlink:href="#icon-dropdown"></use>
             </svg>

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -14,10 +14,6 @@
     .dialog-header-content();
 }
 
-.lightbox-dialog__window--mini .lightbox-dialog__header {
-    margin-top: @spacing-100;
-}
-
 .lightbox-dialog__main {
     .dialog-body-content();
 

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -51,40 +51,6 @@ export const baseWithFooter = () => `
 </div>
 `;
 
-export const mini = () => `
-<div aria-label="mini Example" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" role="dialog">
-    <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
-        <div class="lightbox-dialog__header">
-            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close-small"></use>
-                </svg>
-            </button>
-        </div>
-        <div class="lightbox-dialog__main">
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
-        </div>
-    </div>
-</div>
-`;
-
-export const miniMinHeight = () => `
-<div aria-label="miniMinHeight Example" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" role="dialog">
-    <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
-        <div class="lightbox-dialog__header">
-            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close-small"></use>
-                </svg>
-            </button>
-        </div>
-        <div class="lightbox-dialog__main">
-            <p>Lorem ipsum dolor sit amet.</p>
-        </div>
-    </div>
-</div>
-`;
-
 export const baseRTL = () => `
 <div dir="rtl">
     <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
@@ -104,25 +70,6 @@ export const baseRTL = () => `
                 <h3>Heading</h3>
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
                 <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-            </div>
-        </div>
-    </div>
-</div>
-`;
-
-export const miniRTL = () => `
-<div dir="rtl">
-    <div aria-label="mini Example RTL" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" role="dialog">
-        <div class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini">
-            <div class="lightbox-dialog__header">
-                <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
-                    <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="16" width="16">
-                        <use xlink:href="#icon-close-small"></use>
-                    </svg>
-                </button>
-            </div>
-            <div class="lightbox-dialog__main">
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
A couple of fixes found during visual regression.

* removed `Lightbox Dialog: Mini` from storybook as it's no longer needed.
* fixed remaining expanded button issues in `Global`, adding some missing styles that had been left void during removal.
