### PR TITLE
fix(page-notice): fixed paragraph-only positioning

### DIFF
--- a/dist/inline-notice/inline-notice.css
+++ b/dist/inline-notice/inline-notice.css
@@ -13,7 +13,7 @@ span.inline-notice {
   margin-top: 4px;
 }
 .inline-notice p {
-  margin: 4px 0;
+  margin: 3px 0;
 }
 .inline-notice a,
 .inline-notice button.fake-link {

--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -86,9 +86,12 @@ span[role="region"].page-notice {
   grid-row: 1;
   text-align: right;
 }
-/* support legacy 6.5 notice with heading + paragaphs */
 .page-notice__main p {
   font-size: 0.875rem;
+  margin: 2px 0 0;
+}
+/* support legacy 6.5 notice with heading + paragaphs */
+.page-notice__main .page-notice__title + p {
   margin: 4px 0 0;
 }
 p.page-notice__cta {

--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -91,7 +91,7 @@ span[role="region"].page-notice {
   margin: 2px 0 0;
 }
 /* support legacy 6.5 notice with heading + paragaphs */
-.page-notice__main .page-notice__title + p {
+.page-notice__main .page-notice__title ~ p {
   margin: 4px 0 0;
 }
 p.page-notice__cta {

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -56,9 +56,12 @@ span[role="region"].section-notice {
   padding-left: 0;
   width: auto;
 }
-/* support legacy 6.5 notice with heading + paragaphs */
 .section-notice__main p {
   font-size: 0.875rem;
+  margin: 0;
+}
+/* support legacy 6.5 notice with heading + paragaphs */
+.section-notice__main .section-notice__title + p {
   margin: 4px 0 0;
 }
 /* LARGE SCREEN ADJUSTMENTS */

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -61,7 +61,7 @@ span[role="region"].section-notice {
   margin: 0;
 }
 /* support legacy 6.5 notice with heading + paragaphs */
-.section-notice__main .section-notice__title + p {
+.section-notice__main .section-notice__title ~ p {
   margin: 4px 0 0;
 }
 /* LARGE SCREEN ADJUSTMENTS */

--- a/src/less/inline-notice/inline-notice.less
+++ b/src/less/inline-notice/inline-notice.less
@@ -20,7 +20,7 @@ span.inline-notice {
 }
 
 .inline-notice p {
-    margin: @spacing-50 0;
+    margin: 3px 0;
 }
 
 .inline-notice a,

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -118,7 +118,7 @@ span[role="region"].page-notice {
 }
 
 /* support legacy 6.5 notice with heading + paragaphs */
-.page-notice__main .page-notice__title + p {
+.page-notice__main .page-notice__title ~ p {
     margin: @spacing-50 0 0;
 }
 

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -114,7 +114,7 @@ span[role="region"].page-notice {
 
 .page-notice__main p {
     font-size: @font-size-regular;
-    margin: 2px 0 -0;
+    margin: 2px 0 0;
 }
 
 /* support legacy 6.5 notice with heading + paragaphs */

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -112,9 +112,13 @@ span[role="region"].page-notice {
     text-align: right;
 }
 
-/* support legacy 6.5 notice with heading + paragaphs */
 .page-notice__main p {
     font-size: @font-size-regular;
+    margin: 2px 0 -0;
+}
+
+/* support legacy 6.5 notice with heading + paragaphs */
+.page-notice__main .page-notice__title + p {
     margin: @spacing-50 0 0;
 }
 

--- a/src/less/page-notice/stories/page-notice.stories.js
+++ b/src/less/page-notice/stories/page-notice.stories.js
@@ -126,6 +126,22 @@ export const informationWithLink = () => `
 </section>
 `;
 
+export const InformationWithParagraph = () => `
+<section class="page-notice page-notice--information" role="region" aria-label="Information">
+    <div class="page-notice__header">
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use href="#icon-information-filled-small"></use>
+        </svg>
+    </div>
+    <div class="page-notice__main">
+        <p>You have opted into eBay Pay</p>
+    </div>
+    <div class="page-notice__footer">
+        <button class="fake-link">Dismiss</button>
+    </div>
+</section>
+`;
+
 export const dismissableWithTitle = () => `
 <section class="page-notice page-notice--information" role="region" aria-label="Information">
     <div class="page-notice__header">

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -77,7 +77,7 @@ span[role="region"].section-notice {
 }
 
 /* support legacy 6.5 notice with heading + paragaphs */
-.section-notice__main .section-notice__title + p {
+.section-notice__main .section-notice__title ~ p {
     margin: @spacing-50 0 0;
 }
 

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -71,9 +71,13 @@ span[role="region"].section-notice {
     width: auto;
 }
 
-/* support legacy 6.5 notice with heading + paragaphs */
 .section-notice__main p {
     font-size: @font-size-regular;
+    margin: 0;
+}
+
+/* support legacy 6.5 notice with heading + paragaphs */
+.section-notice__main .section-notice__title + p {
     margin: @spacing-50 0 0;
 }
 

--- a/src/less/section-notice/stories/section-notice.stories.js
+++ b/src/less/section-notice/stories/section-notice.stories.js
@@ -30,6 +30,22 @@ export const generalWithLink = () => `
 </div>
 `;
 
+export const confirmationWithParagraph = () => `
+<div class="section-notice section-notice--confirmation" role="region">
+    <div class="section-notice__header" role="region" aria-roledescription="Notice">
+        <svg aria-hidden="true" focusable="false" class="icon--confirmation-filled-small">
+            <use href="#icon-confirmation-filled-small"></use>
+        </svg>
+    </div>
+    <div class="section-notice__main">
+        <p>Your price has been updated.</p>
+    </div>
+    <div class="section-notice__footer">
+        <button class="fake-link">Dismiss</button>
+    </div>
+</div>
+`;
+
 export const confirmationWithButton = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1868 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I fixed notices which only had a `<p>` and no `<h2>`.

## Screenshots

Before:
<img width="563" alt="Screen Shot 2022-09-30 at 8 45 15 AM" src="https://user-images.githubusercontent.com/1675667/193355448-7512a8e2-da7e-49fa-a5e0-250323c5075a.png">

After:
<img width="665" alt="Screen Shot 2022-09-30 at 10 28 38 AM" src="https://user-images.githubusercontent.com/1675667/193355497-8acca179-83d4-4dc0-a11c-0b7530c1cea6.png">
<img width="714" alt="Screen Shot 2022-09-30 at 10 30 24 AM" src="https://user-images.githubusercontent.com/1675667/193355539-94fe367b-6466-4736-b8c0-d660f0da52e2.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
