### PR TITLE
feat(dialog): added truncation to dialog headers

### DIFF
--- a/dist/drawer-dialog/drawer-dialog.css
+++ b/dist/drawer-dialog/drawer-dialog.css
@@ -32,6 +32,9 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .drawer-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;

--- a/dist/fullscreen-dialog/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/fullscreen-dialog.css
@@ -42,6 +42,9 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .fullscreen-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -41,6 +41,9 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .lightbox-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -45,6 +45,9 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .panel-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -75,3 +75,26 @@ export const baseRTL = () => `
     </div>
 </div>
 `;
+
+export const baseWithLongHeader = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window">
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox with a very long header that should wrap to the next line, but is actually cut off</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/mixins/private/dialog-mixins.less
+++ b/src/less/mixins/private/dialog-mixins.less
@@ -62,6 +62,9 @@
         align-self: center;
         flex: 1 1 auto;
         margin: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     & > :last-child:not(:only-child) {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1878

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added truncation to dialog headers. Added no overflow, whitespace no wrap and text-overflow ellipsis.


## Screenshots
<img width="643" alt="Screen Shot 2022-10-03 at 8 40 34 AM" src="https://user-images.githubusercontent.com/1755269/193620446-e36e7d86-132a-467b-8f32-5b1f2b2c3d63.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
