### PR TITLE
feat(drawer-dialog): added support for text close and updated handle

### DIFF
--- a/dist/drawer-dialog/drawer-dialog.css
+++ b/dist/drawer-dialog/drawer-dialog.css
@@ -36,6 +36,9 @@
 .drawer-dialog__header > :last-child:not(:only-child) {
   margin-left: 16px;
 }
+.drawer-dialog__header .fake-link {
+  text-decoration: none;
+}
 .drawer-dialog__handle {
   background-color: transparent;
   border: none;
@@ -48,12 +51,12 @@
   z-index: 2;
 }
 .drawer-dialog__handle::after {
-  background-color: var(--dialog-handle-color, var(--color-foreground-secondary));
-  border-radius: 5px;
+  background-color: var(--dialog-handle-color, var(--color-stroke-default));
+  border-radius: 3px;
   content: "";
   display: block;
-  height: 3px;
-  width: 20px;
+  height: 2px;
+  width: 24px;
 }
 .drawer-dialog__main {
   box-sizing: border-box;
@@ -82,7 +85,7 @@
 .drawer-dialog__footer > :not(:first-child) {
   margin-left: 8px;
 }
-button.drawer-dialog__close {
+button.icon-button.drawer-dialog__close {
   background-color: transparent;
   border: 0;
   height: auto;

--- a/docs/_includes/drawer-dialog.html
+++ b/docs/_includes/drawer-dialog.html
@@ -76,4 +76,71 @@
 </div>
     {% endhighlight %}
 
+
+    <h3>Drawer with text close button</h3>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-button" data-makeup-for="drawer-dialog-2" type="button">Open Drawer</button>
+            <div class="drawer-dialog drawer-dialog--mask-fade" id="drawer-dialog-2" role="dialog" aria-labelledby="drawer-dialog-title-2" aria-modal="true" hidden>
+                <div class="drawer-dialog__window drawer-dialog__window--slide">
+                    <button class="drawer-dialog__handle" type="button"></button>
+                    <div class="drawer-dialog__header">
+                        <h2 id="drawer-dialog-title-1" class="large-text-1 bold-text">Drawer Dialog</h2>
+                        <button class="drawer-dialog__close fake-link">Done</button>
+                    </div>
+                    <div class="drawer-dialog__main">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        </p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        </p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        </p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        </p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        </p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        </p>
+                        <p><a href="https://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="drawer-dialog drawer-dialog--mask-fade" role="dialog" aria-labelledby="drawer-dialog-title" aria-modal="true" hidden>
+    <div class="drawer-dialog__window">
+        <div class="drawer-dialog__window drawer-dialog__window--slide">
+            <button aria-label="Expand Dialog" class="drawer-dialog__handle" type="button"></button>
+            <div class="drawer-dialog__header">
+                <h2 id="drawer-dialog-title" class="large-text-1 bold-text">Heading</h2>
+                <button class="fake-link">Done</button>
+            </div>
+            <div class="drawer-dialog__main">
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                    magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                </p>
+                <!-- content removed for brevity -->
+            </div>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+
 </div>

--- a/src/less/drawer-dialog/drawer-dialog.less
+++ b/src/less/drawer-dialog/drawer-dialog.less
@@ -16,6 +16,10 @@
     .dialog-header-content();
 }
 
+.drawer-dialog__header .fake-link {
+    text-decoration: none;
+}
+
 .drawer-dialog__handle {
     background-color: transparent;
     border: none;
@@ -30,12 +34,12 @@
 
 // Added :after class in order to increase parent hit box
 .drawer-dialog__handle::after {
-    .background-color-token(dialog-handle-color, color-foreground-secondary);
-    border-radius: 5px;
+    .background-color-token(dialog-handle-color, color-stroke-default);
+    border-radius: 3px;
     content: "";
     display: block;
-    height: 3px;
-    width: 20px;
+    height: 2px;
+    width: 24px;
 }
 
 .drawer-dialog__main {
@@ -61,7 +65,8 @@
 }
 
 // inherits from .icon-btn
-button.drawer-dialog__close {
+// Added icon button selector so it doesn't override fake-link
+button.icon-button.drawer-dialog__close {
     background-color: transparent;
     border: 0;
     height: auto;

--- a/src/less/drawer-dialog/stories/drawer-dialog.stories.js
+++ b/src/less/drawer-dialog/stories/drawer-dialog.stories.js
@@ -211,181 +211,19 @@ export const full = () => `
 </div>
 `;
 
-export const bottomContainerDefault = () => `
-<div aria-labelledby="drawer-title-default" aria-modal="true"
-    class="drawer drawer--mask-fade-slow" id="default-0" role="dialog">
-    <div class="drawer__window drawer__window--slide">
-        <button aria-label="Toggle Expanded" class="drawer__handle"></button>
-        <div class="drawer__header">
-            <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="drawer__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
-                </svg>
-            </button>
+export const textClose = () => `
+<div aria-labelledby="drawer-dialog-title" aria-modal="true" class="drawer-dialog drawer-dialog--mask-fade-slow" role="dialog">
+    <div class="drawer-dialog__window drawer-dialog__window--slide">
+        <button class="drawer-dialog__handle"></button>
+        <div class="drawer-dialog__header">
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
+            <button class="fake-link">Apply</button>
         </div>
-        <div class="drawer__main">
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-        </div>
-    </div>
-</div>
-`;
-
-export const bottomContainerLong = () => `
-<div aria-labelledby="drawer-title-default" aria-modal="true"
-    class="drawer drawer--mask-fade-slow" id="default-0" role="dialog">
-    <div class="drawer__window drawer__window--slide">
-        <button aria-label="Toggle Expanded" class="drawer__handle"></button>
-        <div class="drawer__header">
-            <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="drawer__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
-                </svg>
-            </button>
-        </div>
-        <div class="drawer__main">
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-        </div>
-    </div>
-</div>
-
-`;
-
-export const bottomContainerExpanded = () => `
-<div aria-labelledby="drawer-title-default" aria-modal="true"
-    class="drawer drawer--mask-fade-slow" id="default-0" role="dialog">
-    <div class="drawer__window drawer__window--expanded drawer__window--slide">
-        <button aria-label="Toggle Expanded" class="drawer__handle"></button>
-        <div class="drawer__header">
-            <h2 id="dialog-title-default" class="large-text-1 bold-text">Heading</h2>
-            <button aria-label="Close dialog" class="drawer__close" type="button">
-                <svg aria-hidden="true" class="icon icon--close" focusable="false" height="16" width="16">
-                    <use xlink:href="#icon-close"></use>
-                </svg>
-            </button>
-        </div>
-        <div class="drawer__main">
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-                et dolore
-                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-                ea commodo
-                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                nulla pariatur.
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-                est laborum.</p>
+        <div class="drawer-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            </p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>
         </div>
     </div>


### PR DESCRIPTION
Fixes #1743

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added support for fake-link button in drawer dialog. (As a close button)
* Changed handle CSS to match new designs
* Removed some unused stories which were using the old `drawer` component.

## Screenshots
<img width="510" alt="Screen Shot 2022-10-03 at 9 10 41 AM" src="https://user-images.githubusercontent.com/1755269/193626746-26348ff1-4e1d-4bac-80ea-30acf6546a86.png">
<img width="512" alt="Screen Shot 2022-10-03 at 8 58 38 AM" src="https://user-images.githubusercontent.com/1755269/193626760-5b2e0286-56a3-4533-ae2b-35ab73923992.png">
<img width="501" alt="Screen Shot 2022-10-03 at 9 13 01 AM" src="https://user-images.githubusercontent.com/1755269/193626888-7cab3691-1793-49f4-ab83-3de330eed1d7.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
