### PR TITLE
feat(floating-label): added floating-label--opaque modifier

### DIFF
--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -23,8 +23,17 @@ label.floating-label__label {
   width: calc(100% - 40px);
   z-index: 1;
 }
+.floating-label--opaque label.floating-label__label {
+  background-color: var(--floating-label-background-color, var(--color-background-secondary));
+  padding-top: 3px;
+  top: -3px;
+  width: calc(100% - 40px);
+}
 label.floating-label__label--focus {
   color: var(--color-background-inverse);
+}
+.floating-label--opaque label.floating-label__label--focus {
+  background-color: var(--floating-label-focus-background-color, var(--color-background-primary));
 }
 .floating-label--large label.floating-label__label {
   transform: scale(0.75, 0.75) translate(0, 3px);
@@ -41,6 +50,9 @@ label.floating-label__label--animate {
 }
 label.floating-label__label--disabled {
   color: var(--floating-label-disabled-color, var(--color-foreground-disabled));
+}
+.floating-label--opaque label.floating-label__label--disabled {
+  background-color: var(--floating-label-disabled-background-color, var(--color-background-secondary));
 }
 label.floating-label__label--invalid {
   color: var(--floating-label-invalid-color, var(--color-foreground-attention));

--- a/docs/_includes/floating-label.html
+++ b/docs/_includes/floating-label.html
@@ -325,6 +325,7 @@
     <h3 id="floating-label-transitions">Floating Label Transitions</h3>
     <p>By default, with only the base markup shown above, the label remains in a floating state above the input. This default state ensures that the label does not obscure the textbox value while we wait for JavaScript.</p>
     <p>When JavaScript is ready, the label can be re-positioned inside the textbox by adding the <span class="highlight">floating-label__label--inline</span> modifier class. By default, this re-positioning of label happens instantly, without a transition. Typically, we do not want to show transitions on the initial page render, as this might be too jarring and distracting for some users.</p>
+    <p>You will also need to add the <span class="highlight">floating-label__label--focus</span> class when the input recieves focus and remove it when the input loses focus. This is to ensure the right colors are applied to the label when focusing the input.</p>
     <p>To opt into transitions after the initial render is complete, add the  <span class="highlight">floating-label__label--animate</span> modifier when the textbox receives focus.</p>
     <p>The examples above use <a href="https://github.com/makeup-js/makeup-floating-label">makeup-floating-label</a>, a simple JavaScript module that adds the aforementioned logic. Feel free to use this module or use it as the basis to roll your own.</p>
 </div>

--- a/docs/_includes/floating-label.html
+++ b/docs/_includes/floating-label.html
@@ -143,9 +143,10 @@
     <h3 id="floating-label-textarea">Floating Label with Textarea</h3>
     <p>Use the textarea tag for a multi-line textbox.</p>
     <p>A multi-line textbox allows line breaks and has a minimum height of 200px.</p>
+    <p>In order to prevent overlap for floating label, use <span class="highlight">.floating-label--opaque</span> class</p>
     <div class="demo">
         <div class="demo__inner">
-            <span class="floating-label">
+            <span class="floating-label floating-label--opaque">
                 <label class="floating-label__label" for="first-name">Enter list of users</label>
                 <span class="textbox">
                     <textarea aria-label="Textbox demo" class="textbox__control"></textarea>
@@ -155,7 +156,7 @@
     </div>
 
     {% highlight html %}
-<span class="floating-label">
+<span class="floating-label floating-label--opaque">
     <label class="floating-label__label" for="first-name">Enter list of users</label>
     <span class="textbox">
         <textarea aria-label="Textbox demo" class="textbox__control"></textarea>

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -31,8 +31,19 @@ label.floating-label__label {
     z-index: 1;
 }
 
+.floating-label--opaque label.floating-label__label {
+    .background-color-token(floating-label-background-color, color-background-secondary);
+    padding-top: 3px;
+    top: -3px;
+    width: calc(100% - 40px);
+}
+
 label.floating-label__label--focus {
     color: var(--color-background-inverse);
+}
+
+.floating-label--opaque label.floating-label__label--focus {
+    .background-color-token(floating-label-focus-background-color, color-background-primary);
 }
 
 .floating-label--large label.floating-label__label {
@@ -55,6 +66,10 @@ label.floating-label__label--animate {
 
 label.floating-label__label--disabled {
     .color-token(floating-label-disabled-color, color-foreground-disabled);
+}
+
+.floating-label--opaque label.floating-label__label--disabled {
+    .background-color-token(floating-label-disabled-background-color, color-background-secondary);
 }
 
 label.floating-label__label--invalid {

--- a/src/less/floating-label/stories/floating-label.stories.js
+++ b/src/less/floating-label/stories/floating-label.stories.js
@@ -178,7 +178,7 @@ export const RTLSelectInline = () => `
 `;
 
 export const TextArea = () => `
-<span class="floating-label">
+<span class="floating-label floating-label--opaque">
     <label class="floating-label__label" for="first-name">Enter list of users</label>
     <span class="textbox">
         <textarea aria-label="Textbox demo" class="textbox__control"></textarea>


### PR DESCRIPTION
Fixes #1698

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
See https://github.com/eBay/skin/pull/1804
We had this fix initially but it caused some issues with the base floating label. This time I added a modifier to use the "opaque" version of the floating label which will correctly obscure text behind it. The intended use of this is for textarea.


## Screenshots
<img width="286" alt="Screen Shot 2022-10-03 at 9 26 44 AM" src="https://user-images.githubusercontent.com/1755269/193630430-a667c857-7bbf-4b02-89a0-470ed6c8ca84.png">

![opaque-floating-label](https://user-images.githubusercontent.com/1755269/193630599-538bf2b2-360f-4088-8c74-e3bbaa8676c3.gif)

## Checklist

- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
