### PR TITLE
feat(tourtip): added footer

### DIFF
--- a/dist/tourtip/tourtip.css
+++ b/dist/tourtip/tourtip.css
@@ -33,6 +33,7 @@ span.tourtip__mask {
   display: flex;
   padding: 8px 16px;
   word-break: break-word;
+  flex-wrap: wrap;
 }
 .tourtip__cell a {
   color: var(--tourtip-foreground-color, var(--color-foreground-primary));
@@ -42,6 +43,7 @@ span.tourtip__mask {
 }
 .tourtip__content {
   flex-grow: 1;
+  flex-basis: 0;
 }
 .tourtip__content p {
   margin: 0;
@@ -59,6 +61,7 @@ button.tourtip__close {
   padding: 0;
   white-space: nowrap;
   width: 32px;
+  outline-offset: -2px;
 }
 button.tourtip__close > svg {
   fill: currentColor;
@@ -142,6 +145,31 @@ span.tourtip__heading {
 }
 .tourtip--expanded .tourtip__overlay {
   display: block;
+}
+.tourtip__footer {
+  align-items: center;
+  display: flex;
+  justify-content: end;
+  margin-top: 16px;
+  width: 100%;
+}
+.tourtip__footer > button:not(:last-child),
+.tourtip__footer > a:not(:last-child) {
+  margin-right: 8px;
+}
+.tourtip__footer > .fake-link,
+.tourtip__footer > a {
+  color: var(--color-foreground-primary);
+  text-decoration: none;
+}
+.tourtip__footer > .fake-link:hover:not(:disabled),
+.tourtip__footer > a:hover:not(:disabled) {
+  color: var(--color-foreground-primary);
+  text-decoration: underline;
+}
+.tourtip__index {
+  color: var(--tourtip-index-color, var(--color-foreground-secondary));
+  flex: 1;
 }
 @media (min-width: 601px) {
   .tourtip__overlay {

--- a/docs/_includes/tourtip.html
+++ b/docs/_includes/tourtip.html
@@ -48,4 +48,65 @@
     </div>
 </div>
     {% endhighlight %}
+
+    <h3>With footer</h3>
+    <p>Tourtip also supports having a footer as well as an index in the case there are multiple tourtips on the page</p>
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="tourtip tourtip--expanded">
+                <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+                    <span class="tourtip__pointer tourtip__pointer--top"></span>
+                    <div class="tourtip__mask">
+                        <div class="tourtip__cell">
+                            <span class="tourtip__content">
+                                <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                                <p>Here's something new to help you be successful at your task.</p>
+                            </span>
+                            <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
+                                <svg class="icon icon--close-small" focusable="false" height="16" width="16" aria-hidden="true">
+                                    {% include symbol.html name="close-small" %}
+                                </svg>
+                            </button>
+                            <div class="tourtip__footer">
+                                <span class="tourtip__index">1 / 3</span>
+                                <button class="fake-link">Back</button>
+                                <button class="btn btn--primary">Next</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% highlight html %}
+<div class="tourtip tourtip--expanded">
+    <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+        <span class="tourtip__pointer tourtip__pointer--top"></span>
+        <div class="tourtip__mask">
+            <div class="tourtip__cell">
+                <span class="tourtip__content">
+                    <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                    <p>Here's something new to help you be successful at your task.</p>
+                </span>
+                <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
+                    <svg class="icon icon--close-small" focusable="false" height="16" width="16" aria-hidden="true">
+                        <use xlink:href="#icon-close-small"></use>
+                    </svg>
+                </button>
+                <div class="tourtip__footer">
+                    <span class="tourtip__index">1 / 3</span>
+                    <button class="fake-link">Back</button>
+                    <button class="btn btn--primary">Next</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
+    {% endhighlight %}
+</div>
+
+
+</div>
+

--- a/src/less/tourtip/stories/tourtip.stories.js
+++ b/src/less/tourtip/stories/tourtip.stories.js
@@ -41,3 +41,54 @@ export const expanded = () => `
         </div>
     </div>
 </div>`;
+
+export const withActions = () => `
+<div class="tourtip tourtip--expanded">
+    <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+        <span class="tourtip__pointer tourtip__pointer--top"></span>
+        <div class="tourtip__mask">
+            <div class="tourtip__cell">
+                <span class="tourtip__content">
+                    <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                    <p>Here's something new to help you be successful at your task.</p>
+                </span>
+                <button class="icon-btn tourtip__close" type="button" aria-label="Dismiss tourtip">
+                    <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
+                        <use xlink:href="#icon-close"></use>
+                    </svg>
+                </button>
+                <div class="tourtip__footer">
+                    <span class="tourtip__index">1 / 3</span>
+                    <button class="fake-link">Back</button>
+                    <button class="btn btn--primary">Next</button>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>`;
+
+export const withOneAction = () => `
+<div class="tourtip tourtip--expanded">
+    <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+        <span class="tourtip__pointer tourtip__pointer--top"></span>
+        <div class="tourtip__mask">
+            <div class="tourtip__cell">
+                <span class="tourtip__content">
+                    <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                    <p>Here's something new to help you be successful at your task.</p>
+                </span>
+                <button class="icon-btn tourtip__close" type="button" aria-label="Dismiss tourtip">
+                    <svg class="icon icon--close" focusable="false" height="24" width="24" aria-hidden="true">
+                        <use xlink:href="#icon-close"></use>
+                    </svg>
+                </button>
+                <div class="tourtip__footer">
+                    <span class="tourtip__index">2 / 3</span>
+                    <button class="btn btn--primary">Next</button>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>`;

--- a/src/less/tourtip/tourtip.less
+++ b/src/less/tourtip/tourtip.less
@@ -30,6 +30,8 @@ span.tourtip__mask {
 .tourtip__cell {
     .bubble-cell();
 
+    flex-wrap: wrap;
+
     a {
         .color-token(tourtip-foreground-color, color-foreground-primary);
 
@@ -41,10 +43,14 @@ span.tourtip__mask {
 
 .tourtip__content {
     .bubble-content();
+
+    flex-basis: 0;
 }
 
 button.tourtip__close {
     .bubble-close();
+
+    outline-offset: -2px;
 }
 
 button.tourtip__close > svg {
@@ -119,6 +125,40 @@ span.tourtip__heading {
 
 .tourtip--expanded .tourtip__overlay {
     display: block;
+}
+
+.tourtip__footer {
+    align-items: center;
+    display: flex;
+    justify-content: end;
+    margin-top: 16px;
+    width: 100%;
+}
+
+.tourtip__footer > button:not(:last-child),
+.tourtip__footer > a:not(:last-child) {
+    margin-right: 8px;
+}
+
+// stylelint-disable no-descending-specificity
+// TODO need to remove this once we update fake-links/links to allow no underline and black text
+.tourtip__footer > .fake-link,
+.tourtip__footer > a {
+    color: var(--color-foreground-primary);
+
+    text-decoration: none;
+
+    &:hover:not(:disabled) {
+        color: var(--color-foreground-primary);
+
+        text-decoration: underline;
+    }
+}
+// stylelint-enable no-descending-specificity
+
+.tourtip__index {
+    .color-token(tourtip-index-color, color-foreground-secondary);
+    flex: 1;
 }
 
 @media (min-width: 601px) {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1744

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added `tourtip__footer` selector to show tourtip footer.
* Had to modify a bit of the flex code to allow the footer to properly flex to the bottom
* Added an `tourtip__index` container which holds the index. It should flex to the beginning
* If there are only buttons and no index, should flex to the end (there wasn't a case for this, but this is supported)
* The usecase showed a black link for back. I used fake link for now, but it was blue. I believe we will have an upcoming change to change links to be black and allow non-inline links to not have an underline. But for now, I added a selector to support that case in tourtip.

## Screenshots
<img width="1123" alt="Screen Shot 2022-10-10 at 9 15 04 AM" src="https://user-images.githubusercontent.com/1755269/194911173-015999a7-defd-4124-8e85-b8816efcfe46.png">

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
