### PR TITLE
feat(listbox-button): separate styling for label and value bolding

### DIFF
--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -56,6 +56,15 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 .listbox-button button.btn--borderless[aria-expanded="true"] ~ .listbox-button__listbox {
   top: 41px;
 }
+.listbox-button .btn__label {
+  color: var(--listbox-button-label-color, var(--color-foreground-secondary));
+}
+.listbox-button--expanded .btn__label {
+  color: var(--listbox-button-label-color, var(--color-foreground-primary));
+}
+.listbox-button .btn__text {
+  font-weight: bold;
+}
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {
   background-color: var(--color-state-primary-hover);
 }

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -58,12 +58,14 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 }
 .listbox-button .btn__label {
   color: var(--listbox-button-label-color, var(--color-foreground-secondary));
+  margin-right: 3px;
 }
 .listbox-button--expanded .btn__label {
   color: var(--listbox-button-label-color, var(--color-foreground-primary));
 }
 .listbox-button .btn__text {
   font-weight: bold;
+  margin-right: auto;
 }
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {
   background-color: var(--color-state-primary-hover);

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -138,3 +138,8 @@ span.listbox-button__value {
   margin-left: 0;
   margin-right: 8px;
 }
+[dir="rtl"] .listbox-button .btn__label {
+  color: var(--listbox-button-label-color, var(--color-foreground-secondary));
+  margin-left: 3px;
+  margin-right: 0;
+}

--- a/docs/_includes/listbox-button.html
+++ b/docs/_includes/listbox-button.html
@@ -12,9 +12,12 @@
     <div class="demo">
         <div class="demo__inner">
             <span class="listbox-button" data-makeup-auto-select="false">
-                <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox" data-listbox-button-prefix="Color: ">
+                <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
                     <span class="btn__cell">
-                        <span class="btn__text">Color: -</span>
+                        <span class="btn__contents">
+                            <span class="btn__label">Color: </span>
+                            <span class="btn__text">-</span>
+                        </span>
                         <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                             {% include symbol.html name="dropdown" %}
                         </svg>
@@ -56,9 +59,12 @@
 <span class="listbox-button">
     <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color: -</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">-</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -67,25 +73,25 @@
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -147,7 +153,7 @@
             <span class="btn__floating-label">Color</span>
             <span class="btn__text"></span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -156,25 +162,25 @@
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -190,7 +196,10 @@
             <span class="listbox-button" data-makeup-auto-select="false">
                 <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox" data-listbox-button-prefix="Color: ">
                     <span class="btn__cell">
-                        <span class="btn__text">Color: Blue</span>
+                        <span class="btn__contents">
+                            <span class="btn__label">Color: </span>
+                            <span class="btn__text">Blue</span>
+                        </span>
                         <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                             {% include symbol.html name="dropdown" %}
                         </svg>
@@ -232,9 +241,12 @@
 <span class="listbox-button">
     <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color: Blue</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Blue</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -243,25 +255,25 @@
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -322,7 +334,7 @@
             <span class="btn__floating-label">Color:</span>
             <span class="btn__text">Blue</span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -331,25 +343,25 @@
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -365,7 +377,10 @@
             <span class="listbox-button">
                 <button class="btn btn--borderless" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox" data-listbox-button-prefix="Quantity: ">
                     <span class="btn__cell">
-                        <span class="btn__text">Quantity: 1</span>
+                        <span class="btn__contents">
+                            <span class="btn__label">Quantity: </span>
+                            <span class="btn__text">1</span>
+                        </span>
                         <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                             {% include symbol.html name="dropdown" %}
                         </svg>
@@ -401,9 +416,12 @@
 <span class="listbox-button">
     <button class="btn btn--borderless" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Quantity</span>
+            <span class="btn__contents">
+                <span class="btn__label">Quantity: </span>
+                <span class="btn__text">1</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -412,19 +430,19 @@
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">1</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">2</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">3</span>
                 <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>

--- a/docs/_includes/listbox-button.html
+++ b/docs/_includes/listbox-button.html
@@ -14,10 +14,8 @@
             <span class="listbox-button" data-makeup-auto-select="false">
                 <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
                     <span class="btn__cell">
-                        <span class="btn__contents">
-                            <span class="btn__label">Color: </span>
-                            <span class="btn__text">-</span>
-                        </span>
+                        <span class="btn__label">Color: </span>
+                        <span class="btn__text">-</span>
                         <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                             {% include symbol.html name="dropdown" %}
                         </svg>
@@ -59,10 +57,8 @@
 <span class="listbox-button">
     <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">-</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -196,10 +192,8 @@
             <span class="listbox-button" data-makeup-auto-select="false">
                 <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox" data-listbox-button-prefix="Color: ">
                     <span class="btn__cell">
-                        <span class="btn__contents">
-                            <span class="btn__label">Color: </span>
-                            <span class="btn__text">Blue</span>
-                        </span>
+                        <span class="btn__label">Color: </span>
+                        <span class="btn__text">Blue</span>
                         <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                             {% include symbol.html name="dropdown" %}
                         </svg>
@@ -241,10 +235,8 @@
 <span class="listbox-button">
     <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">Blue</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -377,10 +369,8 @@
             <span class="listbox-button">
                 <button class="btn btn--borderless" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox" data-listbox-button-prefix="Quantity: ">
                     <span class="btn__cell">
-                        <span class="btn__contents">
-                            <span class="btn__label">Quantity: </span>
-                            <span class="btn__text">1</span>
-                        </span>
+                        <span class="btn__label">Quantity: </span>
+                        <span class="btn__text">1</span>
                         <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                             {% include symbol.html name="dropdown" %}
                         </svg>
@@ -416,10 +406,8 @@
 <span class="listbox-button">
     <button class="btn btn--borderless" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Quantity: </span>
-                <span class="btn__text">1</span>
-            </span>
+            <span class="btn__label">Quantity: </span>
+            <span class="btn__text">1</span>
             <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -106,5 +106,11 @@ span.listbox-button__value {
         margin-left: 0;
         margin-right: @spacing-100;
     }
+
+    .listbox-button .btn__label {
+        .color-token(listbox-button-label-color, color-foreground-secondary);
+        margin-left: 3px;
+        margin-right: 0;
+    }
 }
 // stylelint-enable no-descending-specificity

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -52,6 +52,7 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 
 .listbox-button .btn__label {
     .color-token(listbox-button-label-color, color-foreground-secondary);
+    margin-right: 3px;
 }
 
 .listbox-button--expanded .btn__label {
@@ -60,6 +61,7 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 
 .listbox-button .btn__text {
     font-weight: bold;
+    margin-right: auto;
 }
 
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -50,6 +50,18 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
     }
 }
 
+.listbox-button .btn__label {
+    .color-token(listbox-button-label-color, color-foreground-secondary);
+}
+
+.listbox-button--expanded .btn__label {
+    .color-token(listbox-button-label-color, color-foreground-primary);
+}
+
+.listbox-button .btn__text {
+    font-weight: bold;
+}
+
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {
     background-color: var(--color-state-primary-hover);
 }

--- a/src/less/listbox-button/stories/base.stories.js
+++ b/src/less/listbox-button/stories/base.stories.js
@@ -4,9 +4,12 @@ export const collapsedUnselected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">-</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -15,25 +18,25 @@ export const collapsedUnselected = () => `
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -45,9 +48,12 @@ export const expandedUnselected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">-</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -56,25 +62,25 @@ export const expandedUnselected = () => `
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -86,9 +92,12 @@ export const collapsedSelected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color: Blue</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Blue</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -97,25 +106,25 @@ export const collapsedSelected = () => `
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -127,9 +136,12 @@ export const expandedSelected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color: Blue</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Blue</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -138,25 +150,25 @@ export const expandedSelected = () => `
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -168,9 +180,12 @@ export const disabled = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" disabled>
         <span class="btn__cell">
-            <span class="btn__text">Color</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Blue</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -179,25 +194,25 @@ export const disabled = () => `
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -209,9 +224,12 @@ export const invalid = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" aria-invalid="true">
         <span class="btn__cell">
-            <span class="btn__text">Color</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Blue</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -220,25 +238,25 @@ export const invalid = () => `
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>
@@ -250,9 +268,12 @@ export const longOption = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color: Red with very very very long text</span>
+            <span class="btn__contents">
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Red with very very very long text</span>
+            </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -261,19 +282,19 @@ export const longOption = () => `
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red with very very very long text</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>

--- a/src/less/listbox-button/stories/base.stories.js
+++ b/src/less/listbox-button/stories/base.stories.js
@@ -4,10 +4,8 @@ export const collapsedUnselected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">-</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -48,10 +46,8 @@ export const expandedUnselected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">-</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -92,10 +88,8 @@ export const collapsedSelected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">Blue</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -136,10 +130,8 @@ export const expandedSelected = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">Blue</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -180,10 +172,8 @@ export const disabled = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" disabled>
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">Blue</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -224,10 +214,8 @@ export const invalid = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" aria-invalid="true">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">Blue</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>
@@ -268,10 +256,8 @@ export const longOption = () => `
 <span class="listbox-button">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__contents">
-                <span class="btn__label">Color: </span>
-                <span class="btn__text">Red with very very very long text</span>
-            </span>
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Red with very very very long text</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>

--- a/src/less/listbox-button/stories/cascade.stories.js
+++ b/src/less/listbox-button/stories/cascade.stories.js
@@ -5,10 +5,8 @@ export const RTL = () => `
     <span class="listbox-button">
         <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
             <span class="btn__cell">
-                <span class="btn__contents">
-                    <span class="btn__label">Color: </span>
-                    <span class="btn__text">Red</span>
-                </span>
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Red</span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                     <use href="#icon-dropdown"></use>
                 </svg>
@@ -51,10 +49,8 @@ export const color = () => `
     <span class="listbox-button">
         <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
             <span class="btn__cell">
-                <span class="btn__contents">
-                    <span class="btn__label">Color: </span>
-                    <span class="btn__text">Red</span>
-                </span>
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Red</span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                     <use href="#icon-dropdown"></use>
                 </svg>
@@ -97,10 +93,8 @@ export const fontSize = () => `
     <span class="listbox-button">
         <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
             <span class="btn__cell">
-                <span class="btn__contents">
-                    <span class="btn__label">Color: </span>
-                    <span class="btn__text">Red</span>
-                </span>
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Red</span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                     <use href="#icon-dropdown"></use>
                 </svg>

--- a/src/less/listbox-button/stories/cascade.stories.js
+++ b/src/less/listbox-button/stories/cascade.stories.js
@@ -5,9 +5,12 @@ export const RTL = () => `
     <span class="listbox-button">
         <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
             <span class="btn__cell">
-                <span class="btn__text">Color: Red</span>
+                <span class="btn__contents">
+                    <span class="btn__label">Color: </span>
+                    <span class="btn__text">Red</span>
+                </span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                    <use xlink:href="#icon-dropdown"></use>
+                    <use href="#icon-dropdown"></use>
                 </svg>
             </span>
         </button>
@@ -16,25 +19,25 @@ export const RTL = () => `
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Blue</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Yellow</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Green</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
             </div>
@@ -48,9 +51,12 @@ export const color = () => `
     <span class="listbox-button">
         <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
             <span class="btn__cell">
-                <span class="btn__text">Color: Red</span>
+                <span class="btn__contents">
+                    <span class="btn__label">Color: </span>
+                    <span class="btn__text">Red</span>
+                </span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                    <use xlink:href="#icon-dropdown"></use>
+                    <use href="#icon-dropdown"></use>
                 </svg>
             </span>
         </button>
@@ -59,25 +65,25 @@ export const color = () => `
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Blue</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Yellow</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Green</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
             </div>
@@ -91,9 +97,12 @@ export const fontSize = () => `
     <span class="listbox-button">
         <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
             <span class="btn__cell">
-                <span class="btn__text">Color: Red</span>
+                <span class="btn__contents">
+                    <span class="btn__label">Color: </span>
+                    <span class="btn__text">Red</span>
+                </span>
                 <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                    <use xlink:href="#icon-dropdown"></use>
+                    <use href="#icon-dropdown"></use>
                 </svg>
             </span>
         </button>
@@ -102,25 +111,25 @@ export const fontSize = () => `
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Blue</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Yellow</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
                 <div class="listbox-button__option" role="option">
                     <span class="listbox-button__value">Green</span>
                     <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                        <use xlink:href="#icon-tick-small"></use>
+                        <use href="#icon-tick-small"></use>
                     </svg>
                 </div>
             </div>

--- a/src/less/listbox-button/stories/dimensions.stories.js
+++ b/src/less/listbox-button/stories/dimensions.stories.js
@@ -4,10 +4,8 @@ export const fluid = () => `
 <span class="listbox-button listbox-button--fluid">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-                <span class="btn__contents">
-                    <span class="btn__label">Color: </span>
-                    <span class="btn__text">Red</span>
-                </span>
+                <span class="btn__label">Color: </span>
+                <span class="btn__text">Red</span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
                 <use href="#icon-dropdown"></use>
             </svg>

--- a/src/less/listbox-button/stories/dimensions.stories.js
+++ b/src/less/listbox-button/stories/dimensions.stories.js
@@ -4,9 +4,12 @@ export const fluid = () => `
 <span class="listbox-button listbox-button--fluid">
     <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
         <span class="btn__cell">
-            <span class="btn__text">Color: Red</span>
+                <span class="btn__contents">
+                    <span class="btn__label">Color: </span>
+                    <span class="btn__text">Red</span>
+                </span>
             <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-dropdown"></use>
+                <use href="#icon-dropdown"></use>
             </svg>
         </span>
     </button>
@@ -15,25 +18,25 @@ export const fluid = () => `
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
                 <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
-                    <use xlink:href="#icon-tick-small"></use>
+                    <use href="#icon-tick-small"></use>
                 </svg>
             </div>
         </div>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1880 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I updated the label color to match new design specs and bolded the values.

## Notes
To achieve the styling adjustment to labels and values individually, I had to update the DOM and separate the label and text value. While the previous structure had the two inside the same element (`<span class="btn__text">Color: Blue</span>`), the new structure looks like this:

`````html
<span class="btn__contents">
    <span class="btn__label">Color: </span>
    <span class="btn__text">Blue</span>
</span>
`````

## Screenshots
**Before**:
<img width="163" alt="image" src="https://user-images.githubusercontent.com/1675667/194933645-45f8bf8a-4f2f-463d-b27a-3ae0311d4355.png">

**After**:
<img width="170" alt="image" src="https://user-images.githubusercontent.com/1675667/194933727-1e34e8a8-1dae-4dd0-ad70-5697fca579d6.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
