### PR TITLE
feat(section-notice): added dismiss layout variation and top aligned icons and links

### DIFF
--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -109,3 +109,7 @@ p.section-notice__cta {
 [dir="rtl"] .section-notice__main {
   padding-right: 0;
 }
+[dir="rtl"] p.page-notice__cta {
+  margin-left: 16px;
+  padding-left: 16px;
+}

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -2,21 +2,24 @@
   background-color: var(--section-notice-default-background-color, var(--color-background-secondary));
   border-radius: var(--section-notice-border-radius, var(--border-radius-50));
   font-size: 0.875rem;
-  justify-content: flex-start;
   margin: 8px 0;
   padding: 16px;
 }
 div[role="region"].section-notice,
 section.section-notice {
-  display: flex;
+  display: grid;
+  grid-template-columns: 32px auto auto auto;
 }
 span[role="region"].section-notice {
-  display: inline-flex;
+  display: grid;
 }
 .section-notice__title {
   font-size: 0.875rem;
   font-weight: normal;
   margin: 0;
+}
+.section-notice__cta a {
+  white-space: nowrap;
 }
 /* legacy version with separate bold heading */
 .section-notice__title:not(:only-child) {
@@ -38,27 +41,35 @@ span[role="region"].section-notice {
 .section-notice a:hover {
   color: var(--section-notice-foreground-color, var(--color-foreground-primary));
 }
+.section-notice .icon {
+  vertical-align: top;
+}
 .section-notice__header {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  padding-right: 12px;
+  grid-column: 1;
+  grid-row: 1;
+  height: 16px;
+  padding-right: 16px;
 }
-.section-notice__main,
-.section-notice__footer {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+.section-notice__main {
+  grid-column: 2;
+  grid-row: 1;
+  padding-right: 16px;
 }
 .section-notice__footer {
-  flex-shrink: 0;
-  margin-left: auto;
-  padding-left: 0;
-  width: auto;
+  grid-column: 4;
+  grid-row: 1;
+  justify-self: end;
 }
 .section-notice__main p {
   font-size: 0.875rem;
   margin: 0;
+}
+p.section-notice__cta {
+  grid-column: 2;
+  grid-row: 2;
+  justify-self: start;
+  margin-right: 16px;
+  margin-top: 16px;
 }
 /* support legacy 6.5 notice with heading + paragaphs */
 .section-notice__main .section-notice__title ~ p {
@@ -71,6 +82,14 @@ span[role="region"].section-notice {
     flex-wrap: nowrap;
     margin: 16px 0;
   }
+  p.section-notice__cta {
+    grid-column: 4;
+    grid-row: 1;
+    justify-self: end;
+    margin-bottom: 0;
+    margin-top: 0;
+    padding-right: 16px;
+  }
   .section-notice__footer {
     margin-top: 0;
     padding-left: 16px;
@@ -81,8 +100,12 @@ span[role="region"].section-notice {
   padding-right: 0;
 }
 [dir="rtl"] .section-notice__footer {
+  justify-self: start;
   margin-left: initial;
   margin-right: auto;
   padding-left: initial;
+  padding-right: 0;
+}
+[dir="rtl"] .section-notice__main {
   padding-right: 0;
 }

--- a/docs/_includes/section-notice.html
+++ b/docs/_includes/section-notice.html
@@ -113,4 +113,49 @@
 </section>
     {% endhighlight %}
 
+    <h3 id="section-notice-dismissable-title">Dismissable Section Notice</h3>
+    <section class="section-notice section-notice--information" role="region" aria-label="Information">
+        <div class="section-notice__header">
+            <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+                {% include symbol.html name="information-filled-small" %}
+            </svg>
+        </div>
+        <div class="section-notice__main">
+            <h3 class="section-notice__title">Notice Title</h3>
+            <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+        </div>
+        <p class="section-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
+        <div class="section-notice__footer">
+            <button aria-label="Dismiss notification" class="fake-link section-notice__dismiss">
+                 <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
+                    {% include symbol.html name="close" %}
+                 </svg>
+            </a>
+        </div>
+    </section>
+
+
+{% highlight html %}
+<h3 id="section-notice-dismissable-title">Dismissable Section Notice</h3>
+<section class="section-notice section-notice--information" role="region" aria-label="Information">
+    <div class="section-notice__header">
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use href="#icon-information-filled-small"></use>
+        </svg>
+    </div>
+    <div class="section-notice__main">
+        <h3 class="section-notice__title">Notice Title</h3>
+        <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+    </div>
+    <p class="section-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
+    <div class="section-notice__footer">
+        <button aria-label="Dismiss notification" class="fake-link section-notice__dismiss">
+            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
+                <use href="#icon-close"></use>
+            </svg>
+        </a>
+    </div>
+</section>
+{% endhighlight %}
+
 </div>

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -138,4 +138,9 @@ p.section-notice__cta {
     .section-notice__main {
         padding-right: 0;
     }
+
+    p.page-notice__cta {
+        margin-left: 16px;
+        padding-left: 16px;
+    }
 }

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -5,24 +5,30 @@
     .background-color-token(section-notice-default-background-color, color-background-secondary);
     .border-radius-token(section-notice-border-radius, border-radius-50);
     font-size: @font-size-14;
-    justify-content: flex-start;
     margin: 8px 0;
     padding: 16px;
 }
 
 div[role="region"].section-notice,
 section.section-notice {
-    display: flex;
+    display: grid;
+    // provide explicit structure up front, create loose markup model
+    grid-template-columns: 32px auto auto auto;
 }
 
 span[role="region"].section-notice {
-    display: inline-flex;
+    display: grid;
 }
 
 .section-notice__title {
     font-size: @font-size-regular;
     font-weight: normal;
     margin: 0;
+}
+
+// force links with text having more than one word to remain on same line
+.section-notice__cta a {
+    white-space: nowrap;
 }
 
 /* legacy version with separate bold heading */
@@ -50,30 +56,40 @@ span[role="region"].section-notice {
     .color-token(section-notice-foreground-color, color-foreground-primary);
 }
 
+.section-notice .icon {
+    vertical-align: top;
+}
+
 .section-notice__header {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    padding-right: @spacing-150;
+    grid-column: 1;
+    grid-row: 1;
+    height: @spacing-200;
+    padding-right: @spacing-200;
 }
 
-.section-notice__main,
-.section-notice__footer {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+.section-notice__main {
+    grid-column: 2;
+    grid-row: 1;
+    padding-right: @spacing-200;
 }
 
 .section-notice__footer {
-    flex-shrink: 0;
-    margin-left: auto;
-    padding-left: 0;
-    width: auto;
+    grid-column: 4;
+    grid-row: 1;
+    justify-self: end;
 }
 
 .section-notice__main p {
     font-size: @font-size-regular;
     margin: 0;
+}
+
+p.section-notice__cta {
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: start;
+    margin-right: @spacing-200;
+    margin-top: @spacing-200;
 }
 
 /* support legacy 6.5 notice with heading + paragaphs */
@@ -90,6 +106,15 @@ span[role="region"].section-notice {
         margin: @spacing-200 0;
     }
 
+    p.section-notice__cta {
+        grid-column: 4;
+        grid-row: 1;
+        justify-self: end;
+        margin-bottom: 0;
+        margin-top: 0;
+        padding-right: @spacing-200;
+    }
+
     .section-notice__footer {
         margin-top: 0;
         padding-left: @spacing-200;
@@ -103,9 +128,14 @@ span[role="region"].section-notice {
     }
 
     .section-notice__footer {
+        justify-self: start;
         margin-left: initial;
         margin-right: auto;
         padding-left: initial;
+        padding-right: 0;
+    }
+
+    .section-notice__main {
         padding-right: 0;
     }
 }

--- a/src/less/section-notice/stories/rtl.stories.js
+++ b/src/less/section-notice/stories/rtl.stories.js
@@ -1,0 +1,66 @@
+export default { title: 'Section Notice/RTL' };
+
+export const confirmationWithButton = () => `
+<div dir="rtl">
+    <section class="page-notice page-notice--confirmation" role="region" aria-label="Confirmation">
+        <div class="page-notice__header">
+            <svg class="icon icon--confirmation-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Confirmation">
+                <use href="#icon-confirmation-filled-small"></use>
+            </svg>
+        </div>
+        <div class="page-notice__main">
+            <h2 class="page-notice__title">You have opted into eBay Pay</h2>
+        </div>
+        <div class="page-notice__footer">
+            <button class="fake-link">Dismiss</button>
+        </div>
+    </section>
+</div>
+`;
+
+export const dismissableWithTitle = () => `
+<div dir="rtl">
+    <section class="page-notice page-notice--information" role="region" aria-label="Information">
+        <div class="page-notice__header">
+            <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+                <use href="#icon-information-filled-small"></use>
+            </svg>
+        </div>
+        <div class="page-notice__main">
+            <h3 class="page-notice__title">Notice Title</h3>
+            <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+        </div>
+        <p class="page-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
+        <div class="page-notice__footer">
+            <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="14" width="14">
+                    <use href="#icon-close-small"></use>
+                </svg>
+            </a>
+        </div>
+    </section>
+</div>
+`;
+
+export const dismissableWithoutTitle = () => `
+<div dir="rtl">
+    <section class="page-notice page-notice--information" role="region" aria-label="Information">
+        <div class="page-notice__header">
+            <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+                <use href="#icon-information-filled-small"></use>
+            </svg>
+        </div>
+        <div class="page-notice__main">
+            <h3 class="page-notice__title">Opt into eBay payments before Jan 12th to pay no selling fees.</h3>
+        </div>
+        <p class="page-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
+        <div class="page-notice__footer">
+            <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="14" width="14">
+                    <use href="#icon-close-small"></use>
+                </svg>
+            </a>
+        </div>
+    </section>
+</div>
+`;

--- a/src/less/section-notice/stories/section-notice.stories.js
+++ b/src/less/section-notice/stories/section-notice.stories.js
@@ -141,3 +141,46 @@ export const informationWithLink = () => `
     </div>
 </div>
 `;
+
+export const dismissableWithTitle = () => `
+<section class="section-notice section-notice--information" role="region" aria-label="Information">
+    <div class="section-notice__header">
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use href="#icon-information-filled-small"></use>
+        </svg>
+    </div>
+    <div class="section-notice__main">
+        <h3 class="section-notice__title">Notice Title</h3>
+        <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+    </div>
+    <p class="section-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
+    <div class="section-notice__footer">
+        <button aria-label="Dismiss notification" class="fake-link section-notice__dismiss">
+            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
+                <use href="#icon-close"></use>
+            </svg>
+        </a>
+    </div>
+</section>
+`;
+
+export const dismissableWithoutTitle = () => `
+<section class="section-notice section-notice--information" role="region" aria-label="Information">
+    <div class="section-notice__header">
+        <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+            <use href="#icon-information-filled-small"></use>
+        </svg>
+    </div>
+    <div class="section-notice__main">
+        <h3 class="section-notice__title">Opt into eBay payments before Jan 12th to pay no selling fees.</h3>
+    </div>
+    <p class="section-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
+    <div class="section-notice__footer">
+        <button aria-label="Dismiss notification" class="fake-link section-notice__dismiss">
+            <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="10" width="10">
+                <use href="#icon-close"></use>
+            </svg>
+        </a>
+    </div>
+</section>
+`;

--- a/src/less/section-notice/stories/test.stories.js
+++ b/src/less/section-notice/stories/test.stories.js
@@ -18,6 +18,30 @@ export const RTL = () => `
 </div>
 `;
 
+export const RTLDismissable = () => `
+<div dir="rtl">
+    <section class="page-notice page-notice--information" role="region" aria-label="Information">
+        <div class="page-notice__header">
+            <svg class="icon icon--information-filled-small" focusable="false" height="16" width="16" role="img" aria-label="Information">
+                <use href="#icon-information-filled-small"></use>
+            </svg>
+        </div>
+        <div class="page-notice__main">
+            <h3 class="page-notice__title">Notice Title</h3>
+            <p>Opt into eBay payments before Jan 12th to pay no selling fees.</p>
+        </div>
+        <p class="page-notice__cta"><a href="https://www.ebay.com">Opt in</a></p>
+        <div class="page-notice__footer">
+            <button aria-label="Dismiss notification" class="fake-link page-notice__dismiss">
+                <svg aria-hidden="true" class="icon icon--close-small" focusable="false" height="14" width="14">
+                    <use href="#icon-close-small"></use>
+                </svg>
+            </a>
+        </div>
+    </section>
+</div>
+`;
+
 export const longText = () => `
 <div class="section-notice section-notice--confirmation" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1883 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Added new dismiss variation to section notice similar to the one applied to page notice a few weeks back.

## Notes
I also top-aligned the icons and action elements similar to the implementation for page notice.

The approach I took followed the pattern for page notice since shifting placement of this kind is more easily achieved with a `grid` layout.

## Screenshots
New variation with dismiss:
<img width="763" alt="image" src="https://user-images.githubusercontent.com/1675667/195927397-3596dd8b-8249-4de4-85c3-3447c8269f9d.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [x] I ran a visual regression build in Percy and verified the changes
- [x] I added/updated/removed Storybook coverage as appropriate
