### PR TITLE
fix(notice): removed spacing on no icon

### DIFF
--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -77,9 +77,12 @@ span[role="region"].page-notice {
   padding-right: 16px;
 }
 .page-notice__main {
-  grid-column: 2;
+  grid-column: 1 / 3;
   grid-row: 1;
   padding-right: 16px;
+}
+.page-notice__header + .page-notice__main {
+  grid-column: 2;
 }
 .page-notice__footer {
   grid-column: 4;

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -51,9 +51,12 @@ span[role="region"].section-notice {
   padding-right: 16px;
 }
 .section-notice__main {
-  grid-column: 2;
+  grid-column: 1 / 3;
   grid-row: 1;
   padding-right: 16px;
+}
+.section-notice__header + .section-notice__main {
+  grid-column: 2;
 }
 .section-notice__footer {
   grid-column: 4;

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -101,9 +101,13 @@ span[role="region"].page-notice {
 }
 
 .page-notice__main {
-    grid-column: 2;
+    grid-column: 1 / 3;
     grid-row: 1;
     padding-right: @spacing-200;
+}
+
+.page-notice__header + .page-notice__main {
+    grid-column: 2;
 }
 
 .page-notice__footer {

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -68,9 +68,13 @@ span[role="region"].section-notice {
 }
 
 .section-notice__main {
-    grid-column: 2;
+    grid-column: 1 / 3;
     grid-row: 1;
     padding-right: @spacing-200;
+}
+
+.section-notice__header + .section-notice__main {
+    grid-column: 2;
 }
 
 .section-notice__footer {


### PR DESCRIPTION

Fixes https://github.com/eBay/skin/issues/1913


- [X] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
* The grid template requires a 32px space for the first element. This causes extra padding when removing the icon. 
* Changed the main container to span 2 columns. If it is preceeded by header (which is the icon container), it should span only column 2. 

## Screenshots
<img width="1143" alt="Screen Shot 2022-10-26 at 4 42 28 PM" src="https://user-images.githubusercontent.com/1755269/198159339-1f47bf2b-08d6-4b87-a2e1-c4269cf474b2.png">
<img width="1116" alt="Screen Shot 2022-10-26 at 4 42 34 PM" src="https://user-images.githubusercontent.com/1755269/198159342-f0021874-a5ed-47ec-9c7c-9188d9174b2f.png">


## Checklist

- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
