### PR TITLE
fix(cta-button): added content padding to center align for large btn

### DIFF
--- a/dist/cta-button/cta-button.css
+++ b/dist/cta-button/cta-button.css
@@ -94,10 +94,12 @@ a.cta-btn--large {
   border-radius: calc(48px / 2);
   font-size: 1rem;
   min-height: 48px;
+  padding: 13px 20px;
 }
 a.cta-btn--large-truncated {
   font-size: 1rem;
   height: 48px;
+  padding: 13px 20px;
 }
 a.cta-btn--large-truncated,
 a.cta-btn--large-truncated span {
@@ -109,4 +111,5 @@ a.cta-btn--large-truncated span {
 a.cta-btn--large-fixed-height {
   font-size: 1rem;
   height: 48px;
+  padding: 13px 20px;
 }

--- a/src/less/cta-button/cta-button.less
+++ b/src/less/cta-button/cta-button.less
@@ -62,6 +62,7 @@ a.cta-btn--large {
     border-radius: calc(@button-height-large / 2);
     font-size: @font-size-16;
     min-height: @button-height-large;
+    padding: @button-padding-vertical-large @button-padding-horizontal;
 }
 
 a.cta-btn--large-truncated {
@@ -69,9 +70,11 @@ a.cta-btn--large-truncated {
 
     font-size: @font-size-16;
     height: @button-height-large;
+    padding: @button-padding-vertical-large @button-padding-horizontal;
 }
 
 a.cta-btn--large-fixed-height {
     font-size: @font-size-16;
     height: @button-height-large;
+    padding: @button-padding-vertical-large @button-padding-horizontal;
 }

--- a/src/less/cta-button/stories/dimensions.stories.js
+++ b/src/less/cta-button/stories/dimensions.stories.js
@@ -1,0 +1,34 @@
+export default { title: 'CTA Button/Dimensions' };
+
+export const large = () => `
+<a class="cta-btn cta-btn--large" href="http://www.ebay.com">
+    <span class="cta-btn__cell">
+        <span>Link</span>
+        <svg class="icon icon--cta" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-cta"></use>
+        </svg>
+    </span>
+</a>
+`;
+
+export const largeTruncated = () => `
+<a class="cta-btn cta-btn--large-truncated" href="http://www.ebay.com">
+    <span class="cta-btn__cell">
+        <span>Link</span>
+        <svg class="icon icon--cta" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-cta"></use>
+        </svg>
+    </span>
+</a>
+`;
+
+export const largeFixedHeight = () => `
+<a class="cta-btn cta-btn--large-fixed-height" href="http://www.ebay.com">
+    <span class="cta-btn__cell">
+        <span>Link</span>
+        <svg class="icon icon--cta" focusable="false" height="8" width="8" aria-hidden="true">
+            <use xlink:href="#icon-cta"></use>
+        </svg>
+    </span>
+</a>
+`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1890 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
- Added padding to the CTA large button (also in truncated and fixed-height state) to center align the content.

## Screenshots
### Before
Large Button
<img width="716" alt="image" src="https://user-images.githubusercontent.com/6342519/199318658-3e2acd05-5512-4097-a043-9f7009fdfb27.png">

Large Button Truncated
<img width="561" alt="image" src="https://user-images.githubusercontent.com/6342519/199319708-9edf5d78-c652-440a-bf75-c5aa1258de56.png">

Large Button Fixed height
<img width="561" alt="image" src="https://user-images.githubusercontent.com/6342519/199319857-a6444fd4-6c39-478e-af2f-35f62f49ee58.png">


### After
Large Button
<img width="716" alt="image" src="https://user-images.githubusercontent.com/6342519/199318824-ecc496b5-80c7-4816-a17b-6940773cdab0.png">

Large Button Truncated
<img width="664" alt="image" src="https://user-images.githubusercontent.com/6342519/199319476-d5c6b1cc-3128-4a47-a0aa-6809938b470d.png">

Large Button Fixed height
<img width="616" alt="image" src="https://user-images.githubusercontent.com/6342519/199319983-72cd0789-f3a1-4f27-8994-0edcc38a75bd.png">



## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I tested the UI in dark mode and RTL mode
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I added/updated/removed Storybook coverage as appropriate
