### PR TITLE
feat(breadcrumbs): added overflow and changed colors

### DIFF
--- a/dist/breadcrumbs/breadcrumbs.css
+++ b/dist/breadcrumbs/breadcrumbs.css
@@ -5,9 +5,7 @@ nav.breadcrumbs {
   height: fit-content;
   margin: 8px 0;
   min-height: 16px;
-  overflow-x: scroll;
   padding: 8px;
-  scrollbar-width: none;
   white-space: nowrap;
 }
 nav.breadcrumbs ul {
@@ -20,6 +18,7 @@ nav.breadcrumbs ul {
 nav.breadcrumbs li {
   align-items: center;
   display: inline-flex;
+  vertical-align: middle;
 }
 nav.breadcrumbs li svg {
   margin-left: 7px;
@@ -60,8 +59,22 @@ nav.breadcrumbs a:focus:not(:focus-visible),
 nav.breadcrumbs button:focus:not(:focus-visible) {
   outline: none;
 }
-nav.breadcrumbs::-webkit-scrollbar {
-  display: none;
+nav.breadcrumbs .menu-button__button {
+  background-color: var(--icon-button-background-color, var(--color-background-secondary));
+  height: 20px;
+  min-height: 20px;
+  min-width: 20px;
+  outline-offset: 1px;
+  width: 20px;
+}
+nav.breadcrumbs .menu-button__menu {
+  font-size: 0.875rem;
+}
+nav.breadcrumbs svg.icon--overflow-small {
+  transform: rotate(90deg);
+}
+nav.breadcrumbs div.menu-button__item[role^="menuitem"] {
+  display: block;
 }
 @media (min-width: 601px) {
   nav.breadcrumbs {

--- a/dist/breadcrumbs/breadcrumbs.css
+++ b/dist/breadcrumbs/breadcrumbs.css
@@ -5,7 +5,9 @@ nav.breadcrumbs {
   height: fit-content;
   margin: 8px 0;
   min-height: 16px;
+  overflow-x: scroll;
   padding: 8px;
+  scrollbar-width: none;
   white-space: nowrap;
 }
 nav.breadcrumbs ul {
@@ -58,6 +60,13 @@ nav.breadcrumbs a:visited {
 nav.breadcrumbs a:focus:not(:focus-visible),
 nav.breadcrumbs button:focus:not(:focus-visible) {
   outline: none;
+}
+nav.breadcrumbs nav.breadcrumbs::-webkit-scrollbar {
+  display: none;
+}
+nav.breadcrumbs.breadcrumb--overflow {
+  overflow-x: unset;
+  scrollbar-width: unset;
 }
 nav.breadcrumbs .menu-button__button {
   background-color: var(--icon-button-background-color, var(--color-background-secondary));

--- a/dist/breadcrumbs/breadcrumbs.css
+++ b/dist/breadcrumbs/breadcrumbs.css
@@ -1,5 +1,5 @@
 nav.breadcrumbs {
-  color: var(--breadcrumbs-item-foreground-color, var(--color-foreground-primary));
+  color: var(--breadcrumbs-item-foreground-color, var(--color-foreground-secondary));
   font-size: 0.75rem;
   height: -webkit-fit-content;
   height: fit-content;
@@ -49,7 +49,7 @@ nav.breadcrumbs button:hover {
 }
 nav.breadcrumbs a[aria-current],
 nav.breadcrumbs button[aria-current] {
-  color: var(--breadcrumbs-item-current-foreground-color, var(--color-foreground-secondary));
+  color: var(--breadcrumbs-item-current-foreground-color, var(--color-foreground-primary));
   text-decoration: none;
 }
 nav.breadcrumbs a:visited {

--- a/docs/_includes/breadcrumbs.html
+++ b/docs/_includes/breadcrumbs.html
@@ -40,19 +40,19 @@
         <li>
             <a href="https://www.ebay.com/">ebay</a>
             <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-breadcrumb"></use>
+                <use href="#icon-breadcrumb"></use>
             </svg>
         </li>
         <li>
             <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
             <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-breadcrumb"></use>
+                <use href="#icon-breadcrumb"></use>
             </svg>
         </li>
         <li>
             <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
             <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-breadcrumb"></use>
+                <use href="#icon-breadcrumb"></use>
             </svg>
         </li>
         <li>
@@ -95,13 +95,13 @@
         <li>
             <a href="https://www.ebay.com/">ebay</a>
             <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-breadcrumb"></use>
+                <use href="#icon-breadcrumb"></use>
             </svg>
         </li>
         <li>
             <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
             <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                <use xlink:href="#icon-breadcrumb"></use>
+                <use href="#icon-breadcrumb"></use>
             </svg>
         </li>
         <li>
@@ -111,50 +111,121 @@
 </nav>
     {% endhighlight %}
 
-    <p>Long breadcrumbs can arise due to any combination of small screen sizes, large category names and language translations. In these situations the breadcrumbs region is horizontally scrollable.</p>
-    <div class="demo">
-        <div class="demo__inner">
-            <nav aria-labelledby="breadcrumbs-heading-3" class="breadcrumbs" role="navigation">
-                <h2 id="breadcrumbs-heading-3" class="clipped">You are here</h2>
-                <ul>
-                    <li>
-                        <a href="https://www.ebay.com/">ebay</a>
-                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include symbol.html name="breadcrumb" %}
-                        </svg>
-                    </li>
-                    <li>
-                        <a href="https://www.ebay.com/b/Business-Industrial/12576/bn_1853744">Business & Industrial</a>
-                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include symbol.html name="breadcrumb" %}
-                        </svg>
-                    </li>
-                    <li>
-                        <a href="https://www.ebay.com/b/CNC-Metalworking-Manufacturing/11804/bn_1861284">CNC, Metalworking & Manufacturing</a>
-                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include symbol.html name="breadcrumb" %}
-                        </svg>
-                    </li>
-                    <li>
-                        <a href="https://www.ebay.com/b/Semiconductor-PCB-Manufacturing-Equipment/58290/bn_2310616">Semiconductor & PCB Manufacturing Equipment</a>
-                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include symbol.html name="breadcrumb" %}
-                        </svg>
-                    </li>
-                    <li>
-                        <a href="https://www.ebay.com/b/Semiconductor-Test-Assembly-Equipment/258284/bn_7115875865">Semiconductor Test & Assembly Equipment</a>
-                        <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
-                            {% include symbol.html name="breadcrumb" %}
-                        </svg>
-                    </li>
-                    <li>
-                        <a aria-current="location">Other Semiconductor Test & Assembly Equipment & Components</a>
-                    </li>
-                </ul>
-            </nav>
-        </div>
-    </div>
-
     <p>Anchor tags can be replaced with buttons if the hierarchy is not intended to be <a href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks">deep linkable</a>. This is a rare &amp; unlikely scenario - therefore please exercise caution!</p>
+
+    <h3>Long Breadcrumbs with Overflows</h3>
+
+    <p>Long breadcrumbs can arise due to any combination of small screen sizes, large category names and language translations. In these situations the breadcrumbs will need to get an overflow treatment in the second node with an overflow button and menu items.</p>
+
+    <p>If there are 4 or more nodes for breadcrumbs, an overflow on node 2 should be used instead of various additional nodes between that node and the final one. The list of items in the overflow menu should include content from node 2 until last node minur 2 nodes so that there are always 4 nodes on screen including the overflow button node.</p>
+
+    <nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+        <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+        <ul>
+            <li>
+                <a href="https://www.ebay.com/">ebay</a>
+                <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                    {% include symbol.html name="breadcrumb" %}
+                </svg>
+            </li>
+            <li>
+                <span class="menu-button">
+                    <button class="menu-button__button icon-btn" aria-expanded="false" aria-haspopup="true" aria-label="eBay Menu"  type="button">
+                        <svg aria-hidden="true" class="icon icon--overflow-small" focusable="false">
+                            {% include symbol.html name="overflow-small" %}
+                        </svg>
+                    </button>
+    
+                    <span tabindex="-1" class="menu-button__menu">
+                        <div role="menu" class="menu-button__items">
+                            <div class="menu-button__item" role="menuitem" tabindex="-1">
+                                <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
+                            </div>
+                            <div class="menu-button__item" role="menuitem" tabindex="-1">
+                                <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+                            </div>
+                            <div class="menu-button__item" role="menuitem" tabindex="-1">
+                                <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</a>
+                            </div>
+                        </div>
+                    </span>
+                </span>
+    
+                <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                    <use href="#icon-breadcrumb"></use>
+                </svg>
+            </li>
+            <li>
+                <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand1">Smart Watch Band Type 1</a>
+                <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                    {% include symbol.html name="breadcrumb" %}
+                </svg>
+            </li>
+            <li>
+                <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand2">Smart Watch Band Type 2</a>
+                <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                    {% include symbol.html name="breadcrumb" %}
+                </svg>
+            </li>
+            <li>
+                <a aria-current="location">Current Band</a>
+            </li>
+        </ul>
+    </nav>
+    {% highlight html %}
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+    <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+    <ul>
+        <li>
+            <a href="https://www.ebay.com/">ebay</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <span class="menu-button">
+                <button class="menu-button__button icon-btn" aria-expanded="false" aria-haspopup="true" aria-label="eBay Menu"  type="button">
+                    <svg aria-hidden="true" class="icon icon--overflow-small" focusable="false">
+                        <use href="#icon-overflow-small"></use>
+                    </svg>
+                </button>
+
+                <span tabindex="-1" class="menu-button__menu">
+                    <div role="menu" class="menu-button__items">
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</a>
+                        </div>
+                    </div>
+                </span>
+            </span>
+
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand1">Smart Watch Band Type 1</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand2">Smart Watch Band Type 2</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a aria-current="location">Current Band</a>
+        </li>
+    </ul>
+</nav>
+    {% endhighlight %}
 
 </div>

--- a/docs/_includes/breadcrumbs.html
+++ b/docs/_includes/breadcrumbs.html
@@ -119,7 +119,7 @@
 
     <p>If there are 4 or more nodes for breadcrumbs, an overflow on node 2 should be used instead of various additional nodes between that node and the final one. The list of items in the overflow menu should include content from node 2 until last node minur 2 nodes so that there are always 4 nodes on screen including the overflow button node.</p>
 
-    <nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+    <nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs breadcrumb--overflow" role="navigation">
         <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
         <ul>
             <li>
@@ -173,7 +173,7 @@
         </ul>
     </nav>
     {% highlight html %}
-<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs breadcrumb--overflow" role="navigation">
     <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
     <ul>
         <li>

--- a/src/less/breadcrumbs/breadcrumbs.less
+++ b/src/less/breadcrumbs/breadcrumbs.less
@@ -7,9 +7,7 @@ nav.breadcrumbs {
     height: fit-content;
     margin: 8px 0;
     min-height: 16px;
-    overflow-x: scroll;
     padding: 8px;
-    scrollbar-width: none;
     white-space: nowrap;
 
     ul {
@@ -25,6 +23,7 @@ nav.breadcrumbs {
     li {
         align-items: center;
         display: inline-flex;
+        vertical-align: middle;
     }
 
     li svg {
@@ -72,8 +71,25 @@ nav.breadcrumbs {
     }
 }
 
-nav.breadcrumbs::-webkit-scrollbar {
-    display: none;
+nav.breadcrumbs .menu-button__button {
+    background-color: var(--icon-button-background-color, var(--color-background-secondary));
+    height: @spacing-250;
+    min-height: @spacing-250;
+    min-width: @spacing-250;
+    outline-offset: 1px;
+    width: @spacing-250;
+}
+
+nav.breadcrumbs .menu-button__menu {
+    font-size: @font-size-14;
+}
+
+nav.breadcrumbs svg.icon--overflow-small {
+    transform: rotate(90deg);
+}
+
+nav.breadcrumbs div.menu-button__item[role^="menuitem"] {
+    display: block;
 }
 
 @media (min-width: 601px) {

--- a/src/less/breadcrumbs/breadcrumbs.less
+++ b/src/less/breadcrumbs/breadcrumbs.less
@@ -7,7 +7,9 @@ nav.breadcrumbs {
     height: fit-content;
     margin: 8px 0;
     min-height: 16px;
+    overflow-x: scroll; // Deprecated in 15.2.0; kept it in to support deprecated implementations; @TODO remove in 16.0.0
     padding: 8px;
+    scrollbar-width: none; // Deprecated in 15.2.0; kept it in to support deprecated implementations; @TODO remove in 16.0.0
     white-space: nowrap;
 
     ul {
@@ -69,6 +71,17 @@ nav.breadcrumbs {
     button:focus:not(:focus-visible) {
         outline: none;
     }
+
+    // Deprecated in 15.2.0; kept it in to support deprecated implementations; @TODO remove in 16.0.0
+    nav.breadcrumbs::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+// Introduced modifier in 15.2.0; supports new implementations; @TODO remove in 16.0.0 and remove modifier class from markup
+nav.breadcrumbs.breadcrumb--overflow {
+    overflow-x: unset;
+    scrollbar-width: unset;
 }
 
 nav.breadcrumbs .menu-button__button {

--- a/src/less/breadcrumbs/breadcrumbs.less
+++ b/src/less/breadcrumbs/breadcrumbs.less
@@ -2,7 +2,7 @@
 @import "../mixins/private/token-mixins.less";
 
 nav.breadcrumbs {
-    .color-token(breadcrumbs-item-foreground-color, color-foreground-primary);
+    .color-token(breadcrumbs-item-foreground-color, color-foreground-secondary);
     font-size: @font-size-12;
     height: fit-content;
     margin: 8px 0;
@@ -56,7 +56,7 @@ nav.breadcrumbs {
         }
 
         &[aria-current] {
-            .color-token(breadcrumbs-item-current-foreground-color, color-foreground-secondary);
+            .color-token(breadcrumbs-item-current-foreground-color, color-foreground-primary);
             text-decoration: none;
         }
     }

--- a/src/less/breadcrumbs/stories/button-overflow.stories.js
+++ b/src/less/breadcrumbs/stories/button-overflow.stories.js
@@ -1,0 +1,113 @@
+export default { title: 'Breadcrumbs/Buttons/Overflow' };
+
+export const collapsed = () => `
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+    <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+    <ul>
+        <li>
+            <button>ebay</button>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <span class="menu-button">
+                <button class="menu-button__button icon-btn" aria-expanded="false" aria-haspopup="true" aria-label="eBay Menu"  type="button">
+                    <svg aria-hidden="true" class="icon icon--overflow-small" focusable="false">
+                        <use href="#icon-overflow-small"></use>
+                    </svg>
+                </button>
+
+                <span tabindex="-1" class="menu-button__menu">
+                    <div role="menu" class="menu-button__items">
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="#">Smart Watch Bands</a>
+                        </div>
+                    </div>
+                </span>
+            </span>
+
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <button>Smart Watch Band Type 1</button>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <button>Smart Watch Band Type 2</button>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <button aria-current="location">Current Band</button>
+        </li>
+    </ul>
+</nav>
+`;
+
+export const expanded = () => `
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+    <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+    <ul>
+        <li>
+            <button>ebay</button>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <span class="menu-button">
+                <button class="menu-button__button icon-btn" aria-expanded="true" aria-haspopup="true" aria-label="eBay Menu"  type="button">
+                    <svg aria-hidden="true" class="icon icon--overflow-small" focusable="false">
+                        <use href="#icon-overflow-small"></use>
+                    </svg>
+                </button>
+
+                <span tabindex="-1" class="menu-button__menu">
+                    <div role="menu" class="menu-button__items">
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="#">Cell Phones, Smart Watches &amp; Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="#">Smart Watch Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="#">Smart Watch Bands</a>
+                        </div>
+                    </div>
+                </span>
+            </span>
+
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <button>Smart Watch Band Type 1</button>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <button>Smart Watch Band Type 2</button>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <button aria-current="location">Current Band</button>
+        </li>
+    </ul>
+</nav>
+`;

--- a/src/less/breadcrumbs/stories/button-overflow.stories.js
+++ b/src/less/breadcrumbs/stories/button-overflow.stories.js
@@ -1,7 +1,7 @@
 export default { title: 'Breadcrumbs/Buttons/Overflow' };
 
 export const collapsed = () => `
-<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs breadcrumb--overflow" role="navigation">
     <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
     <ul>
         <li>
@@ -57,7 +57,7 @@ export const collapsed = () => `
 `;
 
 export const expanded = () => `
-<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs breadcrumb--overflow" role="navigation">
     <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
     <ul>
         <li>

--- a/src/less/breadcrumbs/stories/link-overflow.stories.js
+++ b/src/less/breadcrumbs/stories/link-overflow.stories.js
@@ -1,0 +1,113 @@
+export default { title: 'Breadcrumbs/Links/Overflow' };
+
+export const collapsed = () => `
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+    <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+    <ul>
+        <li>
+            <a href="https://www.ebay.com/">ebay</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <span class="menu-button">
+                <button class="menu-button__button icon-btn" aria-expanded="false" aria-haspopup="true" aria-label="eBay Menu"  type="button">
+                    <svg aria-hidden="true" class="icon icon--overflow-small" focusable="false">
+                        <use href="#icon-overflow-small"></use>
+                    </svg>
+                </button>
+
+                <span tabindex="-1" class="menu-button__menu">
+                    <div role="menu" class="menu-button__items">
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</a>
+                        </div>
+                    </div>
+                </span>
+            </span>
+
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand1">Smart Watch Band Type 1</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand2">Smart Watch Band Type 2</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a aria-current="location">Current Band</a>
+        </li>
+    </ul>
+</nav>
+`;
+
+export const expanded = () => `
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+    <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
+    <ul>
+        <li>
+            <a href="https://www.ebay.com/">ebay</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <span class="menu-button">
+                <button class="menu-button__button icon-btn" aria-expanded="true" aria-haspopup="true" aria-label="eBay Menu"  type="button">
+                    <svg aria-hidden="true" class="icon icon--overflow-small" focusable="false">
+                        <use href="#icon-overflow-small"></use>
+                    </svg>
+                </button>
+
+                <span tabindex="-1" class="menu-button__menu">
+                    <div role="menu" class="menu-button__items">
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/rpp/cell-phone-pda">Cell Phones, Smart Watches &amp; Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/b/Smart-Watch-Accessories/182064/bn_16565905">Smart Watch Accessories</a>
+                        </div>
+                        <div class="menu-button__item" role="menuitem" tabindex="-1">
+                            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906">Smart Watch Bands</a>
+                        </div>
+                    </div>
+                </span>
+            </span>
+
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand1">Smart Watch Band Type 1</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a href="https://www.ebay.com/b/Smart-Watch-Bands/182068/bn_16565906/Some-Random-Watch-Pand2">Smart Watch Band Type 2</a>
+            <svg class="icon icon--breadcrumb" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-breadcrumb"></use>
+            </svg>
+        </li>
+        <li>
+            <a aria-current="location">Current Band</a>
+        </li>
+    </ul>
+</nav>
+`;

--- a/src/less/breadcrumbs/stories/link-overflow.stories.js
+++ b/src/less/breadcrumbs/stories/link-overflow.stories.js
@@ -1,7 +1,7 @@
 export default { title: 'Breadcrumbs/Links/Overflow' };
 
 export const collapsed = () => `
-<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs breadcrumb--overflow" role="navigation">
     <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
     <ul>
         <li>
@@ -57,7 +57,7 @@ export const collapsed = () => `
 `;
 
 export const expanded = () => `
-<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs" role="navigation">
+<nav aria-labelledby="breadcrumbs-heading" class="breadcrumbs breadcrumb--overflow" role="navigation">
     <h2 id="breadcrumbs-heading" class="clipped">You are here</h2>
     <ul>
         <li>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1896 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Updated breadcrumbs...
1. Added overflow menu based on rules specified in Playbook
2. Removed the scroll-based longer breadcrumbs in lieu of the overflow
3. Changed breadcrumb colors per new specs

## Notes
Things not completed in this PR:
1. The overflow called for a menu box with a shadow, but since the shadow is part of menu button, we will be completing that in a future issue for proper feature scoping.

## Screenshots
Before:
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/1675667/199559587-336da426-e680-44cc-8dbb-f5b7603f8c71.png">

After:
<img width="541" alt="image" src="https://user-images.githubusercontent.com/1675667/199559679-f289328a-77f6-461d-9e04-daf16f49ce84.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
