### PR TITLE
feat(icon-button): add size modifiers

### DIFF
--- a/dist/icon-button/icon-button.css
+++ b/dist/icon-button/icon-button.css
@@ -14,7 +14,6 @@ a.icon-link {
   font-family: inherit;
   height: 40px;
   margin: 0;
-  min-width: 40px;
   padding: 0;
   vertical-align: text-bottom;
   width: 40px;
@@ -22,7 +21,7 @@ a.icon-link {
 button.icon-btn > svg,
 a.icon-link > svg {
   fill: var(--icon-button-icon-foreground-color, var(--color-foreground-primary));
-  max-width: 100%;
+  max-width: 75%;
   position: relative;
 }
 button.icon-btn:focus,
@@ -38,6 +37,16 @@ a.icon-link:active {
 button.icon-btn:not(:focus-visible),
 a.icon-link:not(:focus-visible) {
   outline: none;
+}
+button.icon-btn.icon-btn--small,
+a.icon-link.icon-link--small {
+  height: 32px;
+  width: 32px;
+}
+button.icon-btn.icon-btn--large,
+a.icon-link.icon-link--large {
+  height: 48px;
+  width: 48px;
 }
 button.icon-btn--transparent,
 a.icon-link--transparent {

--- a/docs/_includes/icon-button.html
+++ b/docs/_includes/icon-button.html
@@ -31,6 +31,44 @@
 </a>
     {% endhighlight %}
 
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="icon-btn icon-btn--large" type="button" aria-label="Save">
+                <svg class="icon icon--save" focusable="false" width="16" height="16" aria-hidden="true">
+                    {% include symbol.html name="save" %}
+                </svg>
+            </button>
+            <button class="icon-btn" type="button" aria-label="Save">
+                <svg class="icon icon--save" focusable="false" width="16" height="16" aria-hidden="true">
+                    {% include symbol.html name="save" %}
+                </svg>
+            </button>
+            <button class="icon-btn icon-btn--small" type="button" aria-label="Save">
+                <svg class="icon icon--save" focusable="false" width="16" height="16" aria-hidden="true">
+                    {% include symbol.html name="save" %}
+                </svg>
+            </button>
+        </div>
+    </div>
+
+    {% highlight html %}
+<button class="icon-btn icon-btn--large" type="button" aria-label="Save">
+    <svg class="icon icon--save" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="icons.svg#icon-save"></use>
+    </svg>
+</button>
+<button class="icon-btn" type="button" aria-label="Save">
+    <svg class="icon icon--save" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="icons.svg#icon-save"></use>
+    </svg>
+</button>
+<button class="icon-btn icon-btn--small" type="button" aria-label="Save">
+    <svg class="icon icon--save" focusable="false" width="16" height="16" aria-hidden="true">
+        <use xlink:href="icons.svg#icon-save"></use>
+    </svg>
+</button>
+    {% endhighlight %}
+
     <p>To remove the background colour and hover states, apply the <span class="highlight">icon-btn--transparent</span> modifier. This is typically needed if the icon button is placed on a non-default background colour or if the icon has a colour fill (as in the case below).</p>
 
     <div class="demo">

--- a/src/less/icon-button/icon-button.less
+++ b/src/less/icon-button/icon-button.less
@@ -19,7 +19,6 @@ a.icon-link {
     font-family: inherit;
     height: 40px;
     margin: 0;
-    min-width: 40px;
     padding: 0;
     vertical-align: text-bottom;
     width: 40px;
@@ -27,7 +26,7 @@ a.icon-link {
     > svg {
         .fill-token(icon-button-icon-foreground-color, color-foreground-primary);
 
-        max-width: 100%; // helps when width & height HTML attrs not set
+        max-width: 75%;
         position: relative; // Safari centering
     }
 
@@ -43,6 +42,18 @@ a.icon-link {
     &:not(:focus-visible) {
         outline: none;
     }
+}
+
+button.icon-btn.icon-btn--small,
+a.icon-link.icon-link--small {
+    height: 32px;
+    width: 32px;
+}
+
+button.icon-btn.icon-btn--large,
+a.icon-link.icon-link--large {
+    height: 48px;
+    width: 48px;
 }
 
 button.icon-btn--transparent,


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
- Fixes #1884 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Add size modifiers to icon button and icon link

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
- SUBJECTIVE CHANGE: Icons typically filled most of the button when a small modifier was applied, so I reduced `max-width` from `100%` to `75%`. Other values may be better (i.e. if we want to be mathematically precise and fill the circle with square icons it should be `70.71%`)

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="160" alt="image" src="https://user-images.githubusercontent.com/26027232/200909545-75f55cc4-3775-4200-88d1-d1e212dcb30c.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
