### PR TITLE
feat(panel-dialog): added scolling to panel body only

### DIFF
--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -37,10 +37,6 @@
   flex-shrink: 0;
   margin: 16px 16px 0;
   position: relative;
-  height: 32px;
-  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
-  position: fixed;
-  width: calc(100% - 32px);
 }
 .panel-dialog__header h1,
 .panel-dialog__header h2,
@@ -68,7 +64,6 @@
   margin: 16px;
   position: relative;
   height: 1px;
-  margin-top: 64px;
   overflow-y: auto;
 }
 .panel-dialog__main > :first-child {

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -10,6 +10,8 @@
   will-change: background-color;
   z-index: 100000;
   flex-direction: column;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  overflow-y: hidden;
 }
 .panel-dialog[role="dialog"]:not([hidden]) {
   display: flex;
@@ -35,6 +37,10 @@
   flex-shrink: 0;
   margin: 16px 16px 0;
   position: relative;
+  height: 32px;
+  /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+  position: fixed;
+  width: calc(100% - 32px);
 }
 .panel-dialog__header h1,
 .panel-dialog__header h2,
@@ -61,6 +67,9 @@
   flex: 1 1 auto;
   margin: 16px;
   position: relative;
+  height: 1px;
+  margin-top: 64px;
+  overflow-y: auto;
 }
 .panel-dialog__main > :first-child {
   margin-top: 0;

--- a/src/less/panel-dialog/panel-dialog.less
+++ b/src/less/panel-dialog/panel-dialog.less
@@ -27,12 +27,6 @@
 
 .panel-dialog__header {
     .dialog-header-content();
-
-    height: 32px;
-    // need to override base as panel dialog is the only one to scroll the content only
-    /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
-    position: fixed;
-    width: calc(100% - 32px);
 }
 
 .panel-dialog__header .fake-link {
@@ -44,7 +38,6 @@
     .dialog-body-content();
 
     height: 1px;
-    margin-top: 64px;
     overflow-y: auto;
 }
 

--- a/src/less/panel-dialog/panel-dialog.less
+++ b/src/less/panel-dialog/panel-dialog.less
@@ -4,8 +4,11 @@
 
 .panel-dialog[role="dialog"] {
     .dialog-base();
-
     flex-direction: column;
+
+    // need to override base as panel dialog is the only one to scroll the content only
+    /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+    overflow-y: hidden;
 }
 
 .panel-dialog__window {
@@ -24,6 +27,12 @@
 
 .panel-dialog__header {
     .dialog-header-content();
+
+    height: 32px;
+    // need to override base as panel dialog is the only one to scroll the content only
+    /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
+    position: fixed;
+    width: calc(100% - 32px);
 }
 
 .panel-dialog__header .fake-link {
@@ -33,6 +42,10 @@
 
 .panel-dialog__main {
     .dialog-body-content();
+
+    height: 1px;
+    margin-top: 64px;
+    overflow-y: auto;
 }
 
 .panel-dialog__footer {

--- a/src/less/panel-dialog/stories/panel-dialog.stories.js
+++ b/src/less/panel-dialog/stories/panel-dialog.stories.js
@@ -116,3 +116,89 @@ export const panelEndSecondaryButton = () => `
     </div>
 </div>
 `;
+
+export const panelScroll = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window">
+        <div class="panel-dialog__header">
+            <h2 id="panel-title">Scrolling Panel</h2>
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="panel-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;
+
+export const panelScrollWithFooter = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window">
+        <div class="panel-dialog__header">
+            <h2 id="panel-title">Right Panel</h2>
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-small" aria-hidden="true">
+                    <use xlink:href="#icon-close-small"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="panel-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+        <div class="panel-dialog__footer">
+            <button class="btn btn--primary">Submit</button>
+            <button class="btn">Cancel</button>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/panel-dialog/stories/panel-dialog.stories.js
+++ b/src/less/panel-dialog/stories/panel-dialog.stories.js
@@ -162,7 +162,7 @@ export const panelScrollWithFooter = () => `
 <div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
     <div class="panel-dialog__window">
         <div class="panel-dialog__header">
-            <h2 id="panel-title">Right Panel</h2>
+            <h2 id="panel-title">Scrolling Panel with Footer</h2>
             <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close-small" aria-hidden="true">
                     <use xlink:href="#icon-close-small"></use>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1905 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Per spec, the panel dialog gets an enhancement in scrolling from the entire contents of the dialog to only the body, leaving the header and footer fixed.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
Before:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/1675667/201159846-31854f27-af1d-43e9-bc67-2951d33e1bd1.png">

After:
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1675667/201159922-0300a740-483b-405a-871f-89fc71fb1827.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
