### PR TITLE
fix(snackbar-dialog): action link colors

### DIFF
--- a/dist/snackbar-dialog/snackbar-dialog.css
+++ b/dist/snackbar-dialog/snackbar-dialog.css
@@ -49,9 +49,14 @@
   margin-top: 16px;
 }
 .snackbar-dialog__actions .fake-link {
+  color: var(--snackbar-dialog-foreground-color, var(--color-foreground-on-inverse));
   text-decoration: none;
 }
 .snackbar-dialog__actions .fake-link::first-letter {
+  text-decoration: underline;
+}
+.snackbar-dialog__actions button.fake-link:hover:not(:disabled) {
+  color: var(--snackbar-dialog-foreground-color, var(--color-foreground-on-inverse));
   text-decoration: underline;
 }
 @media (min-width: 601px) {

--- a/src/less/snackbar-dialog/snackbar-dialog.less
+++ b/src/less/snackbar-dialog/snackbar-dialog.less
@@ -65,11 +65,18 @@
 }
 
 .snackbar-dialog__actions .fake-link {
+    .color-token(snackbar-dialog-foreground-color, color-foreground-on-inverse);
     text-decoration: none;
 
     &::first-letter {
         text-decoration: underline;
     }
+}
+
+// this needs to be super specific to override base fake-link
+.snackbar-dialog__actions button.fake-link:hover:not(:disabled) {
+    .color-token(snackbar-dialog-foreground-color, color-foreground-on-inverse);
+    text-decoration: underline;
 }
 
 @media (min-width: 601px) {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1924 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixes the action link styling.

## Notes
Hover states have not been defined yet for these but the lack of hover indication feels a bit broken so I added a full underline on hover just to create differentiation for now. Once the hover color has been defined we can adjust these.

## Screenshots
Before:
<img width="456" alt="image" src="https://user-images.githubusercontent.com/1675667/201184455-aff74c62-6404-4608-b811-c658cda79ab1.png">

After:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/1675667/201184537-de0b5b74-7494-4ce9-a8dd-c165432eb950.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
