### PR TITLE
fix(cta-button): added border radius for large dimensions

### DIFF
--- a/dist/cta-button/cta-button.css
+++ b/dist/cta-button/cta-button.css
@@ -90,16 +90,24 @@ span.cta-btn__cell--fixed-height svg.icon {
   overflow: visible;
   width: 1rem;
 }
+a.cta-btn--truncated,
+a.cta-btn--truncated span {
+  line-height: 1.4em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 a.cta-btn--large {
-  border-radius: calc(48px / 2);
+  border-radius: 24px;
+  display: inline-flex;
   font-size: 1rem;
   min-height: 48px;
-  padding: 13px 20px;
 }
 a.cta-btn--large-truncated {
+  border-radius: 24px;
+  display: inline-flex;
   font-size: 1rem;
   height: 48px;
-  padding: 13px 20px;
 }
 a.cta-btn--large-truncated,
 a.cta-btn--large-truncated span {
@@ -109,7 +117,8 @@ a.cta-btn--large-truncated span {
   white-space: nowrap;
 }
 a.cta-btn--large-fixed-height {
+  border-radius: 24px;
+  display: inline-flex;
   font-size: 1rem;
   height: 48px;
-  padding: 13px 20px;
 }

--- a/src/less/cta-button/cta-button.less
+++ b/src/less/cta-button/cta-button.less
@@ -58,23 +58,30 @@ span.cta-btn__cell--fixed-height svg.icon {
     width: 1rem;
 }
 
+a.cta-btn--truncated {
+    .btn-truncate();
+}
+
 a.cta-btn--large {
-    border-radius: calc(@button-height-large / 2);
+    border-radius: @button-border-radius-large;
+    display: inline-flex;
     font-size: @font-size-16;
     min-height: @button-height-large;
-    padding: @button-padding-vertical-large @button-padding-horizontal;
 }
 
+// DEPRECATED remove cta-btn--large-truncated in next major version
 a.cta-btn--large-truncated {
     .btn-truncate();
-
+    border-radius: @button-border-radius-large;
+    display: inline-flex;
     font-size: @font-size-16;
     height: @button-height-large;
-    padding: @button-padding-vertical-large @button-padding-horizontal;
 }
 
+// DEPRECATED remove cta-btn--large-fixed-height in next major version
 a.cta-btn--large-fixed-height {
+    border-radius: @button-border-radius-large;
+    display: inline-flex;
     font-size: @font-size-16;
     height: @button-height-large;
-    padding: @button-padding-vertical-large @button-padding-horizontal;
 }

--- a/src/less/cta-button/stories/dimensions.stories.js
+++ b/src/less/cta-button/stories/dimensions.stories.js
@@ -11,21 +11,10 @@ export const large = () => `
 </a>
 `;
 
-export const largeTruncated = () => `
-<a class="cta-btn cta-btn--large-truncated" href="http://www.ebay.com">
+export const largeFixedWidthTruncated = () => `
+<a style="width: 200px;" class="cta-btn cta-btn--large cta-btn--truncated" href="http://www.ebay.com">
     <span class="cta-btn__cell">
-        <span>Link</span>
-        <svg class="icon icon--cta" focusable="false" height="8" width="8" aria-hidden="true">
-            <use xlink:href="#icon-cta"></use>
-        </svg>
-    </span>
-</a>
-`;
-
-export const largeFixedHeight = () => `
-<a class="cta-btn cta-btn--large-fixed-height" href="http://www.ebay.com">
-    <span class="cta-btn__cell">
-        <span>Link</span>
+        <span>Link with a lot of text that should wrap</span>
         <svg class="icon icon--cta" focusable="false" height="8" width="8" aria-hidden="true">
             <use xlink:href="#icon-cta"></use>
         </svg>

--- a/src/less/mixins/private/button-mixins.less
+++ b/src/less/mixins/private/button-mixins.less
@@ -4,6 +4,7 @@
 @button-padding-horizontal: 20px;
 @button-padding-vertical-large: 13px;
 @button-padding-horizontal-large: 20px;
+@button-border-radius-large: 24px;
 
 .btn-base() {
     border: 1px solid;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes visual regression issues. Part of #1890 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Added missing `border-radius` for large and truncated use cases
- Also added a new class(`cta-btn--truncated`) to apply truncation on the button

## Notes
- `cta-btn--large-truncated` and `cta-btn--large-fixed-height`  can be deprecated as `cta-btn--truncated` can be used instead

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/6342519/201417784-e440ecaa-f7b6-469e-8d09-30dda62ae311.png">
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/6342519/201417842-86ac51f9-767c-41f2-89f9-3e882c8450d7.png">



## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
