### PR TITLE
fix(fake-link): remove color change on hover

### DIFF
--- a/dist/link/link.css
+++ b/dist/link/link.css
@@ -24,6 +24,3 @@ button.fake-link {
 button.fake-link[disabled] {
   color: var(--fake-link-foreground-disabled-color, var(--color-foreground-disabled));
 }
-button.fake-link:hover:not(:disabled) {
-  color: var(--color-state-accent-hover);
-}

--- a/src/less/link/link.less
+++ b/src/less/link/link.less
@@ -29,8 +29,4 @@ button.fake-link {
     &[disabled] {
         .color-token(fake-link-foreground-disabled-color, color-foreground-disabled);
     }
-
-    &:hover:not(:disabled) {
-        color: var(--color-state-accent-hover);
-    }
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
- Addresses #1934

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Remove color change on hover -- this may be an accessiblity affordance since there also aren't any style changes on active, I'd like to know your thoughts on this @ianmcburnie 

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
