### PR TITLE
fix(breadcrumbs): color and icon fixes

### DIFF
--- a/dist/breadcrumbs/breadcrumbs.css
+++ b/dist/breadcrumbs/breadcrumbs.css
@@ -52,16 +52,12 @@ nav.breadcrumbs > ul > li > a:focus,
 nav.breadcrumbs > ul > li > button:focus,
 nav.breadcrumbs > ul > li > a:hover,
 nav.breadcrumbs > ul > li > button:hover {
-  color: var(--breadcrumbs-item-hover-foreground-color, var(--color-foreground-accent));
   text-decoration: underline;
 }
 nav.breadcrumbs > ul > li > a[aria-current],
 nav.breadcrumbs > ul > li > button[aria-current] {
   color: var(--breadcrumbs-item-current-foreground-color, var(--color-foreground-primary));
   text-decoration: none;
-}
-nav.breadcrumbs > ul > li > a:visited {
-  color: inherit;
 }
 nav.breadcrumbs > ul > li > a:focus:not(:focus-visible),
 nav.breadcrumbs > ul > li > button:focus:not(:focus-visible) {
@@ -77,11 +73,15 @@ nav.breadcrumbs.breadcrumb--overflow {
 nav.breadcrumbs .fake-menu-button__button,
 nav.breadcrumbs .menu-button__button {
   background-color: var(--icon-button-background-color, var(--color-background-secondary));
-  height: 20px;
-  min-height: 20px;
-  min-width: 20px;
+  height: 24px;
+  min-height: 24px;
+  min-width: 24px;
   outline-offset: 1px;
-  width: 20px;
+  width: 24px;
+}
+nav.breadcrumbs .fake-menu-button__button svg.icon,
+nav.breadcrumbs .menu-button__button svg.icon {
+  fill: var(--breadcrumbs-overflow-foreground-color, var(--color-foreground-secondary));
 }
 nav.breadcrumbs .fake-menu-button__menu,
 nav.breadcrumbs .menu-button__menu {

--- a/src/less/breadcrumbs/breadcrumbs.less
+++ b/src/less/breadcrumbs/breadcrumbs.less
@@ -61,7 +61,6 @@ nav.breadcrumbs > ul > li > button {
 
     &:focus,
     &:hover {
-        .color-token(breadcrumbs-item-hover-foreground-color, color-foreground-accent);
         text-decoration: underline;
     }
 
@@ -69,10 +68,6 @@ nav.breadcrumbs > ul > li > button {
         .color-token(breadcrumbs-item-current-foreground-color, color-foreground-primary);
         text-decoration: none;
     }
-}
-
-nav.breadcrumbs > ul > li > a:visited {
-    color: inherit;
 }
 
 nav.breadcrumbs > ul > li > a:focus:not(:focus-visible),
@@ -94,11 +89,16 @@ nav.breadcrumbs.breadcrumb--overflow {
 nav.breadcrumbs .fake-menu-button__button,
 nav.breadcrumbs .menu-button__button {
     background-color: var(--icon-button-background-color, var(--color-background-secondary));
-    height: @spacing-250;
-    min-height: @spacing-250;
-    min-width: @spacing-250;
+    height: @spacing-300;
+    min-height: @spacing-300;
+    min-width: @spacing-300;
     outline-offset: 1px;
-    width: @spacing-250;
+    width: @spacing-300;
+}
+
+nav.breadcrumbs .fake-menu-button__button svg.icon,
+nav.breadcrumbs .menu-button__button svg.icon {
+    .fill-token(breadcrumbs-overflow-foreground-color, color-foreground-secondary);
 }
 
 nav.breadcrumbs .fake-menu-button__menu,


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1934 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixes breadcrumb style issues per design review feedback

## Screenshots
<img width="442" alt="image" src="https://user-images.githubusercontent.com/1675667/201432453-6252a560-396b-42c8-82e2-7152fde413bf.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
