### PR TITLE
fix(icon-button): Isolated icon resizing inside non-transparent buttons/links

### DIFF
--- a/dist/icon-button/icon-button.css
+++ b/dist/icon-button/icon-button.css
@@ -21,6 +21,7 @@ a.icon-link {
 button.icon-btn > svg,
 a.icon-link > svg {
   fill: var(--icon-button-icon-foreground-color, var(--color-foreground-primary));
+  max-width: 75%;
   position: relative;
 }
 button.icon-btn:focus,
@@ -37,9 +38,9 @@ button.icon-btn:not(:focus-visible),
 a.icon-link:not(:focus-visible) {
   outline: none;
 }
-button.icon-btn:not(.icon-btn--transparent) > svg,
-a.icon-link:not(.icon-link--transparent) > svg {
-  max-width: 75%;
+button.icon-btn.icon-btn--transparent > svg,
+a.icon-link.icon-link--transparent > svg {
+  max-width: 100%;
 }
 button.icon-btn.icon-btn--small,
 a.icon-link.icon-link--small {

--- a/dist/icon-button/icon-button.css
+++ b/dist/icon-button/icon-button.css
@@ -21,7 +21,6 @@ a.icon-link {
 button.icon-btn > svg,
 a.icon-link > svg {
   fill: var(--icon-button-icon-foreground-color, var(--color-foreground-primary));
-  max-width: 75%;
   position: relative;
 }
 button.icon-btn:focus,
@@ -37,6 +36,10 @@ a.icon-link:active {
 button.icon-btn:not(:focus-visible),
 a.icon-link:not(:focus-visible) {
   outline: none;
+}
+button.icon-btn:not(.icon-btn--transparent) > svg,
+a.icon-link:not(.icon-link--transparent) > svg {
+  max-width: 75%;
 }
 button.icon-btn.icon-btn--small,
 a.icon-link.icon-link--small {

--- a/src/less/icon-button/icon-button.less
+++ b/src/less/icon-button/icon-button.less
@@ -25,7 +25,7 @@ a.icon-link {
 
     > svg {
         .fill-token(icon-button-icon-foreground-color, color-foreground-primary);
-
+        max-width: 75%;
         position: relative; // Safari centering
     }
 
@@ -43,9 +43,9 @@ a.icon-link {
     }
 }
 
-button.icon-btn:not(.icon-btn--transparent) > svg,
-a.icon-link:not(.icon-link--transparent) > svg {
-    max-width: 75%;
+button.icon-btn.icon-btn--transparent > svg,
+a.icon-link.icon-link--transparent > svg {
+    max-width: 100%;
 }
 
 button.icon-btn.icon-btn--small,

--- a/src/less/icon-button/icon-button.less
+++ b/src/less/icon-button/icon-button.less
@@ -26,7 +26,6 @@ a.icon-link {
     > svg {
         .fill-token(icon-button-icon-foreground-color, color-foreground-primary);
 
-        max-width: 75%;
         position: relative; // Safari centering
     }
 
@@ -42,6 +41,11 @@ a.icon-link {
     &:not(:focus-visible) {
         outline: none;
     }
+}
+
+button.icon-btn:not(.icon-btn--transparent) > svg,
+a.icon-link:not(.icon-link--transparent) > svg {
+    max-width: 75%;
 }
 
 button.icon-btn.icon-btn--small,


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Isolates icon sizing to non-transparent buttons/links since icons in transparent buttons/links should encapsulate the entire button/link.

## Screenshots

This story included both versions of icon buttons making the difference very prevalent. Infotip icon is inside transparent button; the infotip close icon is inside non-transparent button.

Before:
<img width="561" alt="Screen Shot 2022-11-18 at 11 36 31 AM" src="https://user-images.githubusercontent.com/1675667/202789084-7291dd3f-8cbb-4ce8-aaba-c4280b043805.png">

After:
<img width="581" alt="Screen Shot 2022-11-18 at 11 37 25 AM" src="https://user-images.githubusercontent.com/1675667/202789112-0dadfda0-5a59-4d67-863b-1031cfb18a5b.png">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
