### PR TITLE
feat(links): removed hover state and visited from standalone link

### DIFF
--- a/dist/global/global.css
+++ b/dist/global/global.css
@@ -21,7 +21,8 @@ a:visited {
 a:hover {
   opacity: 0.7;
 }
-a[disabled] {
+a:not([href]),
+a[aria-disabled="true"] {
   color: var(--link-forground-color-disabled, var(--color-foreground-disabled));
   opacity: 1;
 }

--- a/dist/global/global.css
+++ b/dist/global/global.css
@@ -19,5 +19,9 @@ a:visited {
   color: var(--link-foreground-color-visited, var(--color-foreground-visited));
 }
 a:hover {
-  color: var(--link-foreground-color-visited, var(--color-foreground-visited));
+  opacity: 0.7;
+}
+a[disabled] {
+  color: var(--link-forground-color-disabled, var(--color-foreground-disabled));
+  opacity: 1;
 }

--- a/dist/link/link.css
+++ b/dist/link/link.css
@@ -12,6 +12,14 @@ a.nav-link:visited,
 a.standalone-link:visited {
   color: var(--link-foreground-color-default, var(--color-foreground-primary));
 }
+a.nav-link:not([href]),
+a.standalone-link:not([href]),
+a.nav-link[aria-disabled="true"],
+a.standalone-link[aria-disabled="true"] {
+  color: var(--link-forground-color-disabled, var(--color-foreground-disabled));
+  opacity: 1;
+  text-decoration: none;
+}
 button.fake-link {
   background-color: transparent;
   border: 0;
@@ -24,6 +32,7 @@ button.fake-link {
 button.fake-link:hover {
   opacity: 0.7;
 }
-button.fake-link[disabled] {
+button.fake-link:not([href]),
+button.fake-link[aria-disabled="true"] {
   color: var(--fake-link-foreground-disabled-color, var(--color-foreground-disabled));
 }

--- a/dist/link/link.css
+++ b/dist/link/link.css
@@ -3,14 +3,14 @@ a.standalone-link {
   color: var(--nav-link-foreground-color, var(--color-foreground-primary));
   text-decoration: none;
 }
-a.nav-link:visited,
-a.standalone-link:visited {
-  color: var(--nav-link-foreground-color, var(--color-foreground-primary));
-}
 a.nav-link:hover,
 a.standalone-link:hover {
-  color: var(--nav-link-foreground-color-hover, var(--color-foreground-primary));
+  opacity: 0.7;
   text-decoration: underline;
+}
+a.nav-link:visited,
+a.standalone-link:visited {
+  color: var(--link-foreground-color-default, var(--color-foreground-primary));
 }
 button.fake-link {
   background-color: transparent;
@@ -20,6 +20,9 @@ button.fake-link {
   font-size: inherit;
   padding: 0;
   text-decoration: underline;
+}
+button.fake-link:hover {
+  opacity: 0.7;
 }
 button.fake-link[disabled] {
   color: var(--fake-link-foreground-disabled-color, var(--color-foreground-disabled));

--- a/src/less/global/global.less
+++ b/src/less/global/global.less
@@ -26,6 +26,12 @@ a {
     }
 
     &:hover {
-        .color-token(link-foreground-color-visited, color-foreground-visited);
+        opacity: 0.7;
+    }
+
+    &[disabled] {
+        .color-token(link-forground-color-disabled, color-foreground-disabled);
+
+        opacity: 1;
     }
 }

--- a/src/less/global/global.less
+++ b/src/less/global/global.less
@@ -29,7 +29,8 @@ a {
         opacity: 0.7;
     }
 
-    &[disabled] {
+    &:not([href]),
+    &[aria-disabled="true"] {
         .color-token(link-forground-color-disabled, color-foreground-disabled);
 
         opacity: 1;

--- a/src/less/link/link.less
+++ b/src/less/link/link.less
@@ -10,8 +10,17 @@ a.standalone-link {
         opacity: 0.7;
         text-decoration: underline;
     }
+
     &:visited {
         .color-token(link-foreground-color-default, color-foreground-primary);
+    }
+
+    &:not([href]),
+    &[aria-disabled="true"] {
+        .color-token(link-forground-color-disabled, color-foreground-disabled);
+
+        opacity: 1;
+        text-decoration: none;
     }
 }
 
@@ -28,7 +37,8 @@ button.fake-link {
         opacity: 0.7;
     }
 
-    &[disabled] {
+    &:not([href]),
+    &[aria-disabled="true"] {
         .color-token(fake-link-foreground-disabled-color, color-foreground-disabled);
     }
 }

--- a/src/less/link/link.less
+++ b/src/less/link/link.less
@@ -6,14 +6,12 @@ a.standalone-link {
     .color-token(nav-link-foreground-color, color-foreground-primary);
     text-decoration: none;
 
-    &:visited {
-        .color-token(nav-link-foreground-color, color-foreground-primary);
-    }
-
     &:hover {
-        .color-token(nav-link-foreground-color-hover, color-foreground-primary);
-
+        opacity: 0.7;
         text-decoration: underline;
+    }
+    &:visited {
+        .color-token(link-foreground-color-default, color-foreground-primary);
     }
 }
 
@@ -25,6 +23,10 @@ button.fake-link {
     font-size: inherit;
     padding: 0;
     text-decoration: underline;
+
+    &:hover {
+        opacity: 0.7;
+    }
 
     &[disabled] {
         .color-token(fake-link-foreground-disabled-color, color-foreground-disabled);


### PR DESCRIPTION
Fixes #1950 


- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Removed purple hover color. Changed it to be opacity of 0.7
* Removed visited on standlone link
* Added disabled state

## Screenshots
<img width="148" alt="Screen Shot 2022-12-02 at 2 39 23 PM" src="https://user-images.githubusercontent.com/1755269/205401796-4fad39ea-4f10-40f6-88a7-7025e3620f4c.png">
### Hover
<img width="549" alt="Screen Shot 2022-12-02 at 2 39 49 PM" src="https://user-images.githubusercontent.com/1755269/205401797-9119cd99-35a8-44bf-8c6d-465100b4a9c9.png">
### No hover
<img width="521" alt="Screen Shot 2022-12-02 at 2 39 55 PM" src="https://user-images.githubusercontent.com/1755269/205401799-4e2dda4a-4d1d-43be-a075-489e5b706be3.png">
## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
