### PR TITLE
fix(link): changed hover to be foreground-secondary

### DIFF
--- a/dist/global/global.css
+++ b/dist/global/global.css
@@ -19,10 +19,9 @@ a:visited {
   color: var(--link-foreground-color-visited, var(--color-foreground-visited));
 }
 a:hover {
-  opacity: 0.7;
+  color: var(--link-foreground-color-hover, var(--color-foreground-secondary));
 }
 a:not([href]),
 a[aria-disabled="true"] {
   color: var(--link-forground-color-disabled, var(--color-foreground-disabled));
-  opacity: 1;
 }

--- a/dist/link/link.css
+++ b/dist/link/link.css
@@ -3,21 +3,20 @@ a.standalone-link {
   color: var(--nav-link-foreground-color, var(--color-foreground-primary));
   text-decoration: none;
 }
-a.nav-link:hover,
-a.standalone-link:hover {
-  opacity: 0.7;
-  text-decoration: underline;
-}
 a.nav-link:visited,
 a.standalone-link:visited {
   color: var(--link-foreground-color-default, var(--color-foreground-primary));
+}
+a.nav-link:hover,
+a.standalone-link:hover {
+  color: var(--nav-link-foreground-hover-color, var(--color-foreground-secondary));
+  text-decoration: underline;
 }
 a.nav-link:not([href]),
 a.standalone-link:not([href]),
 a.nav-link[aria-disabled="true"],
 a.standalone-link[aria-disabled="true"] {
   color: var(--link-forground-color-disabled, var(--color-foreground-disabled));
-  opacity: 1;
   text-decoration: none;
 }
 button.fake-link {
@@ -30,9 +29,9 @@ button.fake-link {
   text-decoration: underline;
 }
 button.fake-link:hover {
-  opacity: 0.7;
+  color: var(--fake-link-foreground-color-hover, var(--color-foreground-secondary));
 }
-button.fake-link:not([href]),
+button.fake-link[disabled],
 button.fake-link[aria-disabled="true"] {
   color: var(--fake-link-foreground-disabled-color, var(--color-foreground-disabled));
 }

--- a/src/less/global/global.less
+++ b/src/less/global/global.less
@@ -26,13 +26,11 @@ a {
     }
 
     &:hover {
-        opacity: 0.7;
+        .color-token(link-foreground-color-hover, color-foreground-secondary);
     }
 
     &:not([href]),
     &[aria-disabled="true"] {
         .color-token(link-forground-color-disabled, color-foreground-disabled);
-
-        opacity: 1;
     }
 }

--- a/src/less/link/link.less
+++ b/src/less/link/link.less
@@ -6,20 +6,20 @@ a.standalone-link {
     .color-token(nav-link-foreground-color, color-foreground-primary);
     text-decoration: none;
 
-    &:hover {
-        opacity: 0.7;
-        text-decoration: underline;
-    }
-
     &:visited {
         .color-token(link-foreground-color-default, color-foreground-primary);
+    }
+
+    &:hover {
+        .color-token(nav-link-foreground-hover-color, color-foreground-secondary);
+
+        text-decoration: underline;
     }
 
     &:not([href]),
     &[aria-disabled="true"] {
         .color-token(link-forground-color-disabled, color-foreground-disabled);
 
-        opacity: 1;
         text-decoration: none;
     }
 }
@@ -34,10 +34,10 @@ button.fake-link {
     text-decoration: underline;
 
     &:hover {
-        opacity: 0.7;
+        .color-token(fake-link-foreground-color-hover, color-foreground-secondary);
     }
 
-    &:not([href]),
+    &[disabled],
     &[aria-disabled="true"] {
         .color-token(fake-link-foreground-disabled-color, color-foreground-disabled);
     }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1952

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed links to be `color-foreground-secondary`. This was the recommended color by design for now to resolve this issue. The other hover ones will not work properly.

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
