### PR TITLE
fix(carousel): removed will-change and transform to allow fixed passthrough

### DIFF
--- a/dist/carousel/carousel.css
+++ b/dist/carousel/carousel.css
@@ -15,10 +15,8 @@
   margin: 0;
   padding: 0;
   position: relative;
-  transform: translate3d(0, 0, 0);
   transition: transform 0.45s ease-in-out;
   width: 100%;
-  will-change: transform;
 }
 .carousel__list > li {
   display: inline-block;

--- a/src/less/carousel/carousel.less
+++ b/src/less/carousel/carousel.less
@@ -118,10 +118,8 @@
         margin: 0;
         padding: 0;
         position: relative;
-        transform: translate3d(0, 0, 0); // Same as above, but for backward compatibility to (ie10).
         transition: transform @ebay-carousel-transition-time @ebay-carousel-transition-function;
         width: 100%;
-        will-change: transform; // Ensures that the list is on a new layer for better scrolling perf.
 
         > li {
             display: inline-block;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1961

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* There are two attributes preventing any fixed items from going outside of carousel, `will-change` and `transform`. Both do not seem like they are needed. Removing them makes carousel work as before. 

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
