### PR TITLE
fix(filter-menu-button): outline on safari

### DIFF
--- a/dist/filter-menu-button/filter-menu-button.css
+++ b/dist/filter-menu-button/filter-menu-button.css
@@ -115,6 +115,7 @@ button.filter-menu-button__button[aria-expanded="true"] + .filter-menu-button__m
   min-width: 100%;
   overflow-y: auto;
   position: relative;
+  transform: translateZ(0);
 }
 span.filter-menu-button__items {
   display: inline-block;
@@ -222,7 +223,9 @@ button.filter-menu-button__footer {
   border-top-style: solid;
   border-top-width: 1px;
   bottom: 0;
+  outline-offset: -10;
   padding: 16px;
+  transform: translateZ(0);
 }
 button.filter-menu-button__footer:hover {
   background-color: var(--color-state-primary-hover, color-state-primary-hover);

--- a/src/less/filter-menu-button/filter-menu-button.less
+++ b/src/less/filter-menu-button/filter-menu-button.less
@@ -112,6 +112,7 @@ button.filter-menu-button__button[aria-expanded="true"] + .filter-menu-button__m
     min-width: 100%;
     overflow-y: auto;
     position: relative;
+    transform: translateZ(0);
 }
 
 span.filter-menu-button__items {
@@ -210,7 +211,9 @@ button.filter-menu-button__footer {
     border-top-style: solid;
     border-top-width: 1px;
     bottom: 0;
+    outline-offset: -10;
     padding: 16px;
+    transform: translateZ(0);
 
     &:focus,
     &:hover {


### PR DESCRIPTION
Fixes #1967

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Fixed issue by adding a `transform: translateZ(0);`. What is happening is the parent element has overflow hidden. In safari, the child will have the outline cutoff and hidden because of that. If we pop the child element on higher z index (but using translate), it shows correctly. 

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
