### PR TITLE
fix(page notice, section-notice): text alignment

### DIFF
--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -19,7 +19,7 @@ span[role="region"].page-notice {
 .page-notice__title {
   font-size: 0.875rem;
   font-weight: normal;
-  margin: 4px 0 0;
+  margin: 1px 0 0;
 }
 /* legacy version with separate bold heading */
 .page-notice__title:not(:only-child) {
@@ -107,18 +107,17 @@ p.page-notice__cta {
 @media (min-width: 601px) {
   section.page-notice,
   div[role="region"].page-notice {
-    flex-wrap: nowrap;
     margin: 16px 0;
   }
   .page-notice__title {
-    margin-top: 2px;
+    margin-bottom: 2px;
   }
   p.page-notice__cta {
     grid-column: 4;
     grid-row: 1;
     justify-self: end;
     margin-bottom: 0;
-    margin-top: 0;
+    margin-top: 1px;
     padding-right: 16px;
   }
   .page-notice__footer {

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -48,6 +48,7 @@ span[role="region"].section-notice {
   grid-column: 1;
   grid-row: 1;
   height: 16px;
+  margin-top: 1px;
   padding-right: 16px;
 }
 .section-notice__main {
@@ -62,6 +63,7 @@ span[role="region"].section-notice {
   grid-column: 4;
   grid-row: 1;
   justify-self: end;
+  margin-top: 2px;
 }
 .section-notice__main p {
   font-size: 0.875rem;
@@ -82,7 +84,6 @@ p.section-notice__cta {
 @media (min-width: 601px) {
   section.section-notice,
   div[role="region"].section-notice {
-    flex-wrap: nowrap;
     margin: 16px 0;
   }
   p.section-notice__cta {
@@ -94,7 +95,6 @@ p.section-notice__cta {
     padding-right: 16px;
   }
   .section-notice__footer {
-    margin-top: 0;
     padding-left: 16px;
   }
 }

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -26,7 +26,7 @@ span[role="region"].page-notice {
 .page-notice__title {
     font-size: @font-size-regular;
     font-weight: normal;
-    margin: 4px 0 0;
+    margin: 1px 0 0;
 }
 
 /* legacy version with separate bold heading */
@@ -137,12 +137,11 @@ p.page-notice__cta {
 @media (min-width: 601px) {
     section.page-notice,
     div[role="region"].page-notice {
-        flex-wrap: nowrap;
         margin: @spacing-200 0;
     }
 
     .page-notice__title {
-        margin-top: 2px;
+        margin-bottom: 2px;
     }
 
     p.page-notice__cta {
@@ -150,7 +149,7 @@ p.page-notice__cta {
         grid-row: 1;
         justify-self: end;
         margin-bottom: 0;
-        margin-top: 0;
+        margin-top: 1px;
         padding-right: @spacing-200;
     }
 

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -64,6 +64,7 @@ span[role="region"].section-notice {
     grid-column: 1;
     grid-row: 1;
     height: @spacing-200;
+    margin-top: 1px;
     padding-right: @spacing-200;
 }
 
@@ -81,6 +82,7 @@ span[role="region"].section-notice {
     grid-column: 4;
     grid-row: 1;
     justify-self: end;
+    margin-top: 2px;
 }
 
 .section-notice__main p {
@@ -106,7 +108,6 @@ p.section-notice__cta {
 @media (min-width: 601px) {
     section.section-notice,
     div[role="region"].section-notice {
-        flex-wrap: nowrap;
         margin: @spacing-200 0;
     }
 
@@ -120,7 +121,6 @@ p.section-notice__cta {
     }
 
     .section-notice__footer {
-        margin-top: 0;
         padding-left: @spacing-200;
     }
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1945 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I made a few very minor spacing adjustments to `page-notice` and `section-notice` to make them look properly balanced according to design specs. 

## Notes
* Unless you inspect the screenshot images in an image editor, you may not notice the changes.
* I also removed some old flex styles that were no longer doing anything.

## Screenshots
Before:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/1675667/211675172-faef70a3-3967-4f83-b949-ffb5bd5b7b81.png">

After:
<img width="748" alt="image" src="https://user-images.githubusercontent.com/1675667/211675236-49d1e176-0658-4746-937f-2d74c1e1ea3e.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
