### PR TITLE
feat(listbox-button): added form variant

### DIFF
--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -57,13 +57,13 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
   top: 41px;
 }
 .listbox-button.listbox-button--form button {
-  background-color: var(--combobox-textbox-background-color, var(--color-background-secondary));
-  border-color: var(--combobox-textbox-border-color, var(--color-stroke-default));
+  background-color: var(--listbox-button-background-color, var(--color-background-secondary));
+  border-color: var(--listbox-button-border-color, var(--color-stroke-default));
 }
 .listbox-button.listbox-button--form button[disabled],
 .listbox-button.listbox-button--form button[aria-disabled="true"] {
-  border-color: var(--combobox-textbox-disabled-border-color, var(--color-background-disabled));
-  color: var(--combobox-textbox-disabled-foreground-color, var(--color-foreground-disabled));
+  border-color: var(--listbox-button-disabled-border-color, var(--color-background-disabled));
+  color: var(--listbox-button-disabled-foreground-color, var(--color-foreground-disabled));
 }
 .listbox-button .btn__label {
   color: var(--listbox-button-label-color, var(--color-foreground-secondary));

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -56,6 +56,15 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 .listbox-button button.btn--borderless[aria-expanded="true"] ~ .listbox-button__listbox {
   top: 41px;
 }
+.listbox-button.listbox-button--form button {
+  background-color: var(--combobox-textbox-background-color, var(--color-background-secondary));
+  border-color: var(--combobox-textbox-border-color, var(--color-stroke-default));
+}
+.listbox-button.listbox-button--form button[disabled],
+.listbox-button.listbox-button--form button[aria-disabled="true"] {
+  border-color: var(--combobox-textbox-disabled-border-color, var(--color-background-disabled));
+  color: var(--combobox-textbox-disabled-foreground-color, var(--color-foreground-disabled));
+}
 .listbox-button .btn__label {
   color: var(--listbox-button-label-color, var(--color-foreground-secondary));
   margin-right: 3px;

--- a/docs/_includes/listbox-button.html
+++ b/docs/_includes/listbox-button.html
@@ -438,4 +438,106 @@
 </span>
     {% endhighlight %}
 
+    <h3 id="listbox-button-borderless">Form Variant</h3>
+    <p>Apply the <span class="highlight">listbox-button--form</span> modifier to create a listbox button inside a form matching other form controls.</p>
+    <p>Additionally, to allow the component to send the value from a selected option in a form submission, there needs to be custom <span class="highlight">js</span> to populate the <span class="highlight">select.listbox__native</span> with the value upon selection. If using Skin outside of eBay UI, you will need to account for that independantly.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="listbox-button listbox-button--form" data-makeup-auto-select="false">
+                <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
+                    <span class="btn__cell">
+                        <span class="btn__label">Color: </span>
+                        <span class="btn__text">-</span>
+                        <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                            {% include symbol.html name="dropdown" %}
+                        </svg>
+                    </span>
+                </button>
+                <div class="listbox-button__listbox">
+                    <div class="listbox-button__options" role="listbox">
+                        <div class="listbox-button__option" role="option">
+                            <span class="listbox-button__value">Red</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-small" %}
+                            </svg>
+                        </div>
+                        <div class="listbox-button__option" role="option">
+                            <span class="listbox-button__value">Blue</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-small" %}
+                            </svg>
+                        </div>
+                        <div class="listbox-button__option" role="option" aria-disabled="true">
+                            <span class="listbox-button__value">Yellow</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-small" %}
+                            </svg>
+                        </div>
+                        <div class="listbox-button__option" role="option">
+                            <span class="listbox-button__value">Green</span>
+                            <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-small" %}
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+                <select hidden="" class="listbox__native">
+                    <option value="1"></option>
+                    <option value="2"></option>
+                    <option value="3"></option>
+                    <option value="4"></option>
+                </select>
+            </span>
+        </div>
+    </div>
+
+    {% highlight html %}
+<span class="listbox-button listbox-button--form">
+    <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
+            <svg class="icon icon--dropdown" focusable="false" height="10" width="14" aria-hidden="true">
+                <use href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox" tabindex="0">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option" aria-disabled="true">
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--tick-small" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+    <select hidden="" class="listbox__native">
+        <option value="1"></option>
+        <option value="2"></option>
+        <option value="3"></option>
+        <option value="4"></option>
+    </select>
+</span>
+    {% endhighlight %}
+
 </div>

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -50,6 +50,17 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
     }
 }
 
+.listbox-button.listbox-button--form button {
+    .background-color-token(combobox-textbox-background-color, color-background-secondary);
+    .border-color-token(combobox-textbox-border-color, color-stroke-default);
+}
+
+.listbox-button.listbox-button--form button[disabled],
+.listbox-button.listbox-button--form button[aria-disabled="true"] {
+    .border-color-token(combobox-textbox-disabled-border-color, color-background-disabled);
+    .color-token(combobox-textbox-disabled-foreground-color, color-foreground-disabled);
+}
+
 .listbox-button .btn__label {
     .color-token(listbox-button-label-color, color-foreground-secondary);
     margin-right: 3px;

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -51,14 +51,14 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 }
 
 .listbox-button.listbox-button--form button {
-    .background-color-token(combobox-textbox-background-color, color-background-secondary);
-    .border-color-token(combobox-textbox-border-color, color-stroke-default);
+    .background-color-token(listbox-button-background-color, color-background-secondary);
+    .border-color-token(listbox-button-border-color, color-stroke-default);
 }
 
 .listbox-button.listbox-button--form button[disabled],
 .listbox-button.listbox-button--form button[aria-disabled="true"] {
-    .border-color-token(combobox-textbox-disabled-border-color, color-background-disabled);
-    .color-token(combobox-textbox-disabled-foreground-color, color-foreground-disabled);
+    .border-color-token(listbox-button-disabled-border-color, color-background-disabled);
+    .color-token(listbox-button-disabled-foreground-color, color-foreground-disabled);
 }
 
 .listbox-button .btn__label {

--- a/src/less/listbox-button/stories/form.stories.js
+++ b/src/less/listbox-button/stories/form.stories.js
@@ -1,0 +1,97 @@
+export default { title: 'Listbox Button/Form' };
+
+export const enabled = () => `
+<span class="listbox-button listbox-button--form">
+    <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+    <select hidden="" class="listbox__native">
+        <option value="1"></option>
+        <option value="2"></option>
+        <option value="3"></option>
+        <option value="4"></option>
+    </select>
+</span>
+`;
+
+export const disabled = () => `
+<span class="listbox-button listbox-button--form">
+    <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" disabled>
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+    <select hidden="" class="listbox__native">
+        <option value="1"></option>
+        <option value="2"></option>
+        <option value="3"></option>
+        <option value="4"></option>
+    </select>
+</span>
+`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1842 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This adds a form variant to listbox button

## Screenshots
Enabled:
<img width="153" alt="image" src="https://user-images.githubusercontent.com/1675667/212400053-31e2968b-d7e4-4145-9954-578e763bfb8e.png">

Disabled:
<img width="147" alt="image" src="https://user-images.githubusercontent.com/1675667/212400107-7c6e9f3c-bf0d-4854-8790-31de68f314a3.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
