### PR TITLE
fix(listbox-button): added invalid state to form

### DIFF
--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -68,6 +68,9 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 .listbox-button.listbox-button--form button:focus {
   background-color: var(--combobox-textbox-focus-background-color, var(--color-background-primary));
 }
+.listbox-button.listbox-button--form button[aria-invalid="true"] {
+  border-color: var(--listbox-button-invalid-border-color, var(--color-stroke-attention));
+}
 .listbox-button .btn__label {
   color: var(--listbox-button-label-color, var(--color-foreground-secondary));
   margin-right: 3px;

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -65,6 +65,10 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
     .background-color-token(combobox-textbox-focus-background-color, color-background-primary);
 }
 
+.listbox-button.listbox-button--form button[aria-invalid="true"] {
+    .border-color-token(listbox-button-invalid-border-color, color-stroke-attention);
+}
+
 .listbox-button .btn__label {
     .color-token(listbox-button-label-color, color-foreground-secondary);
     margin-right: 3px;

--- a/src/less/listbox-button/stories/form.stories.js
+++ b/src/less/listbox-button/stories/form.stories.js
@@ -95,3 +95,51 @@ export const disabled = () => `
     </select>
 </span>
 `;
+
+export const invalid = () => `
+<span class="listbox-button listbox-button--form">
+    <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" aria-invalid="true">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
+            <svg class="icon icon--dropdown" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-dropdown"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--tick-small" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-small"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+    <select hidden="" class="listbox__native">
+        <option value="1"></option>
+        <option value="2"></option>
+        <option value="3"></option>
+        <option value="4"></option>
+    </select>
+</span>
+`;


### PR DESCRIPTION
Fixes #1981

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Added an aria-invalid style to listbox-button form styling. This was not being picked up since the selector is too strong
I could have added another style selector in the invalid part, but I kept it separate because we are planning on cleaning this up next tech debt. 
Also added a story.

## Screenshots
<img width="213" alt="Screen Shot 2023-02-10 at 10 31 57 AM" src="https://user-images.githubusercontent.com/1755269/218171004-148becbd-90ca-4993-81fb-c648b6ba605f.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
