### PR TITLE
fix(switch): was broken for projects that had `box-sizing` set to `border-box` globally

### DIFF
--- a/dist/switch/switch.css
+++ b/dist/switch/switch.css
@@ -17,6 +17,7 @@ span.switch__button {
   border-radius: 400px;
   border-style: solid;
   border-width: 1px;
+  box-sizing: content-box;
   color: transparent;
   display: inline-block;
   height: 24px;

--- a/src/less/switch/switch.less
+++ b/src/less/switch/switch.less
@@ -23,6 +23,7 @@ span.switch__button {
     border-radius: 400px;
     border-style: solid;
     border-width: 1px;
+    box-sizing: content-box;
     color: transparent;
     display: inline-block;
     height: 24px;


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description

Some projects set `box-sizing` to `border-box` globally using the `*` selector. This breaks the switch component, unless the following change is made.

## Screenshots

With `* { box-sizing: border-box }`
![a switch with box-sizing messed up](https://user-images.githubusercontent.com/26027232/222288009-d1bc233a-36ea-442b-ba15-9ed04e716952.png)

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
