### PR TITLE
fix(filter-menu-button, filter-button): improve container contrast

### DIFF
--- a/dist/filter-button/filter-button.css
+++ b/dist/filter-button/filter-button.css
@@ -24,6 +24,7 @@ a.filter-link {
   text-decoration: none;
   vertical-align: bottom;
   background-color: var(--filter-button-background-color, var(--color-background-secondary));
+  border-color: var(--filter-button-selected-border-color, var(--color-stroke-default));
 }
 button.filter-button + button.filter-button,
 button.filter-button + a.filter-link,
@@ -53,11 +54,11 @@ a.filter-link:visited {
 }
 button.filter-button[aria-pressed="true"],
 a.filter-link--selected {
-  border-color: var(--filter-button-selected-border-color, var(--color-foreground-primary));
+  border-color: var(--filter-button-selected-border-color, var(--color-stroke-strong));
   font-weight: bold;
 }
 a.filter-link--selected:visited {
-  border-color: var(--filter-button-selected-border-color, var(--color-foreground-primary));
+  border-color: var(--filter-button-selected-border-color, var(--color-stroke-strong));
 }
 button.filter-button[disabled],
 button.filter-button[aria-disabled="true"],

--- a/dist/filter-menu-button/filter-menu-button.css
+++ b/dist/filter-menu-button/filter-menu-button.css
@@ -30,6 +30,7 @@ button.filter-menu-button__button {
   text-decoration: none;
   vertical-align: bottom;
   background-color: var(--filter-button-background-color, var(--color-background-secondary));
+  border-color: var(--filter-button-selected-border-color, var(--color-stroke-default));
 }
 button.filter-menu-button__button + button.filter-menu-button__button {
   margin-left: 8px;
@@ -58,7 +59,7 @@ button.filter-menu-button__button:active {
   transform: rotate(180deg);
 }
 button.filter-menu-button__button[aria-pressed="true"] {
-  border-color: var(--filter-button-foreground-color, var(--color-foreground-primary));
+  border-color: var(--filter-button-foreground-color, var(--color-stroke-strong));
   font-weight: bold;
 }
 button.filter-menu-button__button[disabled],

--- a/src/less/filter-button/filter-button.less
+++ b/src/less/filter-button/filter-button.less
@@ -14,6 +14,7 @@ a.filter-link {
     .filter-button-base();
 
     .background-color-token(filter-button-background-color, color-background-secondary);
+    .border-color-token(filter-button-selected-border-color, color-stroke-default);
 
     &:focus,
     &:hover,
@@ -38,12 +39,12 @@ a.filter-link:visited {
 
 button.filter-button[aria-pressed="true"],
 a.filter-link--selected {
-    .border-color-token(filter-button-selected-border-color, color-foreground-primary);
+    .border-color-token(filter-button-selected-border-color, color-stroke-strong);
     font-weight: bold;
 }
 
 a.filter-link--selected:visited {
-    .border-color-token(filter-button-selected-border-color, color-foreground-primary);
+    .border-color-token(filter-button-selected-border-color, color-stroke-strong);
 }
 
 button.filter-button[disabled],

--- a/src/less/filter-menu-button/filter-menu-button.less
+++ b/src/less/filter-menu-button/filter-menu-button.less
@@ -23,6 +23,7 @@ span.filter-menu-button {
 button.filter-menu-button__button {
     .filter-button-base();
     .background-color-token(filter-button-background-color, color-background-secondary);
+    .border-color-token(filter-button-selected-border-color, color-stroke-default);
 
     &:focus,
     &:hover,
@@ -54,7 +55,7 @@ button.filter-menu-button__button {
 }
 
 button.filter-menu-button__button[aria-pressed="true"] {
-    .border-color-token(filter-button-foreground-color, color-foreground-primary);
+    .border-color-token(filter-button-foreground-color, color-stroke-strong);
     font-weight: bold;
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1985 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Added default border for `filter-button`, `filter-menu-button` and `filter-link` in enabled state and a strong border on focus.

## Notes
The color tokens being considered currently might not be accurate as per design requirements and might need an update.

## Screenshots

### filter-button, filter-link
**Before**
<img width="853" alt="image" src="https://user-images.githubusercontent.com/6342519/226475928-ae16eb47-60f7-4ef7-a29a-379c9b79d510.png">

**After**
<img width="853" alt="image" src="https://user-images.githubusercontent.com/6342519/226475837-7b2585a6-2418-4661-9280-54933902ed60.png">

### filter-menu-button
**Before**
<img width="853" alt="image" src="https://user-images.githubusercontent.com/6342519/226476088-fd6f2a61-6146-4ac1-8d5c-a9c38942d8f5.png">

**After**
<img width="853" alt="image" src="https://user-images.githubusercontent.com/6342519/226476131-f52083bd-a2a7-4b5b-bf93-387fceceb240.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
