### PR TITLE
feat(calendar): clipped text for static calendars

### DIFF
--- a/dist/calendar/calendar.css
+++ b/dist/calendar/calendar.css
@@ -84,7 +84,8 @@
 /************
  *** DAYS ***
  ************/
-.calendar__month td[aria-current="date"]:not(.calendar__cell--selected) > :not(:disabled, .calendar__cell--disabled) {
+.calendar__month td:not(.calendar__cell--selected) > [aria-current="date"]:not(:disabled),
+.calendar__month td:not(.calendar__cell--selected) > .calendar__cell--current:not(.calendar__cell--disabled) {
   border-color: var(--calendar-day-today-border-color, var(--color-foreground-primary));
   border-style: solid;
 }

--- a/dist/calendar/calendar.css
+++ b/dist/calendar/calendar.css
@@ -89,11 +89,14 @@
   border-style: solid;
 }
 .calendar__month td > :disabled,
-.calendar__month .calendar__cell--disabled {
+.calendar__month td > [aria-disabled="true"] {
   color: var(--calendar-day-disabled-color, var(--color-foreground-disabled));
 }
 .calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):hover {
   background-color: var(--calendar-day-hover-background-color, var(--color-state-primary-hover));
+}
+.calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):active {
+  font-weight: bold;
 }
 .calendar__month td[aria-selected="true"] > * {
   background-color: var(--calendar-day-selected-background-color, var(--color-background-inverse));

--- a/dist/calendar/calendar.css
+++ b/dist/calendar/calendar.css
@@ -84,21 +84,21 @@
 /************
  *** DAYS ***
  ************/
-.calendar__month td[aria-current="date"]:not([aria-selected="true"]) > :not(:disabled, [aria-disabled="true"]) {
+.calendar__month td[aria-current="date"]:not(.calendar__cell--selected) > :not(:disabled, .calendar__cell--disabled) {
   border-color: var(--calendar-day-today-border-color, var(--color-foreground-primary));
   border-style: solid;
 }
 .calendar__month td > :disabled,
-.calendar__month td > [aria-disabled="true"] {
+.calendar__month td > .calendar__cell--disabled {
   color: var(--calendar-day-disabled-color, var(--color-foreground-disabled));
 }
-.calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):hover {
+.calendar__month td:not(.calendar__range, .calendar__cell--selected) > button:not(:disabled):hover {
   background-color: var(--calendar-day-hover-background-color, var(--color-state-primary-hover));
 }
-.calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):active {
+.calendar__month td:not(.calendar__range, .calendar__cell--selected) > button:not(:disabled):active {
   font-weight: bold;
 }
-.calendar__month td[aria-selected="true"] > * {
+.calendar__month td.calendar__cell--selected > * {
   background-color: var(--calendar-day-selected-background-color, var(--color-background-inverse));
   color: var(--calendar-day-selected-color, var(--color-foreground-on-inverse));
   font-weight: bold;
@@ -136,7 +136,7 @@
 .calendar__range--start.calendar__range--end {
   background: transparent;
 }
-.calendar__range--start:not([aria-selected="true"]) > :not(:disabled, [aria-disabled="true"]),
-.calendar__range--end:not([aria-selected="true"]) > :not(:disabled, [aria-disabled="true"]) {
+.calendar__range--start:not(.calendar__cell--selected) > :not(:disabled, [aria-disabled="true"]),
+.calendar__range--end:not(.calendar__cell--selected) > :not(:disabled, [aria-disabled="true"]) {
   background-color: var(--calendar-day-range-end, var(--color-state-secondary-active));
 }

--- a/docs/_includes/calendar-month.html
+++ b/docs/_includes/calendar-month.html
@@ -107,36 +107,36 @@
         <tr>
             <td><{{dayTag}}{{tabIndexAttr}}>15</{{dayTag}}></td>
             <td class="calendar__range calendar__range--start" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="16 - start of range">16</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="16 - start of range"{% endif %}>16{% if include.interactive != "true" %} <span class="clipped">- start of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="17 - in range">17</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="17 - in range"{% endif %}>17{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="18 - in range">18</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="18 - in range"{% endif %}>18{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="19 - in range">19</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="19 - in range"{% endif %}>19{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="20 - in range">20</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="20 - in range"{% endif %}>20{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="21 - in range">21</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="21 - in range"{% endif %}>21{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
         </tr>
         <tr>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="22 - in range">22</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="22 - in range"{% endif %}>22{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="23 - in range">23</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - in range"{% endif %}>23{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="24 - in range">24</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range calendar__range--end" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="25 - end of range">25</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - end of range"{% endif %}>25{% if include.interactive != "true" %} <span class="clipped">- end of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td><{{dayTag}}{{tabIndexAttr}}>26</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>27</{{dayTag}}></td>
@@ -259,21 +259,21 @@
             <td><{{dayTag}}{{tabIndexAttr}}>21</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>22</{{dayTag}}></td>
             <td class="calendar__range calendar__range--start" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="23 - start of range">23</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - start of range"{% endif %}>23{% if include.interactive != "true" %} <span class="clipped">- start of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="24 - in range">24</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
         </tr>
         <tr>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="25 - in range">25</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - in range"{% endif %}>25{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="26 - in range">26</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="26 - in range"{% endif %}>26{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range calendar__range--end" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}} aria-label="27 - end of range">27</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="27 - end of range"{% endif %}>27{% if include.interactive != "true" %} <span class="clipped">- end of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td><{{dayTag}}{{tabIndexAttr}}>28</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>29</{{dayTag}}></td>

--- a/docs/_includes/calendar-month.html
+++ b/docs/_includes/calendar-month.html
@@ -1,7 +1,7 @@
 {% if include.interactive == "true" %}
     {% assign dayTag = "button" %}
     {% assign tabIndexAttr = ' tabindex="-1"' %}
-    {% assign disabledAttr = "disabled" %}
+    {% assign disabledAttr = 'disabled aria-label="- inactive"' %}
 {% else %}
     {% assign dayTag = "span" %}
     {% assign tabIndexAttr = "" %}
@@ -167,23 +167,23 @@
     <tbody>
         <tr>
             <td colspan="4"></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
             <td aria-current="date">
                 <{{dayTag}}>14</{{dayTag}}>
             </td>
@@ -230,23 +230,23 @@
     <tbody>
         <tr>
             <td colspan="4"></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
             <td aria-current="date"><{{dayTag}}>14</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>15</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>16</{{dayTag}}></td>

--- a/docs/_includes/calendar-month.html
+++ b/docs/_includes/calendar-month.html
@@ -2,10 +2,12 @@
     {% assign dayTag = "button" %}
     {% assign tabIndexAttr = ' tabindex="-1"' %}
     {% assign disabledAttr = 'disabled aria-label="- inactive"' %}
+    {% assign currentAttr = 'aria-current="date"' %}
 {% else %}
     {% assign dayTag = "span" %}
     {% assign tabIndexAttr = "" %}
     {% assign disabledAttr = 'class="calendar__cell--disabled"' %}
+    {% assign currentAttr = 'class="calendar__cell--current"' %}
 {% endif %}
 
 {% if include.index == "3" %}
@@ -184,9 +186,7 @@
             <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
-            <td aria-current="date">
-                <{{dayTag}}>14</{{dayTag}}>
-            </td>
+            <td><{{dayTag}} {{currentAttr}}>14{% if include.interactive != "true" %}<span class="clipped"> - today</span>{% endif %}</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>15</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>16</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>17</{{dayTag}}></td>
@@ -247,7 +247,7 @@
             <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
-            <td aria-current="date"><{{dayTag}}>14</{{dayTag}}></td>
+            <td><{{dayTag}} {{currentAttr}}>14{% if include.interactive != "true" %}<span class="clipped"> - today</span>{% endif %}</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>15</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>16</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>17</{{dayTag}}></td>

--- a/docs/_includes/calendar-month.html
+++ b/docs/_includes/calendar-month.html
@@ -107,36 +107,36 @@
         <tr>
             <td><{{dayTag}}{{tabIndexAttr}}>15</{{dayTag}}></td>
             <td class="calendar__cell--selected calendar__range calendar__range--start">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="16 - selected - start of range"{% endif %}>16{% if include.interactive != "true" %} <span class="clipped">- selected - start of range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="16 - selected - start of range"{% endif %}>16{% if include.interactive != "true" %}<span class="clipped"> - selected - start of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="17 - in range"{% endif %}>17{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="17 - in range"{% endif %}>17{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="18 - in range"{% endif %}>18{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="18 - in range"{% endif %}>18{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="19 - in range"{% endif %}>19{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="19 - in range"{% endif %}>19{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="20 - in range"{% endif %}>20{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="20 - in range"{% endif %}>20{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="21 - in range"{% endif %}>21{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="21 - in range"{% endif %}>21{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
         </tr>
         <tr>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="22 - in range"{% endif %}>22{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="22 - in range"{% endif %}>22{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - in range"{% endif %}>23{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - in range"{% endif %}>23{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__cell--selected calendar__range calendar__range--end">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - selected - end of range"{% endif %}>25{% if include.interactive != "true" %} <span class="clipped">- selected - end of range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - selected - end of range"{% endif %}>25{% if include.interactive != "true" %}<span class="clipped"> - selected - end of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td><{{dayTag}}{{tabIndexAttr}}>26</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>27</{{dayTag}}></td>
@@ -167,23 +167,23 @@
     <tbody>
         <tr>
             <td colspan="4"></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
             <td aria-current="date">
                 <{{dayTag}}>14</{{dayTag}}>
             </td>
@@ -230,23 +230,23 @@
     <tbody>
         <tr>
             <td colspan="4"></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>1{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>2{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>3{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>4{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>5{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>6{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>7{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>8{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>9{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>10{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
         </tr>
         <tr>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
-            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %} <span class="clipped">- inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>11{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>12{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
+            <td><{{dayTag}}{{tabIndexAttr}} {{disabledAttr}}>13{% if include.interactive != "true" %}<span class="clipped"> - inactive</span>{% endif %}</{{dayTag}}></td>
             <td aria-current="date"><{{dayTag}}>14</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>15</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>16</{{dayTag}}></td>
@@ -259,21 +259,21 @@
             <td><{{dayTag}}{{tabIndexAttr}}>21</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>22</{{dayTag}}></td>
             <td class="calendar__cell--selected calendar__range calendar__range--start">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - selected - start of range"{% endif %}>23{% if include.interactive != "true" %} <span class="clipped">- selected - start of range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - selected - start of range"{% endif %}>23{% if include.interactive != "true" %}<span class="clipped"> - selected - start of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
         </tr>
         <tr>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - in range"{% endif %}>25{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - in range"{% endif %}>25{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="26 - in range"{% endif %}>26{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="26 - in range"{% endif %}>26{% if include.interactive != "true" %}<span class="clipped"> - in range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__cell--selected calendar__range calendar__range--end">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="27 - selected - end of range"{% endif %}>27{% if include.interactive != "true" %} <span class="clipped">- selected - end of range</span>{% endif %}</{{dayTag}}>
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="27 - selected - end of range"{% endif %}>27{% if include.interactive != "true" %}<span class="clipped"> - selected - end of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td><{{dayTag}}{{tabIndexAttr}}>28</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>29</{{dayTag}}></td>

--- a/docs/_includes/calendar-month.html
+++ b/docs/_includes/calendar-month.html
@@ -106,8 +106,8 @@
         </tr>
         <tr>
             <td><{{dayTag}}{{tabIndexAttr}}>15</{{dayTag}}></td>
-            <td class="calendar__range calendar__range--start" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="16 - start of range"{% endif %}>16{% if include.interactive != "true" %} <span class="clipped">- start of range</span>{% endif %}</{{dayTag}}>
+            <td class="calendar__cell--selected calendar__range calendar__range--start">
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="16 - selected - start of range"{% endif %}>16{% if include.interactive != "true" %} <span class="clipped">- selected - start of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
                 <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="17 - in range"{% endif %}>17{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
@@ -135,8 +135,8 @@
             <td class="calendar__range">
                 <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
-            <td class="calendar__range calendar__range--end" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - end of range"{% endif %}>25{% if include.interactive != "true" %} <span class="clipped">- end of range</span>{% endif %}</{{dayTag}}>
+            <td class="calendar__cell--selected calendar__range calendar__range--end">
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="25 - selected - end of range"{% endif %}>25{% if include.interactive != "true" %} <span class="clipped">- selected - end of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td><{{dayTag}}{{tabIndexAttr}}>26</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>27</{{dayTag}}></td>
@@ -258,8 +258,8 @@
             <td><{{dayTag}}{{tabIndexAttr}}>20</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>21</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>22</{{dayTag}}></td>
-            <td class="calendar__range calendar__range--start" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - start of range"{% endif %}>23{% if include.interactive != "true" %} <span class="clipped">- start of range</span>{% endif %}</{{dayTag}}>
+            <td class="calendar__cell--selected calendar__range calendar__range--start">
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="23 - selected - start of range"{% endif %}>23{% if include.interactive != "true" %} <span class="clipped">- selected - start of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td class="calendar__range">
                 <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="24 - in range"{% endif %}>24{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
@@ -272,8 +272,8 @@
             <td class="calendar__range">
                 <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="26 - in range"{% endif %}>26{% if include.interactive != "true" %} <span class="clipped">- in range</span>{% endif %}</{{dayTag}}>
             </td>
-            <td class="calendar__range calendar__range--end" aria-selected="true">
-                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="27 - end of range"{% endif %}>27{% if include.interactive != "true" %} <span class="clipped">- end of range</span>{% endif %}</{{dayTag}}>
+            <td class="calendar__cell--selected calendar__range calendar__range--end">
+                <{{dayTag}}{{tabIndexAttr}}{% if include.interactive == "true" %} aria-label="27 - selected - end of range"{% endif %}>27{% if include.interactive != "true" %} <span class="clipped">- selected - end of range</span>{% endif %}</{{dayTag}}>
             </td>
             <td><{{dayTag}}{{tabIndexAttr}}>28</{{dayTag}}></td>
             <td><{{dayTag}}{{tabIndexAttr}}>29</{{dayTag}}></td>

--- a/docs/_includes/calendar.html
+++ b/docs/_includes/calendar.html
@@ -156,8 +156,8 @@
                     ...
                     <tr>
                         <td><span>15</span></td>
-                        <td class="calendar__range calendar__range--start" aria-selected="true">
-                            <span>16 <span class="clipped">- end of range</span></span>
+                        <td class="calendar__cell--selected calendar__range calendar__range--start">
+                            <span>16 <span class="clipped">- selected - end of range</span></span>
                         </td>
                         <td class="calendar__range">
                             <span>17 <span class="clipped">- in range</span></span>
@@ -185,8 +185,8 @@
                         <td class="calendar__range">
                             <span>24 <span class="clipped">- in range</span></span>
                         </td>
-                        <td class="calendar__range calendar__range--end" aria-selected="true">
-                            <span>25 <span class="clipped">- end of range</span></span>
+                        <td class="calendar__cell--selected calendar__range calendar__range--end">
+                            <span>25 <span class="clipped">- selected - end of range</span></span>
                         </td>
                         <td><span>26</span></td>
                         <td><span>27</span></td>

--- a/docs/_includes/calendar.html
+++ b/docs/_includes/calendar.html
@@ -93,15 +93,15 @@
                 <tbody>
                     <tr>
                         <td colspan="4"></td>
-                        <td><span aria-disabled="true">1</span></td>
-                        <td><span aria-disabled="true">2</span></td>
-                        <td><span aria-disabled="true">3</span></td>
+                        <td><span class="calendar__cell--disabled">1 <span class="clipped">- inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">2 <span class="clipped">- inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">3 <span class="clipped">- inactive</span></span></td>
                     </tr>
                     ...
                     <tr>
-                        <td><span aria-disabled="true">11</span></td>
-                        <td><span aria-disabled="true">12</span></td>
-                        <td><span aria-disabled="true">13</span></td>
+                        <td><span class="calendar__cell--disabled">11 <span class="clipped">- inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">12 <span class="clipped">- inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">13 <span class="clipped">- inactive</span></span></td>
                         <td aria-current="date"><span>14</span></td>
                         <td><span>15</span></td>
                         <td><span>16</span></td>
@@ -202,7 +202,7 @@
 
     <h3>Interactive Calendar</h3>
 
-    <p>To make a calendar interactive, replace the <code>span</code> elements with <code>button</code>. Buttons are disabled directly instead of with <code>aria-disabled</code> and clipped text for screen readers can be moved into <code>aria-label</code>, but all other attributes remain the same between static and interactive calendars. Keyboard focus management should be handled with JavaScript and a roving tab index.</p>
+    <p>To make a calendar interactive, replace the <code>span</code> elements with <code>button</code>. Buttons are disabled directly instead of with a class and clipped text can be moved into <code>aria-label</code>, but all other attributes remain the same between static and interactive calendars. Keyboard focus management should be handled with JavaScript and a roving tab index.</p>
 
     <div class="demo">
         <div class="demo__inner">

--- a/docs/_includes/calendar.html
+++ b/docs/_includes/calendar.html
@@ -93,15 +93,15 @@
                 <tbody>
                     <tr>
                         <td colspan="4"></td>
-                        <td><span class="calendar__cell--disabled">1 <span class="clipped">- inactive</span></span></td>
-                        <td><span class="calendar__cell--disabled">2 <span class="clipped">- inactive</span></span></td>
-                        <td><span class="calendar__cell--disabled">3 <span class="clipped">- inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">1<span class="clipped"> - inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">2<span class="clipped"> - inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">3<span class="clipped"> - inactive</span></span></td>
                     </tr>
                     ...
                     <tr>
-                        <td><span class="calendar__cell--disabled">11 <span class="clipped">- inactive</span></span></td>
-                        <td><span class="calendar__cell--disabled">12 <span class="clipped">- inactive</span></span></td>
-                        <td><span class="calendar__cell--disabled">13 <span class="clipped">- inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">11<span class="clipped"> - inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">12<span class="clipped"> - inactive</span></span></td>
+                        <td><span class="calendar__cell--disabled">13<span class="clipped"> - inactive</span></span></td>
                         <td aria-current="date"><span>14</span></td>
                         <td><span>15</span></td>
                         <td><span>16</span></td>
@@ -157,36 +157,36 @@
                     <tr>
                         <td><span>15</span></td>
                         <td class="calendar__cell--selected calendar__range calendar__range--start">
-                            <span>16 <span class="clipped">- selected - end of range</span></span>
+                            <span>16<span class="clipped"> - selected - end of range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span>17 <span class="clipped">- in range</span></span>
+                            <span>17<span class="clipped"> - in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span>18 <span class="clipped">- in range</span></span>
+                            <span>18<span class="clipped"> - in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span>19 <span class="clipped">- in range</span></span>
+                            <span>19<span class="clipped"> - in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span>20 <span class="clipped">- in range</span></span>
+                            <span>20<span class="clipped"> - in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span>21 <span class="clipped">- in range</span></span>
+                            <span>21<span class="clipped"> - in range</span></span>
                         </td>
                     </tr>
                     <tr>
                         <td class="calendar__range">
-                            <span>22 <span class="clipped">- in range</span></span>
+                            <span>22<span class="clipped"> - in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span>23 <span class="clipped">- in range</span></span>
+                            <span>23<span class="clipped"> - in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span>24 <span class="clipped">- in range</span></span>
+                            <span>24<span class="clipped"> - in range</span></span>
                         </td>
                         <td class="calendar__cell--selected calendar__range calendar__range--end">
-                            <span>25 <span class="clipped">- selected - end of range</span></span>
+                            <span>25<span class="clipped"> - selected - end of range</span></span>
                         </td>
                         <td><span>26</span></td>
                         <td><span>27</span></td>

--- a/docs/_includes/calendar.html
+++ b/docs/_includes/calendar.html
@@ -102,7 +102,7 @@
                         <td><span class="calendar__cell--disabled">11<span class="clipped"> - inactive</span></span></td>
                         <td><span class="calendar__cell--disabled">12<span class="clipped"> - inactive</span></span></td>
                         <td><span class="calendar__cell--disabled">13<span class="clipped"> - inactive</span></span></td>
-                        <td aria-current="date"><span>14</span></td>
+                        <td><span>14<span class="clipped calendar__cell--current"> - today</span></span></td>
                         <td><span>15</span></td>
                         <td><span>16</span></td>
                         <td><span>17</span></td>
@@ -202,7 +202,7 @@
 
     <h3>Interactive Calendar</h3>
 
-    <p>To make a calendar interactive, replace the <code>span</code> elements with <code>button</code>. Buttons are disabled directly instead of with a class and clipped text can be moved into <code>aria-label</code>, but all other attributes remain the same between static and interactive calendars. Keyboard focus management should be handled with JavaScript and a roving tab index.</p>
+    <p>To make a calendar interactive, replace the <code>span</code> elements with <code>button</code>. Buttons are disabled directly instead of with a class and clipped text can be moved into <code>aria</code> roles, but all other attributes remain the same between static and interactive calendars. Keyboard focus management should be handled with JavaScript and a roving tab index.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -240,9 +240,7 @@
                         <td><button tabindex="-1" disabled>11</button></td>
                         <td><button tabindex="-1" disabled>12</button></td>
                         <td><button tabindex="-1" disabled>13</button></td>
-                        <td aria-current="date">
-                            <button>14</button>
-                        </td>
+                        <td><button aria-current="date">14</button></td>
                         <td><button tabindex="-1">15</button></td>
                         <td><button tabindex="-1">16</button></td>
                         <td><button tabindex="-1">17</button></td>

--- a/docs/_includes/calendar.html
+++ b/docs/_includes/calendar.html
@@ -102,7 +102,7 @@
                         <td><span class="calendar__cell--disabled">11<span class="clipped"> - inactive</span></span></td>
                         <td><span class="calendar__cell--disabled">12<span class="clipped"> - inactive</span></span></td>
                         <td><span class="calendar__cell--disabled">13<span class="clipped"> - inactive</span></span></td>
-                        <td><span>14<span class="clipped calendar__cell--current"> - today</span></span></td>
+                        <td><span class="calendar__cell--current">14<span class="clipped"> - today</span></span></td>
                         <td><span>15</span></td>
                         <td><span>16</span></td>
                         <td><span>17</span></td>

--- a/docs/_includes/calendar.html
+++ b/docs/_includes/calendar.html
@@ -93,15 +93,15 @@
                 <tbody>
                     <tr>
                         <td colspan="4"></td>
-                        <td><span class="calendar__cell--disabled">1</span></td>
-                        <td><span class="calendar__cell--disabled">2</span></td>
-                        <td><span class="calendar__cell--disabled">3</span></td>
+                        <td><span aria-disabled="true">1</span></td>
+                        <td><span aria-disabled="true">2</span></td>
+                        <td><span aria-disabled="true">3</span></td>
                     </tr>
                     ...
                     <tr>
-                        <td><span class="calendar__cell--disabled">11</span></td>
-                        <td><span class="calendar__cell--disabled">12</span></td>
-                        <td><span class="calendar__cell--disabled">13</span></td>
+                        <td><span aria-disabled="true">11</span></td>
+                        <td><span aria-disabled="true">12</span></td>
+                        <td><span aria-disabled="true">13</span></td>
                         <td aria-current="date"><span>14</span></td>
                         <td><span>15</span></td>
                         <td><span>16</span></td>
@@ -157,36 +157,36 @@
                     <tr>
                         <td><span>15</span></td>
                         <td class="calendar__range calendar__range--start" aria-selected="true">
-                            <span aria-label="16 - start of range">16</span>
+                            <span>16 <span class="clipped">- end of range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span aria-label="17 - in range">17</span>
+                            <span>17 <span class="clipped">- in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span aria-label="18 - in range">18</span>
+                            <span>18 <span class="clipped">- in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span aria-label="19 - in range">19</span>
+                            <span>19 <span class="clipped">- in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span aria-label="20 - in range">20</span>
+                            <span>20 <span class="clipped">- in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span aria-label="21 - in range">21</span>
+                            <span>21 <span class="clipped">- in range</span></span>
                         </td>
                     </tr>
                     <tr>
                         <td class="calendar__range">
-                            <span aria-label="22 - in range">22</span>
+                            <span>22 <span class="clipped">- in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span aria-label="23 - in range">23</span>
+                            <span>23 <span class="clipped">- in range</span></span>
                         </td>
                         <td class="calendar__range">
-                            <span aria-label="24 - in range">24</span>
+                            <span>24 <span class="clipped">- in range</span></span>
                         </td>
                         <td class="calendar__range calendar__range--end" aria-selected="true">
-                            <span aria-label="25 - end of range">25</span>
+                            <span>25 <span class="clipped">- end of range</span></span>
                         </td>
                         <td><span>26</span></td>
                         <td><span>27</span></td>
@@ -202,7 +202,7 @@
 
     <h3>Interactive Calendar</h3>
 
-    <p>To make a calendar interactive, replace the <code>span</code> elements with <code>button</code>. Buttons are disabled directly instead of with a class, but all other attributes remain the same between static and interactive calendars. Keyboard focus management should be handled via JavaScript and a roving tab index.</p>
+    <p>To make a calendar interactive, replace the <code>span</code> elements with <code>button</code>. Buttons are disabled directly instead of with <code>aria-disabled</code> and clipped text for screen readers can be moved into <code>aria-label</code>, but all other attributes remain the same between static and interactive calendars. Keyboard focus management should be handled with JavaScript and a roving tab index.</p>
 
     <div class="demo">
         <div class="demo__inner">

--- a/src/less/calendar/calendar.less
+++ b/src/less/calendar/calendar.less
@@ -108,9 +108,10 @@
  *** DAYS ***
  ************/
 
+.calendar__month td:not(.calendar__cell--selected) > [aria-current="date"]:not(:disabled),
 .calendar__month
-    td[aria-current="date"]:not(.calendar__cell--selected)
-    > :not(:disabled, .calendar__cell--disabled) {
+    td:not(.calendar__cell--selected)
+    > .calendar__cell--current:not(.calendar__cell--disabled) {
     .border-color-token(calendar-day-today-border-color, color-foreground-primary);
     border-style: solid;
 }

--- a/src/less/calendar/calendar.less
+++ b/src/less/calendar/calendar.less
@@ -109,26 +109,28 @@
  ************/
 
 .calendar__month
-    td[aria-current="date"]:not([aria-selected="true"])
-    > :not(:disabled, [aria-disabled="true"]) {
+    td[aria-current="date"]:not(.calendar__cell--selected)
+    > :not(:disabled, .calendar__cell--disabled) {
     .border-color-token(calendar-day-today-border-color, color-foreground-primary);
     border-style: solid;
 }
 
 .calendar__month td > :disabled,
-.calendar__month td > [aria-disabled="true"] {
+.calendar__month td > .calendar__cell--disabled {
     .color-token(calendar-day-disabled-color, color-foreground-disabled);
 }
 
-.calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):hover {
+.calendar__month td:not(.calendar__range, .calendar__cell--selected) > button:not(:disabled):hover {
     .background-color-token(calendar-day-hover-background-color, color-state-primary-hover);
 }
 
-.calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):active {
+.calendar__month
+    td:not(.calendar__range, .calendar__cell--selected)
+    > button:not(:disabled):active {
     font-weight: bold;
 }
 
-.calendar__month td[aria-selected="true"] > * {
+.calendar__month td.calendar__cell--selected > * {
     .background-color-token(calendar-day-selected-background-color, color-background-inverse);
     .color-token(calendar-day-selected-color, color-foreground-on-inverse);
     font-weight: bold;
@@ -178,7 +180,7 @@
     background: transparent;
 }
 
-.calendar__range--start:not([aria-selected="true"]) > :not(:disabled, [aria-disabled="true"]),
-.calendar__range--end:not([aria-selected="true"]) > :not(:disabled, [aria-disabled="true"]) {
+.calendar__range--start:not(.calendar__cell--selected) > :not(:disabled, [aria-disabled="true"]),
+.calendar__range--end:not(.calendar__cell--selected) > :not(:disabled, [aria-disabled="true"]) {
     .background-color-token(calendar-day-range-end, color-state-secondary-active);
 }

--- a/src/less/calendar/calendar.less
+++ b/src/less/calendar/calendar.less
@@ -116,12 +116,16 @@
 }
 
 .calendar__month td > :disabled,
-.calendar__month .calendar__cell--disabled {
+.calendar__month td > [aria-disabled="true"] {
     .color-token(calendar-day-disabled-color, color-foreground-disabled);
 }
 
 .calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):hover {
     .background-color-token(calendar-day-hover-background-color, color-state-primary-hover);
+}
+
+.calendar__month td:not(.calendar__range, [aria-selected="true"]) > button:not(:disabled):active {
+    font-weight: bold;
 }
 
 .calendar__month td[aria-selected="true"] > * {

--- a/src/less/calendar/stories/calendar.stories.js
+++ b/src/less/calendar/stories/calendar.stories.js
@@ -24,71 +24,71 @@ export const base = () => /* HTML */ `
                             <td colspan="4"></td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >1 <span class="clipped">- inactive</span></span
+                                    >1<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >2 <span class="clipped">- inactive</span></span
+                                    >2<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >3 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >4 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >5 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >6 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >7 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >8 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >9 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >10 <span class="clipped">- inactive</span></span
+                                    >3<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                         </tr>
                         <tr>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >11 <span class="clipped">- inactive</span></span
+                                    >4<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >12 <span class="clipped">- inactive</span></span
+                                    >5<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >13 <span class="clipped">- inactive</span></span
+                                    >6<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td aria-current="date">
@@ -108,26 +108,27 @@ export const base = () => /* HTML */ `
                                 class="calendar__cell--selected calendar__range calendar__range--start"
                             >
                                 <span
-                                    >23
-                                    <span class="clipped">- selected - start of range</span></span
+                                    >23<span class="clipped">
+                                        - selected - start of range</span
+                                    ></span
                                 >
                             </td>
                             <td class="calendar__range">
-                                <span>24 <span class="clipped">- in range</span></span>
+                                <span>24<span class="clipped"> - in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span>25 <span class="clipped">- in range</span></span>
+                                <span>25<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>26 <span class="clipped">- in range</span></span>
+                                <span>26<span class="clipped"> - in range</span></span>
                             </td>
                             <td
                                 class="calendar__cell--selected calendar__range calendar__range--end"
                             >
                                 <span
-                                    >27 <span class="clipped">- selected - end of range</span></span
+                                    >27<span class="clipped"> - selected - end of range</span></span
                                 >
                             </td>
                             <td><span>28</span></td>
@@ -278,71 +279,71 @@ export const header = () => /* HTML */ `
                             <td colspan="4"></td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >1 <span class="clipped">- inactive</span></span
+                                    >1<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >2 <span class="clipped">- inactive</span></span
+                                    >2<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >3 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >4 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >5 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >6 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >7 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >8 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >9 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >10 <span class="clipped">- inactive</span></span
+                                    >3<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                         </tr>
                         <tr>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >11 <span class="clipped">- inactive</span></span
+                                    >4<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >12 <span class="clipped">- inactive</span></span
+                                    >5<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >13 <span class="clipped">- inactive</span></span
+                                    >6<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td aria-current="date">
@@ -362,26 +363,27 @@ export const header = () => /* HTML */ `
                                 class="calendar__cell--selected calendar__range calendar__range--start"
                             >
                                 <span
-                                    >23
-                                    <span class="clipped">- selected - start of range</span></span
+                                    >23<span class="clipped">
+                                        - selected - start of range</span
+                                    ></span
                                 >
                             </td>
                             <td class="calendar__range">
-                                <span>24 <span class="clipped">- in range</span></span>
+                                <span>24<span class="clipped"> - in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span>25 <span class="clipped">- in range</span></span>
+                                <span>25<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>26 <span class="clipped">- in range</span></span>
+                                <span>26<span class="clipped"> - in range</span></span>
                             </td>
                             <td
                                 class="calendar__cell--selected calendar__range calendar__range--end"
                             >
                                 <span
-                                    >27 <span class="clipped">- selected - end of range</span></span
+                                    >27<span class="clipped"> - selected - end of range</span></span
                                 >
                             </td>
                             <td><span>28</span></td>
@@ -420,71 +422,71 @@ export const double = () => /* HTML */ `
                             <td colspan="4"></td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >1 <span class="clipped">- inactive</span></span
+                                    >1<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >2 <span class="clipped">- inactive</span></span
+                                    >2<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >3 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >4 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >5 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >6 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >7 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >8 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >9 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >10 <span class="clipped">- inactive</span></span
+                                    >3<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                         </tr>
                         <tr>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >11 <span class="clipped">- inactive</span></span
+                                    >4<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >12 <span class="clipped">- inactive</span></span
+                                    >5<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >13 <span class="clipped">- inactive</span></span
+                                    >6<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td aria-current="date">
@@ -556,41 +558,42 @@ export const double = () => /* HTML */ `
                                 class="calendar__cell--selected calendar__range calendar__range--start"
                             >
                                 <span
-                                    >16
-                                    <span class="clipped">- selected - start of range</span></span
+                                    >16<span class="clipped">
+                                        - selected - start of range</span
+                                    ></span
                                 >
                             </td>
                             <td class="calendar__range">
-                                <span>17 <span class="clipped">- in range</span></span>
+                                <span>17<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>18 <span class="clipped">- in range</span></span>
+                                <span>18<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>19 <span class="clipped">- in range</span></span>
+                                <span>19<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>20 <span class="clipped">- in range</span></span>
+                                <span>20<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>21 <span class="clipped">- in range</span></span>
+                                <span>21<span class="clipped"> - in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span>22 <span class="clipped">- in range</span></span>
+                                <span>22<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>23 <span class="clipped">- in range</span></span>
+                                <span>23<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>24 <span class="clipped">- in range</span></span>
+                                <span>24<span class="clipped"> - in range</span></span>
                             </td>
                             <td
                                 class="calendar__cell--selected calendar__range calendar__range--end"
                             >
                                 <span
-                                    >25 <span class="clipped">- selected - end of range</span></span
+                                    >25<span class="clipped"> - selected - end of range</span></span
                                 >
                             </td>
                             <td><span>26</span></td>
@@ -656,71 +659,71 @@ export const doubleWithHeader = () => /* HTML */ `
                             <td colspan="4"></td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >1 <span class="clipped">- inactive</span></span
+                                    >1<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >2 <span class="clipped">- inactive</span></span
+                                    >2<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >3 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >4 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >5 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >6 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >7 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >8 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >9 <span class="clipped">- inactive</span></span
-                                >
-                            </td>
-                            <td>
-                                <span class="calendar__cell--disabled"
-                                    >10 <span class="clipped">- inactive</span></span
+                                    >3<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                         </tr>
                         <tr>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >11 <span class="clipped">- inactive</span></span
+                                    >4<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >12 <span class="clipped">- inactive</span></span
+                                    >5<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td>
                                 <span class="calendar__cell--disabled"
-                                    >13 <span class="clipped">- inactive</span></span
+                                    >6<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12<span class="clipped"> - inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
                             <td aria-current="date">
@@ -792,41 +795,42 @@ export const doubleWithHeader = () => /* HTML */ `
                                 class="calendar__cell--selected calendar__range calendar__range--start"
                             >
                                 <span
-                                    >16
-                                    <span class="clipped">- selected - start of range</span></span
+                                    >16<span class="clipped">
+                                        - selected - start of range</span
+                                    ></span
                                 >
                             </td>
                             <td class="calendar__range">
-                                <span>17 <span class="clipped">- in range</span></span>
+                                <span>17<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>18 <span class="clipped">- in range</span></span>
+                                <span>18<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>19 <span class="clipped">- in range</span></span>
+                                <span>19<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>20 <span class="clipped">- in range</span></span>
+                                <span>20<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>21 <span class="clipped">- in range</span></span>
+                                <span>21<span class="clipped"> - in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span>22 <span class="clipped">- in range</span></span>
+                                <span>22<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>23 <span class="clipped">- in range</span></span>
+                                <span>23<span class="clipped"> - in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span>24 <span class="clipped">- in range</span></span>
+                                <span>24<span class="clipped"> - in range</span></span>
                             </td>
                             <td
                                 class="calendar__cell--selected calendar__range calendar__range--end"
                             >
                                 <span
-                                    >25 <span class="clipped">- selected - end of range</span></span
+                                    >25<span class="clipped"> - selected - end of range</span></span
                                 >
                             </td>
                             <td><span>26</span></td>

--- a/src/less/calendar/stories/calendar.stories.js
+++ b/src/less/calendar/stories/calendar.stories.js
@@ -22,23 +22,75 @@ export const base = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >1 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >2 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >3 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >4 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >5 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >6 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -224,23 +276,75 @@ export const header = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >1 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >2 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >3 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >4 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >5 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >6 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -314,23 +418,75 @@ export const double = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >1 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >2 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >3 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >4 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >5 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >6 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -498,23 +654,75 @@ export const doubleWithHeader = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >1 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >2 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >3 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >4 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >5 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >6 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >7 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >8 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >9 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >10 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >11 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >12 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
+                            <td>
+                                <span class="calendar__cell--disabled"
+                                    >13 <span class="clipped">- inactive</span></span
+                                >
+                            </td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>

--- a/src/less/calendar/stories/calendar.stories.js
+++ b/src/less/calendar/stories/calendar.stories.js
@@ -22,23 +22,23 @@ export const base = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span aria-disabled="true">1</span></td>
-                            <td><span aria-disabled="true">2</span></td>
-                            <td><span aria-disabled="true">3</span></td>
+                            <td><span class="calendar__cell--disabled">1</span></td>
+                            <td><span class="calendar__cell--disabled">2</span></td>
+                            <td><span class="calendar__cell--disabled">3</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">4</span></td>
-                            <td><span aria-disabled="true">5</span></td>
-                            <td><span aria-disabled="true">6</span></td>
-                            <td><span aria-disabled="true">7</span></td>
-                            <td><span aria-disabled="true">8</span></td>
-                            <td><span aria-disabled="true">9</span></td>
-                            <td><span aria-disabled="true">10</span></td>
+                            <td><span class="calendar__cell--disabled">4</span></td>
+                            <td><span class="calendar__cell--disabled">5</span></td>
+                            <td><span class="calendar__cell--disabled">6</span></td>
+                            <td><span class="calendar__cell--disabled">7</span></td>
+                            <td><span class="calendar__cell--disabled">8</span></td>
+                            <td><span class="calendar__cell--disabled">9</span></td>
+                            <td><span class="calendar__cell--disabled">10</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">11</span></td>
-                            <td><span aria-disabled="true">12</span></td>
-                            <td><span aria-disabled="true">13</span></td>
+                            <td><span class="calendar__cell--disabled">11</span></td>
+                            <td><span class="calendar__cell--disabled">12</span></td>
+                            <td><span class="calendar__cell--disabled">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -52,8 +52,13 @@ export const base = () => /* HTML */ `
                             <td><span>20</span></td>
                             <td><span>21</span></td>
                             <td><span>22</span></td>
-                            <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span>23 <span class="clipped">- start of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--start"
+                            >
+                                <span
+                                    >23
+                                    <span class="clipped">- selected - start of range</span></span
+                                >
                             </td>
                             <td class="calendar__range">
                                 <span>24 <span class="clipped">- in range</span></span>
@@ -66,8 +71,12 @@ export const base = () => /* HTML */ `
                             <td class="calendar__range">
                                 <span>26 <span class="clipped">- in range</span></span>
                             </td>
-                            <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span>27 <span class="clipped">- end of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--end"
+                            >
+                                <span
+                                    >27 <span class="clipped">- selected - end of range</span></span
+                                >
                             </td>
                             <td><span>28</span></td>
                             <td><span>29</span></td>
@@ -133,8 +142,12 @@ export const interactive = () => /* HTML */ `
                             <td><button tabindex="-1">20</button></td>
                             <td><button tabindex="-1">21</button></td>
                             <td><button tabindex="-1">22</button></td>
-                            <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <button tabindex="-1" aria-label="23 - start of range">23</button>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--start"
+                            >
+                                <button tabindex="-1" aria-label="23 - selected - start of range">
+                                    23
+                                </button>
                             </td>
                             <td class="calendar__range">
                                 <button tabindex="-1" aria-label="24 - in range">24</button>
@@ -147,8 +160,12 @@ export const interactive = () => /* HTML */ `
                             <td class="calendar__range">
                                 <button tabindex="-1" aria-label="26 - in range">26</button>
                             </td>
-                            <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <button tabindex="-1" aria-label="27 - end of range">27</button>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--end"
+                            >
+                                <button tabindex="-1" aria-label="27 - selected - end of range">
+                                    27
+                                </button>
                             </td>
                             <td><button tabindex="-1">28</button></td>
                             <td><button tabindex="-1">29</button></td>
@@ -207,23 +224,23 @@ export const header = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span aria-disabled="true">1</span></td>
-                            <td><span aria-disabled="true">2</span></td>
-                            <td><span aria-disabled="true">3</span></td>
+                            <td><span class="calendar__cell--disabled">1</span></td>
+                            <td><span class="calendar__cell--disabled">2</span></td>
+                            <td><span class="calendar__cell--disabled">3</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">4</span></td>
-                            <td><span aria-disabled="true">5</span></td>
-                            <td><span aria-disabled="true">6</span></td>
-                            <td><span aria-disabled="true">7</span></td>
-                            <td><span aria-disabled="true">8</span></td>
-                            <td><span aria-disabled="true">9</span></td>
-                            <td><span aria-disabled="true">10</span></td>
+                            <td><span class="calendar__cell--disabled">4</span></td>
+                            <td><span class="calendar__cell--disabled">5</span></td>
+                            <td><span class="calendar__cell--disabled">6</span></td>
+                            <td><span class="calendar__cell--disabled">7</span></td>
+                            <td><span class="calendar__cell--disabled">8</span></td>
+                            <td><span class="calendar__cell--disabled">9</span></td>
+                            <td><span class="calendar__cell--disabled">10</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">11</span></td>
-                            <td><span aria-disabled="true">12</span></td>
-                            <td><span aria-disabled="true">13</span></td>
+                            <td><span class="calendar__cell--disabled">11</span></td>
+                            <td><span class="calendar__cell--disabled">12</span></td>
+                            <td><span class="calendar__cell--disabled">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -237,8 +254,13 @@ export const header = () => /* HTML */ `
                             <td><span>20</span></td>
                             <td><span>21</span></td>
                             <td><span>22</span></td>
-                            <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span>23 <span class="clipped">- start of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--start"
+                            >
+                                <span
+                                    >23
+                                    <span class="clipped">- selected - start of range</span></span
+                                >
                             </td>
                             <td class="calendar__range">
                                 <span>24 <span class="clipped">- in range</span></span>
@@ -251,8 +273,12 @@ export const header = () => /* HTML */ `
                             <td class="calendar__range">
                                 <span>26 <span class="clipped">- in range</span></span>
                             </td>
-                            <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span>27 <span class="clipped">- end of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--end"
+                            >
+                                <span
+                                    >27 <span class="clipped">- selected - end of range</span></span
+                                >
                             </td>
                             <td><span>28</span></td>
                             <td><span>29</span></td>
@@ -288,23 +314,23 @@ export const double = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span aria-disabled="true">1</span></td>
-                            <td><span aria-disabled="true">2</span></td>
-                            <td><span aria-disabled="true">3</span></td>
+                            <td><span class="calendar__cell--disabled">1</span></td>
+                            <td><span class="calendar__cell--disabled">2</span></td>
+                            <td><span class="calendar__cell--disabled">3</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">4</span></td>
-                            <td><span aria-disabled="true">5</span></td>
-                            <td><span aria-disabled="true">6</span></td>
-                            <td><span aria-disabled="true">7</span></td>
-                            <td><span aria-disabled="true">8</span></td>
-                            <td><span aria-disabled="true">9</span></td>
-                            <td><span aria-disabled="true">10</span></td>
+                            <td><span class="calendar__cell--disabled">4</span></td>
+                            <td><span class="calendar__cell--disabled">5</span></td>
+                            <td><span class="calendar__cell--disabled">6</span></td>
+                            <td><span class="calendar__cell--disabled">7</span></td>
+                            <td><span class="calendar__cell--disabled">8</span></td>
+                            <td><span class="calendar__cell--disabled">9</span></td>
+                            <td><span class="calendar__cell--disabled">10</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">11</span></td>
-                            <td><span aria-disabled="true">12</span></td>
-                            <td><span aria-disabled="true">13</span></td>
+                            <td><span class="calendar__cell--disabled">11</span></td>
+                            <td><span class="calendar__cell--disabled">12</span></td>
+                            <td><span class="calendar__cell--disabled">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -370,8 +396,13 @@ export const double = () => /* HTML */ `
                         </tr>
                         <tr>
                             <td><span>15</span></td>
-                            <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span>16 <span class="clipped">- start of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--start"
+                            >
+                                <span
+                                    >16
+                                    <span class="clipped">- selected - start of range</span></span
+                                >
                             </td>
                             <td class="calendar__range">
                                 <span>17 <span class="clipped">- in range</span></span>
@@ -399,8 +430,12 @@ export const double = () => /* HTML */ `
                             <td class="calendar__range">
                                 <span>24 <span class="clipped">- in range</span></span>
                             </td>
-                            <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span>25 <span class="clipped">- end of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--end"
+                            >
+                                <span
+                                    >25 <span class="clipped">- selected - end of range</span></span
+                                >
                             </td>
                             <td><span>26</span></td>
                             <td><span>27</span></td>
@@ -463,23 +498,23 @@ export const doubleWithHeader = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span aria-disabled="true">1</span></td>
-                            <td><span aria-disabled="true">2</span></td>
-                            <td><span aria-disabled="true">3</span></td>
+                            <td><span class="calendar__cell--disabled">1</span></td>
+                            <td><span class="calendar__cell--disabled">2</span></td>
+                            <td><span class="calendar__cell--disabled">3</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">4</span></td>
-                            <td><span aria-disabled="true">5</span></td>
-                            <td><span aria-disabled="true">6</span></td>
-                            <td><span aria-disabled="true">7</span></td>
-                            <td><span aria-disabled="true">8</span></td>
-                            <td><span aria-disabled="true">9</span></td>
-                            <td><span aria-disabled="true">10</span></td>
+                            <td><span class="calendar__cell--disabled">4</span></td>
+                            <td><span class="calendar__cell--disabled">5</span></td>
+                            <td><span class="calendar__cell--disabled">6</span></td>
+                            <td><span class="calendar__cell--disabled">7</span></td>
+                            <td><span class="calendar__cell--disabled">8</span></td>
+                            <td><span class="calendar__cell--disabled">9</span></td>
+                            <td><span class="calendar__cell--disabled">10</span></td>
                         </tr>
                         <tr>
-                            <td><span aria-disabled="true">11</span></td>
-                            <td><span aria-disabled="true">12</span></td>
-                            <td><span aria-disabled="true">13</span></td>
+                            <td><span class="calendar__cell--disabled">11</span></td>
+                            <td><span class="calendar__cell--disabled">12</span></td>
+                            <td><span class="calendar__cell--disabled">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -545,8 +580,13 @@ export const doubleWithHeader = () => /* HTML */ `
                         </tr>
                         <tr>
                             <td><span>15</span></td>
-                            <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span>16 <span class="clipped">- start of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--start"
+                            >
+                                <span
+                                    >16
+                                    <span class="clipped">- selected - start of range</span></span
+                                >
                             </td>
                             <td class="calendar__range">
                                 <span>17 <span class="clipped">- in range</span></span>
@@ -574,8 +614,12 @@ export const doubleWithHeader = () => /* HTML */ `
                             <td class="calendar__range">
                                 <span>24 <span class="clipped">- in range</span></span>
                             </td>
-                            <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span>25 <span class="clipped">- end of range</span></span>
+                            <td
+                                class="calendar__cell--selected calendar__range calendar__range--end"
+                            >
+                                <span
+                                    >25 <span class="clipped">- selected - end of range</span></span
+                                >
                             </td>
                             <td><span>26</span></td>
                             <td><span>27</span></td>

--- a/src/less/calendar/stories/calendar.stories.js
+++ b/src/less/calendar/stories/calendar.stories.js
@@ -22,23 +22,23 @@ export const base = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td><span aria-disabled="true">1</span></td>
+                            <td><span aria-disabled="true">2</span></td>
+                            <td><span aria-disabled="true">3</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td><span aria-disabled="true">4</span></td>
+                            <td><span aria-disabled="true">5</span></td>
+                            <td><span aria-disabled="true">6</span></td>
+                            <td><span aria-disabled="true">7</span></td>
+                            <td><span aria-disabled="true">8</span></td>
+                            <td><span aria-disabled="true">9</span></td>
+                            <td><span aria-disabled="true">10</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td><span aria-disabled="true">11</span></td>
+                            <td><span aria-disabled="true">12</span></td>
+                            <td><span aria-disabled="true">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -53,21 +53,21 @@ export const base = () => /* HTML */ `
                             <td><span>21</span></td>
                             <td><span>22</span></td>
                             <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span aria-label="23 - start of range">23</span>
+                                <span>23 <span class="clipped">- start of range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="24 - in range">24</span>
+                                <span>24 <span class="clipped">- in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span aria-label="25 - in range">25</span>
+                                <span>25 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="26 - in range">26</span>
+                                <span>26 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span aria-label="27 - end of range">27</span>
+                                <span>27 <span class="clipped">- end of range</span></span>
                             </td>
                             <td><span>28</span></td>
                             <td><span>29</span></td>
@@ -207,23 +207,23 @@ export const header = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td><span aria-disabled="true">1</span></td>
+                            <td><span aria-disabled="true">2</span></td>
+                            <td><span aria-disabled="true">3</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td><span aria-disabled="true">4</span></td>
+                            <td><span aria-disabled="true">5</span></td>
+                            <td><span aria-disabled="true">6</span></td>
+                            <td><span aria-disabled="true">7</span></td>
+                            <td><span aria-disabled="true">8</span></td>
+                            <td><span aria-disabled="true">9</span></td>
+                            <td><span aria-disabled="true">10</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td><span aria-disabled="true">11</span></td>
+                            <td><span aria-disabled="true">12</span></td>
+                            <td><span aria-disabled="true">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -238,21 +238,21 @@ export const header = () => /* HTML */ `
                             <td><span>21</span></td>
                             <td><span>22</span></td>
                             <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span aria-label="23 - start of range">23</span>
+                                <span>23 <span class="clipped">- start of range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="24 - in range">24</span>
+                                <span>24 <span class="clipped">- in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span aria-label="25 - in range">25</span>
+                                <span>25 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="26 - in range">26</span>
+                                <span>26 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span aria-label="27 - end of range">27</span>
+                                <span>27 <span class="clipped">- end of range</span></span>
                             </td>
                             <td><span>28</span></td>
                             <td><span>29</span></td>
@@ -288,23 +288,23 @@ export const double = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td><span aria-disabled="true">1</span></td>
+                            <td><span aria-disabled="true">2</span></td>
+                            <td><span aria-disabled="true">3</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td><span aria-disabled="true">4</span></td>
+                            <td><span aria-disabled="true">5</span></td>
+                            <td><span aria-disabled="true">6</span></td>
+                            <td><span aria-disabled="true">7</span></td>
+                            <td><span aria-disabled="true">8</span></td>
+                            <td><span aria-disabled="true">9</span></td>
+                            <td><span aria-disabled="true">10</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td><span aria-disabled="true">11</span></td>
+                            <td><span aria-disabled="true">12</span></td>
+                            <td><span aria-disabled="true">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -371,36 +371,36 @@ export const double = () => /* HTML */ `
                         <tr>
                             <td><span>15</span></td>
                             <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span aria-label="16 - start of range">16</span>
+                                <span>16 <span class="clipped">- start of range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="17 - in range">17</span>
+                                <span>17 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="18 - in range">18</span>
+                                <span>18 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="19 - in range">19</span>
+                                <span>19 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="20 - in range">20</span>
+                                <span>20 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="21 - in range">21</span>
+                                <span>21 <span class="clipped">- in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span aria-label="22 - in range">22</span>
+                                <span>22 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="23 - in range">23</span>
+                                <span>23 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="24 - in range">24</span>
+                                <span>24 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span aria-label="25 - end of range">25</span>
+                                <span>25 <span class="clipped">- end of range</span></span>
                             </td>
                             <td><span>26</span></td>
                             <td><span>27</span></td>
@@ -463,23 +463,23 @@ export const doubleWithHeader = () => /* HTML */ `
                     <tbody>
                         <tr>
                             <td colspan="4"></td>
-                            <td><span class="calendar__cell--disabled">1</span></td>
-                            <td><span class="calendar__cell--disabled">2</span></td>
-                            <td><span class="calendar__cell--disabled">3</span></td>
+                            <td><span aria-disabled="true">1</span></td>
+                            <td><span aria-disabled="true">2</span></td>
+                            <td><span aria-disabled="true">3</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">4</span></td>
-                            <td><span class="calendar__cell--disabled">5</span></td>
-                            <td><span class="calendar__cell--disabled">6</span></td>
-                            <td><span class="calendar__cell--disabled">7</span></td>
-                            <td><span class="calendar__cell--disabled">8</span></td>
-                            <td><span class="calendar__cell--disabled">9</span></td>
-                            <td><span class="calendar__cell--disabled">10</span></td>
+                            <td><span aria-disabled="true">4</span></td>
+                            <td><span aria-disabled="true">5</span></td>
+                            <td><span aria-disabled="true">6</span></td>
+                            <td><span aria-disabled="true">7</span></td>
+                            <td><span aria-disabled="true">8</span></td>
+                            <td><span aria-disabled="true">9</span></td>
+                            <td><span aria-disabled="true">10</span></td>
                         </tr>
                         <tr>
-                            <td><span class="calendar__cell--disabled">11</span></td>
-                            <td><span class="calendar__cell--disabled">12</span></td>
-                            <td><span class="calendar__cell--disabled">13</span></td>
+                            <td><span aria-disabled="true">11</span></td>
+                            <td><span aria-disabled="true">12</span></td>
+                            <td><span aria-disabled="true">13</span></td>
                             <td aria-current="date">
                                 <span>14</span>
                             </td>
@@ -546,36 +546,36 @@ export const doubleWithHeader = () => /* HTML */ `
                         <tr>
                             <td><span>15</span></td>
                             <td class="calendar__range calendar__range--start" aria-selected="true">
-                                <span aria-label="16 - start of range">16</span>
+                                <span>16 <span class="clipped">- start of range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="17 - in range">17</span>
+                                <span>17 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="18 - in range">18</span>
+                                <span>18 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="19 - in range">19</span>
+                                <span>19 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="20 - in range">20</span>
+                                <span>20 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="21 - in range">21</span>
+                                <span>21 <span class="clipped">- in range</span></span>
                             </td>
                         </tr>
                         <tr>
                             <td class="calendar__range">
-                                <span aria-label="22 - in range">22</span>
+                                <span>22 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="23 - in range">23</span>
+                                <span>23 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range">
-                                <span aria-label="24 - in range">24</span>
+                                <span>24 <span class="clipped">- in range</span></span>
                             </td>
                             <td class="calendar__range calendar__range--end" aria-selected="true">
-                                <span aria-label="25 - end of range">25</span>
+                                <span>25 <span class="clipped">- end of range</span></span>
                             </td>
                             <td><span>26</span></td>
                             <td><span>27</span></td>

--- a/src/less/calendar/stories/calendar.stories.js
+++ b/src/less/calendar/stories/calendar.stories.js
@@ -91,8 +91,10 @@ export const base = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td class="calendar__cell--current">
-                                <span>14<span class="clipped"> - today</span></span>
+                            <td>
+                                <span class="calendar__cell--current"
+                                    >14<span class="clipped"> - today</span></span
+                                >
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>
@@ -346,8 +348,10 @@ export const header = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td class="calendar__cell--current">
-                                <span>14<span class="clipped"> - today</span></span>
+                            <td>
+                                <span class="calendar__cell--current"
+                                    >14<span class="clipped"> - today</span></span
+                                >
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>
@@ -489,8 +493,10 @@ export const double = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td class="calendar__cell--current">
-                                <span>14<span class="clipped"> - today</span></span>
+                            <td>
+                                <span class="calendar__cell--current"
+                                    >14<span class="clipped"> - today</span></span
+                                >
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>
@@ -726,8 +732,10 @@ export const doubleWithHeader = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td class="calendar__cell--current">
-                                <span>14<span class="clipped"> - today</span></span>
+                            <td>
+                                <span class="calendar__cell--current"
+                                    >14<span class="clipped"> - today</span></span
+                                >
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>

--- a/src/less/calendar/stories/calendar.stories.js
+++ b/src/less/calendar/stories/calendar.stories.js
@@ -91,8 +91,8 @@ export const base = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td aria-current="date">
-                                <span>14</span>
+                            <td class="calendar__cell--current">
+                                <span>14<span class="clipped"> - today</span></span>
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>
@@ -182,8 +182,8 @@ export const interactive = () => /* HTML */ `
                             <td><button tabindex="-1" disabled>11</button></td>
                             <td><button tabindex="-1" disabled>12</button></td>
                             <td><button tabindex="-1" disabled>13</button></td>
-                            <td aria-current="date">
-                                <button>14</button>
+                            <td>
+                                <button aria-current="date">14</button>
                             </td>
                             <td><button tabindex="-1">15</button></td>
                             <td><button tabindex="-1">16</button></td>
@@ -346,8 +346,8 @@ export const header = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td aria-current="date">
-                                <span>14</span>
+                            <td class="calendar__cell--current">
+                                <span>14<span class="clipped"> - today</span></span>
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>
@@ -489,8 +489,8 @@ export const double = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td aria-current="date">
-                                <span>14</span>
+                            <td class="calendar__cell--current">
+                                <span>14<span class="clipped"> - today</span></span>
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>
@@ -726,8 +726,8 @@ export const doubleWithHeader = () => /* HTML */ `
                                     >13<span class="clipped"> - inactive</span></span
                                 >
                             </td>
-                            <td aria-current="date">
-                                <span>14</span>
+                            <td class="calendar__cell--current">
+                                <span>14<span class="clipped"> - today</span></span>
                             </td>
                             <td><span>15</span></td>
                             <td><span>16</span></td>


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->

A few minor clean-up changes that were noticed during review of the date input on eBayUI:
- `span` should now have full support for `aria-disabled` so there is no need for the `calendar__cell--disabled` class
- In the static calendar, `aria-label` is replaced with an additional clipped span
- There is now indication that a button is active (I opted for bolded text, this may be debated in the comments)

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
