### PR TITLE
fix(buttons): reverted primary disabled state handling

### DIFF
--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -168,8 +168,8 @@ a.fake-btn--primary.fake-btn--destructive {
 }
 button.btn--primary.btn--destructive[disabled],
 button.btn--primary.btn--destructive[aria-disabled="true"] {
-  background-color: var(--btn-primary-destructive-disabled-background, var(--color-background-attention));
-  border-color: var(--btn-primary-destructive-disabled-border, var(--color-stroke-attention));
+  background-color: var(--btn-primary-destructive-disabled-background, var(--color-background-disabled));
+  border-color: var(--btn-primary-destructive-disabled-border, var(--color-stroke-disabled));
 }
 button.btn--primary.btn--destructive:not([disabled], [aria-disabled="true"]):focus,
 a.fake-btn--primary.fake-btn--destructive[href]:focus,
@@ -208,8 +208,8 @@ a.fake-btn--large svg.icon {
 }
 button.btn--primary[disabled],
 button.btn--primary[aria-disabled="true"] {
-  background-color: var(--btn-primary-disabled-background-color, var(--color-background-accent));
-  border-color: var(--btn-primary-disabled-border-color, var(--color-background-accent));
+  background-color: var(--btn-primary-disabled-background-color, var(--color-foreground-disabled));
+  border-color: var(--btn-primary-disabled-border-color, var(--color-foreground-disabled));
   color: var(--btn-primary-foreground-color, var(--color-foreground-on-accent));
 }
 button.btn--primary[disabled] svg.icon,

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -132,8 +132,8 @@ a.fake-btn--primary.fake-btn--destructive {
 
 button.btn--primary.btn--destructive[disabled],
 button.btn--primary.btn--destructive[aria-disabled="true"] {
-    .background-color-token(btn-primary-destructive-disabled-background, color-background-attention);
-    .border-color-token(btn-primary-destructive-disabled-border, color-stroke-attention);
+    .background-color-token(btn-primary-destructive-disabled-background, color-background-disabled);
+    .border-color-token(btn-primary-destructive-disabled-border, color-stroke-disabled);
 }
 
 button.btn--primary.btn--destructive:not([disabled], [aria-disabled="true"]),
@@ -181,8 +181,8 @@ a.fake-btn--large svg.icon {
 
 button.btn--primary[disabled],
 button.btn--primary[aria-disabled="true"] {
-    .background-color-token(btn-primary-disabled-background-color, color-background-accent);
-    .border-color-token(btn-primary-disabled-border-color, color-background-accent);
+    .background-color-token(btn-primary-disabled-background-color, color-foreground-disabled);
+    .border-color-token(btn-primary-disabled-border-color, color-foreground-disabled);
     .color-token(btn-primary-foreground-color, color-foreground-on-accent);
 
     svg.icon {

--- a/src/less/button/stories/button/primary.stories.js
+++ b/src/less/button/stories/button/primary.stories.js
@@ -40,15 +40,3 @@ export const busy = () => `
     </span>
 </button>
 `;
-
-export const busyDisabled = () => `
-<button class="btn btn--primary" aria-label="Busy" aria-disabled="true" disabled>
-    <span class="btn__cell">
-        <span class="progress-spinner">
-            <svg class="icon icon--spinner-24" focusable="false" aria-hidden="true">
-                <use href="#icon-spinner-24"></use>
-            </svg>
-        </span>
-    </span>
-</button>
-`;

--- a/src/less/button/stories/destructive-button/primary.stories.js
+++ b/src/less/button/stories/destructive-button/primary.stories.js
@@ -34,13 +34,3 @@ export const busy = () => `
     </span>
 </button>
 `;
-
-export const busyDisabled = () => `
-<button class="btn btn--primary btn--destructive" aria-label="Busy" aria-disabled="true" disabled>
-    <span class="progress-spinner">
-        <svg aria-hidden="true" class="icon icon--spinner-24" focusable="false">
-            <use href="#icon-spinner-24"></use>
-        </svg>
-    </span>
-</button>
-`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Reverts button disabled state handling #2010 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This reverts the disabled primary button spinner use case because of various visual and a11y complications.

## Notes
Loading buttons should not be disabled in markup. More information from the team to follow.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
