### PR TITLE
fix(icons): adjusted/removed sizing overrides for icons

### DIFF
--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -111,10 +111,6 @@ a.fake-btn--borderless .fake-btn__cell {
 button.btn svg.icon,
 a.fake-btn svg.icon {
   align-self: center;
-  flex-shrink: 0;
-  height: 100%;
-  max-height: 21px;
-  width: 1em;
 }
 button.btn svg.icon:first-child,
 a.fake-btn svg.icon:first-child {

--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -100,12 +100,10 @@ span.combobox {
 .combobox__option[role^="option"] svg.icon {
   align-self: center;
   fill: currentColor;
-  height: 10px;
   margin: 0 auto;
   opacity: 0;
   stroke: currentColor;
   stroke-width: 0;
-  width: 14px;
 }
 .combobox__option--active[role^="option"] {
   background-color: var(--color-state-primary-active);

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -88,12 +88,10 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 .listbox-button__option svg.icon {
   align-self: center;
   fill: currentColor;
-  height: 10px;
   margin: 0 auto;
   opacity: 0;
   stroke: currentColor;
   stroke-width: 0;
-  width: 14px;
   margin-left: 8px;
 }
 div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {

--- a/dist/listbox/listbox.css
+++ b/dist/listbox/listbox.css
@@ -62,12 +62,10 @@ span.listbox__value {
 div.listbox__option svg.icon {
   align-self: center;
   fill: currentColor;
-  height: 10px;
   margin: 0 auto;
   opacity: 0;
   stroke: currentColor;
   stroke-width: 0;
-  width: 14px;
   margin-left: 8px;
 }
 [dir="rtl"] div.listbox__option svg.icon {

--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -79,12 +79,10 @@ div.menu-button__item[role^="menuitem"]:last-child {
 .fake-menu-button__item svg.icon--tick-16 {
   align-self: center;
   fill: currentColor;
-  height: 10px;
   margin: 0 auto;
   opacity: 0;
   stroke: currentColor;
   stroke-width: 0;
-  width: 14px;
 }
 .menu-button__item svg.icon--tick-16:last-child,
 .fake-menu-button__item svg.icon--tick-16:last-child {

--- a/dist/menu/menu.css
+++ b/dist/menu/menu.css
@@ -21,12 +21,10 @@ span.fake-menu__items {
 .fake-menu__item > svg.icon--tick-16 {
   align-self: center;
   fill: currentColor;
-  height: 10px;
   margin: 0 auto;
   opacity: 0;
   stroke: currentColor;
   stroke-width: 0;
-  width: 14px;
 }
 .menu__item > svg.icon--tick-16:last-child,
 .fake-menu__item > svg.icon--tick-16:last-child,

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -78,11 +78,6 @@ a.fake-btn--borderless .fake-btn__cell {
 button.btn svg.icon,
 a.fake-btn svg.icon {
     .btn-icon-base();
-
-    // flex-shrink: 0;
-    // height: 100%;
-    // max-height: @button-height-small - (@button-padding-vertical * 2);
-    // width: 1em;
 }
 
 button.btn__cell--fixed-height svg.icon,

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -79,10 +79,10 @@ button.btn svg.icon,
 a.fake-btn svg.icon {
     .btn-icon-base();
 
-    flex-shrink: 0;
-    height: 100%;
-    max-height: @button-height-small - (@button-padding-vertical * 2);
-    width: 1em;
+    // flex-shrink: 0;
+    // height: 100%;
+    // max-height: @button-height-small - (@button-padding-vertical * 2);
+    // width: 1em;
 }
 
 button.btn__cell--fixed-height svg.icon,

--- a/src/less/mixins/private/selection-list-mixins.less
+++ b/src/less/mixins/private/selection-list-mixins.less
@@ -21,10 +21,8 @@
 .selection-list-item-status() {
     align-self: center;
     fill: currentColor;
-    height: 10px;
     margin: 0 auto;
     opacity: 0;
     stroke: currentColor;
     stroke-width: 0;
-    width: 14px;
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2031 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I removed various sizing adjustments and overrides to allow the new icons to display properly. 

I also ran a targeted Percy build on the impacted components: https://percy.io/79bdc98e/eBay-Skin/builds/26489814

## Screenshots

**Before**
<img width="182" alt="image" src="https://user-images.githubusercontent.com/1675667/230465106-ec1f6771-3687-4beb-830d-427c68995c46.png">

**After**
<img width="172" alt="image" src="https://user-images.githubusercontent.com/1675667/230465238-0b07447c-e07f-4178-8133-08a84e6ef975.png">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
