### PR TITLE
feat: updated dialog to new sizes and constraints

### DIFF
--- a/dist/alert-dialog/alert-dialog.css
+++ b/dist/alert-dialog/alert-dialog.css
@@ -20,8 +20,10 @@
   min-height: 55px;
   will-change: opacity, transform;
   border-radius: var(--lightbox-border-radius, var(--border-radius-100));
-  margin-top: 15vh;
+  margin: auto;
+  max-height: 90%;
   max-width: calc(100% - 32px);
+  min-width: 208px;
   margin-left: 16px;
   margin-right: 16px;
   padding: 16px;

--- a/dist/confirm-dialog/confirm-dialog.css
+++ b/dist/confirm-dialog/confirm-dialog.css
@@ -20,8 +20,10 @@
   min-height: 55px;
   will-change: opacity, transform;
   border-radius: var(--lightbox-border-radius, var(--border-radius-100));
-  margin-top: 15vh;
+  margin: auto;
+  max-height: 90%;
   max-width: calc(100% - 32px);
+  min-width: 208px;
   margin-left: 16px;
   margin-right: 16px;
   padding: 16px;

--- a/dist/drawer-dialog/drawer-dialog.css
+++ b/dist/drawer-dialog/drawer-dialog.css
@@ -61,7 +61,7 @@
 .drawer-dialog__main {
   box-sizing: border-box;
   flex: 1 1 auto;
-  margin: 16px;
+  padding: 16px;
   position: relative;
   min-height: auto;
   overflow: auto;

--- a/dist/fullscreen-dialog/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/fullscreen-dialog.css
@@ -53,7 +53,7 @@
 .fullscreen-dialog__main {
   box-sizing: border-box;
   flex: 1 1 auto;
-  margin: 16px;
+  padding: 16px;
   position: relative;
   min-height: auto;
 }

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -20,8 +20,10 @@
   min-height: 55px;
   will-change: opacity, transform;
   border-radius: var(--lightbox-border-radius, var(--border-radius-100));
-  margin-top: 15vh;
+  margin: auto;
+  max-height: 90%;
   max-width: calc(100% - 32px);
+  min-width: 208px;
 }
 .lightbox-dialog__header {
   display: flex;
@@ -48,9 +50,10 @@
 .lightbox-dialog__main {
   box-sizing: border-box;
   flex: 1 1 auto;
-  margin: 16px;
+  padding: 16px;
   position: relative;
   min-height: 18px;
+  overflow: auto;
 }
 .lightbox-dialog__main > :first-child {
   margin-top: 0;
@@ -135,6 +138,9 @@ button.icon-btn.lightbox-dialog__close {
 @media (min-width: 769px) {
   .lightbox-dialog__window {
     max-width: 616px;
+  }
+  .lightbox-dialog__window--wide {
+    max-width: 896px;
   }
 }
 @media (min-width: 601px) {

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -139,7 +139,7 @@ button.icon-btn.lightbox-dialog__close {
   .lightbox-dialog__window {
     max-width: 616px;
   }
-  .lightbox-dialog__window--wide {
+  .lightbox-dialog--wide .lightbox-dialog__window {
     max-width: 896px;
   }
 }

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -58,7 +58,7 @@
 .panel-dialog__main {
   box-sizing: border-box;
   flex: 1 1 auto;
-  margin: 16px;
+  padding: 16px;
   position: relative;
   height: 1px;
   overflow-y: auto;

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -104,16 +104,16 @@
 </div>
     {% endhighlight %}
 
-    <h3 id="lightbox-scrolling">Wide Lightbox</h3>
-    <p>To have a wider lightbox add  <span class="highlight">lightbox-dialog__window--wide</span> to the window part of the dialog</p>
+    <h3 id="lightbox-wide">Wide Lightbox</h3>
+    <p>To have a wider lightbox add  <span class="highlight">lightbox-dialog--wide</span> to the dialog</p>
 
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-wide" type="button">Open Lightbox</button>
-            <div aria-labelledby="dialog-title-default" aria-modal="true" class="lightbox-dialog" hidden id="lightbox-dialog-wide" role="dialog">
-                <div class="lightbox-dialog__window lightbox-dialog__window--wide">
+            <div aria-labelledby="dialog-title-wide" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" hidden id="lightbox-dialog-wide" role="dialog">
+                <div class="lightbox-dialog__window">
                     <div class="lightbox-dialog__header">
-                        <h2 id="dialog-title-default" class="large-text-1 bold-text">Lightbox Dialog</h2>
+                        <h2 id="dialog-title-wide" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close-16" %}
@@ -133,8 +133,8 @@
     </div>
 
     {% highlight html %}
-<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
-    <div class="lightbox-dialog__window lightbox-dialog__window--wide">
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" hidden role="dialog">
+    <div class="lightbox-dialog__window">
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -104,6 +104,56 @@
 </div>
     {% endhighlight %}
 
+    <h3 id="lightbox-scrolling">Wide Lightbox</h3>
+    <p>To have a wider lightbox add  <span class="highlight">lightbox-dialog__window--wide</span> to the window part of the dialog</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-wide" type="button">Open Lightbox</button>
+            <div aria-labelledby="dialog-title-default" aria-modal="true" class="lightbox-dialog" hidden id="lightbox-dialog-wide" role="dialog">
+                <div class="lightbox-dialog__window lightbox-dialog__window--wide">
+                    <div class="lightbox-dialog__header">
+                        <h2 id="dialog-title-default" class="large-text-1 bold-text">Lightbox Dialog</h2>
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
+                                {% include symbol.html name="close-16" %}
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="lightbox-dialog__main">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        <p><a href="https://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
+    <div class="lightbox-dialog__window lightbox-dialog__window--wide">
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p><a href="https://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
     <h3 id="lightbox-transitioned">Transitioned Lightbox</h3>
     <p>Any lightbox can be transitioned in and out, using the <span class="highlight">lightbox-dialog__window--fade</span> and <span class="highlight">lightbox-dialog--mask-fade</span> modifiers.</p>
     <p>The default fade duration is 16ms.<p>

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -106,7 +106,7 @@ button.icon-btn.lightbox-dialog__close {
         max-width: @dialog-lightbox-max-width;
     }
 
-    .lightbox-dialog__window--wide {
+    .lightbox-dialog--wide .lightbox-dialog__window {
         max-width: @dialog-lightbox-wide-max-width;
     }
 }

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -18,6 +18,7 @@
     .dialog-body-content();
 
     min-height: 18px;
+    overflow: auto;
 }
 
 .lightbox-dialog__footer {
@@ -103,6 +104,10 @@ button.icon-btn.lightbox-dialog__close {
 @media (min-width: 769px) {
     .lightbox-dialog__window {
         max-width: @dialog-lightbox-max-width;
+    }
+
+    .lightbox-dialog__window--wide {
+        max-width: @dialog-lightbox-wide-max-width;
     }
 }
 

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -23,6 +23,73 @@ export const base = () => `
 </div>
 `;
 
+export const scrollingLightbox = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window">
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+
+        </div>
+    </div>
+</div>
+`;
+
 export const baseWithFooter = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
@@ -100,8 +167,8 @@ export const baseWithLongHeader = () => `
 `;
 
 export const wide = () => `
-<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
-    <div class="lightbox-dialog__window lightbox-dialog__window--wide">
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" role="dialog">
+    <div class="lightbox-dialog__window">
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -98,3 +98,26 @@ export const baseWithLongHeader = () => `
     </div>
 </div>
 `;
+
+export const wide = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window lightbox-dialog__window--wide">
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/mixins/private/dialog-mixins.less
+++ b/src/less/mixins/private/dialog-mixins.less
@@ -3,6 +3,7 @@
 @dialog-scrim-color-hide: rgba(17, 24, 32, 0);
 @dialog-scrim-color-show: rgba(17, 24, 32, 0.7);
 @dialog-lightbox-max-width: 616px;
+@dialog-lightbox-wide-max-width: 896px;
 
 .dialog-base() {
     background-color: @dialog-scrim-color-show;
@@ -39,8 +40,10 @@
     .dialog-window();
     .border-radius-token(lightbox-border-radius, border-radius-100);
 
-    margin-top: 15vh;
+    margin: auto;
+    max-height: 90%;
     max-width: calc(100% - 32px);
+    min-width: 208px;
 }
 
 .dialog-header-content(@top-margin: @spacing-200) {
@@ -72,7 +75,7 @@
 .dialog-body-content() {
     box-sizing: border-box;
     flex: 1 1 auto;
-    margin: @spacing-200;
+    padding: @spacing-200;
     position: relative;
 
     & > :first-child {


### PR DESCRIPTION
Fixes #1937

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Updated lightbox dialog min-width
* Removed the 50vh margin. Dialog should be centered
* Added `max-height` of 90%
* Added a `wide` size for lightbox dialog
* Added a scrolling body only

## Screenshots
<img width="762" alt="Screen Shot 2023-04-06 at 3 03 30 PM" src="https://user-images.githubusercontent.com/1755269/230502238-549250eb-4927-4cd5-890b-fb0f1624e42f.png">
<img width="800" alt="Screen Shot 2023-04-06 at 3 03 24 PM" src="https://user-images.githubusercontent.com/1755269/230502241-f6239345-e37f-4ae7-933b-ea7f7aff2100.png">
<img width="1325" alt="Screen Shot 2023-04-06 at 3 03 17 PM" src="https://user-images.githubusercontent.com/1755269/230502243-e0603573-0037-4394-bc29-18ad184b7586.png">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
