### PR TITLE
feat(page-grid): updated components to standard breakpoints

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,6 +1,7 @@
 version: 2
 snapshot:
-    widths: [602]
+    widths: [320,512,768,1280]
+discovery:
     device-pixel-ratio: 2
 storybook:
     include: []

--- a/dist/alert-dialog/alert-dialog.css
+++ b/dist/alert-dialog/alert-dialog.css
@@ -89,12 +89,12 @@
 .alert-dialog--hide-init .alert-dialog__window--fade {
   opacity: 1;
 }
-@media (min-width: calc(768px + 1px)) and (max-width: 1024px) {
+@media (min-width: 768px) {
   .alert-dialog__window {
     max-width: calc(88% - 32px);
   }
 }
-@media (min-width: calc(1024px + 1px)) {
+@media (min-width: 1024px) {
   .alert-dialog__window {
     max-width: 616px;
   }

--- a/dist/breadcrumbs/breadcrumbs.css
+++ b/dist/breadcrumbs/breadcrumbs.css
@@ -90,7 +90,7 @@ nav.breadcrumbs .menu-button__menu {
 [dir="rtl"] nav.breadcrumbs svg.icon--chevron-right-12 {
   transform: rotate(180deg);
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   nav.breadcrumbs {
     margin: 16px 0;
   }

--- a/dist/carousel/carousel.css
+++ b/dist/carousel/carousel.css
@@ -129,7 +129,7 @@ div.carousel {
 .carousel__control:focus:not(:focus-visible) {
   outline: none;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .carousel:focus-within .carousel__control {
     opacity: 0.92;
   }
@@ -137,7 +137,7 @@ div.carousel {
     opacity: 0.3;
   }
 }
-@media (min-width: 601px) and (hover: hover) {
+@media (min-width: 512px) and (hover: hover) {
   .carousel:hover .carousel__control {
     opacity: 0.92;
   }
@@ -259,7 +259,7 @@ span.carousel__container {
     scroll-snap-coordinate: 0 0;
   }
   /* autoprefixer: on */
-  @media (min-width: 601px) {
+  @media (min-width: 512px) {
     div.carousel {
       margin: 16px 0;
     }

--- a/dist/confirm-dialog/confirm-dialog.css
+++ b/dist/confirm-dialog/confirm-dialog.css
@@ -93,12 +93,12 @@ button.confirm-dialog__confirm {
 .confirm-dialog--hide-init .confirm-dialog__window--fade {
   opacity: 1;
 }
-@media (min-width: calc(768px + 1px)) and (max-width: 1024px) {
+@media (min-width: 768px) {
   .confirm-dialog__window {
     max-width: calc(88% - 32px);
   }
 }
-@media (min-width: calc(1024px + 1px)) {
+@media (min-width: 1024px) {
   .confirm-dialog__window {
     max-width: 616px;
   }

--- a/dist/date-textbox/date-textbox.css
+++ b/dist/date-textbox/date-textbox.css
@@ -19,7 +19,7 @@
 .date-textbox__popover[hidden] {
   display: none;
 }
-@media only screen and (max-width: 600px) {
+@media only screen and (max-width: 512px) {
   .date-textbox__popover {
     left: 0;
     margin-left: 0;

--- a/dist/infotip/infotip.css
+++ b/dist/infotip/infotip.css
@@ -135,7 +135,7 @@ button.infotip__close,
 .infotip__close {
   margin-left: 16px;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .infotip__overlay {
     max-width: 400px;
   }

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -130,20 +130,10 @@ button.icon-btn.lightbox-dialog__close {
 .lightbox-dialog--hide-init .lightbox-dialog__window--fade {
   opacity: 1;
 }
-@media (min-width: 601px) and (max-width: 768px) {
+@media (min-width: 512px) {
   .lightbox-dialog__window {
     max-width: calc(88% - 32px);
   }
-}
-@media (min-width: 769px) {
-  .lightbox-dialog__window {
-    max-width: 616px;
-  }
-  .lightbox-dialog--wide .lightbox-dialog__window {
-    max-width: 896px;
-  }
-}
-@media (min-width: 601px) {
   .lightbox-dialog__window .lightbox-dialog__footer {
     flex-direction: row;
     justify-content: flex-end;
@@ -152,5 +142,13 @@ button.icon-btn.lightbox-dialog__close {
   .lightbox-dialog__window .lightbox-dialog__footer > :not(:first-child) {
     margin-left: 8px;
     margin-top: initial;
+  }
+}
+@media (min-width: 768px) {
+  .lightbox-dialog__window {
+    max-width: 616px;
+  }
+  .lightbox-dialog--wide .lightbox-dialog__window {
+    max-width: 896px;
   }
 }

--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -104,7 +104,7 @@ p.page-notice__cta {
   margin-right: 16px;
   margin-top: 16px;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   section.page-notice,
   div[role="region"].page-notice {
     margin: 16px 0;

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -148,7 +148,7 @@ button.icon-btn.panel-dialog__close {
 .panel-dialog--hide-init .panel-dialog__window--slide {
   transform: translateX(0);
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .panel-dialog__window {
     width: 384px;
   }

--- a/dist/progress-bar/progress-bar.css
+++ b/dist/progress-bar/progress-bar.css
@@ -20,7 +20,7 @@
 .progress-bar--fluid {
   width: 100%;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .progress-bar {
     margin: 16px 0;
   }

--- a/dist/progress-stepper/progress-stepper.css
+++ b/dist/progress-stepper/progress-stepper.css
@@ -168,7 +168,7 @@ hr.progress-stepper__separator {
   margin-left: inherit;
   margin-right: 11px;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   hr.progress-stepper__separator {
     min-width: 120px;
   }

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -81,7 +81,7 @@ p.section-notice__cta {
   margin: 4px 0 0;
 }
 /* LARGE SCREEN ADJUSTMENTS */
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   section.section-notice,
   div[role="region"].section-notice {
     margin: 16px 0;

--- a/dist/section-title/section-title.css
+++ b/dist/section-title/section-title.css
@@ -74,7 +74,7 @@
 [dir="rtl"] .section-title__info {
   margin: 0 8px 0 24px;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .section-title__title {
     font-size: 1.5rem;
     font-weight: 700;

--- a/dist/snackbar-dialog/snackbar-dialog.css
+++ b/dist/snackbar-dialog/snackbar-dialog.css
@@ -59,7 +59,7 @@
   color: var(--snackbar-dialog-foreground-color, var(--color-foreground-on-inverse));
   text-decoration: underline;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .snackbar-dialog {
     bottom: 20px;
   }

--- a/dist/square-corner-theme/square-corner-theme.css
+++ b/dist/square-corner-theme/square-corner-theme.css
@@ -62,7 +62,7 @@ button.expand-btn {
 .toast-dialog {
   --toast-dialog-border-radius: 0;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .toast-dialog {
     --toast-dialog-large-border-radius: 0;
   }

--- a/dist/toast-dialog/toast-dialog.css
+++ b/dist/toast-dialog/toast-dialog.css
@@ -109,7 +109,7 @@ button.toast-dialog__close > svg {
 .toast-dialog__footer button.btn--secondary:not([disabled]):active {
   background-color: var(--color-state-information-active);
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .toast-dialog {
     border-radius: var(--toast-dialog-border-radius, var(--border-radius-100));
     bottom: 16px;

--- a/dist/tooltip/tooltip.css
+++ b/dist/tooltip/tooltip.css
@@ -131,7 +131,7 @@ button.tooltip__close {
 .tooltip__host[aria-expanded="true"] ~ .tooltip__overlay {
   display: block;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .tooltip__overlay {
     max-width: 400px;
   }

--- a/dist/tourtip/tourtip.css
+++ b/dist/tourtip/tourtip.css
@@ -168,7 +168,7 @@ span.tourtip__heading {
   color: var(--tourtip-index-color, var(--color-foreground-secondary));
   flex: 1;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .tourtip__overlay {
     max-width: 400px;
   }

--- a/dist/typography/typography.css
+++ b/dist/typography/typography.css
@@ -79,7 +79,7 @@
 .small-section-title {
   font-weight: 700;
 }
-@media (min-width: 601px) {
+@media (min-width: 512px) {
   .giant-product-title,
   .giant-section-title {
     font-size: 1.875rem;

--- a/src/less/alert-dialog/alert-dialog.less
+++ b/src/less/alert-dialog/alert-dialog.less
@@ -82,14 +82,13 @@
     }
 }
 
-// In order to prevent the margins to meet the ege of the page at medium screen sizes
-@media (min-width: calc(@_screen-size-MD + 1px)) and (max-width: @_screen-size-LG) {
+@media (min-width: @_screen-size-MD) {
     .alert-dialog__window {
         max-width: calc(88% - @spacing-400;);
     }
 }
 
-@media (min-width: calc(@_screen-size-LG + 1px)) {
+@media (min-width: @_screen-size-LG) {
     .alert-dialog__window {
         max-width: @dialog-lightbox-max-width;
     }

--- a/src/less/breadcrumbs/breadcrumbs.less
+++ b/src/less/breadcrumbs/breadcrumbs.less
@@ -113,7 +113,7 @@ nav.breadcrumbs .menu-button__menu {
     transform: rotate(180deg);
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     nav.breadcrumbs {
         margin: 16px 0;
     }

--- a/src/less/carousel/carousel.less
+++ b/src/less/carousel/carousel.less
@@ -63,7 +63,7 @@
     // progressive enhancement for browsers with support
     // :focus-within and :hover cannot be combined as
     // IE/Edge will discard the entire rule
-    @media (min-width: 601px) {
+    @media (min-width: @_screen-size-SM) {
         .carousel:focus-within & {
             .show-control();
         }
@@ -300,7 +300,7 @@ span.carousel__container {
         scroll-snap-coordinate: 0 0;
     }
     /* autoprefixer: on */
-    @media (min-width: 601px) {
+    @media (min-width: @_screen-size-SM) {
         div.carousel {
             margin: 16px 0;
         }

--- a/src/less/confirm-dialog/confirm-dialog.less
+++ b/src/less/confirm-dialog/confirm-dialog.less
@@ -87,14 +87,13 @@ button.confirm-dialog__confirm {
     }
 }
 
-// In order to prevent the margins to meet the ege of the page at medium screen sizes
-@media (min-width: calc(@_screen-size-MD + 1px)) and (max-width: @_screen-size-LG) {
+@media (min-width: @_screen-size-MD) {
     .confirm-dialog__window {
         max-width: calc(88% - @spacing-400);
     }
 }
 
-@media (min-width: calc(@_screen-size-LG + 1px)) {
+@media (min-width: @_screen-size-LG) {
     .confirm-dialog__window {
         max-width: @dialog-lightbox-max-width;
     }

--- a/src/less/date-textbox/date-textbox.less
+++ b/src/less/date-textbox/date-textbox.less
@@ -25,7 +25,7 @@
     display: none;
 }
 
-@media only screen and (max-width: 600px) {
+@media only screen and (max-width: @_screen-size-SM) {
     .date-textbox__popover {
         left: 0;
         margin-left: 0;

--- a/src/less/infotip/infotip.less
+++ b/src/less/infotip/infotip.less
@@ -123,7 +123,7 @@ button.infotip__close,
     margin-left: @spacing-200;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .infotip__overlay {
         .bubble-large-screen();
     }

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -95,24 +95,22 @@ button.icon-btn.lightbox-dialog__close {
 }
 
 // In order to prevent the margins to meet the ege of the page at medium screen sizes
-@media (min-width: 601px) and (max-width: 768px) {
+@media (min-width: @_screen-size-SM) {
     .lightbox-dialog__window {
         max-width: calc(88% - @spacing-400);
     }
+
+    .lightbox-dialog__window .lightbox-dialog__footer {
+        .dialog-footer-content-large();
+    }
 }
 
-@media (min-width: 769px) {
+@media (min-width: @_screen-size-MD) {
     .lightbox-dialog__window {
         max-width: @dialog-lightbox-max-width;
     }
 
     .lightbox-dialog--wide .lightbox-dialog__window {
         max-width: @dialog-lightbox-wide-max-width;
-    }
-}
-
-@media (min-width: 601px) {
-    .lightbox-dialog__window .lightbox-dialog__footer {
-        .dialog-footer-content-large();
     }
 }

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -134,7 +134,7 @@ p.page-notice__cta {
     margin-top: @spacing-200;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     section.page-notice,
     div[role="region"].page-notice {
         margin: @spacing-200 0;

--- a/src/less/panel-dialog/panel-dialog.less
+++ b/src/less/panel-dialog/panel-dialog.less
@@ -129,7 +129,7 @@ button.icon-btn.panel-dialog__close {
 // MEDIA QUERIES
 //-----------------------------
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .panel-dialog__window {
         width: 384px;
     }

--- a/src/less/progress-bar/progress-bar.less
+++ b/src/less/progress-bar/progress-bar.less
@@ -28,7 +28,7 @@
     width: 100%;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .progress-bar {
         margin: @spacing-200 0;
     }

--- a/src/less/progress-stepper/progress-stepper.less
+++ b/src/less/progress-stepper/progress-stepper.less
@@ -280,7 +280,7 @@ hr.progress-stepper__separator {
     }
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     hr.progress-stepper__separator {
         min-width: @progress-stepper-large-min-width;
     }

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -105,7 +105,7 @@ p.section-notice__cta {
 
 /* LARGE SCREEN ADJUSTMENTS */
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     section.section-notice,
     div[role="region"].section-notice {
         margin: @spacing-200 0;

--- a/src/less/section-title/section-title.less
+++ b/src/less/section-title/section-title.less
@@ -94,7 +94,7 @@
     }
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .section-title__title {
         .typography-large-2();
     }

--- a/src/less/snackbar-dialog/snackbar-dialog.less
+++ b/src/less/snackbar-dialog/snackbar-dialog.less
@@ -79,7 +79,7 @@
     text-decoration: underline;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .snackbar-dialog {
         bottom: 20px;
     }

--- a/src/less/square-corner-theme/square-corner-theme.less
+++ b/src/less/square-corner-theme/square-corner-theme.less
@@ -83,7 +83,7 @@ button.expand-btn {
     --toast-dialog-border-radius: 0;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .toast-dialog {
         --toast-dialog-large-border-radius: 0;
     }

--- a/src/less/toast-dialog/toast-dialog.less
+++ b/src/less/toast-dialog/toast-dialog.less
@@ -142,7 +142,7 @@ button.toast-dialog__close > svg {
     }
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .toast-dialog {
         .border-radius-token(toast-dialog-border-radius, border-radius-100);
         bottom: @spacing-200;

--- a/src/less/tooltip/tooltip.less
+++ b/src/less/tooltip/tooltip.less
@@ -109,7 +109,7 @@ button.tooltip__close {
     display: block;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .tooltip__overlay {
         .bubble-large-screen();
     }

--- a/src/less/tourtip/tourtip.less
+++ b/src/less/tourtip/tourtip.less
@@ -161,7 +161,7 @@ span.tourtip__heading {
     flex: 1;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .tourtip__overlay {
         .bubble-large-screen();
     }

--- a/src/less/typography/typography.less
+++ b/src/less/typography/typography.less
@@ -85,7 +85,7 @@
     font-weight: @font-weight-bold;
 }
 
-@media (min-width: 601px) {
+@media (min-width: @_screen-size-SM) {
     .giant-product-title,
     .giant-section-title {
         .title-giant-screen-large();


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2032 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This updates all component breakpoints with standard breakpoints for consistency. I also added a subset of the standard breakpoints for visual regression in Percy.

Percy Build: https://percy.io/f1364dca/eBay-Skin/builds/26661937
Most of the visual diffs had to do with the `512px` breakpoint since previously our visual responsive changes were at `600px`/`601px` pixels.

## Notes
I also simplified some of the breakpoints. Whereas previously, they were doing `600px + 1px` (for some margin fixes?), they're now simply at the standard breakpoint of `512px`. I did some testing with the breakpoints to see what the difference between `600px` and `601px` was and could not find any issue at either, and since it's best to keep breakpoints at even numbers, it made sense to consolidate `600px` and `601px` and simplify into just the one standard.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
