### PR TITLE
fix(icons): adjusted icons used in storybook

### DIFF
--- a/src/less/button/stories/button/base.stories.js
+++ b/src/less/button/stories/button/base.stories.js
@@ -10,7 +10,7 @@ export const formSlim = () =>
 export const iconAndText = () => `
 <button type="button" class="btn">
     <span class="btn__cell">
-        <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+        <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
         <span>Button</span>
     </span>
 </button>
@@ -19,7 +19,7 @@ export const iconAndText = () => `
 export const disabled = () => `
 <button type="button" class="btn" disabled>
     <span class="btn__cell">
-        <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+        <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
         <span>Button</span>
     </span>
 </button>

--- a/src/less/button/stories/button/cascade.stories.js
+++ b/src/less/button/stories/button/cascade.stories.js
@@ -3,7 +3,7 @@ export default { title: "Button/Cascade" };
 export const color = () => `
 <button type="button" class="btn" style="color: red;">
     <span class="btn__cell">
-        <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+        <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
         <span>Button</span>
     </span>
 </button>
@@ -13,7 +13,7 @@ export const fontSize = () => `
 <div style="font-size: 200%;">
     <button type="button" class="btn">
         <span class="btn__cell">
-            <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+            <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
             <span>Button</span>
         </span>
     </button>

--- a/src/less/button/stories/button/dimensions.stories.js
+++ b/src/less/button/stories/button/dimensions.stories.js
@@ -3,7 +3,7 @@ export default { title: "Button/Dimensions" };
 export const large = () => `
 <button type="button" class="btn btn--large">
     <span class="btn__cell">
-        <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+        <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
         <span>Button</span>
     </span>
 </button>

--- a/src/less/button/stories/fake-button/base.stories.js
+++ b/src/less/button/stories/fake-button/base.stories.js
@@ -6,7 +6,7 @@ export const textOnly = () =>
 export const iconAndText = () => `
 <a class="fake-btn" href="http://www.ebay.com">
     <span class="fake-btn__cell">
-        <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+        <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
         <span>Fake Button</span>
     </span>
 </a>
@@ -15,7 +15,7 @@ export const iconAndText = () => `
 export const disabled = () => `
 <a class="fake-btn">
     <span class="fake-btn__cell">
-        <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+        <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
         <span>Fake Button</span>
     </span>
 </a>

--- a/src/less/button/stories/fake-button/cascade.stories.js
+++ b/src/less/button/stories/fake-button/cascade.stories.js
@@ -4,7 +4,7 @@ export const RTL = () => `
 <div dir="rtl">
     <a class="fake-btn" href="http://www.ebay.com">
         <span class="fake-btn__cell">
-            <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+            <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
             <span>Fake Button</span>
         </span>
     </a>
@@ -15,7 +15,7 @@ export const color = () => `
 <div style="color: red;">
     <a class="fake-btn" href="http://www.ebay.com">
         <span class="fake-btn__cell">
-            <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+            <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
             <span>Fake Button</span>
         </span>
     </a>
@@ -26,7 +26,7 @@ export const fontSize = () => `
 <div style="font-size: 200%">
     <a class="fake-btn" href="http://www.ebay.com">
         <span class="fake-btn__cell">
-            <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+            <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
             <span>Fake Button</span>
         </span>
     </a>

--- a/src/less/button/stories/fake-button/dimensions.stories.js
+++ b/src/less/button/stories/fake-button/dimensions.stories.js
@@ -3,7 +3,7 @@ export default { title: "Fake Button/Dimensions" };
 export const large = () => `
 <a class="fake-btn fake-btn--large" href="http://www.ebay.com">
     <span class="fake-btn__cell">
-        <svg class="icon icon--settings-24" width="16" height="16"><use href="#icon-settings-24"></use></svg>
+        <svg class="icon icon--settings-16" width="16" height="16"><use href="#icon-settings-16"></use></svg>
         <span>Fake Button</span>
     </span>
 </a>

--- a/src/less/icon-button/stories/alignment.stories.js
+++ b/src/less/icon-button/stories/alignment.stories.js
@@ -2,10 +2,10 @@ export default { title: "Icon Button/Alignment" };
 
 export const menu = () => `
 <button aria-label="menu" type="button" class="icon-btn">
-    <svg class="icon icon--menu-16" aria-hidden="true" focusable="false" width="16" height="16"><use href="#icon-menu-16"></use></svg>
+    <svg class="icon icon--menu-20" aria-hidden="true" focusable="false" width="16" height="16"><use href="#icon-menu-20"></use></svg>
 </button>
 <a aria-label="menu" class="icon-link" href="http://www.ebay.com">
-     <svg class="icon icon--menu-16" aria-hidden="true" focusable="false" width="16" height="16"><use href="#icon-menu-16"></use></svg>
+     <svg class="icon icon--menu-20" aria-hidden="true" focusable="false" width="16" height="16"><use href="#icon-menu-20"></use></svg>
 </a>
 `;
 


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
This is fixing the icon usage issues found in visual regression (https://percy.io/f1364dca/eBay-Skin/builds/26768330). I also fixed a missing icon of an `Icon Button` story.

## Notes
I reran another Percy build after the fixes to verify the updates match `master`: https://percy.io/f1364dca/eBay-Skin/builds/26799373

## Screenshots
**Issue**
![icon-size-issues](https://user-images.githubusercontent.com/1675667/233424938-69b0a588-e70e-44b4-a0d3-ff27314fa50d.png)


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
