### PR TITLE
fix(infotip,textbox): bugfixes on size and border

### DIFF
--- a/dist/infotip/infotip.css
+++ b/dist/infotip/infotip.css
@@ -124,6 +124,7 @@ span.infotip__heading {
   display: block;
 }
 .infotip .icon-btn {
+  display: inline-flex;
   flex-shrink: 0;
   height: 20px;
   min-width: 20px;

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -107,7 +107,7 @@ input.textbox__control--large {
 }
 input.textbox__control:not(:read-only):focus,
 textarea.textbox__control:not(:read-only):focus {
-  border-color: var(--textbox-focus-border-color, var(--color-stroke-default));
+  border-color: var(--textbox-focus-border-color, var(--color-stroke-strong));
   background-color: var(--textbox-focus-background-color, var(--color-background-primary));
   outline: 0;
 }

--- a/src/less/infotip/infotip.less
+++ b/src/less/infotip/infotip.less
@@ -110,6 +110,7 @@ span.infotip__heading {
 
 // todo: refactor out this dependency. Use a mixin instead
 .infotip .icon-btn {
+    display: inline-flex;
     flex-shrink: 0; // todo: Should move to icon-btn in next major
     height: 20px;
     min-width: 20px;

--- a/src/less/textbox/textbox.less
+++ b/src/less/textbox/textbox.less
@@ -130,7 +130,7 @@ input.textbox__control--large {
 
 input.textbox__control:not(:read-only):focus,
 textarea.textbox__control:not(:read-only):focus {
-    .border-color-token(textbox-focus-border-color, color-stroke-default);
+    .border-color-token(textbox-focus-border-color, color-stroke-strong);
     .background-color-token(textbox-focus-background-color, color-background-primary);
     outline: 0;
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2055, #2050


- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Fixed infotip by adding line height
* Fixed textbox by adding strong border color

## Screenshots
<img width="271" alt="Screen Shot 2023-05-19 at 11 06 02 AM" src="https://github.com/eBay/skin/assets/1755269/07ef5b1e-e738-41d1-aa5d-5c93fa04526c">
<img width="143" alt="Screen Shot 2023-05-19 at 11 06 46 AM" src="https://github.com/eBay/skin/assets/1755269/a0758872-e484-443a-bc49-5e3824137c71">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
