### PR TITLE
feat(segmented-button): added large/small

### DIFF
--- a/dist/segmented-buttons/segmented-buttons.css
+++ b/dist/segmented-buttons/segmented-buttons.css
@@ -1,6 +1,6 @@
 .segmented-buttons {
   border: 1px solid var(--color-stroke-default);
-  border-radius: 24px;
+  border-radius: var(--segmented-button-border-radius, calc(48px / 2));
   max-width: 720px;
   min-width: 215px;
   padding: 4px;

--- a/dist/segmented-buttons/segmented-buttons.css
+++ b/dist/segmented-buttons/segmented-buttons.css
@@ -23,9 +23,12 @@
   border: none;
   border-radius: var(--btn-border-radius, calc(40px / 2));
   font-size: 0.875rem;
-  min-height: 40px;
+  min-height: 32px;
   padding: 8px 16px;
   width: 100%;
+}
+.segmented-buttons--large .segmented-buttons__button {
+  min-height: 40px;
 }
 .segmented-buttons__button-cell {
   align-items: center;

--- a/docs/_includes/segmented-buttons.html
+++ b/docs/_includes/segmented-buttons.html
@@ -32,6 +32,32 @@
 </div>
     {% endhighlight %}
 
+    <h3 id="button-default">Segmented buttons - large </h3>
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="segmented-buttons segmented-buttons--large">
+                <ul>
+                    <li><button type="button" class="segmented-buttons__button"
+                            aria-current="true">Day</button></li>
+                    <li><button type="button" class="segmented-buttons__button">Month</button></li>
+                    <li><button type="button" class="segmented-buttons__button">Year</button></li>
+                </ul>
+            </div>
+
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="segmented-buttons segmented-buttons--large">
+    <ul>
+        <li><button type="button" class="segmented-buttons__button"
+                aria-current="true">Day</button></li>
+        <li><button type="button" class="segmented-buttons__button">Month</button></li>
+        <li><button type="button" class="segmented-buttons__button">Year</button></li>
+    </ul>
+</div>
+    {% endhighlight %}
+
     <h3 id="button-default">Segmented buttons - with icons</h3>
     <div class="demo">
         <div class="demo__inner">

--- a/docs/_includes/segmented-buttons.html
+++ b/docs/_includes/segmented-buttons.html
@@ -6,7 +6,8 @@
     <p><strong>NOTE:</strong> JavaScript is required to handle segmented buttons currently selected button.</p>
     <p></p>
 
-    <h3 id="button-default">Default Segmented buttons</h3>
+    <h3 id="button-default">Default Segmented Buttons</h3>
+    <p>The default segmented button has a 40px height that matches other buttons.</p>
     <div class="demo">
         <div class="demo__inner">
             <div class="segmented-buttons">
@@ -32,7 +33,8 @@
 </div>
     {% endhighlight %}
 
-    <h3 id="button-default">Segmented buttons - large </h3>
+    <h3 id="button-default">Segmented Buttons - large </h3>
+    <p>Use the <span class="highlight">segmented-buttons--large</span> modifier to create large segemented buttons. These have a 48px height to match large buttons.</p>
     <div class="demo">
         <div class="demo__inner">
             <div class="segmented-buttons segmented-buttons--large">
@@ -59,6 +61,7 @@
     {% endhighlight %}
 
     <h3 id="button-default">Segmented buttons - with icons</h3>
+    <p>Any 24x24 <a href="#icon">icon</a> can be added inside of a <span class="highlight">segmented-buttons__button-cell</span> block.</p>
     <div class="demo">
         <div class="demo__inner">
             <div class="segmented-buttons">

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -334,10 +334,7 @@ button.btn--tertiary.btn--destructive .progress-spinner {
 
 button.btn--large,
 a.fake-btn--large {
-    border-radius: var(--btn-border-radius, calc(@button-height-large / 2));
-    font-size: @font-size-medium;
-    min-height: @button-height-large;
-    padding: @button-padding-vertical-large @button-padding-horizontal;
+    .btn-large();
 }
 
 button.btn--small,

--- a/src/less/mixins/private/button-mixins.less
+++ b/src/less/mixins/private/button-mixins.less
@@ -35,6 +35,13 @@
     }
 }
 
+.btn-large() {
+    border-radius: var(--btn-border-radius, calc(@button-height-large / 2));
+    font-size: @font-size-medium;
+    min-height: @button-height-large;
+    padding: @button-padding-vertical-large @button-padding-horizontal;
+}
+
 .btn-icon-base() {
     align-self: center;
 

--- a/src/less/segmented-buttons/segmented-buttons.less
+++ b/src/less/segmented-buttons/segmented-buttons.less
@@ -28,11 +28,19 @@
 .segmented-buttons__button {
     background-color: transparent;
     border: none;
-    border-radius: var(--btn-border-radius, calc(@button-height-small / 2));
+    border-radius: var(--btn-border-radius, calc(@button-height-regular / 2));
     font-size: @font-size-regular;
-    min-height: @button-height-small;
+    // Use xsmall height for regular segmented buttons, this will make the container be regular size
+    // (32px + 4px top padding + 4px button padding = 40px)
+    min-height: @button-height-xsmall;
     padding: 8px 16px;
     width: 100%;
+}
+
+.segmented-buttons--large .segmented-buttons__button {
+    // Use regular height for large segmented buttons. This will cause the container to be large size
+    // (40px + 4px top padding + 4px button padding = 48px)
+    min-height: @button-height-regular;
 }
 
 .segmented-buttons__button-cell {

--- a/src/less/segmented-buttons/segmented-buttons.less
+++ b/src/less/segmented-buttons/segmented-buttons.less
@@ -1,12 +1,17 @@
 @import "../variables/variables.less";
 @import "../mixins/private/button-mixins.less";
 
+@segmented-buttons-padding: @spacing-50;
+
 .segmented-buttons {
     border: 1px solid var(--color-stroke-default);
-    border-radius: 24px;
+    border-radius: var(
+        --segmented-button-border-radius,
+        calc(@button-height-large / 2)
+    );
     max-width: 720px;
     min-width: 215px;
-    padding: 4px;
+    padding: @segmented-buttons-padding;
 }
 
 .segmented-buttons > ul {
@@ -22,7 +27,7 @@
 }
 
 .segmented-buttons > ul > li:not(:first-child) {
-    margin-left: 8px;
+    margin-left: @spacing-100;
 }
 
 .segmented-buttons__button {
@@ -30,17 +35,13 @@
     border: none;
     border-radius: var(--btn-border-radius, calc(@button-height-regular / 2));
     font-size: @font-size-regular;
-    // Use xsmall height for regular segmented buttons, this will make the container be regular size
-    // (32px + 4px top padding + 4px button padding = 40px)
-    min-height: @button-height-xsmall;
-    padding: 8px 16px;
+    min-height: @button-height-regular - (@segmented-buttons-padding * 2);
+    padding: @spacing-100 @spacing-200;
     width: 100%;
 }
 
 .segmented-buttons--large .segmented-buttons__button {
-    // Use regular height for large segmented buttons. This will cause the container to be large size
-    // (40px + 4px top padding + 4px button padding = 48px)
-    min-height: @button-height-regular;
+    min-height: @button-height-large - (@segmented-buttons-padding * 2);
 }
 
 .segmented-buttons__button-cell {
@@ -72,6 +73,6 @@
 [dir="rtl"] {
     .segmented-buttons > ul > li:not(:first-child) {
         margin-left: 0;
-        margin-right: 8px;
+        margin-right: @spacing-100;
     }
 }

--- a/src/less/segmented-buttons/stories/segmented-buttons.stories.js
+++ b/src/less/segmented-buttons/stories/segmented-buttons.stories.js
@@ -20,6 +20,16 @@ export const shortItems = () => `
     </div>
 `;
 
+export const large = () => `
+    <div class="segmented-buttons segmented-buttons--large">
+        <ul>
+            <li><button type="button" class="segmented-buttons__button" aria-current="true">Day</button></li>
+            <li><button type="button" class="segmented-buttons__button">Month</button></li>
+            <li><button type="button" class="segmented-buttons__button">Year</button></li>
+        </ul>
+    </div>
+`;
+
 export const withIcons = () => `
     <div class="segmented-buttons">
         <ul>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2064

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added large size. 

## Notes
* In order to have the sizes be correct based on designs, regular buttons are using 32px (small) button size and then with 4px padding top+bottom create a 40px container. The same with large, 40px (regular) button size with 4px padding top+bottom create a 48px container. I added a comment to address this. 

## Screenshots
<img width="930" alt="Screen Shot 2023-05-25 at 10 52 35 AM" src="https://github.com/eBay/skin/assets/1755269/b7004d17-953d-4710-bcf2-bfc307a739fb">

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
