### PR TITLE
fix(floating-label): override inline transform during autofill

### DIFF
--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -78,3 +78,9 @@ label.floating-label__label--invalid {
   right: 16px;
   transform-origin: right;
 }
+label.floating-label__label:has(+ .textbox :autofill) {
+  transform: scale(0.75, 0.75) translate(0, 2px);
+}
+.floating-label--large label.floating-label__label:has(+ .textbox :autofill) {
+  transform: scale(0.75, 0.75) translate(0, 3px);
+}

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -106,3 +106,13 @@ label.floating-label__label--invalid {
         transform-origin: right;
     }
 }
+
+// Autofill
+
+label.floating-label__label:has(+ .textbox :autofill) {
+    transform: scale(0.75, 0.75) translate(0, 2px);
+}
+
+.floating-label--large label.floating-label__label:has(+ .textbox :autofill) {
+    transform: scale(0.75, 0.75) translate(0, 3px);
+}


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
There are some edge cases that we can't currently handle without a major JavaScript refactor regarding floating labels, which are simple to fix with modern CSS. In this PR I provide a few selectors which will fix these issues on modern browsers, and preserve current behavior if the `:has` selector is not supported.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
- I had originally planned to use the `@supports` group to handle browsers which did not support `:has`, but our `less` bundler is outdated and it will not compile properly. Related to [this issue](https://github.com/postcss/autoprefixer/issues/1391), which was fixed in version `10.2.5` of `autoprefixer`, but `less-plugin-autoprefix` uses an older version and also breaks when I force it to use the newest.
  - I think I actually prefer the way I did it, since it is not absolutely necessary to bring in `@supports`.
- The `transform` rules here are duplicated from above which I am not a fan of, but `stylelint` won't let me group them together because of the `no-descending-specificity` rule.


## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
### Before:
<img width="692" alt="image" src="https://github.com/eBay/skin/assets/26027232/3cee01c3-ec58-4114-ab99-b003af30c801">

### After:
<img width="630" alt="image" src="https://github.com/eBay/skin/assets/26027232/4e0c0ccd-032c-4813-9f32-668bba8fc5d4">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
