### PR TITLE
fix(floating-label): override inline transform during autofill (#2079)

### DIFF
--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -78,3 +78,13 @@ label.floating-label__label--invalid {
   right: 16px;
   transform-origin: right;
 }
+label.floating-label__label.floating-label__label--inline:has(
+        + .textbox > :autofill
+    ) {
+  transform: scale(0.75, 0.75) translate(0, 2px);
+}
+.floating-label--large label.floating-label__label.floating-label__label--inline:has(
+        + .textbox > :autofill
+    ) {
+  transform: scale(0.75, 0.75) translate(0, 3px);
+}

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -106,3 +106,18 @@ label.floating-label__label--invalid {
         transform-origin: right;
     }
 }
+
+// Autofill
+
+label.floating-label__label.floating-label__label--inline:has(
+        + .textbox > :autofill
+    ) {
+    transform: scale(0.75, 0.75) translate(0, 2px);
+}
+
+.floating-label--large
+    label.floating-label__label.floating-label__label--inline:has(
+        + .textbox > :autofill
+    ) {
+    transform: scale(0.75, 0.75) translate(0, 3px);
+}


### PR DESCRIPTION
Release pull request for `16.2.2` release.