### PR TITLE
fix(segmented-button): fixed non-current buttons on dark mode

### DIFF
--- a/dist/segmented-buttons/segmented-buttons.css
+++ b/dist/segmented-buttons/segmented-buttons.css
@@ -22,6 +22,7 @@
   background-color: transparent;
   border: none;
   border-radius: var(--btn-border-radius, calc(40px / 2));
+  color: var(--color-foreground-on-primary);
   font-size: 0.875rem;
   min-height: 32px;
   padding: 8px 16px;

--- a/src/less/segmented-buttons/segmented-buttons.less
+++ b/src/less/segmented-buttons/segmented-buttons.less
@@ -34,6 +34,7 @@
     background-color: transparent;
     border: none;
     border-radius: var(--btn-border-radius, calc(@button-height-regular / 2));
+    color: var(--color-foreground-on-primary);
     font-size: @font-size-regular;
     min-height: @button-height-regular - (@segmented-buttons-padding * 2);
     padding: @spacing-100 @spacing-200;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2096 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed segmented button non-current button colors on dark mode.

## Screenshots
Before:
<img width="791" alt="image" src="https://github.com/eBay/skin/assets/1675667/90fbb57c-3d73-4f80-9065-ca24980ba50a">


After:
<img width="797" alt="image" src="https://github.com/eBay/skin/assets/1675667/5813faea-e624-46d3-a0a3-f4643ba36031">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
