### PR TITLE
fix(toast-dialog): secondary button hover issue

### DIFF
--- a/dist/toast-dialog/toast-dialog.css
+++ b/dist/toast-dialog/toast-dialog.css
@@ -110,10 +110,14 @@ button.toast-dialog__close > svg {
 }
 .toast-dialog__footer button.btn--secondary:not([disabled]):focus,
 .toast-dialog__footer button.btn--secondary:not([disabled]):hover {
-  background-color: var(--color-state-information-hover);
+  background-color: var(--color-state-accent-hover);
+  border-color: var(--toast-dialog-foreground-color, var(--color-foreground-on-accent));
+  color: var(--toast-dialog-foreground-color, var(--color-background-primary));
 }
 .toast-dialog__footer button.btn--secondary:not([disabled]):active {
-  background-color: var(--color-state-information-active);
+  background-color: var(--color-state-accent-active);
+  border-color: var(--toast-dialog-foreground-color, var(--color-foreground-on-accent));
+  color: var(--toast-dialog-foreground-color, var(--color-background-primary));
 }
 @media (min-width: 512px) {
   .toast-dialog {

--- a/src/less/toast-dialog/toast-dialog.less
+++ b/src/less/toast-dialog/toast-dialog.less
@@ -132,12 +132,16 @@ button.toast-dialog__close > svg {
     button.btn--secondary:not([disabled]) {
         &:focus,
         &:hover {
-            background-color: var(--color-state-information-hover);
+            background-color: var(--color-state-accent-hover);
+            .border-color-token(toast-dialog-foreground-color, color-foreground-on-accent);
+            .color-token(toast-dialog-foreground-color, color-background-primary);
         }
 
         /* prettier-ignore */
         &:active {
-            background-color: var(--color-state-information-active);
+            background-color: var(--color-state-accent-active);
+            .border-color-token(toast-dialog-foreground-color, color-foreground-on-accent);
+            .color-token(toast-dialog-foreground-color, color-background-primary);
         }
     }
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2092 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed the hover and active states.

## Notes
I found out that `--color-state-information-hover` used for the hover background doesn't exist. When I used the tokens for accent hover/active, it looked more like what it should have looked like all along. We can remove that if it's not relevant, but it seems to resolve all of the hover state issues to what was likely originally intended. 

## Screenshots
Before:
(see issue)

After:
<img width="489" alt="image" src="https://github.com/eBay/skin/assets/1675667/357b8ee9-4b6c-4331-8508-352ac0f7c2b4">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
