### PR TITLE
chore(textbox): add blue focus indicator

### DIFF
--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -109,7 +109,6 @@ input.textbox__control:not(:read-only):focus,
 textarea.textbox__control:not(:read-only):focus {
   border-color: var(--textbox-focus-border-color, var(--color-stroke-strong));
   background-color: var(--textbox-focus-background-color, var(--color-background-primary));
-  outline: 0;
 }
 input.textbox__control[readonly]:focus,
 textarea.textbox__control[readonly]:focus {

--- a/src/less/textbox/textbox.less
+++ b/src/less/textbox/textbox.less
@@ -132,7 +132,6 @@ input.textbox__control:not(:read-only):focus,
 textarea.textbox__control:not(:read-only):focus {
     .border-color-token(textbox-focus-border-color, color-stroke-strong);
     .background-color-token(textbox-focus-background-color, color-background-primary);
-    outline: 0;
 }
 
 input.textbox__control[readonly]:focus,


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2089 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Added blue focus indicator to improve UX and `a11y` as well as focus consistency across controls.

## Screenshots
Before:
<img width="323" alt="image" src="https://github.com/eBay/skin/assets/1675667/b7e7a6b2-fb4b-4dad-9d5d-353082db4a8b">

After:
<img width="322" alt="image" src="https://github.com/eBay/skin/assets/1675667/1a394a3b-dd56-4bc5-936b-172820970eeb">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
