### PR TITLE
fix(page-notice): anchor and fake link focus state

### DIFF
--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -47,8 +47,8 @@ span[role="region"].page-notice {
 .page-notice button.fake-link:hover {
   color: var(--page-notice-color, var(--color-foreground-on-inverse));
 }
-.page-notice a:focus,
-.page-notice button.fake-link:focus {
+.page-notice a:focus-visible,
+.page-notice button.fake-link:focus-visible {
   outline: 2px solid var(--color-foreground-on-inverse);
   outline-offset: 2px;
 }

--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -47,6 +47,11 @@ span[role="region"].page-notice {
 .page-notice button.fake-link:hover {
   color: var(--page-notice-color, var(--color-foreground-on-inverse));
 }
+.page-notice a:focus,
+.page-notice button.fake-link:focus {
+  outline: 2px solid var(--color-foreground-on-inverse);
+  outline-offset: 2px;
+}
 .page-notice--attention {
   background-color: var(--page-notice-attention-background-color, var(--color-background-attention));
   border-color: var(--page-notice-attention-border-color, var(--color-stroke-attention));

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -63,8 +63,10 @@ span[role="region"].page-notice {
     .color-token(page-notice-color, color-foreground-on-inverse);
 }
 
-.page-notice a:focus,
-.page-notice button.fake-link:focus {
+// for explicit focus only: the `focus-visible` instead of `focus`
+// is to exclude the styling on clicks (implied focus) */
+.page-notice a:focus-visible,
+.page-notice button.fake-link:focus-visible {
     outline: 2px solid var(--color-foreground-on-inverse);
     outline-offset: 2px;
 }

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -63,6 +63,12 @@ span[role="region"].page-notice {
     .color-token(page-notice-color, color-foreground-on-inverse);
 }
 
+.page-notice a:focus,
+.page-notice button.fake-link:focus {
+    outline: 2px solid var(--color-foreground-on-inverse);
+    outline-offset: 2px;
+}
+
 .page-notice--attention {
     .background-color-token(page-notice-attention-background-color, color-background-attention);
     .border-color-token(page-notice-attention-border-color, color-stroke-attention);

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -63,8 +63,10 @@ span[role="region"].page-notice {
     .color-token(page-notice-color, color-foreground-on-inverse);
 }
 
-// for explicit focus only: the `focus-visible` instead of `focus`
-// is to exclude the styling on clicks (implied focus) */
+// Override default outline color to avoid contrast issues
+// with the darker background colors in page notices
+// For explicit focus only: the `focus-visible` instead of `focus`
+// is to exclude the styling on clicks (implied focus).
 .page-notice a:focus-visible,
 .page-notice button.fake-link:focus-visible {
     outline: 2px solid var(--color-foreground-on-inverse);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2082 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed the focus indicator.

## Screenshots
Before:
<img width="800" alt="image" src="https://github.com/eBay/skin/assets/1675667/a6ca35a1-1ec8-45ae-bf66-199d2be69ced">

After:
<img width="800" alt="image" src="https://github.com/eBay/skin/assets/1675667/de36be43-364c-47e3-887c-e20af419f031">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
