### PR TITLE
feat(lightbox-dialog): added prev button to header

### DIFF
--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -102,6 +102,7 @@
 .lightbox-dialog--expressive .lightbox-dialog__footer {
   padding: 16px 24px;
 }
+button.icon-btn.lightbox-dialog__prev,
 button.icon-btn.lightbox-dialog__close {
   align-self: center;
   border: 0;
@@ -111,9 +112,16 @@ button.icon-btn.lightbox-dialog__close {
   width: 32px;
   z-index: 1;
 }
+button.icon-btn.lightbox-dialog__prev {
+  margin-right: 16px;
+}
+.lightbox-dialog--expressive button.icon-btn.lightbox-dialog__prev,
 .lightbox-dialog--expressive button.icon-btn.lightbox-dialog__close {
   align-self: self-start;
   margin: 0;
+}
+.lightbox-dialog--expressive button.icon-btn.lightbox-dialog__prev + * {
+  margin-left: -32px;
 }
 .lightbox-dialog__title:not(:first-child) {
   margin-left: 16px;
@@ -164,6 +172,13 @@ button.icon-btn.lightbox-dialog__close {
 .lightbox-dialog--show .lightbox-dialog__window--fade,
 .lightbox-dialog--hide-init .lightbox-dialog__window--fade {
   opacity: 1;
+}
+[dir="rtl"] button.icon-btn.lightbox-dialog__prev {
+  margin-left: 16px;
+  margin-right: 0;
+}
+[dir="rtl"] button.icon-btn.lightbox-dialog__prev .icon--chevron-left-16 {
+  transform: rotate(180deg);
 }
 @media (min-width: 512px) {
   .lightbox-dialog__window {

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -104,6 +104,66 @@
 </div>
     {% endhighlight %}
 
+    <h3 id="lightbox-wide">Previous button in header Lightbox</h3>
+
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-prev-button" type="button">Open Lightbox</button>
+            <div aria-labelledby="dialog-title-prev-button" aria-modal="true" class="lightbox-dialog" hidden id="lightbox-dialog-prev-button" role="dialog">
+                <div class="lightbox-dialog__window">
+                    <div class="lightbox-dialog__header">
+                        <button aria-label="Go back" class="icon-btn lightbox-dialog__prev" type="button">
+                            <svg aria-hidden="true" class="icon icon--chevron-left-16" focusable="false" height="16" width="16">
+                                {% include symbol.html name="chevron-left-16" %}
+                            </svg>
+                        </button>
+                        <h2 id="dialog-title-prev-button" class="large-text-1 bold-text">Lightbox Dialog</h2>
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
+                                {% include symbol.html name="close-16" %}
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="lightbox-dialog__main">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        <p><a href="https://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
+    <div class="lightbox-dialog__window">
+        <div class="lightbox-dialog__header">
+            <button aria-label="Go back" class="icon-btn lightbox-dialog__prev" type="button">
+                <svg aria-hidden="true" class="icon icon--chevron-left-16" focusable="false" height="16" width="16">
+                    <use href="#icon-chevron-left-16"></use>
+                </svg>
+            </button>
+            <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p><a href="https://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
     <h3 id="lightbox-wide">Wide Lightbox</h3>
     <p>To have a wider lightbox add  <span class="highlight">lightbox-dialog--wide</span> to the dialog</p>
 

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -54,6 +54,7 @@
 
 // inherits from .icon-btn
 // Might need to see if icon-btn can support a small version
+button.icon-btn.lightbox-dialog__prev,
 button.icon-btn.lightbox-dialog__close {
     align-self: center;
     border: 0;
@@ -64,9 +65,18 @@ button.icon-btn.lightbox-dialog__close {
     z-index: 1;
 }
 
+button.icon-btn.lightbox-dialog__prev {
+    margin-right: 16px;
+}
+
+.lightbox-dialog--expressive button.icon-btn.lightbox-dialog__prev,
 .lightbox-dialog--expressive button.icon-btn.lightbox-dialog__close {
     align-self: self-start;
     margin: 0;
+}
+
+.lightbox-dialog--expressive button.icon-btn.lightbox-dialog__prev + * {
+    margin-left: -32px;
 }
 
 .lightbox-dialog__title {
@@ -126,6 +136,15 @@ button.icon-btn.lightbox-dialog__close {
     }
 }
 
+[dir="rtl"] {
+    button.icon-btn.lightbox-dialog__prev {
+        margin-left: 16px;
+        margin-right: 0;
+    }
+    button.icon-btn.lightbox-dialog__prev .icon--chevron-left-16 {
+        transform: rotate(180deg);
+    }
+}
 // In order to prevent the margins to meet the ege of the page at medium screen sizes
 @media (min-width: @_screen-size-SM) {
     .lightbox-dialog__window {

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -28,6 +28,34 @@ export const expressiveBase = () => `
     <div class="lightbox-dialog__window">
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
+           <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;
+
+export const basePrev = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window">
+        <div class="lightbox-dialog__header">
+            <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">
+                <svg class="icon icon--chevron-left-16" aria-hidden="true">
+                    <use href="#icon-chevron-left-16"></use>
+                </svg>
+            </button>
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close-16" aria-hidden="true">
@@ -233,6 +261,36 @@ export const baseRTL = () => `
 </div>
 `;
 
+export const prevRTL = () => `
+<div dir="rtl">
+    <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+        <div class="lightbox-dialog__window">
+            <div class="lightbox-dialog__header">
+                <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">
+                    <svg class="icon icon--chevron-left-16" aria-hidden="true">
+                        <use href="#icon-chevron-left-16"></use>
+                    </svg>
+                </button>
+                <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+                <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                    <svg class="icon icon--close-16" aria-hidden="true">
+                        <use href="#icon-close-16"></use>
+                    </svg>
+                </button>
+            </div>
+            <div class="lightbox-dialog__main">
+                <h3>Heading</h3>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+                <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+                <h3>Heading</h3>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+                <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            </div>
+        </div>
+    </div>
+</div>
+`;
+
 export const baseWithLongHeader = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
@@ -284,6 +342,35 @@ export const expressiveWide = () => `
     <div class="lightbox-dialog__window">
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;
+
+export const expressivePrev = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" role="dialog">
+    <div class="lightbox-dialog__window">
+        <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
+        <div class="lightbox-dialog__header">
+            <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">
+                <svg class="icon icon--chevron-left-16" aria-hidden="true">
+                    <use href="#icon-chevron-left-16"></use>
+                </svg>
+            </button>
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
                 <svg class="icon icon--close-16" aria-hidden="true">


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2004

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added prev button to lightbox dialog.
* Also added it to expressive


## Screenshots
<img width="745" alt="Screen Shot 2023-08-02 at 9 06 06 AM" src="https://github.com/eBay/skin/assets/1755269/5a027f5e-7492-4ce4-b3ff-e8373168dddd">
<img width="730" alt="Screen Shot 2023-08-02 at 9 06 15 AM" src="https://github.com/eBay/skin/assets/1755269/cd4a2048-9165-4a33-ae88-82173cbfd2cb">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
