### PR TITLE
fix: changed start to flex-start (and end)

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -72,13 +72,7 @@
                 ],
                 "no-descending-specificity": true,
                 "no-duplicate-selectors": true,
-                "order/properties-alphabetical-order": true,
-                "plugin/no-unsupported-browser-features": [
-                    null,
-                    {
-                        "severity": "warning"
-                    }
-                ]
+                "order/properties-alphabetical-order": true
             }
         }
     ]

--- a/dist/carousel/carousel.css
+++ b/dist/carousel/carousel.css
@@ -261,7 +261,7 @@ span.carousel__container {
     border-right-width: calc(100vw + 100vh);
   }
   .carousel__snap-point {
-    scroll-snap-align: start;
+    scroll-snap-align: flex-start;
     scroll-snap-coordinate: 0 0;
   }
   /* autoprefixer: on */

--- a/dist/field/field.css
+++ b/dist/field/field.css
@@ -111,7 +111,7 @@ div.field__description {
   vertical-align: top;
 }
 .field__group--align-top > .field__label {
-  align-self: start;
+  align-self: flex-start;
   margin-top: 16px;
 }
 [dir="rtl"] .field__description--group > :last-child {

--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -100,7 +100,7 @@ span[role="region"].page-notice {
 p.page-notice__cta {
   grid-column: 2;
   grid-row: 2;
-  justify-self: start;
+  justify-self: flex-start;
   margin-right: 16px;
   margin-top: 16px;
 }
@@ -115,13 +115,13 @@ p.page-notice__cta {
   p.page-notice__cta {
     grid-column: 4;
     grid-row: 1;
-    justify-self: end;
+    justify-self: flex-end;
     margin-bottom: 0;
     margin-top: 1px;
     padding-right: 16px;
   }
   .page-notice__footer {
-    justify-self: end;
+    justify-self: flex-end;
     margin-top: 0;
   }
 }

--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -62,7 +62,7 @@ span[role="region"].section-notice {
 .section-notice__footer {
   grid-column: 4;
   grid-row: 1;
-  justify-self: end;
+  justify-self: flex-end;
   margin-top: 2px;
 }
 .section-notice__main p {
@@ -72,7 +72,7 @@ span[role="region"].section-notice {
 p.section-notice__cta {
   grid-column: 2;
   grid-row: 2;
-  justify-self: start;
+  justify-self: flex-start;
   margin-right: 16px;
   margin-top: 16px;
 }
@@ -89,7 +89,7 @@ p.section-notice__cta {
   p.section-notice__cta {
     grid-column: 4;
     grid-row: 1;
-    justify-self: end;
+    justify-self: flex-end;
     margin-bottom: 0;
     margin-top: 0;
     padding-right: 16px;
@@ -103,7 +103,7 @@ p.section-notice__cta {
   padding-right: 0;
 }
 [dir="rtl"] .section-notice__footer {
-  justify-self: start;
+  justify-self: flex-start;
   margin-left: initial;
   margin-right: auto;
   padding-left: initial;

--- a/src/less/carousel/carousel.less
+++ b/src/less/carousel/carousel.less
@@ -294,7 +294,7 @@ span.carousel__container {
     }
 
     .carousel__snap-point {
-        scroll-snap-align: start;
+        scroll-snap-align: flex-start;
         -webkit-scroll-snap-coordinate: 0 0;
         -ms-scroll-snap-coordinate: 0 0;
         scroll-snap-coordinate: 0 0;

--- a/src/less/field/field.less
+++ b/src/less/field/field.less
@@ -161,7 +161,7 @@ div.field__description {
 }
 
 .field__group--align-top > .field__label {
-    align-self: start;
+    align-self: flex-start;
     margin-top: 16px;
 }
 

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -129,7 +129,7 @@ span[role="region"].page-notice {
 p.page-notice__cta {
     grid-column: 2;
     grid-row: 2;
-    justify-self: start;
+    justify-self: flex-start;
     margin-right: @spacing-200;
     margin-top: @spacing-200;
 }
@@ -147,14 +147,14 @@ p.page-notice__cta {
     p.page-notice__cta {
         grid-column: 4;
         grid-row: 1;
-        justify-self: end;
+        justify-self: flex-end;
         margin-bottom: 0;
         margin-top: 1px;
         padding-right: @spacing-200;
     }
 
     .page-notice__footer {
-        justify-self: end;
+        justify-self: flex-end;
         margin-top: 0;
     }
 }

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -81,7 +81,7 @@ span[role="region"].section-notice {
 .section-notice__footer {
     grid-column: 4;
     grid-row: 1;
-    justify-self: end;
+    justify-self: flex-end;
     margin-top: 2px;
 }
 
@@ -93,7 +93,7 @@ span[role="region"].section-notice {
 p.section-notice__cta {
     grid-column: 2;
     grid-row: 2;
-    justify-self: start;
+    justify-self: flex-start;
     margin-right: @spacing-200;
     margin-top: @spacing-200;
 }
@@ -114,7 +114,7 @@ p.section-notice__cta {
     p.section-notice__cta {
         grid-column: 4;
         grid-row: 1;
-        justify-self: end;
+        justify-self: flex-end;
         margin-bottom: 0;
         margin-top: 0;
         padding-right: @spacing-200;
@@ -132,7 +132,7 @@ p.section-notice__cta {
     }
 
     .section-notice__footer {
-        justify-self: start;
+        justify-self: flex-start;
         margin-left: initial;
         margin-right: auto;
         padding-left: initial;


### PR DESCRIPTION
Fixes #2110

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Changed all end to to flex-end and start to flex-start
## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
