### PR TITLE
build: remove dist folder before running build #1338

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "prepublishOnly": "node scripts gen",
         "postpublish": "node scripts clean",
         "build": "npm run build:css && npm run lint:js && npm run bundle && npm run build:site && npm run copy",
-        "build:css": "npm run lint:less && gulp && npm run lint:css",
+        "build:css": "npm run lint:less && rimraf dist && gulp && npm run lint:css",
         "build:ci": "npm run build:css && npm run lint:js && npm run bundle && npm run copy",
         "build:jekyll": "bundler exec jekyll build --incremental --config docs/_config.yml,docs/_config.localhost.yml",
         "build:site": "npm run copy:svgToDocs && npm run build:jekyll",


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1338

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->

Just a simple PR to get me back in the swing of things :-) Also got my signed commits working again. Woohoo.

By removing the dist folder before every build we ensure there are no stale dist files.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

There was a time when we deliberately kept some stale dist files around (i.e. by stale, we mean they didn't have a corresponding src folder), but this was a bad practice and is no longer the case anyway.

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
