### PR TITLE
fix(page-notice): spacing fix

### DIFF
--- a/dist/page-notice/page-notice.css
+++ b/dist/page-notice/page-notice.css
@@ -106,6 +106,7 @@ p.page-notice__cta {
   grid-column: 2;
   grid-row: 2;
   justify-self: flex-start;
+  margin-bottom: 0;
   margin-right: 16px;
   margin-top: 16px;
 }
@@ -121,7 +122,6 @@ p.page-notice__cta {
     grid-column: 4;
     grid-row: 1;
     justify-self: flex-end;
-    margin-bottom: 0;
     margin-top: 1px;
     padding-right: 16px;
   }

--- a/src/less/page-notice/page-notice.less
+++ b/src/less/page-notice/page-notice.less
@@ -140,6 +140,7 @@ p.page-notice__cta {
     grid-column: 2;
     grid-row: 2;
     justify-self: flex-start;
+    margin-bottom: 0;
     margin-right: @spacing-200;
     margin-top: @spacing-200;
 }
@@ -158,7 +159,6 @@ p.page-notice__cta {
         grid-column: 4;
         grid-row: 1;
         justify-self: flex-end;
-        margin-bottom: 0;
         margin-top: 1px;
         padding-right: @spacing-200;
     }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2112 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed the small spacing issue on smaller screens.

## Screenshots
Before: (see issue)

After: 
<img width="485" alt="image" src="https://github.com/eBay/skin/assets/1675667/f70dc238-32d8-4627-b04f-6430236b327e">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
