### PR TITLE
fix(button): add destructive red to borderless

### DIFF
--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -63,6 +63,10 @@ button.btn--borderless[aria-disabled="true"],
 a.fake-btn--borderless[aria-disabled="true"] {
   border-color: transparent;
 }
+button.btn--borderless.btn--destructive,
+a.fake-btn--borderless.btn--destructive {
+  color: var(--btn-secondary-destructive-foreground-color, var(--color-foreground-attention));
+}
 button.btn--slim,
 a.fake-btn--slim {
   height: 40px;

--- a/src/less/button/button.less
+++ b/src/less/button/button.less
@@ -44,6 +44,11 @@ a.fake-btn--borderless[aria-disabled="true"] {
     border-color: transparent;
 }
 
+button.btn--borderless.btn--destructive,
+a.fake-btn--borderless.btn--destructive {
+    .color-token(btn-secondary-destructive-foreground-color, color-foreground-attention);
+}
+
 button.btn--slim,
 a.fake-btn--slim {
     height: @button-height-regular;

--- a/src/less/button/stories/destructive-button/borderless.stories.js
+++ b/src/less/button/stories/destructive-button/borderless.stories.js
@@ -1,0 +1,4 @@
+export default { title: "Skin/Button/Destructive/Borderless" };
+
+export const base = () =>
+    '<button class="btn btn--borderless btn--destructive">Destructive Borderless Button</button>';


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1910 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Added borderless destructive red to button/fake button

## Screenshots
Before: (see issue)

After:
<img width="273" alt="image" src="https://github.com/eBay/skin/assets/1675667/16e416e3-4736-4a7b-97b1-cd9211699d31">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
