### PR TITLE
fix(listbox-button): alignment

### DIFF
--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -6,6 +6,10 @@
 span.listbox-button {
   display: inline-block;
 }
+.listbox-button .btn {
+  padding-left: 15px;
+  padding-right: 15px;
+}
 span.listbox-button--fluid,
 span.listbox-button--fluid .expand-btn,
 span.listbox-button--fluid .btn {

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -17,6 +17,8 @@ span.listbox-button {
 .listbox-button .btn {
     // these values are used elsewhere in listbox
     // in a non-standard manner and don't have variables
+    // this shares the same value with the horizontal
+    // padding in .selection-list-item-base() to align left
     padding-left: 15px;
     padding-right: 15px;
 }

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -14,6 +14,13 @@ span.listbox-button {
     display: inline-block;
 }
 
+.listbox-button .btn {
+    // these values are used elsewhere in listbox
+    // in a non-standard manner and don't have variables
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
 span.listbox-button--fluid,
 span.listbox-button--fluid .expand-btn,
 span.listbox-button--fluid .btn {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1991 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I fixed the listbox button alignment to match the options. 

## Screenshots
Before:
<img width="162" alt="image" src="https://github.com/eBay/skin/assets/1675667/6c24522d-0835-4aed-b595-c0af1023b53b">

After:
<img width="163" alt="image" src="https://github.com/eBay/skin/assets/1675667/38a1192a-f07c-40f7-90ac-85de5b9f2f45">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
