### PR TITLE
style(carousel): change paddle icon from 24 to 12 (#1925)

### DIFF
--- a/dist/carousel/carousel.css
+++ b/dist/carousel/carousel.css
@@ -123,11 +123,11 @@ div.carousel {
 .carousel__control--next {
   right: 0;
 }
-.carousel__control .icon--chevron-right-24 {
-  margin-left: 2px;
+.carousel__control .icon--chevron-right-12 {
+  margin-left: 1px;
 }
-.carousel__control .icon--chevron-left-24 {
-  margin-left: -2px;
+.carousel__control .icon--chevron-left-12 {
+  margin-left: -1px;
 }
 .carousel__control svg {
   color: var(--carousel-paddle-foreground-color, var(--color-foreground-primary));
@@ -184,18 +184,18 @@ span.carousel__container {
   left: unset;
   right: 0;
 }
-[dir="rtl"] .carousel__control .icon--chevron-left-24 {
-  margin-left: 2px;
+[dir="rtl"] .carousel__control .icon--chevron-left-12 {
+  margin-left: 1px;
 }
 [dir="rtl"] .carousel__control--next {
   left: 0;
   right: unset;
 }
-[dir="rtl"] .carousel__control .icon--chevron-right-24 {
-  margin-left: -2px;
+[dir="rtl"] .carousel__control .icon--chevron-right-12 {
+  margin-left: -1px;
 }
-[dir="rtl"] .carousel__control .icon--chevron-left-24,
-[dir="rtl"] .carousel__control .icon--chevron-right-24 {
+[dir="rtl"] .carousel__control .icon--chevron-left-12,
+[dir="rtl"] .carousel__control .icon--chevron-right-12 {
   transform: rotate(180deg);
 }
 /* autoprefixer: ignore next */

--- a/dist/carousel/carousel.css
+++ b/dist/carousel/carousel.css
@@ -123,6 +123,12 @@ div.carousel {
 .carousel__control--next {
   right: 0;
 }
+.carousel__control .icon--chevron-right-24 {
+  margin-left: 2px;
+}
+.carousel__control .icon--chevron-left-24 {
+  margin-left: -2px;
+}
 .carousel__control .icon--chevron-right-12 {
   margin-left: 1px;
 }
@@ -184,6 +190,9 @@ span.carousel__container {
   left: unset;
   right: 0;
 }
+[dir="rtl"] .carousel__control .icon--chevron-left-24 {
+  margin-left: 2px;
+}
 [dir="rtl"] .carousel__control .icon--chevron-left-12 {
   margin-left: 1px;
 }
@@ -191,9 +200,14 @@ span.carousel__container {
   left: 0;
   right: unset;
 }
+[dir="rtl"] .carousel__control .icon--chevron-right-24 {
+  margin-left: -2px;
+}
 [dir="rtl"] .carousel__control .icon--chevron-right-12 {
   margin-left: -1px;
 }
+[dir="rtl"] .carousel__control .icon--chevron-left-24,
+[dir="rtl"] .carousel__control .icon--chevron-right-24,
 [dir="rtl"] .carousel__control .icon--chevron-left-12,
 [dir="rtl"] .carousel__control .icon--chevron-right-12 {
   transform: rotate(180deg);

--- a/docs/_includes/carousel.html
+++ b/docs/_includes/carousel.html
@@ -14,8 +14,8 @@
             <div class="carousel">
                 <div class="carousel__container">
                     <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-                        <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false">
-                            {% include symbol.html name="chevron-left-24" %}
+                        <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                            {% include symbol.html name="chevron-left-12" %}
                         </svg>
                     </button>
                     <div class="carousel__viewport carousel__viewport--mask">
@@ -31,8 +31,8 @@
                         </ul>
                     </div>
                     <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-                        <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                            {% include symbol.html name="chevron-right-24" %}
+                        <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                            {% include symbol.html name="chevron-right-12" %}
                         </svg>
                     </button>
                 </div>
@@ -43,8 +43,8 @@
 <div class="carousel">
     <div class="carousel__container">
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false" >
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport carousel__viewport--mask">
@@ -60,8 +60,8 @@
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
@@ -81,8 +81,8 @@
                         <span>Top Products - Slide 1 of 2</span>
                     </h4>
                     <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-                        <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false" >
-                            {% include symbol.html name="chevron-left-24" %}
+                        <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                            {% include symbol.html name="chevron-left-12" %}
                         </svg>
                     </button>
                     <div class="carousel__viewport">
@@ -98,8 +98,8 @@
                         </ul>
                     </div>
                     <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-                        <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                            {% include symbol.html name="chevron-right-24" %}
+                        <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                            {% include symbol.html name="chevron-right-12" %}
                         </svg>
                     </button>
                 </div>
@@ -113,8 +113,8 @@
             <span>Top Products - Slide 1 of 2</span>
         </h2>
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false" >
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport">
@@ -130,8 +130,8 @@
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
@@ -150,8 +150,8 @@
                         <span>Top Products - Slide 1 of 4</span>
                     </h4>
                     <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-                        <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false" >
-                            {% include symbol.html name="chevron-left-24" %}
+                        <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                            {% include symbol.html name="chevron-left-12" %}
                         </svg>
                     </button>
                     <div class="carousel__viewport">
@@ -163,8 +163,8 @@
                         </ul>
                     </div>
                     <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-                        <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                            {% include symbol.html name="chevron-right-24" %}
+                        <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                            {% include symbol.html name="chevron-right-12" %}
                         </svg>
                     </button>
                 </div>
@@ -183,8 +183,8 @@
             <span>Top Products - Slide 1 of 4</span>
         </h2>
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false" >
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport">
@@ -196,14 +196,14 @@
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
     <button class="carousel__playback" aria-label="Play - Top Products">
-        <svg class="icon icon--play" focusable="false" aria-hidden="true">
-            <use href="#icon-play"></use>
+        <svg class="icon icon--play-24" focusable="false" aria-hidden="true">
+            <use href="#icon-play-24"></use>
         </svg>
     </button>
 </div>

--- a/src/less/carousel/carousel.less
+++ b/src/less/carousel/carousel.less
@@ -24,6 +24,16 @@
         right: 0;
     }
 
+    // deprecated
+    .icon--chevron-right-24 {
+        margin-left: 2px;
+    }
+
+    // deprecated
+    .icon--chevron-left-24 {
+        margin-left: -2px;
+    }
+
     .icon--chevron-right-12 {
         margin-left: 1px;
     }
@@ -197,6 +207,11 @@ span.carousel__container {
         right: 0;
     }
 
+    // deprecated
+    .carousel__control .icon--chevron-left-24 {
+        margin-left: 2px;
+    }
+
     .carousel__control .icon--chevron-left-12 {
         margin-left: 1px;
     }
@@ -206,10 +221,18 @@ span.carousel__container {
         right: unset;
     }
 
+    // deprecated
+    .carousel__control .icon--chevron-right-24 {
+        margin-left: -2px;
+    }
+
     .carousel__control .icon--chevron-right-12 {
         margin-left: -1px;
     }
 
+    // deprecated (first two selectors only)
+    .carousel__control .icon--chevron-left-24,
+    .carousel__control .icon--chevron-right-24,
     .carousel__control .icon--chevron-left-12,
     .carousel__control .icon--chevron-right-12 {
         transform: rotate(180deg);

--- a/src/less/carousel/carousel.less
+++ b/src/less/carousel/carousel.less
@@ -24,12 +24,12 @@
         right: 0;
     }
 
-    .icon--chevron-right-24 {
-        margin-left: 2px;
+    .icon--chevron-right-12 {
+        margin-left: 1px;
     }
 
-    .icon--chevron-left-24 {
-        margin-left: -2px;
+    .icon--chevron-left-12 {
+        margin-left: -1px;
     }
 
     align-items: center;
@@ -197,8 +197,8 @@ span.carousel__container {
         right: 0;
     }
 
-    .carousel__control .icon--chevron-left-24 {
-        margin-left: 2px;
+    .carousel__control .icon--chevron-left-12 {
+        margin-left: 1px;
     }
 
     .carousel__control--next {
@@ -206,12 +206,12 @@ span.carousel__container {
         right: unset;
     }
 
-    .carousel__control .icon--chevron-right-24 {
-        margin-left: -2px;
+    .carousel__control .icon--chevron-right-12 {
+        margin-left: -1px;
     }
 
-    .carousel__control .icon--chevron-left-24,
-    .carousel__control .icon--chevron-right-24 {
+    .carousel__control .icon--chevron-left-12,
+    .carousel__control .icon--chevron-right-12 {
         transform: rotate(180deg);
     }
 }

--- a/src/less/carousel/stories/carousel.stories.js
+++ b/src/less/carousel/stories/carousel.stories.js
@@ -4,8 +4,8 @@ export const continuous = () => `
 <div class="carousel">
     <div class="carousel__container">
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false">
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport carousel__viewport--mask">
@@ -21,8 +21,8 @@ export const continuous = () => `
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
@@ -33,25 +33,25 @@ export const imageTreatment = () => `
 <div class="carousel">
     <div class="carousel__container">
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false">
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport carousel__viewport--mask">
             <ul class="carousel__list carousel__list--image-treatment carousel__list--image-treatment-demo">
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/aztec-pyramid.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/falls.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/shoes.jpeg"/></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/tall-cat.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/wide-cat.jpeg"/></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/aztec-pyramid.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/falls.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/shoes.jpeg"/></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/tall-cat.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/wide-cat.jpeg"/></li>
                 <li>Card 7</li>
                 <li>Card 8</li>
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
@@ -62,25 +62,25 @@ export const imageTreatmentLarge = () => `
 <div class="carousel">
     <div class="carousel__container">
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false">
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport carousel__viewport--mask">
             <ul class="carousel__list carousel__list--image-treatment-large carousel__list--image-treatment-demo">
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/aztec-pyramid.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/falls.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/shoes.jpeg"/></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/tall-cat.jpeg" /></li>
-                <li><img src="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/wide-cat.jpeg"/></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/aztec-pyramid.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/falls.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/shoes.jpeg"/></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/tall-cat.jpeg" /></li>
+                <li><img src="https://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/wide-cat.jpeg"/></li>
                 <li>Card 7</li>
                 <li>Card 8</li>
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
@@ -94,8 +94,8 @@ export const slides = () => `
             <span>Top Products - Slide 1 of 2</span>
         </h4>
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false" >
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport">
@@ -111,8 +111,8 @@ export const slides = () => `
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
@@ -126,8 +126,8 @@ export const slideshow = () => `
             <span>Top Products - Slide 1 of 4</span>
         </h4>
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false" >
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport">
@@ -139,8 +139,8 @@ export const slideshow = () => `
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>
@@ -160,8 +160,8 @@ export const RTL = () => `
                 <span>Top Products - Slide 1 of 4</span>
             </h4>
             <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-                <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false">
-                    <use href="#icon-chevron-left-24"></use>
+                <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                    <use href="#icon-chevron-left-12"></use>
                 </svg>
             </button>
             <div class="carousel__viewport">
@@ -173,8 +173,8 @@ export const RTL = () => `
                 </ul>
             </div>
             <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-                <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false" >
-                    <use href="#icon-chevron-right-24"></use>
+                <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false" >
+                    <use href="#icon-chevron-right-12"></use>
                 </svg>
             </button>
         </div>
@@ -191,8 +191,8 @@ export const hiddenScrollbar = () => `
 <div class="carousel carousel--hidden-scrollbar">
     <div class="carousel__container">
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-left-24" focusable="false">
-                <use href="#icon-chevron-left-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                <use href="#icon-chevron-left-12"></use>
             </svg>
         </button>
         <div class="carousel__viewport carousel__viewport--mask">
@@ -208,8 +208,8 @@ export const hiddenScrollbar = () => `
             </ul>
         </div>
         <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products">
-            <svg aria-hidden="true" class="icon icon--chevron-right-24" focusable="false">
-                <use href="#icon-chevron-right-24"></use>
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
             </svg>
         </button>
     </div>

--- a/src/less/carousel/stories/carousel.stories.js
+++ b/src/less/carousel/stories/carousel.stories.js
@@ -215,3 +215,100 @@ export const hiddenScrollbar = () => `
     </div>
 </div>
 `;
+
+/* paddle opacity set to 1 for purpose of visual regression testing only */
+export const continuousPaddlesVisible = () => `
+<div class="carousel">
+    <div class="carousel__container">
+        <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                <use href="#icon-chevron-left-12"></use>
+            </svg>
+        </button>
+        <div class="carousel__viewport carousel__viewport--mask">
+            <ul class="carousel__list carousel__list--default-demo">
+                <li>Card 1</li>
+                <li>Card 2</li>
+                <li>Card 3</li>
+                <li>Card 4</li>
+                <li>Card 5</li>
+                <li>Card 6</li>
+                <li>Card 7</li>
+                <li>Card 8</li>
+            </ul>
+        </div>
+        <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
+            </svg>
+        </button>
+    </div>
+</div>
+`;
+
+/* paddle opacity set to 1 for purpose of visual regression testing only */
+export const slidesPaddlesVisible = () => `
+<div class="carousel carousel--slides">
+    <div class="carousel__container">
+        <h4 class="clipped" aria-live="polite">
+            <span>Top Products - Slide 1 of 2</span>
+        </h4>
+        <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                <use href="#icon-chevron-left-12"></use>
+            </svg>
+        </button>
+        <div class="carousel__viewport">
+            <ul class="carousel__list carousel__list--discrete-demo">
+                <li>Card 1</li>
+                <li>Card 2</li>
+                <li>Card 3</li>
+                <li>Card 4</li>
+                <li>Card 5</li>
+                <li>Card 6</li>
+                <li>Card 7</li>
+                <li>Card 8</li>
+            </ul>
+        </div>
+        <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
+            </svg>
+        </button>
+    </div>
+</div>
+`;
+
+/* paddle opacity set to 1 for purpose of visual regression testing only */
+export const slideshowPaddlesVisible = () => `
+<div class="carousel carousel--slides">
+    <div class="carousel__container">
+        <h4 class="clipped" aria-live="polite">
+            <span>Top Products - Slide 1 of 4</span>
+        </h4>
+        <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false" >
+                <use href="#icon-chevron-left-12"></use>
+            </svg>
+        </button>
+        <div class="carousel__viewport">
+            <ul class="carousel__list carousel__list--slideshow-demo">
+                <li>Card 1</li>
+                <li>Card 2</li>
+                <li>Card 3</li>
+                <li>Card 4</li>
+            </ul>
+        </div>
+        <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
+            </svg>
+        </button>
+    </div>
+    <button class="carousel__playback" aria-label="Play - Top Products">
+        <svg class="icon icon--play-24" focusable="false" aria-hidden="true">
+            <use href="#icon-play-24"></use>
+        </svg>
+    </button>
+</div>
+`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
# Issue #1925

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->

This PR is ONLY changing the icon size. It does not move the paddle to the new position. There are some issues with `overflow: hidden` and relative positioning on the carousel__container which will take a little longer to figure out. Might as well get these simpler changes in before then.

I also added new stories that have the paddles shown (for Percy purposes) and fixed a couple of issues in the existing stories.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

Before
<img width="1222" alt="Screen Shot 2023-08-11 at 11 19 47 AM" src="https://github.com/eBay/skin/assets/38065/c7f07998-687b-4732-a4db-ebf968ea7976">

After

<img width="1224" alt="Screen Shot 2023-08-11 at 11 22 23 AM" src="https://github.com/eBay/skin/assets/38065/3e2c7414-6f48-4be1-98c7-ab64016eb77f">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
