### PR TITLE
style(carousel): paddles overlap container edge #1925

### DIFF
--- a/dist/carousel/carousel.css
+++ b/dist/carousel/carousel.css
@@ -296,3 +296,9 @@ span.carousel__container {
 .carousel--hidden-scrollbar .carousel__container .carousel__list {
   padding-bottom: 80px;
 }
+.carousel--hidden-scrollbar .carousel__control--prev {
+  left: 0;
+}
+.carousel--hidden-scrollbar .carousel__control--next {
+  right: 0;
+}

--- a/dist/carousel/carousel.css
+++ b/dist/carousel/carousel.css
@@ -2,7 +2,6 @@
   position: relative;
 }
 .carousel__container {
-  overflow: hidden;
   position: relative;
   white-space: nowrap;
   width: 100%;
@@ -118,10 +117,10 @@ div.carousel {
   z-index: 1;
 }
 .carousel__control--prev {
-  left: 0;
+  left: -16px;
 }
 .carousel__control--next {
-  right: 0;
+  right: -16px;
 }
 .carousel__control .icon--chevron-right-24 {
   margin-left: 2px;
@@ -188,7 +187,7 @@ span.carousel__container {
 }
 [dir="rtl"] .carousel__control--prev {
   left: unset;
-  right: 0;
+  right: -16px;
 }
 [dir="rtl"] .carousel__control .icon--chevron-left-24 {
   margin-left: 2px;
@@ -197,7 +196,7 @@ span.carousel__container {
   margin-left: 1px;
 }
 [dir="rtl"] .carousel__control--next {
-  left: 0;
+  left: -16px;
   right: unset;
 }
 [dir="rtl"] .carousel__control .icon--chevron-right-24 {

--- a/src/less/carousel/carousel.less
+++ b/src/less/carousel/carousel.less
@@ -246,6 +246,7 @@ span.carousel__container {
             (scroll-snap-coordinate: 0 0) or /*!Y */ (scroll-snap-align: start)
     ) {
     // always show paddles when scroll snapping and hover is not supported.
+    // todo: rename to .carousel--autoplay
     .carousel:not(.carousel__autoplay) .carousel__control {
         .show-control();
     }
@@ -267,6 +268,7 @@ span.carousel__container {
         (scroll-snap-coordinate: 0 0) or /*!Y */ (scroll-snap-align: start)
 ) {
     /* autoprefixer: off */
+    // todo: rename to .carousel--autoplay
     .carousel:not(.carousel__autoplay) {
         overflow: visible;
 
@@ -329,6 +331,7 @@ span.carousel__container {
     }
 }
 
+// todo: rename to .carousel--autoplay
 .carousel.carousel--hidden-scrollbar:not(.carousel__autoplay) {
     overflow: hidden;
 }
@@ -343,4 +346,14 @@ span.carousel__container {
 
 .carousel--hidden-scrollbar .carousel__container .carousel__list {
     padding-bottom: 80px;
+}
+
+// hidden-scrollbar must have inner paddle position due to overflow: hidden
+.carousel--hidden-scrollbar .carousel__control--prev {
+    left: 0;
+}
+
+// hidden-scrollbar must have inner paddle position due to overflow: hidden
+.carousel--hidden-scrollbar .carousel__control--next {
+    right: 0;
 }

--- a/src/less/carousel/carousel.less
+++ b/src/less/carousel/carousel.less
@@ -17,11 +17,11 @@
     .background-color-token(carousel-paddle-background-color, color-background-primary);
 
     &--prev {
-        left: 0;
+        left: -@spacing-200;
     }
 
     &--next {
-        right: 0;
+        right: -@spacing-200;
     }
 
     // deprecated
@@ -111,7 +111,6 @@
     position: relative;
 
     &__container {
-        overflow: hidden;
         position: relative;
         white-space: nowrap;
         width: 100%;
@@ -204,7 +203,7 @@ span.carousel__container {
 [dir="rtl"] {
     .carousel__control--prev {
         left: unset;
-        right: 0;
+        right: -@spacing-200;
     }
 
     // deprecated
@@ -217,7 +216,7 @@ span.carousel__container {
     }
 
     .carousel__control--next {
-        left: 0;
+        left: -@spacing-200;
         right: unset;
     }
 

--- a/src/less/carousel/stories/carousel.stories.js
+++ b/src/less/carousel/stories/carousel.stories.js
@@ -217,7 +217,7 @@ export const hiddenScrollbar = () => `
 `;
 
 /* paddle opacity set to 1 for purpose of visual regression testing only */
-export const continuousPaddlesVisible = () => `
+export const continuousWithPaddlesVisible = () => `
 <div class="carousel">
     <div class="carousel__container">
         <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products" style="opacity: 1">
@@ -247,7 +247,7 @@ export const continuousPaddlesVisible = () => `
 `;
 
 /* paddle opacity set to 1 for purpose of visual regression testing only */
-export const slidesPaddlesVisible = () => `
+export const slidesWithPaddlesVisible = () => `
 <div class="carousel carousel--slides">
     <div class="carousel__container">
         <h4 class="clipped" aria-live="polite">
@@ -280,7 +280,7 @@ export const slidesPaddlesVisible = () => `
 `;
 
 /* paddle opacity set to 1 for purpose of visual regression testing only */
-export const slideshowPaddlesVisible = () => `
+export const slideshowWithPaddlesVisible = () => `
 <div class="carousel carousel--slides">
     <div class="carousel__container">
         <h4 class="clipped" aria-live="polite">
@@ -310,5 +310,35 @@ export const slideshowPaddlesVisible = () => `
             <use href="#icon-play-24"></use>
         </svg>
     </button>
+</div>
+`;
+
+/* paddle opacity set to 1 for purpose of visual regression testing only */
+export const hiddenScrollbarWithPaddlesVisible = () => `
+<div class="carousel carousel--hidden-scrollbar">
+    <div class="carousel__container">
+        <button class="carousel__control carousel__control--prev" aria-label="Previous Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-left-12" focusable="false">
+                <use href="#icon-chevron-left-12"></use>
+            </svg>
+        </button>
+        <div class="carousel__viewport carousel__viewport--mask">
+            <ul class="carousel__list carousel__list--default-demo">
+                <li>Card 1</li>
+                <li>Card 2</li>
+                <li>Card 3</li>
+                <li>Card 4</li>
+                <li>Card 5</li>
+                <li>Card 6</li>
+                <li>Card 7</li>
+                <li>Card 8</li>
+            </ul>
+        </div>
+        <button class="carousel__control carousel__control--next" aria-label="Next Slide - Top Products" style="opacity: 1">
+            <svg aria-hidden="true" class="icon icon--chevron-right-12" focusable="false">
+                <use href="#icon-chevron-right-12"></use>
+            </svg>
+        </button>
+    </div>
 </div>
 `;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #1925

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
New paddle position which has moved from the inner edges of the container to now overlapping the container edge.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
I had to remove `overflow: hidden` from the container to make this work with the current markup structure. I've tested this across browsers and not seen any behavior that is different from in production. 

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

<img width="927" alt="Screen Shot 2023-08-14 at 3 38 18 PM" src="https://github.com/eBay/skin/assets/38065/1414e23d-00d4-4f1c-9533-8f0fd04d0a23">
<img width="929" alt="Screen Shot 2023-08-14 at 3 38 09 PM" src="https://github.com/eBay/skin/assets/38065/f988e9a4-54d3-4073-9d56-85e83ebc0fef">
<img width="926" alt="Screen Shot 2023-08-14 at 3 38 00 PM" src="https://github.com/eBay/skin/assets/38065/ea5a3322-a082-4ddd-916f-aac58e7177b2">

### Hidden Scrollbar Version Keeps The Old Position

This is due to overflow: hidden on the root (needs a refactor).

<img width="1175" alt="Screen Shot 2023-08-15 at 2 09 46 PM" src="https://github.com/eBay/skin/assets/38065/656082ca-558c-4226-ad7b-e953f140662b">



## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
