### PR TITLE
feat(lightbox-dialog): added popup sheet variant

### DIFF
--- a/dist/alert-dialog/alert-dialog.css
+++ b/dist/alert-dialog/alert-dialog.css
@@ -27,8 +27,8 @@
   flex-direction: column;
   min-height: 55px;
   will-change: opacity, transform;
-  border-radius: var(--lightbox-border-radius, var(--border-radius-100));
-  margin: auto;
+  border-radius: var(--lightbox-border-radius, var(--border-radius-150));
+  margin: auto auto 16px;
   max-height: 90%;
   max-width: calc(100% - 32px);
   min-width: 208px;

--- a/dist/confirm-dialog/confirm-dialog.css
+++ b/dist/confirm-dialog/confirm-dialog.css
@@ -27,8 +27,8 @@
   flex-direction: column;
   min-height: 55px;
   will-change: opacity, transform;
-  border-radius: var(--lightbox-border-radius, var(--border-radius-100));
-  margin: auto;
+  border-radius: var(--lightbox-border-radius, var(--border-radius-150));
+  margin: auto auto 16px;
   max-height: 90%;
   max-width: calc(100% - 32px);
   min-width: 208px;

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -31,8 +31,8 @@
   flex-direction: column;
   min-height: 55px;
   will-change: opacity, transform;
-  border-radius: var(--lightbox-border-radius, var(--border-radius-100));
-  margin: auto;
+  border-radius: var(--lightbox-border-radius, var(--border-radius-150));
+  margin: auto auto 16px;
   max-height: 90%;
   max-width: calc(100% - 32px);
   min-width: 208px;
@@ -144,6 +144,10 @@ button.icon-btn.lightbox-dialog__prev {
 .lightbox-dialog--hide .lightbox-dialog__window--fade {
   transition: opacity 0.16s ease-out;
 }
+.lightbox-dialog--show .lightbox-dialog__window--animate,
+.lightbox-dialog--hide .lightbox-dialog__window--animate {
+  transition: opacity 0.16s ease-out, transform 0.32s ease-out;
+}
 .lightbox-dialog--hide.lightbox-dialog--hide,
 .lightbox-dialog--hide.lightbox-dialog--show-init,
 .lightbox-dialog--show-init.lightbox-dialog--hide,
@@ -159,6 +163,11 @@ button.icon-btn.lightbox-dialog__prev {
 .lightbox-dialog--hide .lightbox-dialog__window--fade,
 .lightbox-dialog--show-init .lightbox-dialog__window--fade {
   opacity: 0;
+}
+.lightbox-dialog--hide .lightbox-dialog__window--animate,
+.lightbox-dialog--show-init .lightbox-dialog__window--animate {
+  opacity: 0;
+  transform: translateY(100%);
 }
 .lightbox-dialog--show.lightbox-dialog--show,
 .lightbox-dialog--show.lightbox-dialog--hide-init,
@@ -176,6 +185,34 @@ button.icon-btn.lightbox-dialog__prev {
 .lightbox-dialog--hide-init .lightbox-dialog__window--fade {
   opacity: 1;
 }
+.lightbox-dialog--show .lightbox-dialog__window--animate,
+.lightbox-dialog--hide-init .lightbox-dialog__window--animate {
+  opacity: 1;
+  transform: translateY(0);
+}
+.lightbox-dialog__handle {
+  background-color: transparent;
+  border: none;
+  left: 0;
+  margin: -11px auto;
+  padding: 8px;
+  position: relative;
+  right: 0;
+  top: 11px;
+  z-index: 2;
+}
+.lightbox-dialog__handle::after {
+  background-color: var(--dialog-handle-color, var(--color-stroke-default));
+  border-radius: 3px;
+  content: "";
+  display: block;
+  height: 2px;
+  width: 24px;
+}
+.lightbox-dialog__window--expanded {
+  height: 95%;
+  max-height: 95%;
+}
 [dir="rtl"] button.icon-btn.lightbox-dialog__prev {
   margin-left: 16px;
   margin-right: 0;
@@ -185,7 +222,12 @@ button.icon-btn.lightbox-dialog__prev {
 }
 @media (min-width: 512px) {
   .lightbox-dialog__window {
+    margin: auto;
+    border-radius: var(--lightbox-border-radius, var(--border-radius-100));
     max-width: calc(88% - 32px);
+  }
+  .lightbox-dialog__handle {
+    display: none;
   }
   .lightbox-dialog--narrow .lightbox-dialog__window {
     max-width: var(--dialog-lightbox-narrow-max-width);
@@ -198,6 +240,12 @@ button.icon-btn.lightbox-dialog__prev {
   .lightbox-dialog__window .lightbox-dialog__footer > :not(:first-child) {
     margin-left: 8px;
     margin-top: initial;
+  }
+  .lightbox-dialog--show .lightbox-dialog__window--animate,
+  .lightbox-dialog--hide-init .lightbox-dialog__window--animate,
+  .lightbox-dialog--show-init .lightbox-dialog__window--animate,
+  .lightbox-dialog--hide .lightbox-dialog__window--animate {
+    transform: translateY(0);
   }
 }
 @media (min-width: 768px) {

--- a/dist/tokens/evo-core.css
+++ b/dist/tokens/evo-core.css
@@ -1,6 +1,7 @@
 :root {
     --border-radius-50: 8px;
     --border-radius-100: 16px;
+    --border-radius-150: 24px;
     --color-neutral-0: #fff;
     --color-neutral-1: #f7f7f7;
     --color-neutral-2: #e5e5e5;

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -2,12 +2,14 @@
     {% include section-header.html name="lightbox-dialog" version=page.versions.lightbox-dialog %}
 
     <p>A lightbox dialog is a modal window spawned by the main web page or application.</p>
+    <p>On small screens, the lightbox dialog will turn into a bottom sheet. The handle at the top will appear only on small screens.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-default" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-default" aria-modal="true" class="lightbox-dialog" hidden id="lightbox-dialog-default" role="dialog">
                 <div class="lightbox-dialog__window">
+                    <button class="lightbox-dialog__handle" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-default" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -31,6 +33,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -81,6 +84,63 @@
     {% highlight html %}
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
     <div class="lightbox-dialog__window lightbox-dialog__window--full">
+        <button class="lightbox-dialog__handle" type="button"></button>
+        <div class="lightbox-dialog__header">
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Lorem ... 1</p>
+            <p>Lorem ... 2</p>
+            <p>(you get the idea)</p>
+            <p>Lorem ... n</p>
+            <p><a href="https://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+    <h3 id="lightbox-scrolling">Expanded Lightbox</h3>
+    <p>For small screens you can use <span class="highlight">.lightbox-dialog__window--expanded</span> class to expand the viewport. This is generally controlled by the handle.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-expanded" type="button">Open Scrolling Lightbox Dialog</button>
+            <div aria-labelledby="dialog-title-expanded" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-expanded" role="dialog">
+                <div class="lightbox-dialog__window lightbox-dialog__window--expanded">
+                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <div class="lightbox-dialog__header">
+                        <h2 id="dialog-title-expanded">Scrolling Lightbox Dialog</h2>
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
+                            <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
+                                {% include symbol.html name="close-16" %}
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="lightbox-dialog__main">
+                        {% for number in (1...100) %}
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+                            dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        {% endfor %}
+                        <p><a href="https://www.ebay.com">www.ebay.com</a></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
+    <div class="lightbox-dialog__window lightbox-dialog__window-expanded">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -113,6 +173,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-prev-button" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-prev-button" aria-modal="true" class="lightbox-dialog" hidden id="lightbox-dialog-prev-button" role="dialog">
                 <div class="lightbox-dialog__window">
+                    <button class="lightbox-dialog__handle" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <button aria-label="Go back" class="icon-btn lightbox-dialog__prev" type="button">
                             <svg aria-hidden="true" class="icon icon--chevron-left-16" focusable="false" height="16" width="16">
@@ -141,6 +202,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <button aria-label="Go back" class="icon-btn lightbox-dialog__prev" type="button">
                 <svg aria-hidden="true" class="icon icon--chevron-left-16" focusable="false" height="16" width="16">
@@ -173,6 +235,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-wide" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-wide" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" hidden id="lightbox-dialog-wide" role="dialog">
                 <div class="lightbox-dialog__window">
+                    <button class="lightbox-dialog__handle" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-wide" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -196,6 +259,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" hidden role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -223,6 +287,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-narrow" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-narrow" aria-modal="true" class="lightbox-dialog lightbox-dialog--narrow" hidden id="lightbox-dialog-narrow" role="dialog">
                 <div class="lightbox-dialog__window">
+                    <button class="lightbox-dialog__handle" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-narrow" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -246,6 +311,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--narrow" hidden role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -268,14 +334,15 @@
 
 
     <h3 id="lightbox-transitioned">Transitioned Lightbox</h3>
-    <p>Any lightbox can be transitioned in and out, using the <span class="highlight">lightbox-dialog__window--fade</span> and <span class="highlight">lightbox-dialog--mask-fade</span> modifiers.</p>
+    <p>Any lightbox can be transitioned in and out, using the <span class="highlight">lightbox-dialog__window--animate</span> and <span class="highlight">lightbox-dialog--mask-fade</span> modifiers. On large screens, animate will fade in and on small screens the panel will slide in from the bottom.</p>
     <p>The default fade duration is 16ms.<p>
 
     <div class="demo">
         <div class="demo__inner">
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-fade-0" type="button">Open Transitioned Lightbox</button>
             <div aria-labelledby="lightbox-dialog-fade-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-fade-0" role="dialog">
-                <div class="lightbox-dialog__window lightbox-dialog__window--fade">
+                <div class="lightbox-dialog__window lightbox-dialog__window--animate">
+                    <button class="lightbox-dialog__handle" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-fade-title" class="large-text-1 bold-text">Transitioned Lightbox</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -300,7 +367,8 @@
 
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden role="dialog">
-    <div class="lightbox-dialog__window lightbox-dialog__window--fade">
+    <div class="lightbox-dialog__window lightbox-dialog__window--animate">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -330,6 +398,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-footer" type="button">Open Lightbox Dialog with Footer</button>
             <div aria-labelledby="lightbox-dialog-footer-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--no-mask" hidden id="lightbox-dialog-footer" role="dialog">
                 <div class="lightbox-dialog__window">
+                    <button class="lightbox-dialog__handle" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-footer-title" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -357,6 +426,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="large-text-1 lightbox-dialog__header">
             <h2 class="large-text-1 bold-text" id="lightbox-dialog-title">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -388,6 +458,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-expressive" type="button">Open Expressive Lightbox</button>
             <div aria-labelledby="dialog-title-default" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" hidden id="lightbox-dialog-expressive" role="dialog">
                 <div class="lightbox-dialog__window">
+                    <button class="lightbox-dialog__handle" type="button"></button>
                     <div class="lightbox-dialog__image" style="background-image:url({{page.static_dir}}/img/tb-landscape-pic.jpg)"></div>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-default" class="large-text-1 bold-text">Lightbox Dialog</h2>
@@ -412,6 +483,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" hidden role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url({{page.static_dir}}/img/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -2,7 +2,7 @@
     {% include section-header.html name="lightbox-dialog" version=page.versions.lightbox-dialog %}
 
     <p>A lightbox dialog is a modal window spawned by the main web page or application.</p>
-    <p>On small screens, the lightbox dialog will turn into a bottom sheet. The handle at the top will appear only on small screens.</p>
+    <p>The lightbox-dialog is fully responsive. On large screens it will be aligned to the center of the screen; on small screens at the bottom. Small screens display an additional "handle" button, used to expand the dialog height.</p>
 
     <div class="demo">
         <div class="demo__inner">

--- a/docs/_includes/lightbox-dialog.html
+++ b/docs/_includes/lightbox-dialog.html
@@ -9,7 +9,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-default" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-default" aria-modal="true" class="lightbox-dialog" hidden id="lightbox-dialog-default" role="dialog">
                 <div class="lightbox-dialog__window">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-default" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -33,7 +33,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -84,7 +84,7 @@
     {% highlight html %}
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
     <div class="lightbox-dialog__window lightbox-dialog__window--full">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -116,7 +116,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-expanded" type="button">Open Scrolling Lightbox Dialog</button>
             <div aria-labelledby="dialog-title-expanded" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-expanded" role="dialog">
                 <div class="lightbox-dialog__window lightbox-dialog__window--expanded">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-expanded">Scrolling Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -140,7 +140,7 @@
     {% highlight html %}
 <div aria-labelledby="dialog-title" aria-modal="true" class="dialog dialog--no-mask" hidden role="dialog">
     <div class="lightbox-dialog__window lightbox-dialog__window-expanded">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -173,7 +173,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-prev-button" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-prev-button" aria-modal="true" class="lightbox-dialog" hidden id="lightbox-dialog-prev-button" role="dialog">
                 <div class="lightbox-dialog__window">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <button aria-label="Go back" class="icon-btn lightbox-dialog__prev" type="button">
                             <svg aria-hidden="true" class="icon icon--chevron-left-16" focusable="false" height="16" width="16">
@@ -202,7 +202,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <button aria-label="Go back" class="icon-btn lightbox-dialog__prev" type="button">
                 <svg aria-hidden="true" class="icon icon--chevron-left-16" focusable="false" height="16" width="16">
@@ -235,7 +235,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-wide" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-wide" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" hidden id="lightbox-dialog-wide" role="dialog">
                 <div class="lightbox-dialog__window">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-wide" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -259,7 +259,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" hidden role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -287,7 +287,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-narrow" type="button">Open Lightbox</button>
             <div aria-labelledby="dialog-title-narrow" aria-modal="true" class="lightbox-dialog lightbox-dialog--narrow" hidden id="lightbox-dialog-narrow" role="dialog">
                 <div class="lightbox-dialog__window">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-narrow" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -311,7 +311,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--narrow" hidden role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -342,7 +342,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-fade-0" type="button">Open Transitioned Lightbox</button>
             <div aria-labelledby="lightbox-dialog-fade-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden id="lightbox-dialog-fade-0" role="dialog">
                 <div class="lightbox-dialog__window lightbox-dialog__window--animate">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-fade-title" class="large-text-1 bold-text">Transitioned Lightbox</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -368,7 +368,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--mask-fade" hidden role="dialog">
     <div class="lightbox-dialog__window lightbox-dialog__window--animate">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -398,7 +398,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-footer" type="button">Open Lightbox Dialog with Footer</button>
             <div aria-labelledby="lightbox-dialog-footer-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--no-mask" hidden id="lightbox-dialog-footer" role="dialog">
                 <div class="lightbox-dialog__window">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__header">
                         <h2 id="lightbox-dialog-footer-title" class="large-text-1 bold-text">Lightbox Dialog</h2>
                         <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -426,7 +426,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" hidden role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="large-text-1 lightbox-dialog__header">
             <h2 class="large-text-1 bold-text" id="lightbox-dialog-title">Heading</h2>
             <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
@@ -458,7 +458,7 @@
             <button class="btn btn--primary dialog-button" data-makeup-for="lightbox-dialog-expressive" type="button">Open Expressive Lightbox</button>
             <div aria-labelledby="dialog-title-default" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" hidden id="lightbox-dialog-expressive" role="dialog">
                 <div class="lightbox-dialog__window">
-                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
                     <div class="lightbox-dialog__image" style="background-image:url({{page.static_dir}}/img/tb-landscape-pic.jpg)"></div>
                     <div class="lightbox-dialog__header">
                         <h2 id="dialog-title-default" class="large-text-1 bold-text">Lightbox Dialog</h2>
@@ -483,7 +483,7 @@
     {% highlight html %}
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" hidden role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url({{page.static_dir}}/img/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title" class="large-text-1 bold-text">Heading</h2>

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -107,6 +107,10 @@ button.icon-btn.lightbox-dialog__prev {
     .lightbox-dialog__window--fade {
         transition: opacity 0.16s ease-out;
     }
+
+    .lightbox-dialog__window--animate {
+        transition: opacity 0.16s ease-out, transform 0.32s ease-out;
+    }
 }
 
 .lightbox-dialog--hide,
@@ -122,6 +126,11 @@ button.icon-btn.lightbox-dialog__prev {
 
     .lightbox-dialog__window--fade {
         opacity: 0;
+    }
+
+    .lightbox-dialog__window--animate {
+        opacity: 0;
+        transform: translateY(100%);
     }
 }
 
@@ -139,6 +148,38 @@ button.icon-btn.lightbox-dialog__prev {
     .lightbox-dialog__window--fade {
         opacity: 1;
     }
+
+    .lightbox-dialog__window--animate {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.lightbox-dialog__handle {
+    background-color: transparent;
+    border: none;
+    left: 0;
+    margin: -11px auto;
+    padding: 8px;
+    position: relative;
+    right: 0;
+    top: 11px;
+    z-index: 2;
+}
+
+// Added :after class in order to increase parent hit box
+.lightbox-dialog__handle::after {
+    .background-color-token(dialog-handle-color, color-stroke-default);
+    border-radius: 3px;
+    content: "";
+    display: block;
+    height: 2px;
+    width: 24px;
+}
+
+.lightbox-dialog__window--expanded {
+    height: 95%;
+    max-height: 95%;
 }
 
 [dir="rtl"] {
@@ -153,7 +194,13 @@ button.icon-btn.lightbox-dialog__prev {
 // In order to prevent the margins to meet the ege of the page at medium screen sizes
 @media (min-width: @_screen-size-SM) {
     .lightbox-dialog__window {
+        .lightbox-dialog-window-large();
+
         max-width: calc(88% - @spacing-400);
+    }
+
+    .lightbox-dialog__handle {
+        display: none;
     }
 
     .lightbox-dialog--narrow .lightbox-dialog__window {
@@ -162,6 +209,12 @@ button.icon-btn.lightbox-dialog__prev {
 
     .lightbox-dialog__window .lightbox-dialog__footer {
         .dialog-footer-content-large();
+    }
+    .lightbox-dialog--show .lightbox-dialog__window--animate,
+    .lightbox-dialog--hide-init .lightbox-dialog__window--animate,
+    .lightbox-dialog--show-init .lightbox-dialog__window--animate,
+    .lightbox-dialog--hide .lightbox-dialog__window--animate {
+        transform: translateY(0);
     }
 }
 

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -109,7 +109,9 @@ button.icon-btn.lightbox-dialog__prev {
     }
 
     .lightbox-dialog__window--animate {
-        transition: opacity 0.16s ease-out, transform 0.32s ease-out;
+        transition:
+            opacity 0.16s ease-out,
+            transform 0.32s ease-out;
     }
 }
 

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -3,6 +3,7 @@ export default { title: "Skin/Lightbox Dialog" };
 export const base = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -26,6 +27,7 @@ export const base = () => `
 export const expressiveBase = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
@@ -50,6 +52,7 @@ export const expressiveBase = () => `
 export const basePrev = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">
                 <svg class="icon icon--chevron-left-16" aria-hidden="true">
@@ -78,6 +81,74 @@ export const basePrev = () => `
 export const scrollingLightbox = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;
+
+export const expandedLightbox = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window lightbox-dialog__window--expanded">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -144,6 +215,7 @@ export const scrollingLightbox = () => `
 export const expressiveScrolling = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
@@ -211,6 +283,7 @@ export const expressiveScrolling = () => `
 export const baseWithFooter = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -240,6 +313,7 @@ export const baseRTL = () => `
 <div dir="rtl">
     <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
         <div class="lightbox-dialog__window">
+            <button class="lightbox-dialog__handle" type="button"></button>
             <div class="lightbox-dialog__header">
                 <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
                 <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -265,6 +339,7 @@ export const prevRTL = () => `
 <div dir="rtl">
     <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
         <div class="lightbox-dialog__window">
+            <button class="lightbox-dialog__handle" type="button"></button>
             <div class="lightbox-dialog__header">
                 <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">
                     <svg class="icon icon--chevron-left-16" aria-hidden="true">
@@ -294,6 +369,7 @@ export const prevRTL = () => `
 export const baseWithLongHeader = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox with a very long header that should wrap to the next line, but is actually cut off</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -317,6 +393,7 @@ export const baseWithLongHeader = () => `
 export const wide = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -340,6 +417,7 @@ export const wide = () => `
 export const narrow = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--narrow" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -363,6 +441,7 @@ export const narrow = () => `
 export const expressiveWide = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
@@ -387,6 +466,7 @@ export const expressiveWide = () => `
 export const expressivePrev = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -3,7 +3,7 @@ export default { title: "Skin/Lightbox Dialog" };
 export const base = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -27,7 +27,7 @@ export const base = () => `
 export const expressiveBase = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
            <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
@@ -52,7 +52,7 @@ export const expressiveBase = () => `
 export const basePrev = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">
                 <svg class="icon icon--chevron-left-16" aria-hidden="true">
@@ -81,7 +81,7 @@ export const basePrev = () => `
 export const scrollingLightbox = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -148,7 +148,7 @@ export const scrollingLightbox = () => `
 export const expandedLightbox = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window lightbox-dialog__window--expanded">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -215,7 +215,7 @@ export const expandedLightbox = () => `
 export const expressiveScrolling = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
@@ -283,7 +283,7 @@ export const expressiveScrolling = () => `
 export const baseWithFooter = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -313,7 +313,7 @@ export const baseRTL = () => `
 <div dir="rtl">
     <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
         <div class="lightbox-dialog__window">
-            <button class="lightbox-dialog__handle" type="button"></button>
+            <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
             <div class="lightbox-dialog__header">
                 <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
                 <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -339,7 +339,7 @@ export const prevRTL = () => `
 <div dir="rtl">
     <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
         <div class="lightbox-dialog__window">
-            <button class="lightbox-dialog__handle" type="button"></button>
+            <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
             <div class="lightbox-dialog__header">
                 <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">
                     <svg class="icon icon--chevron-left-16" aria-hidden="true">
@@ -369,7 +369,7 @@ export const prevRTL = () => `
 export const baseWithLongHeader = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox with a very long header that should wrap to the next line, but is actually cut off</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -393,7 +393,7 @@ export const baseWithLongHeader = () => `
 export const wide = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -417,7 +417,7 @@ export const wide = () => `
 export const narrow = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--narrow" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
             <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
@@ -441,7 +441,7 @@ export const narrow = () => `
 export const expressiveWide = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--wide lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <h2 id="lightbox-dialog-title">Dialog Lightbox</h2>
@@ -466,7 +466,7 @@ export const expressiveWide = () => `
 export const expressivePrev = () => `
 <div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog lightbox-dialog--expressive" role="dialog">
     <div class="lightbox-dialog__window">
-        <button class="lightbox-dialog__handle" type="button"></button>
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
         <div class="lightbox-dialog__image" style="background-image:url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg)"></div>
         <div class="lightbox-dialog__header">
             <button class="icon-btn lightbox-dialog__prev" type="button" aria-label="Go back">

--- a/src/less/mixins/private/dialog-mixins.less
+++ b/src/less/mixins/private/dialog-mixins.less
@@ -42,12 +42,17 @@
 
 .lightbox-dialog-window() {
     .dialog-window();
-    .border-radius-token(lightbox-border-radius, border-radius-100);
+    .border-radius-token(lightbox-border-radius, border-radius-150);
 
-    margin: auto;
+    margin: auto auto 16px;
     max-height: 90%;
     max-width: calc(100% - 32px);
     min-width: 208px;
+}
+
+.lightbox-dialog-window-large() {
+    margin: auto;
+    .border-radius-token(lightbox-border-radius, border-radius-100);
 }
 
 .dialog-header-content(@top-margin: @spacing-200) {

--- a/src/tokens/evo-core.css
+++ b/src/tokens/evo-core.css
@@ -1,6 +1,7 @@
 :root {
     --border-radius-50: 8px;
     --border-radius-100: 16px;
+    --border-radius-150: 24px;
     --color-neutral-0: #fff;
     --color-neutral-1: #f7f7f7;
     --color-neutral-2: #e5e5e5;


### PR DESCRIPTION
Fixes #2086

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added popup sheet variant to lightbox. This automatically changes based on scrensize
* Added animation class which animates both slide in from bottom and the fade in

## Notes
* At the moment I added expanded support for for both. I could only add it in small screens but I left it for both for now. We can change it if needed. 

## Screenshots
<img width="397" alt="Screenshot 2023-08-25 at 8 52 31 AM" src="https://github.com/eBay/skin/assets/1755269/d621ec1a-0570-4554-a127-b71246cc72da">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
