### PR TITLE
fix(section-notice): cta in rtl #2142

### DIFF
--- a/dist/section-notice/section-notice.css
+++ b/dist/section-notice/section-notice.css
@@ -112,7 +112,7 @@ p.section-notice__cta {
 [dir="rtl"] .section-notice__main {
   padding-right: 0;
 }
-[dir="rtl"] p.page-notice__cta {
+[dir="rtl"] p.section-notice__cta {
   margin-left: 16px;
   padding-left: 16px;
 }

--- a/src/less/section-notice/section-notice.less
+++ b/src/less/section-notice/section-notice.less
@@ -147,7 +147,7 @@ p.section-notice__cta {
         padding-right: 0;
     }
 
-    p.page-notice__cta {
+    p.section-notice__cta {
         margin-left: 16px;
         padding-left: 16px;
     }


### PR DESCRIPTION
Quick fix for #2142. Was just a simple typo.

Working now:

<img width="622" alt="Screenshot 2023-09-20 at 2 48 54 PM" src="https://github.com/eBay/skin/assets/38065/ee15ab8b-1bd3-4cb2-a546-28840acdc8fe">
