### PR TITLE
fix(confirm/alert dialog): added large window mixin

### DIFF
--- a/dist/alert-dialog/alert-dialog.css
+++ b/dist/alert-dialog/alert-dialog.css
@@ -99,6 +99,8 @@
 }
 @media (min-width: 768px) {
   .alert-dialog__window {
+    margin: auto;
+    border-radius: var(--lightbox-border-radius, var(--border-radius-100));
     max-width: calc(88% - 32px);
   }
 }

--- a/dist/confirm-dialog/confirm-dialog.css
+++ b/dist/confirm-dialog/confirm-dialog.css
@@ -103,6 +103,8 @@ button.confirm-dialog__confirm {
 }
 @media (min-width: 768px) {
   .confirm-dialog__window {
+    margin: auto;
+    border-radius: var(--lightbox-border-radius, var(--border-radius-100));
     max-width: calc(88% - 32px);
   }
 }

--- a/src/less/alert-dialog/alert-dialog.less
+++ b/src/less/alert-dialog/alert-dialog.less
@@ -84,6 +84,8 @@
 
 @media (min-width: @_screen-size-MD) {
     .alert-dialog__window {
+        .lightbox-dialog-window-large();
+
         max-width: calc(88% - @spacing-400;);
     }
 }

--- a/src/less/confirm-dialog/confirm-dialog.less
+++ b/src/less/confirm-dialog/confirm-dialog.less
@@ -89,6 +89,8 @@ button.confirm-dialog__confirm {
 
 @media (min-width: @_screen-size-MD) {
     .confirm-dialog__window {
+        .lightbox-dialog-window-large();
+
         max-width: calc(88% - @spacing-400);
     }
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2169


- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* We missed adding the large mixin for confirm and alert dialogs. Added it here

## Screenshots
<img width="1584" alt="Screenshot 2023-10-02 at 5 35 47 PM" src="https://github.com/eBay/skin/assets/1755269/7e4b8dc1-9c86-4ce9-96bd-cd4909e6770f">
<img width="452" alt="Screenshot 2023-10-02 at 5 35 52 PM" src="https://github.com/eBay/skin/assets/1755269/0f8be347-7986-49f3-b55c-98d56b71b6a3">
<img width="1522" alt="Screenshot 2023-10-02 at 5 36 01 PM" src="https://github.com/eBay/skin/assets/1755269/eadf56a2-260f-47d7-9517-456c6ea374f9">
<img width="462" alt="Screenshot 2023-10-02 at 5 36 16 PM" src="https://github.com/eBay/skin/assets/1755269/77e7cfc8-3c06-45f0-a583-2b952b18e4e4">



## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
