### PR TITLE
docs(infotip): updated to use lightbox dialog

### DIFF
--- a/docs/_includes/drawer-dialog.html
+++ b/docs/_includes/drawer-dialog.html
@@ -1,6 +1,7 @@
 <div id="drawer-dialog">
     {% include section-header.html name="drawer-dialog" version=page.versions.drawer-dialog %}
 
+    <p>** DEPRECATED ** Use <span class="highlight">lightbox-dialog</span> instead </p>
     <p>The drawer is a modal dialog that opens and slides out from the bottom of the screen. It is intended for small, mobile screens.</p>
     <p>When opened, a drawer will slide out only as far as its content, up to a maximum screen height of 50%.</p>
     <p>An opened drawer can be expanded beyond 50%, all the way to 95% screen height, by applying the <span class="highlight">.drawer-dialog__window--expanded</span> modifier class. This class should be added with JavaScript when scrolling the content or clicking the handle button.</p>

--- a/docs/_includes/infotip.html
+++ b/docs/_includes/infotip.html
@@ -119,29 +119,29 @@
     {% endhighlight %}
 
     <h3 id="infotip-modal">Modal Infotip</h3>
-    <p>On small screens, the infotip should launch a modal drawer-dialog.</p>
+    <p>On small screens, the infotip should launch a modal lightbox-dialog.</p>
 
     <div class="demo">
         <div class="demo__inner">
             <span class="infotip infotip--modal">
-                <button class="icon-btn icon-btn--transparent dialog-button" type="button" data-makeup-for="drawer-dialog-mini-infotip-0" aria-expanded="false" aria-label="Help">
+                <button class="icon-btn icon-btn--transparent dialog-button" type="button" data-makeup-for="lightbox-dialog-mini-infotip-0" aria-expanded="false" aria-label="Help">
                     <svg class="icon icon--information-16" focusable="false" width="16" height="16" aria-hidden="true">
                         {% include symbol.html name="information-16" %}
                     </svg>
                 </button>
             </span>
-            <div aria-labelledby="mini-dialog-title" aria-modal="true" hidden class="drawer-dialog" id="drawer-dialog-mini-infotip-0" role="dialog">
-                <div class="drawer-dialog__window">
-                    <button class="drawer-dialog__handle" type="button"></button>
-                    <div class="drawer-dialog__header">
+            <div aria-labelledby="mini-dialog-title" aria-modal="true" hidden class="lightbox-dialog" id="lightbox-dialog-mini-infotip-0" role="dialog">
+                <div class="lightbox-dialog__window">
+                    <button class="lightbox-dialog__handle" type="button"></button>
+                    <div class="lightbox-dialog__header">
                         <h2>Info</h2>
-                        <button aria-label="Close dialog" class="icon-btn icon-btn--transparent drawer-dialog__close" type="button">
+                        <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                             <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
                                 {% include symbol.html name="close-16" %}
                             </svg>
                         </button>
                     </div>
-                    <div class="drawer-dialog__main" id="mini-dialog-title">
+                    <div class="lightbox-dialog__main" id="mini-dialog-title">
                         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                     </div>
                 </div>
@@ -157,18 +157,18 @@
         </svg>
     </button>
 </span>
-<div aria-labelledby="drawer-dialog-title" aria-modal="true" hidden class="drawer-dialog" role="dialog">
-    <div class="drawer-dialog__window">
-        <button class="drawer-dialog__handle" type="button"></button>
-        <div class="drawer-dialog__header">
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" hidden class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" type="button"></button>
+        <div class="lightbox-dialog__header">
             <h2>Info</h2>
-            <button aria-label="Close dialog" class="icon-btn icon-btn--transparent drawer-dialog__close" type="button">
+            <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
                 <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
                     <use href="#icon-close-16"></use>
                 </svg>
             </button>
         </div>
-        <div class="drawer-dialog__main" id="drawer-dialog-title">
+        <div class="lightbox-dialog__main" id="lightbox-dialog-title">
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </div>

--- a/src/less/infotip/stories/infotip.stories.js
+++ b/src/less/infotip/stories/infotip.stories.js
@@ -105,3 +105,29 @@ export const paragraphExpanded = () => `
         </span>
     </span>
 </p>`;
+
+export const infotipModal = () => `
+    <span class="infotip infotip--modal">
+        <button class="icon-btn icon-btn--transparent dialog-button" type="button" data-makeup-for="lightbox-dialog-mini-infotip-0" aria-expanded="false" aria-label="Help">
+            <svg class="icon icon--information-16" focusable="false" width="16" height="16" aria-hidden="true">
+                <use href="#icon-information-16"></use>
+            </svg>
+        </button>
+    </span>
+    <div aria-labelledby="mini-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+        <div class="lightbox-dialog__window">
+            <button class="lightbox-dialog__handle" type="button"></button>
+            <div class="lightbox-dialog__header">
+                <h2>Info</h2>
+                <button aria-label="Close dialog" class="icon-btn lightbox-dialog__close" type="button">
+                    <svg aria-hidden="true" class="icon icon--close-16" focusable="false" height="16" width="16">
+                        <use href="#icon-close-16"></use>
+                    </svg>
+                </button>
+            </div>
+            <div class="lightbox-dialog__main" id="mini-dialog-title">
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            </div>
+        </div>
+    </div>
+ `;

--- a/src/less/infotip/stories/infotip.stories.js
+++ b/src/less/infotip/stories/infotip.stories.js
@@ -108,7 +108,7 @@ export const paragraphExpanded = () => `
 
 export const infotipModal = () => `
     <span class="infotip infotip--modal">
-        <button class="icon-btn icon-btn--transparent dialog-button" type="button" data-makeup-for="lightbox-dialog-mini-infotip-0" aria-expanded="false" aria-label="Help">
+        <button class="icon-btn icon-btn--transparent dialog-button" type="button" data-makeup-for="lightbox-dialog-mini-infotip-0" aria-expanded="true" aria-label="Help">
             <svg class="icon icon--information-16" focusable="false" width="16" height="16" aria-hidden="true">
                 <use href="#icon-information-16"></use>
             </svg>


### PR DESCRIPTION
Fixes #2180

- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
* Swapped drawer dialog to lightbox in infotip modal
* Added deprecated message to drawer dialog

## Screenshots
<img width="461" alt="Screenshot 2023-10-11 at 9 42 00 AM" src="https://github.com/eBay/skin/assets/1755269/097b1df0-82d4-4adb-b685-43259e1098e1">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
