### PR TITLE
feat(listbox): added subtitle to each option

### DIFF
--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -56,8 +56,9 @@ span.combobox {
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  display: inline-flex;
+  display: inline-grid;
   font-family: inherit;
+  grid-template-columns: auto auto;
   justify-content: space-between;
   padding: 8px 15px;
   width: 100%;

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -102,13 +102,21 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
   opacity: 1;
 }
+.listbox-button__subtitle {
+  color: var(--listbox-button-subtitle-color, var(--color-foreground-secondary));
+  font-size: var(--font-size-small);
+  font-weight: normal;
+  grid-column: 1 2;
+  grid-row: 2;
+}
 div.listbox-button__option[role="option"] {
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  display: inline-flex;
+  display: inline-grid;
   font-family: inherit;
+  grid-template-columns: auto auto;
   justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
@@ -145,6 +153,12 @@ div.listbox-button__option[role="option"]:first-child {
 div.listbox-button__option[role="option"]:last-child {
   border-bottom-left-radius: var(--listbox-button-listbox-border-radius, var(--border-radius-50));
   border-bottom-right-radius: var(--listbox-button-listbox-border-radius, var(--border-radius-50));
+}
+div.listbox-button__option[role="option"]:disabled .listbox-button__subtitle,
+div.listbox-button__option[role="option"][aria-disabled="true"] .listbox-button__subtitle {
+  color: var(--listbox-option-disabled-foreground-color, var(--color-foreground-disabled));
+  background-color: unset;
+  font-weight: unset;
 }
 div.listbox-button__option--active[role="option"] {
   font-weight: bold;

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -102,7 +102,7 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
   opacity: 1;
 }
-.listbox-button__subtitle {
+.listbox-button__description {
   color: var(--listbox-button-subtitle-color, var(--color-foreground-secondary));
   font-size: var(--font-size-small);
   font-weight: normal;
@@ -154,8 +154,8 @@ div.listbox-button__option[role="option"]:last-child {
   border-bottom-left-radius: var(--listbox-button-listbox-border-radius, var(--border-radius-50));
   border-bottom-right-radius: var(--listbox-button-listbox-border-radius, var(--border-radius-50));
 }
-div.listbox-button__option[role="option"]:disabled .listbox-button__subtitle,
-div.listbox-button__option[role="option"][aria-disabled="true"] .listbox-button__subtitle {
+div.listbox-button__option[role="option"]:disabled .listbox-button__description,
+div.listbox-button__option[role="option"][aria-disabled="true"] .listbox-button__description {
   color: var(--listbox-option-disabled-foreground-color, var(--color-foreground-disabled));
   background-color: unset;
   font-weight: unset;

--- a/dist/listbox/listbox.css
+++ b/dist/listbox/listbox.css
@@ -18,7 +18,7 @@ div.listbox__options--fix-width[role="listbox"] {
 div.listbox__options--reverse[role="listbox"] {
   right: 0;
 }
-.listbox__subtitle {
+.listbox__description {
   color: var(--listbox-button-subtitle-color, var(--color-foreground-secondary));
   font-size: var(--font-size-small);
   font-weight: normal;
@@ -61,8 +61,8 @@ div.listbox__option[role="option"][aria-disabled="true"] {
   background-color: unset;
   font-weight: unset;
 }
-div.listbox__option[role="option"]:disabled .listbox__subtitle,
-div.listbox__option[role="option"][aria-disabled="true"] .listbox__subtitle {
+div.listbox__option[role="option"]:disabled .listbox__description,
+div.listbox__option[role="option"][aria-disabled="true"] .listbox__description {
   color: var(--listbox-option-disabled-foreground-color, var(--color-foreground-disabled));
   background-color: unset;
   font-weight: unset;

--- a/dist/listbox/listbox.css
+++ b/dist/listbox/listbox.css
@@ -18,13 +18,21 @@ div.listbox__options--fix-width[role="listbox"] {
 div.listbox__options--reverse[role="listbox"] {
   right: 0;
 }
+.listbox__subtitle {
+  color: var(--listbox-button-subtitle-color, var(--color-foreground-secondary));
+  font-size: var(--font-size-small);
+  font-weight: normal;
+  grid-column: 1 2;
+  grid-row: 2;
+}
 div.listbox__option[role="option"] {
   background-color: transparent;
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  display: inline-flex;
+  display: inline-grid;
   font-family: inherit;
+  grid-template-columns: auto auto;
   justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
@@ -49,6 +57,12 @@ div.listbox__option[role="option"]:active {
 }
 div.listbox__option[role="option"]:disabled,
 div.listbox__option[role="option"][aria-disabled="true"] {
+  color: var(--listbox-option-disabled-foreground-color, var(--color-foreground-disabled));
+  background-color: unset;
+  font-weight: unset;
+}
+div.listbox__option[role="option"]:disabled .listbox__subtitle,
+div.listbox__option[role="option"][aria-disabled="true"] .listbox__subtitle {
   color: var(--listbox-option-disabled-foreground-color, var(--color-foreground-disabled));
   background-color: unset;
   font-weight: unset;

--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -45,8 +45,9 @@ div.menu-button__item[role^="menuitem"] {
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  display: inline-flex;
+  display: inline-grid;
   font-family: inherit;
+  grid-template-columns: auto auto;
   justify-content: space-between;
   padding: 8px 15px;
   width: 100%;
@@ -119,8 +120,9 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-16 {
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  display: inline-flex;
+  display: inline-grid;
   font-family: inherit;
+  grid-template-columns: auto auto;
   justify-content: space-between;
   padding: 8px 15px;
   width: 100%;

--- a/dist/menu/menu.css
+++ b/dist/menu/menu.css
@@ -46,8 +46,9 @@ div.menu__item[role^="menuitem"] {
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  display: inline-flex;
+  display: inline-grid;
   font-family: inherit;
+  grid-template-columns: auto auto;
   justify-content: space-between;
   padding: 8px 15px;
   width: 100%;

--- a/docs/_includes/listbox-button.html
+++ b/docs/_includes/listbox-button.html
@@ -361,9 +361,9 @@
 </span>
     {% endhighlight %}
 
-    <h3 id="listbox-button-unselected">Listbox Button with option subtitles</h3>
-    <p>You can also add subtitles to each option by using <span class="highlight">.listbox-button__subtitle</span></p>
-    <p>In order to make the subtitles accessible, you need to add a clipped punctuation marker. This ensures screen readers will read the subtitle as a separate sentence.</p>
+    <h3 id="listbox-button-unselected">Listbox Button with option description</h3>
+    <p>You can also add a description to each option by using <span class="highlight">.listbox-button__description</span></p>
+    <p>In order to make the description accessible, you need to add a clipped punctuation marker. This ensures screen readers will read the subtitle as a separate sentence.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -381,7 +381,7 @@
                     <div class="listbox-button__options" role="listbox">
                         <div class="listbox-button__option" role="option">
                             <span class="listbox-button__value">Red</span>
-                            <span class="listbox-button__subtitle">
+                            <span class="listbox-button__description">
                                 <span class="clipped">.</span>
                                 This is a red color
                             </span>
@@ -391,7 +391,7 @@
                         </div>
                         <div class="listbox-button__option" role="option">
                             <span class="listbox-button__value">Blue</span>
-                            <span class="listbox-button__subtitle">
+                            <span class="listbox-button__description">
                                 <span class="clipped">.</span>
                                 This is a blue color
                             </span>
@@ -401,7 +401,7 @@
                         </div>
                         <div class="listbox-button__option" role="option">
                             <span class="listbox-button__value">Yellow</span>
-                            <span class="listbox-button__subtitle">
+                            <span class="listbox-button__description">
                                 <span class="clipped">.</span>
                                 This is a yellow color
                             </span>
@@ -411,7 +411,7 @@
                         </div>
                         <div class="listbox-button__option" role="option">
                             <span class="listbox-button__value">Green</span>
-                            <span class="listbox-button__subtitle">
+                            <span class="listbox-button__description">
                                 <span class="clipped">.</span>
                                 This is a green color
                             </span>

--- a/docs/_includes/listbox-button.html
+++ b/docs/_includes/listbox-button.html
@@ -361,6 +361,114 @@
 </span>
     {% endhighlight %}
 
+    <h3 id="listbox-button-unselected">Listbox Button with option subtitles</h3>
+    <p>You can also add subtitles to each option by using <span class="highlight">.listbox-button__subtitle</span></p>
+    <p>In order to make the subtitles accessible, you need to add a clipped punctuation marker. This ensures screen readers will read the subtitle as a separate sentence.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <span class="listbox-button" data-makeup-auto-select="false">
+                <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
+                    <span class="btn__cell">
+                        <span class="btn__label">Color: </span>
+                        <span class="btn__text">-</span>
+                        <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
+                            {% include symbol.html name="chevron-down-12" %}
+                        </svg>
+                    </span>
+                </button>
+                <div class="listbox-button__listbox">
+                    <div class="listbox-button__options" role="listbox">
+                        <div class="listbox-button__option" role="option">
+                            <span class="listbox-button__value">Red</span>
+                            <span class="listbox-button__subtitle">
+                                <span class="clipped">.</span>
+                                This is a red color
+                            </span>
+                            <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-16" %}
+                            </svg>
+                        </div>
+                        <div class="listbox-button__option" role="option">
+                            <span class="listbox-button__value">Blue</span>
+                            <span class="listbox-button__subtitle">
+                                <span class="clipped">.</span>
+                                This is a blue color
+                            </span>
+                            <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-16" %}
+                            </svg>
+                        </div>
+                        <div class="listbox-button__option" role="option">
+                            <span class="listbox-button__value">Yellow</span>
+                            <span class="listbox-button__subtitle">
+                                <span class="clipped">.</span>
+                                This is a yellow color
+                            </span>
+                            <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-16" %}
+                            </svg>
+                        </div>
+                        <div class="listbox-button__option" role="option">
+                            <span class="listbox-button__value">Green</span>
+                            <span class="listbox-button__subtitle">
+                                <span class="clipped">.</span>
+                                This is a green color
+                            </span>
+                            <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                                {% include symbol.html name="tick-16" %}
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+            </span>
+        </div>
+    </div>
+
+    {% highlight html %}
+<span class="listbox-button">
+    <button class="btn btn--form" style="min-width: 150px" aria-expanded="false" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="10" width="14" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox" tabindex="0">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option" aria-disabled="true">
+                <span class="listbox-button__value">Yellow</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+    {% endhighlight %}
+
+
+
     <h3 id="listbox-button-borderless">Borderless</h3>
     <p>Apply the <span class="highlight">btn--borderless</span> modifier to create a borderless listbox button.</p>
 

--- a/docs/_includes/listbox.html
+++ b/docs/_includes/listbox.html
@@ -126,7 +126,7 @@
     {% endhighlight %}
 
     <h3 id="listbox-selected">Listbox with subtitles</h3>
-    <p>You can add a subtitle to an option by adding a <span class="highlight">.listbox__subtitle</span> element.</p>
+    <p>You can add a subtitle to an option by adding a <span class="highlight">.listbox__description</span> element.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -134,7 +134,7 @@
                 <div aria-label="Listbox demo 2" class="listbox__options" role="listbox" tabindex="0">
                     <div class="listbox__option" role="option" aria-selected="false">
                         <span class="listbox__value">Option 1</span>
-                        <span class="listbox__subtitle">
+                        <span class="listbox__description">
                             <span class="clipped">.</span>
                             More info about option 1
                         </span>
@@ -144,7 +144,7 @@
                     </div>
                     <div class="listbox__option" role="option" aria-selected="true">
                         <span class="listbox__value">Option 2</span>
-                        <span class="listbox__subtitle">
+                        <span class="listbox__description">
                             <span class="clipped">.</span>
                             More info about option 1
                         </span>
@@ -154,7 +154,7 @@
                     </div>
                     <div class="listbox__option" role="option" aria-selected="false">
                         <span class="listbox__value">Option 3</span>
-                        <span class="listbox__subtitle">
+                        <span class="listbox__description">
                             <span class="clipped">.</span>
                             More info about option 1
                         </span>
@@ -172,7 +172,7 @@
     <div aria-label="Listbox demo 2" class="listbox__options" role="listbox" tabindex="0">
         <div class="listbox__option" role="option" aria-selected="true">
             <span class="listbox__value">Option 1</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 1
             </span>
@@ -182,7 +182,7 @@
         </div>
         <div class="listbox__option" role="option" aria-selected="true">
             <span class="listbox__value">Option 2</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 2
             </span>
@@ -192,7 +192,7 @@
         </div>
         <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Option 3</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 3
             </span>

--- a/docs/_includes/listbox.html
+++ b/docs/_includes/listbox.html
@@ -125,4 +125,84 @@
 </div>
     {% endhighlight %}
 
+    <h3 id="listbox-selected">Listbox with subtitles</h3>
+    <p>You can add a subtitle to an option by adding a <span class="highlight">.listbox__subtitle</span> element.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="listbox" data-makeup-auto-select="true">
+                <div aria-label="Listbox demo 2" class="listbox__options" role="listbox" tabindex="0">
+                    <div class="listbox__option" role="option" aria-selected="false">
+                        <span class="listbox__value">Option 1</span>
+                        <span class="listbox__subtitle">
+                            <span class="clipped">.</span>
+                            More info about option 1
+                        </span>
+                        <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                            {% include symbol.html name="tick-16" %}
+                        </svg>
+                    </div>
+                    <div class="listbox__option" role="option" aria-selected="true">
+                        <span class="listbox__value">Option 2</span>
+                        <span class="listbox__subtitle">
+                            <span class="clipped">.</span>
+                            More info about option 1
+                        </span>
+                        <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                            {% include symbol.html name="tick-16" %}
+                        </svg>
+                    </div>
+                    <div class="listbox__option" role="option" aria-selected="false">
+                        <span class="listbox__value">Option 3</span>
+                        <span class="listbox__subtitle">
+                            <span class="clipped">.</span>
+                            More info about option 1
+                        </span>
+                        <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                            {% include symbol.html name="tick-16" %}
+                        </svg>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% highlight html %}
+<div class="listbox">
+    <div aria-label="Listbox demo 2" class="listbox__options" role="listbox" tabindex="0">
+        <div class="listbox__option" role="option" aria-selected="true">
+            <span class="listbox__value">Option 1</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 1
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+        <div class="listbox__option" role="option" aria-selected="true">
+            <span class="listbox__value">Option 2</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 2
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+        <div class="listbox__option" role="option" aria-selected="false">
+            <span class="listbox__value">Option 3</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 3
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="10" width="14">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
+
 </div>

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -107,7 +107,7 @@ div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
     opacity: 1;
 }
 
-.listbox-button__subtitle {
+.listbox-button__description {
     .color-token(listbox-button-subtitle-color, color-foreground-secondary);
 
     font-size: var(--font-size-small);
@@ -122,8 +122,8 @@ div.listbox-button__option[role="option"] {
 
     cursor: default; // needed to override text cursor
 
-    &:disabled .listbox-button__subtitle,
-    &[aria-disabled="true"] .listbox-button__subtitle {
+    &:disabled .listbox-button__description,
+    &[aria-disabled="true"] .listbox-button__description {
         .listbox-disabled();
     }
 }

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -107,11 +107,25 @@ div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
     opacity: 1;
 }
 
+.listbox-button__subtitle {
+    .color-token(listbox-button-subtitle-color, color-foreground-secondary);
+
+    font-size: var(--font-size-small);
+    font-weight: normal;
+    grid-column: 1 2;
+    grid-row: 2;
+}
+
 div.listbox-button__option[role="option"] {
     .listbox-option-base();
     .dropdown-item-border-radius(listbox-button-listbox);
 
     cursor: default; // needed to override text cursor
+
+    &:disabled .listbox-button__subtitle,
+    &[aria-disabled="true"] .listbox-button__subtitle {
+        .listbox-disabled();
+    }
 }
 
 div.listbox-button__option--active[role="option"] {

--- a/src/less/listbox-button/stories/subtitle.stories.js
+++ b/src/less/listbox-button/stories/subtitle.stories.js
@@ -1,0 +1,441 @@
+export default { title: "Skin/Listbox Button/With Subtitle" };
+
+export const collapsedUnselected = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about option 1
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about option 2
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about option 3
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
+export const expandedUnselected = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">-</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about red
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about blue
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about yellow
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about green
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
+export const collapsedSelected = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about red
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option" aria-selected="true">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about blue
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about yellow
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about green
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
+export const expandedSelected = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about red
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option" aria-selected="true">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about blue
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about yellow
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about green
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
+export const disabled = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" disabled>
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about red
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about blue
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about yellow
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about green
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
+export const invalid = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="false" aria-haspopup="listbox" aria-invalid="true">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Blue</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about red
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about blue
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about yellow
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Green</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    More info about green
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
+export const longOption = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Red with very very very long text</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option" aria-selected="true">
+                <span class="listbox-button__value">Red with very very very long text</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    Small text
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    Small blue text
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    Small yellow text
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;
+
+export const longSubtitle = () => `
+<span class="listbox-button">
+    <button class="btn btn--form" aria-expanded="true" aria-haspopup="listbox">
+        <span class="btn__cell">
+            <span class="btn__label">Color: </span>
+            <span class="btn__text">Red</span>
+            <svg class="icon icon--chevron-down-12" focusable="false" height="8" width="8" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </button>
+    <div class="listbox-button__listbox">
+        <div class="listbox-button__options" role="listbox">
+            <div class="listbox-button__option" role="option" aria-selected="true">
+                <span class="listbox-button__value">Red</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    There is a lot of text here in this subtitle even though red does not have much
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Blue</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    Small blue text
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+            <div class="listbox-button__option" role="option">
+                <span class="listbox-button__value">Yellow</span>
+                <span class="listbox-button__subtitle">
+                    <span class="clipped">.</span>
+                    Small yellow text
+                </span>
+                <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                    <use href="#icon-tick-16"></use>
+                </svg>
+            </div>
+        </div>
+    </div>
+</span>
+`;

--- a/src/less/listbox-button/stories/subtitle.stories.js
+++ b/src/less/listbox-button/stories/subtitle.stories.js
@@ -15,7 +15,7 @@ export const collapsedUnselected = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about option 1
                 </span>
@@ -25,7 +25,7 @@ export const collapsedUnselected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about option 2
                 </span>
@@ -35,7 +35,7 @@ export const collapsedUnselected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about option 3
                 </span>
@@ -69,7 +69,7 @@ export const expandedUnselected = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about red
                 </span>
@@ -79,7 +79,7 @@ export const expandedUnselected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about blue
                 </span>
@@ -89,7 +89,7 @@ export const expandedUnselected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about yellow
                 </span>
@@ -99,7 +99,7 @@ export const expandedUnselected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about green
                 </span>
@@ -127,7 +127,7 @@ export const collapsedSelected = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about red
                 </span>
@@ -137,7 +137,7 @@ export const collapsedSelected = () => `
             </div>
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about blue
                 </span>
@@ -147,7 +147,7 @@ export const collapsedSelected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about yellow
                 </span>
@@ -157,7 +157,7 @@ export const collapsedSelected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about green
                 </span>
@@ -185,7 +185,7 @@ export const expandedSelected = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about red
                 </span>
@@ -195,7 +195,7 @@ export const expandedSelected = () => `
             </div>
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about blue
                 </span>
@@ -205,7 +205,7 @@ export const expandedSelected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about yellow
                 </span>
@@ -215,7 +215,7 @@ export const expandedSelected = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about green
                 </span>
@@ -243,7 +243,7 @@ export const disabled = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about red
                 </span>
@@ -253,7 +253,7 @@ export const disabled = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about blue
                 </span>
@@ -263,7 +263,7 @@ export const disabled = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about yellow
                 </span>
@@ -273,7 +273,7 @@ export const disabled = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about green
                 </span>
@@ -301,7 +301,7 @@ export const invalid = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about red
                 </span>
@@ -311,7 +311,7 @@ export const invalid = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about blue
                 </span>
@@ -321,7 +321,7 @@ export const invalid = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about yellow
                 </span>
@@ -331,7 +331,7 @@ export const invalid = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Green</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     More info about green
                 </span>
@@ -359,7 +359,7 @@ export const longOption = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red with very very very long text</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     Small text
                 </span>
@@ -369,7 +369,7 @@ export const longOption = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     Small blue text
                 </span>
@@ -379,7 +379,7 @@ export const longOption = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     Small yellow text
                 </span>
@@ -407,7 +407,7 @@ export const longSubtitle = () => `
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     There is a lot of text here in this subtitle even though red does not have much
                 </span>
@@ -417,7 +417,7 @@ export const longSubtitle = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Blue</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     Small blue text
                 </span>
@@ -427,7 +427,7 @@ export const longSubtitle = () => `
             </div>
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Yellow</span>
-                <span class="listbox-button__subtitle">
+                <span class="listbox-button__description">
                     <span class="clipped">.</span>
                     Small yellow text
                 </span>

--- a/src/less/listbox/listbox.less
+++ b/src/less/listbox/listbox.less
@@ -30,8 +30,22 @@ div.listbox__options--reverse[role="listbox"] {
     right: 0;
 }
 
+.listbox__subtitle {
+    .color-token(listbox-button-subtitle-color, color-foreground-secondary);
+
+    font-size: var(--font-size-small);
+    font-weight: normal;
+    grid-column: 1 2;
+    grid-row: 2;
+}
+
 div.listbox__option[role="option"] {
     .listbox-option-base();
+
+    &:disabled .listbox__subtitle,
+    &[aria-disabled="true"] .listbox__subtitle {
+        .listbox-disabled();
+    }
 }
 
 span.listbox__value {

--- a/src/less/listbox/listbox.less
+++ b/src/less/listbox/listbox.less
@@ -30,7 +30,7 @@ div.listbox__options--reverse[role="listbox"] {
     right: 0;
 }
 
-.listbox__subtitle {
+.listbox__description {
     .color-token(listbox-button-subtitle-color, color-foreground-secondary);
 
     font-size: var(--font-size-small);
@@ -42,8 +42,8 @@ div.listbox__options--reverse[role="listbox"] {
 div.listbox__option[role="option"] {
     .listbox-option-base();
 
-    &:disabled .listbox__subtitle,
-    &[aria-disabled="true"] .listbox__subtitle {
+    &:disabled .listbox__description,
+    &[aria-disabled="true"] .listbox__description {
         .listbox-disabled();
     }
 }

--- a/src/less/listbox/stories/listbox.stories.js
+++ b/src/less/listbox/stories/listbox.stories.js
@@ -74,3 +74,77 @@ export const multiSelected = () => `
     </div>
 </span>
 `;
+
+export const subtitleUnselected = () => `
+<span class="listbox">
+    <div class="listbox__options" role="listbox" tabindex="0">
+        <div class="listbox__option" role="option" aria-selected="false">
+            <span class="listbox__value">Option 1</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 1
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+        <div class="listbox__option" role="option" aria-selected="false">
+            <span class="listbox__value">Option 2</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 2
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+        <div class="listbox__option" role="option" aria-selected="false">
+            <span class="listbox__value">Option 3</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 3
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+    </div>
+</span>
+`;
+
+export const subtitleSelected = () => `
+<span class="listbox">
+    <div class="listbox__options" role="listbox" tabindex="0">
+        <div class="listbox__option" role="option" aria-selected="true">
+            <span class="listbox__value">Option 1</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 1
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+        <div class="listbox__option" role="option" aria-selected="false">
+            <span class="listbox__value">Option 2</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 2
+            </span>
+             <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+        <div class="listbox__option" role="option" aria-selected="false">
+            <span class="listbox__value">Option 3</span>
+            <span class="listbox__subtitle">
+                <span class="clipped">.</span>
+                More info about option 3
+            </span>
+            <svg class="icon icon--tick-16" focusable="false" height="8" width="8">
+                <use href="#icon-tick-16"></use>
+            </svg>
+        </div>
+    </div>
+</span>
+`;

--- a/src/less/listbox/stories/listbox.stories.js
+++ b/src/less/listbox/stories/listbox.stories.js
@@ -80,7 +80,7 @@ export const subtitleUnselected = () => `
     <div class="listbox__options" role="listbox" tabindex="0">
         <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Option 1</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 1
             </span>
@@ -90,7 +90,7 @@ export const subtitleUnselected = () => `
         </div>
         <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Option 2</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 2
             </span>
@@ -100,7 +100,7 @@ export const subtitleUnselected = () => `
         </div>
         <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Option 3</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 3
             </span>
@@ -117,7 +117,7 @@ export const subtitleSelected = () => `
     <div class="listbox__options" role="listbox" tabindex="0">
         <div class="listbox__option" role="option" aria-selected="true">
             <span class="listbox__value">Option 1</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 1
             </span>
@@ -127,7 +127,7 @@ export const subtitleSelected = () => `
         </div>
         <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Option 2</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 2
             </span>
@@ -137,7 +137,7 @@ export const subtitleSelected = () => `
         </div>
         <div class="listbox__option" role="option" aria-selected="false">
             <span class="listbox__value">Option 3</span>
-            <span class="listbox__subtitle">
+            <span class="listbox__description">
                 <span class="clipped">.</span>
                 More info about option 3
             </span>

--- a/src/less/mixins/private/listbox-mixins.less
+++ b/src/less/mixins/private/listbox-mixins.less
@@ -20,10 +20,14 @@
 
     &:disabled,
     &[aria-disabled="true"] {
-        .color-token(listbox-option-disabled-foreground-color, color-foreground-disabled);
-        background-color: unset;
-        font-weight: unset;
+        .listbox-disabled();
     }
+}
+
+.listbox-disabled() {
+    .color-token(listbox-option-disabled-foreground-color, color-foreground-disabled);
+    background-color: unset;
+    font-weight: unset;
 }
 
 .listbox-option-status() {

--- a/src/less/mixins/private/selection-list-mixins.less
+++ b/src/less/mixins/private/selection-list-mixins.less
@@ -3,8 +3,9 @@
     border-style: solid;
     border-width: 1px;
     box-sizing: border-box;
-    display: inline-flex;
+    display: inline-grid;
     font-family: inherit;
+    grid-template-columns: auto auto;
     justify-content: space-between;
     padding: 8px 15px;
     width: 100%;


### PR DESCRIPTION
Fixes #2179

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added subtitle to each option
* I named it subtitle. It's kinda weird since we don't have a title, but I thought it sounded better than subvalue or subtext. 

## Notes (_Please read before testing_)
This will require makeup changes. If you select an option currently it will fill the textbox with both title and subtitle. I want to finalize the structure and naming before doing the makeup changes. This is why this PR is up to get early feedback.
Once the naming and structure is approved I will update makeup and then upgrade makeup in this PR.

## Screenshots
<img width="294" alt="Screenshot 2023-10-27 at 10 31 16 AM" src="https://github.com/eBay/skin/assets/1755269/1258d46d-a987-4170-a2e5-5e2e5667b980">


## Checklist

- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
