### PR TITLE
fix(progress-stepper): updated font-size to be default

### DIFF
--- a/dist/progress-stepper/progress-stepper.css
+++ b/dist/progress-stepper/progress-stepper.css
@@ -20,7 +20,7 @@ hr.progress-stepper__separator {
   top: 10px;
 }
 .progress-stepper__text {
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-default);
   justify-self: center;
   margin-top: 8px;
   text-align: center;
@@ -32,7 +32,7 @@ hr.progress-stepper__separator {
 .progress-stepper__text h5,
 .progress-stepper__text h6 {
   color: var(--progress-stepper-text-color, var(--color-foreground-primary));
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-default);
   font-weight: normal;
 }
 .progress-stepper__items--upcoming .progress-stepper__text h2,
@@ -170,14 +170,6 @@ hr.progress-stepper__separator {
     min-width: 120px;
   }
   .progress-stepper__text {
-    font-size: var(--font-size-default);
     width: 120px;
-  }
-  .progress-stepper__text h2,
-  .progress-stepper__text h3,
-  .progress-stepper__text h4,
-  .progress-stepper__text h5,
-  .progress-stepper__text h6 {
-    font-size: var(--font-size-default);
   }
 }

--- a/src/less/progress-stepper/progress-stepper.less
+++ b/src/less/progress-stepper/progress-stepper.less
@@ -40,7 +40,7 @@ hr.progress-stepper__separator {
 }
 
 .progress-stepper__text {
-    font-size: var(--font-size-small);
+    font-size: var(--font-size-default);
     justify-self: center;
     margin-top: 8px;
     text-align: center;
@@ -54,7 +54,7 @@ hr.progress-stepper__separator {
 .progress-stepper__text h6 {
     .color-token(progress-stepper-text-color, color-foreground-primary);
 
-    font-size: var(--font-size-small);
+    font-size: var(--font-size-default);
     font-weight: normal;
 }
 
@@ -280,15 +280,6 @@ hr.progress-stepper__separator {
     }
 
     .progress-stepper__text {
-        font-size: var(--font-size-default);
         width: @progress-stepper-large-min-width;
-    }
-
-    .progress-stepper__text h2,
-    .progress-stepper__text h3,
-    .progress-stepper__text h4,
-    .progress-stepper__text h5,
-    .progress-stepper__text h6 {
-        font-size: var(--font-size-default);
     }
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2176

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* We were overriding the font size for small screens (my guess is this was the old design). Removed those old overrides. 

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
