### PR TITLE
feat(listbox-button): changed default border color

### DIFF
--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -44,6 +44,14 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 .listbox-button button[aria-invalid="true"] {
   border-color: var(--listbox-button-invalid-border-color, var(--color-stroke-attention));
 }
+.listbox-button button.btn--form {
+  border-color: var(--listbox-button-border-color, var(--color-stroke-default));
+}
+.listbox-button button.btn--form:hover,
+.listbox-button button.btn--form:focus,
+.listbox-button button.btn--form:active {
+  border-color: inherit;
+}
 .listbox-button button.expand-btn--borderless,
 .listbox-button button.btn--borderless {
   background-color: transparent;

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -42,6 +42,16 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
     .border-color-token(listbox-button-invalid-border-color, color-stroke-attention);
 }
 
+.listbox-button button.btn--form {
+    .border-color-token(listbox-button-border-color, color-stroke-default);
+
+    &:hover,
+    &:focus,
+    &:active {
+        border-color: inherit;
+    }
+}
+
 .listbox-button button.expand-btn--borderless,
 .listbox-button button.btn--borderless {
     background-color: transparent;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2192

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Set the border color to btn--form for listbox. I did not want to change it in button becasue this is used by menu button as well. 
* We should look to refactor in future possibly. 

## Screenshots

<img width="449" alt="Screenshot 2023-11-10 at 9 41 53 AM" src="https://github.com/eBay/skin/assets/1755269/3acdb28e-2eb9-41d1-9309-835a9adf2b23">
<img width="402" alt="Screenshot 2023-11-10 at 9 41 56 AM" src="https://github.com/eBay/skin/assets/1755269/9bcceffc-e1bc-479d-adfc-1be75ccaf008">

## Checklist

- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build (percy is not working so I did not run it)
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
