### PR TITLE
chore(combobox): add blue focus indicator

### DIFF
--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -198,7 +198,6 @@ span.combobox {
 .combobox__control > input:focus {
   background-color: var(--combobox-textbox-focus-background-color, var(--color-background-primary));
   border-color: var(--combobox-textbox-focus-border-color, var(--color-foreground-primary));
-  outline: 0;
 }
 .combobox__control--borderless > input:focus {
   border-color: transparent;

--- a/src/less/combobox/combobox.less
+++ b/src/less/combobox/combobox.less
@@ -164,7 +164,6 @@ span.combobox {
 .combobox__control > input:focus {
     .background-color-token(combobox-textbox-focus-background-color, color-background-primary);
     .border-color-token(combobox-textbox-focus-border-color, color-foreground-primary);
-    outline: 0;
 }
 
 .combobox__control--borderless > input:focus {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2201

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Removed outline 0 from combobox

## Screenshots
<img width="268" alt="Screenshot 2023-11-14 at 2 52 08 PM" src="https://github.com/eBay/skin/assets/1755269/57a6b848-5945-4884-bf34-50d4027c13e1">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
