### PR TITLE
feat(tourtip): added leading image

### DIFF
--- a/dist/tourtip/tourtip.css
+++ b/dist/tourtip/tourtip.css
@@ -155,7 +155,8 @@ span.tourtip__heading {
 }
 .tourtip__footer > button:not(:last-child),
 .tourtip__footer > a:not(:last-child) {
-  margin-right: 8px;
+  -webkit-margin-end: var(--spacing-100);
+          margin-inline-end: var(--spacing-100);
 }
 .tourtip__footer > .fake-link,
 .tourtip__footer > a {
@@ -170,6 +171,14 @@ span.tourtip__heading {
 .tourtip__index {
   color: var(--tourtip-index-color, var(--color-foreground-secondary));
   flex: 1;
+}
+.tourtip__leading {
+  -webkit-margin-end: var(--spacing-200);
+          margin-inline-end: var(--spacing-200);
+}
+.tourtip__leading img {
+  border-radius: var(--spacing-200);
+  max-width: 88px;
 }
 @media (min-width: 512px) {
   .tourtip__overlay {

--- a/docs/_includes/tourtip.html
+++ b/docs/_includes/tourtip.html
@@ -105,6 +105,71 @@
     </div>
 </div>
     {% endhighlight %}
+
+
+    <h3>With leading image</h3>
+    <p>Tourtip also supports having a leading image.</p>
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="tourtip tourtip--expanded">
+                <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+                    <span class="tourtip__pointer tourtip__pointer--top"></span>
+                    <div class="tourtip__mask">
+                        <div class="tourtip__cell">
+                            <span class="tourtip__leading">
+                                <img src="{{ page.static_dir }}/img/tb-profile-pic.jpg" alt="">
+                            </span>
+                            <span class="tourtip__content">
+                                <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                                <p>Here's something new to help you be successful at your task.</p>
+                            </span>
+                            <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
+                                <svg class="icon icon--close-16" focusable="false" height="16" width="16" aria-hidden="true">
+                                    {% include symbol.html name="close-16" %}
+                                </svg>
+                            </button>
+                            <div class="tourtip__footer">
+                                <span class="tourtip__index">1 / 3</span>
+                                <button class="fake-link">Back</button>
+                                <button class="btn btn--primary">Next</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% highlight html %}
+<div class="tourtip tourtip--expanded">
+    <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+        <span class="tourtip__pointer tourtip__pointer--top"></span>
+        <div class="tourtip__mask">
+            <div class="tourtip__cell">
+                <span class="tourtip__leading">
+                    <img src="{{ page.static_dir }}/img/tb-profile-pic.jpg" alt="">
+                </span>
+                <span class="tourtip__content">
+                    <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                    <p>Here's something new to help you be successful at your task.</p>
+                </span>
+                <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
+                    <svg class="icon icon--close-16" focusable="false" height="16" width="16" aria-hidden="true">
+                        <use href="#icon-close-16"></use>
+                    </svg>
+                </button>
+                <div class="tourtip__footer">
+                    <span class="tourtip__index">1 / 3</span>
+                    <button class="fake-link">Back</button>
+                    <button class="btn btn--primary">Next</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+    {% endhighlight %}
+
 </div>
 
 

--- a/src/less/tourtip/stories/rtl.stories.js
+++ b/src/less/tourtip/stories/rtl.stories.js
@@ -1,0 +1,134 @@
+export default { title: "Skin/Tourtip/RTL" };
+
+export const collapsed = () => `
+<div dir="rtl">
+    <div class="tourtip">
+        <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+            <span class="tourtip__pointer tourtip__pointer--top"></span>
+            <div class="tourtip__mask">
+                <div class="tourtip__cell">
+                    <span class="tourtip__content">
+                        <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                        <p>Here's something new to help you be successful at your task.</p>
+                    </span>
+                    <button class="icon-btn tourtip__close" type="button" aria-label="Dismiss tourtip">
+                        <svg class="icon icon--close-16" focusable="false" height="24" width="24" aria-hidden="true">
+                            <use href="#icon-close-16"></use>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>`;
+
+export const expanded = () => `
+<div dir="rtl">
+    <div class="tourtip tourtip--expanded">
+        <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+            <span class="tourtip__pointer tourtip__pointer--top"></span>
+            <div class="tourtip__mask">
+                <div class="tourtip__cell">
+                    <span class="tourtip__content">
+                        <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                        <p>Here's something new to help you be successful at your task.</p>
+                    </span>
+                    <button class="icon-btn tourtip__close" type="button" aria-label="Dismiss tourtip">
+                        <svg class="icon icon--close-16" focusable="false" height="24" width="24" aria-hidden="true">
+                            <use href="#icon-close-16"></use>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>`;
+
+export const withActions = () => `
+<div dir="rtl">
+    <div class="tourtip tourtip--expanded">
+        <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+            <span class="tourtip__pointer tourtip__pointer--top"></span>
+            <div class="tourtip__mask">
+                <div class="tourtip__cell">
+                    <span class="tourtip__content">
+                        <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                        <p>Here's something new to help you be successful at your task.</p>
+                    </span>
+                    <button class="icon-btn tourtip__close" type="button" aria-label="Dismiss tourtip">
+                        <svg class="icon icon--close-16" focusable="false" height="24" width="24" aria-hidden="true">
+                            <use href="#icon-close-16"></use>
+                        </svg>
+                    </button>
+                    <div class="tourtip__footer">
+                        <span class="tourtip__index">1 / 3</span>
+                        <button class="fake-link">Back</button>
+                        <button class="btn btn--primary">Next</button>
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>`;
+
+export const withOneAction = () => `
+<div dir="rtl">
+    <div class="tourtip tourtip--expanded">
+        <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+            <span class="tourtip__pointer tourtip__pointer--top"></span>
+            <div class="tourtip__mask">
+                <div class="tourtip__cell">
+                    <span class="tourtip__content">
+                        <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                        <p>Here's something new to help you be successful at your task.</p>
+                    </span>
+                    <button class="icon-btn tourtip__close" type="button" aria-label="Dismiss tourtip">
+                        <svg class="icon icon--close-16" focusable="false" height="24" width="24" aria-hidden="true">
+                            <use href="#icon-close-16"></use>
+                        </svg>
+                    </button>
+                    <div class="tourtip__footer">
+                        <span class="tourtip__index">2 / 3</span>
+                        <button class="btn btn--primary">Next</button>
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>`;
+
+export const withLeadingImage = () => `
+<div dir="rtl">
+    <div class="tourtip tourtip--expanded">
+        <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+            <span class="tourtip__pointer tourtip__pointer--top"></span>
+            <div class="tourtip__mask">
+                <div class="tourtip__cell">
+                    <span class="tourtip__leading">
+                        <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                    </span>
+                    <span class="tourtip__content">
+                        <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                        <p>Here's something new to help you be successful at your task.</p>
+                    </span>
+                    <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
+                        <svg class="icon icon--close-16" focusable="false" height="16" width="16" aria-hidden="true">
+                            <use href="#icon-close-16"></use>
+                        </svg>
+                    </button>
+                    <div class="tourtip__footer">
+                        <span class="tourtip__index">1 / 3</span>
+                        <button class="fake-link">Back</button>
+                        <button class="btn btn--primary">Next</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/tourtip/stories/tourtip.stories.js
+++ b/src/less/tourtip/stories/tourtip.stories.js
@@ -1,4 +1,4 @@
-export default { title: "Skin/Tourtip" };
+export default { title: "Skin/Tourtip/Base" };
 
 export const collapsed = () => `
 <div class="tourtip">
@@ -92,3 +92,33 @@ export const withOneAction = () => `
         </div>
     </div>
 </div>`;
+
+export const withLeadingImage = () => `
+<div class="tourtip tourtip--expanded">
+    <p class="tourtip__host">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <div class="tourtip__overlay" style="left: calc(50% - 200px); right: auto; top: calc(100% + 12px); bottom: auto" role="region" aria-labelledby="tourtip-label">
+        <span class="tourtip__pointer tourtip__pointer--top"></span>
+        <div class="tourtip__mask">
+            <div class="tourtip__cell">
+                <span class="tourtip__leading">
+                    <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                </span>
+                <span class="tourtip__content">
+                    <h2 class="tourtip__heading" id="tourtip-label">Tourtip</h2>
+                    <p>Here's something new to help you be successful at your task.</p>
+                </span>
+                <button class="icon-btn icon-btn--transparent tourtip__close" type="button" aria-label="Dismiss tourtip">
+                    <svg class="icon icon--close-16" focusable="false" height="16" width="16" aria-hidden="true">
+                        <use href="#icon-close-16"></use>
+                    </svg>
+                </button>
+                <div class="tourtip__footer">
+                    <span class="tourtip__index">1 / 3</span>
+                    <button class="fake-link">Back</button>
+                    <button class="btn btn--primary">Next</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/tourtip/tourtip.less
+++ b/src/less/tourtip/tourtip.less
@@ -137,7 +137,7 @@ span.tourtip__heading {
 
 .tourtip__footer > button:not(:last-child),
 .tourtip__footer > a:not(:last-child) {
-    margin-right: 8px;
+    margin-inline-end: var(--spacing-100);
 }
 
 // stylelint-disable no-descending-specificity
@@ -159,6 +159,15 @@ span.tourtip__heading {
 .tourtip__index {
     .color-token(tourtip-index-color, color-foreground-secondary);
     flex: 1;
+}
+
+.tourtip__leading {
+    margin-inline-end: var(--spacing-200);
+}
+
+.tourtip__leading img {
+    border-radius: var(--spacing-200);
+    max-width: 88px;
 }
 
 @media (min-width: @_screen-size-SM) {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2178 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This adds a leading container (for future flexibility of possibly using an icon) and an image that goes inside.

## Notes
1. There are still some unanswered questions for DS in the issue. I wanted to get this going so I took my best guess at the answers when building it. However, we still need some final guidance from DS before we move ahead with this.
2. Adding stories, I realized there was no RTL for `tourtip`. To add the RTL stories, I had to reorganize the stories a bit (so new Percy baselines will be needed for comparison). 
3. I fixed a minor RTL spacing issue in the footer after the issue got exposed from the RTL stories.

## Screenshots
<img width="415" alt="image" src="https://github.com/eBay/skin/assets/1675667/683699c4-eb8e-4650-abb3-c3cb0cb55436">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
