### PR TITLE
fix(image-placeholder): dark mode color

### DIFF
--- a/dist/image-placeholder/image-placeholder.css
+++ b/dist/image-placeholder/image-placeholder.css
@@ -1,5 +1,6 @@
 svg.image-placeholder {
-  fill: var(--color-foreground-primary);
+  color: var(--color-foreground-primary);
+  fill: currentColor;
   height: inherit;
   width: inherit;
 }

--- a/dist/image-placeholder/image-placeholder.css
+++ b/dist/image-placeholder/image-placeholder.css
@@ -1,5 +1,5 @@
 svg.image-placeholder {
-  color: var(--color-foreground-primary);
+  fill: var(--color-foreground-primary);
   height: inherit;
   width: inherit;
 }

--- a/dist/image-placeholder/image-placeholder.css
+++ b/dist/image-placeholder/image-placeholder.css
@@ -1,4 +1,5 @@
 svg.image-placeholder {
+  color: var(--color-foreground-primary);
   height: inherit;
   width: inherit;
 }

--- a/src/less/image-placeholder/image-placeholder.less
+++ b/src/less/image-placeholder/image-placeholder.less
@@ -1,5 +1,5 @@
 svg.image-placeholder {
-    color: var(--color-foreground-primary);
+    fill: var(--color-foreground-primary);
     height: inherit;
     width: inherit;
 }

--- a/src/less/image-placeholder/image-placeholder.less
+++ b/src/less/image-placeholder/image-placeholder.less
@@ -1,4 +1,5 @@
 svg.image-placeholder {
+    color: var(--color-foreground-primary);
     height: inherit;
     width: inherit;
 }

--- a/src/less/image-placeholder/image-placeholder.less
+++ b/src/less/image-placeholder/image-placeholder.less
@@ -1,5 +1,9 @@
+@import "../variables/variables.less";
+@import "../mixins/private/token-mixins.less";
+
 svg.image-placeholder {
-    fill: var(--color-foreground-primary);
+    .color-token(color-foreground-primary);
+    fill: currentColor;
     height: inherit;
     width: inherit;
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Adds dark mode support to image placeholder

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="392" alt="image" src="https://github.com/eBay/skin/assets/26027232/cb18d8c4-eff8-437c-be20-1e7336832aa3">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
