### PR TITLE
fix(select,combobox): updated large variant font size token

### DIFF
--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -210,7 +210,7 @@ span.combobox {
   width: 100%;
 }
 .combobox--large .combobox__control > input {
-  font-size: var(--font-size-18);
+  font-size: var(--font-size-medium);
   height: 48px;
 }
 .combobox__control > input[disabled] {

--- a/dist/select/select.css
+++ b/dist/select/select.css
@@ -30,7 +30,7 @@ span.select {
   top: 0;
 }
 .select--large select {
-  font-size: var(--font-size-18);
+  font-size: var(--font-size-medium);
   height: 48px;
 }
 .select--fluid {

--- a/src/less/combobox/combobox.less
+++ b/src/less/combobox/combobox.less
@@ -180,7 +180,7 @@ span.combobox {
 }
 
 .combobox--large .combobox__control > input {
-    font-size: var(--font-size-18);
+    font-size: var(--font-size-medium);
     height: @height-textbox + 8px;
 }
 

--- a/src/less/select/select.less
+++ b/src/less/select/select.less
@@ -35,7 +35,7 @@ span.select {
 }
 
 .select--large select {
-    font-size: var(--font-size-18);
+    font-size: var(--font-size-medium);
     height: 48px;
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2175 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This issue was created as part of less to CSS variables conversion. Noticed that `select` and `combobox` components refer to non-design system token `--font-size-18` for large variants. Hence refactored the code to use the DS `--font-size-16` aka `--font-size-medium`

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
- Pending Percy testing to 

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
Combobox
<img width="812" alt="image" src="https://github.com/eBay/skin/assets/6342519/2af71ac1-3738-4d22-a2ae-ecfe4d1f5506">
Select
<img width="812" alt="image" src="https://github.com/eBay/skin/assets/6342519/c7322c75-f956-42e7-a6f4-1770366c646b">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
