### PR TITLE
fix(breadcrumbs): chevron icon spacing

### DIFF
--- a/dist/breadcrumbs/breadcrumbs.css
+++ b/dist/breadcrumbs/breadcrumbs.css
@@ -26,8 +26,8 @@ nav.breadcrumbs > ul > li[hidden] {
   display: none;
 }
 nav.breadcrumbs > ul > li svg {
-  margin-left: 3px;
-  margin-right: 3px;
+  margin-left: 6px;
+  margin-right: 6px;
 }
 nav.breadcrumbs > ul > li > a {
   text-decoration: none;

--- a/src/less/breadcrumbs/breadcrumbs.less
+++ b/src/less/breadcrumbs/breadcrumbs.less
@@ -34,8 +34,8 @@ nav.breadcrumbs > ul > li[hidden] {
 }
 
 nav.breadcrumbs > ul > li svg {
-    margin-left: 3px;
-    margin-right: 3px;
+    margin-left: 6px;
+    margin-right: 6px;
 }
 
 nav.breadcrumbs > ul > li > a {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2053

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Spacing adjustments with chevron on breadcrumbs.

## Notes
The other components mentioned in the issue did not need spacing adjustments.

## Screenshots
Before: 
<img width="321" alt="image" src="https://github.com/eBay/skin/assets/1675667/be87e4e5-40ea-4b43-9360-b3484672d8c6">

After:
<img width="344" alt="image" src="https://github.com/eBay/skin/assets/1675667/aca2ab9f-fd33-489b-93f0-1c61b79b2b1d">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
