### PR TITLE
fix(listbox-button): removed truncation

### DIFF
--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -172,9 +172,6 @@ div.listbox-button__option--active[role="option"] {
   font-weight: bold;
 }
 span.listbox-button__value {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   flex: 1 0 auto;
 }
 .listbox-button__options:focus:not(:focus-visible) {

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -143,8 +143,6 @@ div.listbox-button__option--active[role="option"] {
 }
 
 span.listbox-button__value {
-    .truncate();
-
     flex: 1 0 auto;
 }
 


### PR DESCRIPTION

Fixes #2228
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* So when verifiying older versions of the listbox code on skin site, I noticed that overflow is set but was not doing anything in those versions. 
(In this case I simply changed the html and saw that it stretched until infinite). 
<img width="1588" alt="Screenshot 2023-12-12 at 8 22 38 AM" src="https://github.com/eBay/skin/assets/1755269/359cb49c-52af-4914-8b71-ebeb845e5c1a">

However when we changed it to be `inline-grid` from `inline-flex` the truncation was picked up and we ended up with this bug where the listbox dropdown is aligned to the size of the button.

So removing the truncation on the value solved this issue. We should probably revisit this in the future and put a limit on the container (a max width), but we need to get buy in from design. This is mostly to unblock teams that run into this issue with the last version.
## Screenshots


## Checklist

- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
