### PR TITLE
fix(breadcrumbs,docs): fixed breadcrumbs spacing and missing icons in docs

### DIFF
--- a/dist/breadcrumbs/breadcrumbs.css
+++ b/dist/breadcrumbs/breadcrumbs.css
@@ -26,8 +26,12 @@ nav.breadcrumbs > ul > li[hidden] {
   display: none;
 }
 nav.breadcrumbs > ul > li svg {
-  margin-left: 6px;
-  margin-right: 6px;
+  margin-left: 3px;
+  margin-right: 3px;
+}
+nav.breadcrumbs > ul > li svg.icon--chevron-right-12 {
+  margin-left: var(--spacing-75);
+  margin-right: var(--spacing-75);
 }
 nav.breadcrumbs > ul > li > a {
   text-decoration: none;

--- a/src/less/breadcrumbs/breadcrumbs.less
+++ b/src/less/breadcrumbs/breadcrumbs.less
@@ -34,8 +34,13 @@ nav.breadcrumbs > ul > li[hidden] {
 }
 
 nav.breadcrumbs > ul > li svg {
-    margin-left: 6px;
-    margin-right: 6px;
+    margin-left: 3px;
+    margin-right: 3px;
+}
+
+nav.breadcrumbs > ul > li svg.icon--chevron-right-12 {
+    margin-left: var(--spacing-75);
+    margin-right: var(--spacing-75);
 }
 
 nav.breadcrumbs > ul > li > a {

--- a/src/less/section-notice/stories/icon-24.stories.js
+++ b/src/less/section-notice/stories/icon-24.stories.js
@@ -181,8 +181,8 @@ export const RTL = () => `
 export const vault = () => `
 <div class="section-notice" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--the-ebay-vault-24-fit">
-            <use href="#icon-the-ebay-vault-24-fit"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--the-ebay-vault-24">
+            <use href="#icon-the-ebay-vault-24"></use>
         </svg>
     </div>
     <div class="section-notice__main">
@@ -229,8 +229,8 @@ export const selling = () => `
 export const warranty = () => `
 <div class="section-notice" role="region">
     <div class="section-notice__header" role="region" aria-roledescription="Notice">
-        <svg aria-hidden="true" focusable="false" class="icon--free-warranty-24-fit">
-            <use href="#icon-free-warranty-24-fit"></use>
+        <svg aria-hidden="true" focusable="false" class="icon--free-warranty-24">
+            <use href="#icon-free-warranty-24"></use>
         </svg>
     </div>
     <div class="section-notice__main">


### PR DESCRIPTION
This fixes breadcrumbs overflow spacing and missing icons in docs.

<!-- Insert GitHub issue number below -->
Fixes #

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Post-release visual regression of `17.0.0` revealed some issues. This fixes two of those issues:

1. Breadcrumbs overflow spacing
2. Missing icons in storybook

## Screenshots
Before:
<img width="241" alt="image" src="https://github.com/eBay/skin/assets/1675667/bc2008cf-fa9e-4c15-802a-33df876c6096">

<img width="663" alt="image" src="https://github.com/eBay/skin/assets/1675667/373512e1-a0c6-4b23-a311-b8d1cda385e3">


After:
<img width="228" alt="image" src="https://github.com/eBay/skin/assets/1675667/ae455613-84b9-4af6-a4ac-52c3792dd5d3">

<img width="655" alt="image" src="https://github.com/eBay/skin/assets/1675667/f6fbca38-1d04-4557-b6c0-a845893efc6c">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
