### PR TITLE
docs(icons): updated icon skin and contributing docs

### DIFF
--- a/ICON-CREATION.md
+++ b/ICON-CREATION.md
@@ -2,6 +2,10 @@
 
 Skin uses the SVG tag to deliver all iconography. This guide will help you properly add or modify SVG files for the Skin library.
 
+**Base Icons Only**
+
+Only base icons should be used. No state-based icons, such as disabled icons or even possibly an icon relaying an error state (likely red), should be used. Those state modifications on icons should be handled downstream using `css` modifiers to allow for those variations.
+
 ## Step 1: Import the SVG
 
 In order to import the SVG into Skin, all you need to do is drop the SVG into `src/svg/icon` directory. The icon name will be the way the icon will be imported into Skin. If the icon does not have `icon-` prefix, it will be renamed automatically to include the prefix.
@@ -35,6 +39,12 @@ If you do not want an icon to show up in the skin docs, add the name of the icon
 
 In order to skip an icon to have it's CSS be generated add the name of the icon in `docs/_data/icons.yaml` under `skip` key. Then rerun `step 2` scripts.
 This can be done for certain icons which might want to have different sizes than those specified in the `viewbox`
+
+## Depcrating Icons
+
+When an icon is removed or renamed, it will need to get deprecated. If you want to deprecate an icon, add the name of the icon in `docs/_data/icons.yaml` under `deprecated` key. Then rerun `step 2` scripts. This will show (if none existed yet) a `Deprecated` section in the docs and include the icon. This will also remove the icon from the `icon.svg` bundle and remove the CSS for the icon.
+
+Deprecated icons are to remain until the next major version when they can be removed. After they are removed, the icon can be removed from the `deprecated` key and the `step 2` scripts can be rerun.
 
 ## Script changes
 

--- a/docs/_includes/icon.html
+++ b/docs/_includes/icon.html
@@ -1,8 +1,13 @@
 <div id="icon">
     {% include section-header.html name="icon" version=page.versions.icon %}
 
-    <p>The icon module is a bundle that provides full access to the entire range of eBay iconography via the <span
-            class="highlight">&lt;svg&gt;</span> and <span class="highlight">&lt;use&gt;</span> tags.</p>
+    <p>The icon module is a bundle that provides full access to the entire range of eBay iconography via the <span class="highlight">&lt;svg&gt;</span> and <span class="highlight">&lt;use&gt;</span> tags.</p>
+    
+    <h3>Base Icons Only</h3>
+
+    Only base icons should be used. No state-based icons, such as disabled icons or even possibly an icon relaying an error state (likely red), should be used. Those state modifications on icons should be handled downstream using <span class="highlight">css</span> modifiers to allow for those variations.
+    
+    <h3>General Markup Approach</h3>
     <p>To avoid gigantic icons when in a non-CSS state, we use the SVG width and height attributes to override the
         browser's default 300x150 size.</p>
 


### PR DESCRIPTION
Updated icon docs with missing deprecated workflow and sections for avoiding state-based icons.

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Notes
It looks like we had not added information about deprecating icons in the contributing docs. 

Also, based on the recent ask for creating disabled icons from currently existing base icons, it became clear that we needed to be more explicit about using only base icons and doing all state modifications in `css`. After a discussion with Ian, it was clear that we should be more explicit about that guidance. 

## Screenshots
<img width="1342" alt="image" src="https://github.com/eBay/skin/assets/1675667/d4c5d4e3-2c5d-41a6-9a17-4623bba9463d">


