### PR TITLE
fix(skeletons): incorrect block margins

### DIFF
--- a/dist/skeleton/skeleton.css
+++ b/dist/skeleton/skeleton.css
@@ -92,11 +92,11 @@ span.skeleton__textbox + span {
   -webkit-margin-start: var(--spacing-100);
           margin-inline-start: var(--spacing-100);
 }
-div.skeleton__avatar,
-div.skeleton__button,
-div.skeleton__text,
-div.skeleton__image,
-div.skeleton__textbox {
+div.skeleton__avatar + div,
+div.skeleton__button + div,
+div.skeleton__text + div,
+div.skeleton__image + div,
+div.skeleton__textbox + div {
   -webkit-margin-before: var(--spacing-150);
           margin-block-start: var(--spacing-150);
 }

--- a/dist/skeleton/skeleton.css
+++ b/dist/skeleton/skeleton.css
@@ -84,21 +84,21 @@ span.skeleton__image,
 span.skeleton__textbox {
   display: inline-block;
 }
-span.skeleton__avatar + span,
-span.skeleton__button + span,
-span.skeleton__text + span,
-span.skeleton__image + span,
-span.skeleton__textbox + span {
-  -webkit-margin-start: var(--spacing-100);
-          margin-inline-start: var(--spacing-100);
+span.skeleton__avatar:not(:last-child),
+span.skeleton__button:not(:last-child),
+span.skeleton__text:not(:last-child),
+span.skeleton__image:not(:last-child),
+span.skeleton__textbox:not(:last-child) {
+  -webkit-margin-end: var(--spacing-100);
+          margin-inline-end: var(--spacing-100);
 }
-div.skeleton__avatar + div,
-div.skeleton__button + div,
-div.skeleton__text + div,
-div.skeleton__image + div,
-div.skeleton__textbox + div {
-  -webkit-margin-before: var(--spacing-150);
-          margin-block-start: var(--spacing-150);
+div.skeleton__avatar:not(:last-child),
+div.skeleton__button:not(:last-child),
+div.skeleton__text:not(:last-child),
+div.skeleton__image:not(:last-child),
+div.skeleton__textbox:not(:last-child) {
+  -webkit-margin-after: var(--spacing-150);
+          margin-block-end: var(--spacing-150);
 }
 .skeleton--elevated {
   --skeleton-background: var(--color-loading-fill-elevated);

--- a/src/less/skeleton/skeleton.less
+++ b/src/less/skeleton/skeleton.less
@@ -116,11 +116,11 @@ span.skeleton__textbox + span {
     margin-inline-start: var(--spacing-100);
 }
 
-div.skeleton__avatar,
-div.skeleton__button,
-div.skeleton__text,
-div.skeleton__image,
-div.skeleton__textbox {
+div.skeleton__avatar + div,
+div.skeleton__button + div,
+div.skeleton__text + div,
+div.skeleton__image + div,
+div.skeleton__textbox + div {
     margin-block-start: var(--spacing-150);
 }
 

--- a/src/less/skeleton/skeleton.less
+++ b/src/less/skeleton/skeleton.less
@@ -108,20 +108,20 @@ span.skeleton__textbox {
     display: inline-block;
 }
 
-span.skeleton__avatar + span,
-span.skeleton__button + span,
-span.skeleton__text + span,
-span.skeleton__image + span,
-span.skeleton__textbox + span {
-    margin-inline-start: var(--spacing-100);
+span.skeleton__avatar:not(:last-child),
+span.skeleton__button:not(:last-child),
+span.skeleton__text:not(:last-child),
+span.skeleton__image:not(:last-child),
+span.skeleton__textbox:not(:last-child) {
+    margin-inline-end: var(--spacing-100);
 }
 
-div.skeleton__avatar + div,
-div.skeleton__button + div,
-div.skeleton__text + div,
-div.skeleton__image + div,
-div.skeleton__textbox + div {
-    margin-block-start: var(--spacing-150);
+div.skeleton__avatar:not(:last-child),
+div.skeleton__button:not(:last-child),
+div.skeleton__text:not(:last-child),
+div.skeleton__image:not(:last-child),
+div.skeleton__textbox:not(:last-child) {
+    margin-block-end: var(--spacing-150);
 }
 
 .skeleton--elevated {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2239 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
This change fixes skeletons having default top margins. Instead adds spacing to block level elements after the first one.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
**Before**
<img width="569" alt="image" src="https://github.com/eBay/skin/assets/6342519/47a50be0-deca-4959-8dfd-1824eac16205">
**After**
<img width="569" alt="image" src="https://github.com/eBay/skin/assets/6342519/6dbab91c-cb97-47a0-83d9-9c847bbbdb81">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
