### PR TITLE
feat(icon): added disabled support for complex icons

### DIFF
--- a/dist/icon/icon.css
+++ b/dist/icon/icon.css
@@ -2816,10 +2816,6 @@ svg.icon {
   vertical-align: middle;
 }
 svg.icon--disabled {
-  color: var(--color-foreground-disabled);
-  fill: currentColor;
-}
-svg.icon--disabled[class*="-colored"] {
   filter: var(--color-icon-disabled-filter);
 }
 svg.icon--attention-filled-16,

--- a/dist/icon/icon.css
+++ b/dist/icon/icon.css
@@ -2819,6 +2819,9 @@ svg.icon--disabled {
   color: var(--color-foreground-disabled);
   fill: currentColor;
 }
+svg.icon--disabled[class*="-colored"] {
+  filter: var(--color-icon-disabled-filter);
+}
 svg.icon--attention-filled-16,
 svg.icon--attention-filled-24 {
   color: var(--color-foreground-attention);

--- a/dist/tokens/evo-light.css
+++ b/dist/tokens/evo-light.css
@@ -172,4 +172,5 @@
         var(--color-ai-solid-green-subtle) 66%,
         var(--color-ai-solid-green-subtle) 100%
     );
+    --color-icon-disabled-filter: grayscale(1) opacity(0.25);
 }

--- a/docs/_includes/icon.html
+++ b/docs/_includes/icon.html
@@ -81,6 +81,9 @@
     <p>Most icons can be given a disabled appearance by adding the <span class="highlight">icon--disabled</span>
         modifier.</p>
 
+    <h4>Simple Icons</h4>
+    <p>Icons that are simple and have only a stroke/fill of a single color simply inherit <span class="highlight">color</span> and are disabled by inheriting that color as the stroke/fill.</p>
+
     <div class="demo">
         <div class="demo__inner">
             <svg aria-label="Disabled icon example" class="icon icon--chevron-right-24 icon--disabled" focusable="false"
@@ -91,9 +94,26 @@
     </div>
 
     {% highlight html %}
-    <svg class="icon icon--chevron-right-24 icon--disabled" focusable="false" height="24" width="24">
-        <use href="#icon-chevron-right-24"></use>
-    </svg>
+<svg class="icon icon--chevron-right-24 icon--disabled" focusable="false" height="24" width="24">
+    <use href="#icon-chevron-right-24"></use>
+</svg>
+    {% endhighlight %}
+
+    <h4>Complex Icons</h4>
+    <p>Icons that are more complex and have multiple colors with a suffix of <span class="highlight">-colored</span> are grayscaled with an opacity.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <svg aria-label="Disabled icon example" class="icon icon--mastercard-24-colored icon--disabled" focusable="false" height="24" width="24" role="img">
+                {% include symbol.html name="mastercard-24-colored" %}
+            </svg>
+        </div>
+    </div>
+
+    {% highlight html %}
+<svg class="icon icon--mastercard-24-colored icon--disabled" focusable="false" height="24" width="24">
+    <use href="#icon-mastercard-24-colored"></use>
+</svg>
     {% endhighlight %}
 
     {% if site.data.icons.deprecated.size > 0 %}

--- a/src/less/icon/icon.less
+++ b/src/less/icon/icon.less
@@ -10,6 +10,9 @@ svg {
         .color-token(color-foreground-disabled);
         fill: currentColor;
     }
+    &.icon--disabled[class*="-colored"] {
+        filter: var(--color-icon-disabled-filter);
+    }
     &.icon--attention-filled-16,
     &.icon--attention-filled-24 {
         .color-token(color-foreground-attention);

--- a/src/less/icon/icon.less
+++ b/src/less/icon/icon.less
@@ -7,10 +7,6 @@ svg {
         .icon-base-mixin();
     }
     &.icon--disabled {
-        .color-token(color-foreground-disabled);
-        fill: currentColor;
-    }
-    &.icon--disabled[class*="-colored"] {
         filter: var(--color-icon-disabled-filter);
     }
     &.icon--attention-filled-16,

--- a/src/tokens/evo-light.css
+++ b/src/tokens/evo-light.css
@@ -172,4 +172,5 @@
         var(--color-ai-solid-green-subtle) 66%,
         var(--color-ai-solid-green-subtle) 100%
     );
+    --color-icon-disabled-filter: grayscale(1) opacity(0.25);
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2231 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This simply adds disabled support for complex icons with a suffix, `-colored`. 

## Notes
1. Initially, I was planning on using the `svg.icon--disabled[class~="-colored"]` to find the icons that ended with `-colored` class and isolate complex icons, but I had not taken class ordering into consideration. I opted to use `svg.icon--disabled[class*="-colored"]` instead to find the class string anywhere in the `class` attribute instead. Since this is cascading from `.icon--disabled` the only risk of the more aggressive selector is having a simple icon that has `-colored` in its name _and_ is disabled.
2. I was initially thinking of keeping this change isolated to complex icons, but the more I think about it, I'm thinking it might simply be easier to apply this grayscale+opacity method to all icons instead of just complex ones. That would make things simpler and we would only need one way of doing it for all icons.

## Screenshots
**Before**
<kbd><img width="69" alt="image" src="https://github.com/eBay/skin/assets/1675667/a6b9a570-9205-4893-a691-dd4df6e13232">
</kbd>

**After**
<kbd><img width="64" alt="image" src="https://github.com/eBay/skin/assets/1675667/8de18676-4f99-4c1d-adca-e14a991b64bd"></kbd>

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
