### PR TITLE
fix(floating-label): force select line height to prevent overrides

### DIFF
--- a/dist/floating-label/floating-label.css
+++ b/dist/floating-label/floating-label.css
@@ -68,10 +68,10 @@ label.floating-label__label--invalid {
   padding-top: 23px;
 }
 .floating-label .select select {
-  line-height: 52px;
+  line-height: 52px !important;
 }
 .floating-label .select--large select {
-  line-height: 60px;
+  line-height: 60px !important;
 }
 [dir="rtl"] label.floating-label__label {
   left: initial;

--- a/src/less/floating-label/floating-label.less
+++ b/src/less/floating-label/floating-label.less
@@ -91,12 +91,15 @@ label.floating-label__label--invalid {
     padding-top: 23px;
 }
 
+// We are setting line-height to important because WCAG specs allow setting 1.5 times the line height
+// If we do not set it to important, the line height will be overridden causing text-overlap
+// See https://github.com/eBay/skin/issues/2253
 .floating-label .select select {
-    line-height: 52px;
+    line-height: 52px !important;
 }
 
 .floating-label .select--large select {
-    line-height: 60px;
+    line-height: 60px !important;
 }
 
 // RTL


### PR DESCRIPTION

Fixes #2253

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added `!important` to styles for select line height. This prevents it from being overridden by bookmarklets causing text overlap.

## Screenshots
<img width="216" alt="Screenshot 2024-01-18 at 9 53 51 AM" src="https://github.com/eBay/skin/assets/1755269/f7a8881d-3301-4750-917c-ff1e86b072a5">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
