### PR TITLE
fix(signal): updated spacing

### DIFF
--- a/dist/signal/signal.css
+++ b/dist/signal/signal.css
@@ -1,13 +1,14 @@
 .signal {
-  border: 1.5px solid;
+  border: 1px solid;
   border-radius: var(--border-radius-100);
   box-sizing: border-box;
   display: inline-block;
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-smallest);
   font-weight: bold;
   letter-spacing: 0.5px;
+  line-height: var(--spacing-150);
   margin: var(--spacing-100) 0;
-  padding: 2px 12px 1px;
+  padding: 2px var(--spacing-100) 1px;
   text-align: center;
   text-transform: uppercase;
 }

--- a/src/less/signal/signal.less
+++ b/src/less/signal/signal.less
@@ -2,15 +2,16 @@
 @import "../mixins/private/token-mixins.less";
 
 .signal {
-    border: 1.5px solid;
+    border: 1px solid;
     border-radius: var(--border-radius-100);
     box-sizing: border-box;
     display: inline-block;
-    font-size: var(--font-size-small);
+    font-size: var(--font-size-smallest);
     font-weight: bold;
     letter-spacing: 0.5px;
+    line-height: var(--spacing-150);
     margin: var(--spacing-100) 0;
-    padding: 2px 12px 1px;
+    padding: 2px var(--spacing-100) 1px;
     text-align: center;
     text-transform: uppercase;
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2212 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I updating the spacing to match Figma. I did not use horizontal margins as that should be an implementation-level styling since it won't work in all uses of the module.

## Notes
I'm not sure this is technically a bug. The Figma was likely updated after the module was last updated which likely created this misalignment. 

## Screenshots (zoomed in)
**Before**
<kbd><img width="678" alt="image" src="https://github.com/eBay/skin/assets/1675667/93a1419b-c96c-43f1-952f-94b5ef383eff"></kbd>

**After**
<kbd><img width="640" alt="image" src="https://github.com/eBay/skin/assets/1675667/1f84d558-02ec-4e0e-9320-2a5b2eabfd7e"></kbd>

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
