### PR TITLE
fix(popovers,menus): fixed shadows in Safari and restored borders in menus

### DIFF
--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .combobox {
   box-sizing: border-box;
@@ -22,9 +23,9 @@ span.combobox {
 .combobox__listbox {
   background-color: var(--combobox-listbox-background-color, var(--color-background-elevated));
   border-radius: var(--combobox-listbox-border-radius, var(--border-radius-50));
+  box-shadow: var(--bubble-shadow);
   box-sizing: border-box;
   display: none;
-  filter: var(--bubble-filter);
   left: 0;
   max-height: 400px;
   min-width: 100%;
@@ -53,6 +54,8 @@ span.combobox {
 }
 .combobox__option[role^="option"] {
   background-color: transparent;
+  border-style: solid;
+  border-width: 1px;
   box-sizing: border-box;
   display: inline-grid;
   font-family: inherit;

--- a/dist/date-textbox/date-textbox.css
+++ b/dist/date-textbox/date-textbox.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .date-textbox {
   --calendar-month-width: 311px;
@@ -10,7 +11,7 @@
 .date-textbox__popover {
   background-color: var(--calendar-background-color, var(--color-background-elevated));
   border-radius: var(--spacing-200);
-  filter: var(--bubble-filter);
+  box-shadow: var(--bubble-shadow);
   margin-left: calc(var(--spacing-100) * -1);
   padding: var(--spacing-200);
   position: absolute;

--- a/dist/filter-menu-button/filter-menu-button.css
+++ b/dist/filter-menu-button/filter-menu-button.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 div.filter-group {
   display: flex;
@@ -98,8 +99,8 @@ button.filter-menu-button__button[aria-pressed="true"][aria-disabled="true"]:hov
   background-color: var(--filter-menu-item-background-color, var(--color-background-elevated));
   border: none;
   border-radius: 16px;
+  box-shadow: var(--bubble-shadow);
   display: none;
-  filter: var(--bubble-filter);
   max-width: 288px;
   min-width: 144px;
   overflow: hidden;

--- a/dist/infotip/infotip.css
+++ b/dist/infotip/infotip.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .infotip {
   position: relative;
@@ -9,7 +10,7 @@ span.infotip {
 }
 .infotip__overlay {
   border-radius: var(--bubble-border-radius, var(--border-radius-50));
-  filter: var(--bubble-filter);
+  box-shadow: var(--bubble-shadow);
   font-size: 14px;
   left: 0;
   max-width: 344px;

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .listbox-button {
   line-height: normal;
@@ -21,9 +22,9 @@ span.listbox-button--fluid .btn {
 div.listbox-button__listbox {
   background-color: var(--listbox-button-listbox-background-color, var(--color-background-elevated));
   border-radius: var(--listbox-button-listbox-border-radius, var(--border-radius-50));
+  box-shadow: var(--bubble-shadow);
   box-sizing: border-box;
   display: none;
-  filter: var(--bubble-filter);
   left: 0;
   max-height: 400px;
   min-width: 100%;
@@ -128,6 +129,8 @@ div.listbox-button__option[role="option"][aria-selected="true"] svg.icon {
 }
 div.listbox-button__option[role="option"] {
   background-color: transparent;
+  border-style: solid;
+  border-width: 1px;
   box-sizing: border-box;
   display: inline-grid;
   font-family: inherit;

--- a/dist/listbox/listbox.css
+++ b/dist/listbox/listbox.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 div.listbox {
   margin: var(--spacing-200) 0;
@@ -30,6 +31,8 @@ div.listbox__options--reverse[role="listbox"] {
 }
 div.listbox__option[role="option"] {
   background-color: transparent;
+  border-style: solid;
+  border-width: 1px;
   box-sizing: border-box;
   display: inline-grid;
   font-family: inherit;

--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .menu-button,
 .fake-menu-button {
@@ -10,9 +11,9 @@
 .fake-menu-button__menu {
   background-color: var(--menu-button-menu-background-color, var(--color-background-elevated));
   border-radius: var(--menu-button-menu-border-radius, var(--border-radius-50));
+  box-shadow: var(--bubble-shadow);
   box-sizing: border-box;
   display: none;
-  filter: var(--bubble-filter);
   left: 0;
   max-height: 400px;
   min-width: 100%;
@@ -42,6 +43,8 @@ span.fake-menu-button__button {
 }
 div.menu-button__item[role^="menuitem"] {
   background-color: transparent;
+  border-style: solid;
+  border-width: 1px;
   box-sizing: border-box;
   display: inline-grid;
   font-family: inherit;
@@ -115,6 +118,8 @@ div.menu-button__item[role^="menuitem"][aria-checked="true"] svg.icon--tick-16 {
 .fake-menu-button__menu a.fake-menu-button__item,
 .fake-menu-button__menu button.fake-menu-button__item {
   background-color: transparent;
+  border-style: solid;
+  border-width: 1px;
   box-sizing: border-box;
   display: inline-grid;
   font-family: inherit;

--- a/dist/menu/menu.css
+++ b/dist/menu/menu.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .menu__items,
 .fake-menu__items {
@@ -46,6 +47,8 @@ button.fake-menu__item,
 a.fake-menu__item,
 div.menu__item[role^="menuitem"] {
   background-color: transparent;
+  border-style: solid;
+  border-width: 1px;
   box-sizing: border-box;
   display: inline-grid;
   font-family: inherit;

--- a/dist/tooltip/tooltip.css
+++ b/dist/tooltip/tooltip.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .tooltip {
   position: relative;
@@ -9,8 +10,8 @@ span.tooltip {
 }
 .tooltip__overlay {
   border-radius: var(--bubble-border-radius, var(--border-radius-50));
+  box-shadow: var(--bubble-shadow);
   display: none;
-  filter: var(--bubble-filter);
   font-size: 14px;
   left: 0;
   max-width: 344px;

--- a/dist/tourtip/tourtip.css
+++ b/dist/tourtip/tourtip.css
@@ -1,5 +1,6 @@
 :root {
-  --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15)) drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+  --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 .tourtip {
   position: relative;
@@ -9,8 +10,8 @@ span.tourtip {
 }
 .tourtip__overlay {
   border-radius: var(--bubble-border-radius, var(--border-radius-100));
+  box-shadow: var(--bubble-shadow);
   display: none;
-  filter: var(--bubble-filter);
   font-size: 14px;
   left: 0;
   max-width: 344px;

--- a/src/less/date-textbox/date-textbox.less
+++ b/src/less/date-textbox/date-textbox.less
@@ -14,7 +14,7 @@
 .date-textbox__popover {
     .background-color-token(calendar-background-color, color-background-elevated);
     border-radius: var(--spacing-200);
-    filter: var(--bubble-filter);
+    box-shadow: var(--bubble-shadow);
     margin-left: calc(var(--spacing-100) * -1);
     padding: var(--spacing-200);
     position: absolute;

--- a/src/less/filter-menu-button/filter-menu-button.less
+++ b/src/less/filter-menu-button/filter-menu-button.less
@@ -88,8 +88,8 @@ button.filter-menu-button__button[aria-pressed="true"][aria-disabled="true"]:hov
     .background-color-token(filter-menu-item-background-color, color-background-elevated);
     border: none;
     border-radius: 16px;
+    box-shadow: var(--bubble-shadow);
     display: none;
-    filter: var(--bubble-filter);
     max-width: 288px; // TODO remove max-width restriction to filter-menu styles
     min-width: 144px;
     overflow: hidden;

--- a/src/less/mixins/private/bubble-mixins.less
+++ b/src/less/mixins/private/bubble-mixins.less
@@ -1,15 +1,19 @@
 // this mixin is used by infotip, tooltip, tourtip, date-textbox
 
 :root {
-    --bubble-filter: drop-shadow(0 2px 7px rgba(0, 0, 0, 0.15))
-        drop-shadow(0 5px 17px rgba(0, 0, 0, 0.2));
+    // Do NOT use filter: drop-shadow() as Safari cannot do
+    //   drop-shadows outside an element with overflow.
+    //   Since box-shadow more widely supports various use cases,
+    //   it's a more robust solution.
+    --bubble-shadow: 0 2px 7px rgba(0, 0, 0, 0.15),
+        0 5px 17px rgba(0, 0, 0, 0.2);
 }
 
 .bubble(@border-radius-value: border-radius-50) {
     .border-radius-token(bubble-border-radius, @border-radius-value);
 
+    box-shadow: var(--bubble-shadow);
     display: none;
-    filter: var(--bubble-filter);
     font-size: 14px;
     left: 0;
     max-width: 344px;

--- a/src/less/mixins/private/dropdown-mixins.less
+++ b/src/less/mixins/private/dropdown-mixins.less
@@ -3,9 +3,9 @@
 .dropdown-base(@component) {
     .background-color-token(~"@{component}-background-color", color-background-elevated);
     .border-radius-token(~"@{component}-border-radius", border-radius-50);
+    box-shadow: var(--bubble-shadow);
     box-sizing: border-box;
     display: none;
-    filter: var(--bubble-filter);
     left: 0;
     max-height: 400px;
     min-width: 100%;

--- a/src/less/mixins/private/selection-list-mixins.less
+++ b/src/less/mixins/private/selection-list-mixins.less
@@ -1,5 +1,7 @@
 .selection-list-item-base() {
     background-color: transparent;
+    border-style: solid;
+    border-width: 1px;
     box-sizing: border-box;
     display: inline-grid;
     font-family: inherit;

--- a/src/less/pagination/stories/overflow.stories.js
+++ b/src/less/pagination/stories/overflow.stories.js
@@ -16,8 +16,8 @@ export const start = () => `
         </li>
         <li>
             <span class="pagination__item">
-                <svg class="icon icon--overflow" width="8" height="8" role="separator">
-                    <use href="#icon-overflow"></use>
+                <svg class="icon icon--overflow-horizontal-24" width="8" height="8" role="separator">
+                    <use href="#icon-overflow-horizontal-24"></use>
                 </svg>
             </span>
         </li>
@@ -61,8 +61,8 @@ export const middle = () => `
         </li>
         <li>
             <span class="pagination__item">
-                <svg class="icon icon--overflow" width="8" height="8" role="separator">
-                    <use href="#icon-overflow"></use>
+                <svg class="icon icon--overflow-horizontal-24" width="8" height="8" role="separator">
+                    <use href="#icon-overflow-horizontal-24"></use>
                 </svg>
             </span>
         </li>
@@ -77,8 +77,8 @@ export const middle = () => `
         </li>
         <li>
             <span class="pagination__item">
-                <svg class="icon icon--overflow" width="8" height="8" role="separator">
-                    <use href="#icon-overflow"></use>
+                <svg class="icon icon--overflow-horizontal-24" width="8" height="8" role="separator">
+                    <use href="#icon-overflow-horizontal-24"></use>
                 </svg>
             </span>
         </li>
@@ -122,8 +122,8 @@ export const end = () => `
         </li>
         <li>
             <span class="pagination__item">
-                <svg class="icon icon--overflow" width="8" height="8" role="separator">
-                    <use href="#icon-overflow"></use>
+                <svg class="icon icon--overflow-horizontal-24" width="8" height="8" role="separator">
+                    <use href="#icon-overflow-horizontal-24"></use>
                 </svg>
             </span>
         </li>
@@ -169,8 +169,8 @@ export const endMenuCollapsed = () => `
             <span class="pagination__item">
                 <span class="fake-menu-button">
                     <button class="icon-btn icon-btn--transparent fake-menu-button__button" type="button" aria-label="Menu">
-                        <svg class="icon icon--overflow" width="8" height="8" aria-hidden="true">
-                            <use href="#icon-overflow"></use>
+                        <svg class="icon icon--overflow-horizontal-24" width="8" height="8" role="separator">
+                            <use href="#icon-overflow-horizontal-24"></use>
                         </svg>
                     </button>
                     <ul class="fake-menu-button__menu">
@@ -240,8 +240,8 @@ export const endMenuExpanded = () => `
             <span class="pagination__item">
                 <span class="fake-menu-button">
                     <button class="icon-btn icon-btn--transparent fake-menu-button__button" type="button" aria-expanded="true" aria-label="Menu">
-                        <svg class="icon icon--overflow" width="8" height="8" aria-hidden="true">
-                            <use href="#icon-overflow"></use>
+                        <svg class="icon icon--overflow-horizontal-24" width="8" height="8" role="separator">
+                            <use href="#icon-overflow-horizontal-24"></use>
                         </svg>
                     </button>
                     <ul class="fake-menu-button__menu">


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes prerelease issues discovered by Percy.

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Percy found a couple of issues in the prerelease:

1. Using `filter: drop:shadow()` doesn't work in Safari on elements that have overflows, which is most of our popovers. I changed shadows from using `drop-shadow` to `box-shadow`, which is a more robust solution.
2. During the application of the popovers styles, I inadvertently made changes causing menu item borders to show up. I set those back to what they were to fix menu items.
3. I also fixed a story that was missing overflow icons due to previous icon renaming.

## Screenshots
**Before**
<img width="307" alt="image" src="https://github.com/eBay/skin/assets/1675667/5833f7d0-6781-46e2-8ffd-e3e8fd28ec4a">

<img width="258" alt="image" src="https://github.com/eBay/skin/assets/1675667/8510e797-7331-4aa6-83e5-dc805ce3935b">

<hr>

**After**
<img width="311" alt="image" src="https://github.com/eBay/skin/assets/1675667/9e1bd034-c3bd-41c0-904a-51a214bdf5d9">

<img width="253" alt="image" src="https://github.com/eBay/skin/assets/1675667/bb82db19-8286-4105-9ff9-3ded09835edd">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
