### PR TITLE
fix(toggle-button-group): fixed Safari image size bug and added stories

### DIFF
--- a/dist/toggle-button-group/toggle-button-group.css
+++ b/dist/toggle-button-group/toggle-button-group.css
@@ -6,7 +6,7 @@
   width: 100%;
 }
 .toggle-button-group li {
-  display: inline-table;
+  display: inline-block;
   margin-bottom: var(--spacing-50);
   margin-left: var(--spacing-50);
   margin-right: var(--spacing-50);

--- a/src/less/toggle-button-group/stories/gallery-layout.stories.js
+++ b/src/less/toggle-button-group/stories/gallery-layout.stories.js
@@ -1,5 +1,96 @@
 export default { title: "Skin/Toggle Button Group/Gallery Layout" };
 
+export const usingIMGTag = () => `
+<ul aria-label="Toggle buttons" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
+        <li>
+            <button type="button" class="toggle-button" aria-pressed="false">
+                <span class="toggle-button__image-container">
+                    <span class="toggle-button__image">
+                        <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                    </span>
+                </span>
+                <span class="toggle-button__content">
+                    <span class="toggle-button__title">
+                        <span>HTML Profile Image</span>
+                    </span>
+                    <span class="toggle-button__subtitle">Using Cover</span>
+                </span>
+            </button>
+        </li>
+        <li>
+            <button type="button" class="toggle-button" aria-pressed="false">
+                <span class="toggle-button__image-container">
+                    <span class="toggle-button__image">
+                        <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg" alt="">
+                    </span>
+                </span>
+                <span class="toggle-button__content">
+                    <span class="toggle-button__title">
+                        <span>HTML Landscape Image</span>
+                    </span>
+                    <span class="toggle-button__subtitle">Using Cover</span>
+                </span>
+            </button>
+        </li>
+        <li>
+            <button type="button" class="toggle-button" aria-pressed="false">
+                <span class="toggle-button__image-container">
+                    <span class="toggle-button__image">
+                        <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg" alt="">
+                    </span>
+                </span>
+                <span class="toggle-button__content">
+                    <span class="toggle-button__title">
+                        <span>HTML Square Image</span>
+                    </span>
+                    <span class="toggle-button__subtitle">Using Cover</span>
+                </span>
+            </button>
+        </li>
+    </ul>
+`;
+
+export const usingCSSImage = () => `
+<ul aria-label="Toggle buttons" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
+    <li>
+        <button type="button" class="toggle-button" aria-pressed="false">
+            <span class="toggle-button__image-container">
+                <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: contain; background-position: center 15%;">
+                </span>
+            </span>
+            <span class="toggle-button__content">
+                <span class="toggle-button__title">CSS Profile Image</span>
+                <span class="toggle-button__subtitle">Using Contain</span>
+            </span>
+        </button>
+    </li>
+    <li>
+        <button type="button" class="toggle-button" aria-pressed="false">
+            <span class="toggle-button__image-container">
+                <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                </span>
+            </span>
+            <span class="toggle-button__content">
+                <span class="toggle-button__title">CSS Profile Image</span>
+                <span class="toggle-button__subtitle">Using Cover</span>
+            </span>
+        </button>
+    </li>
+    <li>
+        <button type="button" class="toggle-button" aria-pressed="false">
+            <span class="toggle-button__image-container">
+                <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 30%;">
+                </span>
+            </span>
+            <span class="toggle-button__content">
+                <span class="toggle-button__title">CSS Square Image</span>
+                <span class="toggle-button__subtitle">Using Cover</span>
+            </span>
+        </button>
+    </li>
+</ul>
+`;
+
 export const _2Column = () => `
 <ul aria-label="Buttons" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="2">
     <li>

--- a/src/less/toggle-button-group/toggle-button-group.less
+++ b/src/less/toggle-button-group/toggle-button-group.less
@@ -9,7 +9,7 @@
 }
 
 .toggle-button-group li {
-    display: inline-table;
+    display: inline-block;
     margin-bottom: var(--spacing-50);
     margin-left: var(--spacing-50);
     margin-right: var(--spacing-50);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2241 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed a Safari bug in toggle-button-group that was causing images to ignore its container constraints.

## Notes
* I added stories for use cases.
* I did not run visual regression because we did not have any stories for the error case.

## Screenshots
**Before**

<kbd><img width="626" alt="toggle-button-group-Safari-issue" src="https://github.com/eBay/skin/assets/1675667/16be3ba0-c575-4abd-a133-1a61aec86c1e"></kbd>

<hr>

**After**

<kbd><img width="622" alt="toggle-button-group-Safari-fixed" src="https://github.com/eBay/skin/assets/1675667/a27ca52f-9339-4c14-adf1-ff7f75f1943b"></kbd>

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
