### PR TITLE
fix(listbox-button): border color default to attention in invalid state

### DIFF
--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -45,12 +45,28 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 .listbox-button button[aria-invalid="true"] {
   border-color: var(--listbox-button-invalid-border-color, var(--color-stroke-attention));
 }
-.listbox-button:not(.listbox-button--error) button:not([disabled], [aria-disabled="true"]).btn--form {
+.listbox-button:not(.listbox-button--error) button:not(
+        [disabled],
+        [aria-disabled="true"],
+        [aria-invalid="true"]
+    ).btn--form {
   border-color: var(--listbox-button-border-color, var(--color-stroke-default));
 }
-.listbox-button:not(.listbox-button--error) button:not([disabled], [aria-disabled="true"]).btn--form:hover,
-.listbox-button:not(.listbox-button--error) button:not([disabled], [aria-disabled="true"]).btn--form:focus,
-.listbox-button:not(.listbox-button--error) button:not([disabled], [aria-disabled="true"]).btn--form:active {
+.listbox-button:not(.listbox-button--error) button:not(
+        [disabled],
+        [aria-disabled="true"],
+        [aria-invalid="true"]
+    ).btn--form:hover,
+.listbox-button:not(.listbox-button--error) button:not(
+        [disabled],
+        [aria-disabled="true"],
+        [aria-invalid="true"]
+    ).btn--form:focus,
+.listbox-button:not(.listbox-button--error) button:not(
+        [disabled],
+        [aria-disabled="true"],
+        [aria-invalid="true"]
+    ).btn--form:active {
   border-color: inherit;
 }
 .listbox-button button.expand-btn--borderless,

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -43,7 +43,11 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
 }
 
 .listbox-button:not(.listbox-button--error)
-    button:not([disabled], [aria-disabled="true"]).btn--form {
+    button:not(
+        [disabled],
+        [aria-disabled="true"],
+        [aria-invalid="true"]
+    ).btn--form {
     .border-color-token(listbox-button-border-color, color-stroke-default);
 
     &:hover,


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2270

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Continuation of PR #2281


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
