### PR TITLE
fix(listbox-button): added border radius to container

### DIFF
--- a/.changeset/silly-camels-switch.md
+++ b/.changeset/silly-camels-switch.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+listbox-button: added border radius to container

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -120,6 +120,9 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
   font-weight: bold;
   margin-right: auto;
 }
+.listbox-button__options {
+  border-radius: var(--listbox-button-border-radius, var(--border-radius-50));
+}
 .listbox-button__options[role="listbox"]:focus .listbox-button__option--active[role="option"] {
   background-color: var(--color-state-primary-hover);
 }

--- a/src/less/listbox-button/listbox-button.less
+++ b/src/less/listbox-button/listbox-button.less
@@ -118,6 +118,10 @@ button.expand-btn[aria-expanded="true"] ~ div.listbox-button__listbox,
     margin-right: auto;
 }
 
+.listbox-button__options {
+    .border-radius-token(listbox-button-border-radius, border-radius-50);
+}
+
 .listbox-button__options[role="listbox"]:focus
     .listbox-button__option--active[role="option"] {
     background-color: var(--color-state-primary-hover);


### PR DESCRIPTION
Fixes #2298
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added border radius to listbox contaienr

## Screenshots
<img width="215" alt="Screenshot 2024-03-21 at 8 34 38 AM" src="https://github.com/eBay/skin/assets/1755269/0a4ed1de-6350-4569-8449-58a85e777113">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
