### PR TITLE
fix(icon-button): fixed primary visited link icon color

### DIFF
--- a/.changeset/odd-months-roll.md
+++ b/.changeset/odd-months-roll.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(icon-button): fixed primary visited link icon color

--- a/dist/icon-button/icon-button.css
+++ b/dist/icon-button/icon-button.css
@@ -109,6 +109,9 @@ a.icon-link:visited:hover > svg,
 a.icon-link:visited:focus > svg {
   fill: var(--icon-button-icon-hover-foreground-color, var(--color-foreground-primary));
 }
+a.icon-link.icon-link--primary:visited > svg {
+  fill: var(--icon-button-icon-foreground-color, var(--color-foreground-on-accent));
+}
 button.icon-btn--badged,
 a.icon-link--badged {
   overflow: visible;

--- a/src/less/icon-button/icon-button.less
+++ b/src/less/icon-button/icon-button.less
@@ -122,6 +122,10 @@ a.icon-link:visited {
     }
 }
 
+a.icon-link.icon-link--primary:visited > svg {
+    .fill-token(icon-button-icon-foreground-color, color-foreground-on-accent);
+}
+
 button.icon-btn--badged,
 a.icon-link--badged {
     overflow: visible;


### PR DESCRIPTION
<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixing issue discovered post-release. Icon buttons that use link need to have the same color icons as the ones using non-visited links.

## Screenshots

**Before**

<kbd><img width="401" alt="image" src="https://github.com/eBay/skin/assets/1675667/7aa1c4e3-409b-430d-88a9-294ccea35a30"></kbd>

**After**

<kbd><img width="422" alt="image" src="https://github.com/eBay/skin/assets/1675667/4e469eec-9a0f-47f8-a67d-639ea80f8dc3"></kbd>

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
