### PR TITLE
feat(toggle-button): added hover and pressed states

### DIFF
--- a/.changeset/loud-rivers-pump.md
+++ b/.changeset/loud-rivers-pump.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(toggle-button): added hover and pressed states

--- a/dist/toggle-button/toggle-button.css
+++ b/dist/toggle-button/toggle-button.css
@@ -47,6 +47,12 @@
   border-color: var(--color-stroke-disabled);
   box-shadow: 0 0 0 1px var(--color-stroke-disabled);
 }
+.toggle-button:not([aria-disabled="true"], [disabled]):hover {
+  background-color: var(--state-layer-hover);
+}
+.toggle-button:not([aria-disabled="true"], [disabled]):active {
+  background-color: var(--state-layer-pressed);
+}
 .toggle-button__content {
   align-self: center;
   display: flex;

--- a/dist/tokens/evo-light.css
+++ b/dist/tokens/evo-light.css
@@ -89,10 +89,10 @@
     --color-marketing-orange-background-3: var(--color-orange-3);
     --color-marketing-magenta-foreground-4: var(--color-neutral-0);
     --color-marketing-magenta-background-4: var(--color-magenta-4);
-    --state-layer-focus: rgba(var(--color-neutral-8-rgb), var(--opacity-100));
-    --state-layer-hover: rgba(var(--color-neutral-8-rgb), var(--opacity-100));
-    --state-layer-pressed: rgba(var(--color-neutral-8-rgb), var(--opacity-150));
-    --state-layer-drag: rgba(var(--color-neutral-8-rgb), var(--opacity-200));
+    --state-layer-focus: rgba(var(--color-neutral-8-rgb), var(--opacity-50));
+    --state-layer-hover: rgba(var(--color-neutral-8-rgb), var(--opacity-50));
+    --state-layer-pressed: rgba(var(--color-neutral-8-rgb), var(--opacity-100));
+    --state-layer-drag: rgba(var(--color-neutral-8-rgb), var(--opacity-150));
     --color-ai-gradient-full-spectrum: linear-gradient(
         223deg,
         var(--color-ai-solid-yellow-strong) 9.79%,

--- a/docs/_includes/toggle-button-group.html
+++ b/docs/_includes/toggle-button-group.html
@@ -248,7 +248,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-c">Select Sizes</h5>
-            <div style="width: 500px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 500px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-c" class="toggle-button-group" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -320,7 +320,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-c">Select Sizes</h5>
-<div style="width: 500px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 500px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-c" class="toggle-button-group" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -396,7 +396,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-d">Select Sizes</h5>
-            <div style="width: 500px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 500px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-d" class="toggle-button-group" data-columns="5">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -468,7 +468,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-d">Select Sizes</h5>
-<div style="width: 500px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 500px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-d" class="toggle-button-group" data-columns="5">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -566,7 +566,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-e">Select Sizes</h5>
-            <div style="width: 500px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 500px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-e" class="toggle-button-group" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -638,7 +638,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-e">Select Sizes</h5>
-<div style="width: 500px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 500px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-e" class="toggle-button-group" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -718,7 +718,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-f">Text Options</h5>
-            <div style="width: 750px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 750px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-f" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -748,7 +748,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-f">Text Options</h5>
-<div style="width: 750px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 750px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-f" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -780,7 +780,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-g">Text Options</h5>
-            <div style="width: 750px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 750px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-g" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -813,7 +813,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-g">Text Options</h5>
-<div style="width: 750px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 750px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-g" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -848,7 +848,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-h">Select Payment Option</h5>
-            <div style="width: 800px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 800px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-h" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -896,7 +896,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-h">Select Payment Option</h5>
-<div style="width: 800px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 800px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-h" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -946,7 +946,7 @@
     <p>To add an image to a toggle button, you can use the <span class="highlight">toggle-button__image-container</span> block using an <span class="highlight">&lt;img&gt;</span> or as a <span class="highlight">css</span> background image.</p>
 
     <h5 id="toggle-button-group-i">Select Payment Option</h5>
-    <div style="width: 800px; background-color: lightyellow; border: 1px dashed orange;">
+    <div style="width: 800px; border: 1px dashed orange;">
         <ul aria-labelledby="toggle-button-group-i" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
             <li>
                 <button type="button toggle-button--list-layout" class="toggle-button" aria-pressed="false">
@@ -994,7 +994,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-i">Select Payment Option</h5>
-<div style="width: 800px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 800px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-i" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
         <li>
             <button type="button toggle-button--list-layout" class="toggle-button" aria-pressed="false">
@@ -1044,7 +1044,7 @@
     <h4>List Layout Toggle Button Group with CSS Images</h4>
 
     <h5 id="toggle-button-group-j">Select Payment Option</h5>
-    <div style="width: 800px; background-color: lightyellow; border: 1px dashed orange;">    
+    <div style="width: 800px; border: 1px dashed orange;">    
         <ul aria-labelledby="toggle-button-group-j" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
             <li>
                 <button type="button toggle-button--list-layout" class="toggle-button" aria-pressed="false">
@@ -1076,7 +1076,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-j">Select Payment Option</h5>
-<div style="width: 800px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 800px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-j" class="toggle-button-group toggle-button-group--list-layout" data-columns="3">
         <li>
             <button type="button toggle-button--list-layout" class="toggle-button" aria-pressed="false">
@@ -1122,7 +1122,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-k">Selection Options</h5>
-            <div style="width: 600px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 600px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-k" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -1176,7 +1176,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-k">Selection Options</h5>
-<div style="width: 600px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 600px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-k" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -1238,7 +1238,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-l">Selection Options</h5>
-            <div style="width: 700px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 700px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-l" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -1283,7 +1283,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-l">Selection Options</h5>
-<div style="width: 700px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 700px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-l" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">
@@ -1333,7 +1333,7 @@
     <div class="demo">
         <div class="demo__inner">
             <h5 id="toggle-button-group-m">Selection Options</h5>
-            <div style="width: 750px; background-color: lightyellow; border: 1px dashed orange;">
+            <div style="width: 750px; border: 1px dashed orange;">
                 <ul aria-labelledby="toggle-button-group-m" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
                     <li>
                         <button type="button" class="toggle-button" aria-pressed="false">
@@ -1381,7 +1381,7 @@
 
     {% highlight html %}
 <h5 id="toggle-button-group-m">Selection Options</h5>
-<div style="width: 750px; background-color: lightyellow; border: 1px dashed orange;">
+<div style="width: 750px; border: 1px dashed orange;">
     <ul aria-labelledby="toggle-button-group-m" class="toggle-button-group toggle-button-group--gallery-layout" data-columns="3">
         <li>
             <button type="button" class="toggle-button" aria-pressed="false">

--- a/docs/index.html
+++ b/docs/index.html
@@ -324,7 +324,7 @@ module_metadata:
   toggle-button:
     ds-component:
       name: toggle-button
-      version: 1.0
+      version: 1.0.3
     submodules:
       - icon
   toggle-button-group:

--- a/src/less/toggle-button/toggle-button.less
+++ b/src/less/toggle-button/toggle-button.less
@@ -55,6 +55,14 @@
     box-shadow: 0 0 0 1px var(--color-stroke-disabled);
 }
 
+.toggle-button:not([aria-disabled="true"], [disabled]):hover {
+    background-color: var(--state-layer-hover);
+}
+
+.toggle-button:not([aria-disabled="true"], [disabled]):active {
+    background-color: var(--state-layer-pressed);
+}
+
 .toggle-button__content {
     align-self: center;
     display: flex;

--- a/src/tokens/evo-light.css
+++ b/src/tokens/evo-light.css
@@ -89,10 +89,10 @@
     --color-marketing-orange-background-3: var(--color-orange-3);
     --color-marketing-magenta-foreground-4: var(--color-neutral-0);
     --color-marketing-magenta-background-4: var(--color-magenta-4);
-    --state-layer-focus: rgba(var(--color-neutral-8-rgb), var(--opacity-100));
-    --state-layer-hover: rgba(var(--color-neutral-8-rgb), var(--opacity-100));
-    --state-layer-pressed: rgba(var(--color-neutral-8-rgb), var(--opacity-150));
-    --state-layer-drag: rgba(var(--color-neutral-8-rgb), var(--opacity-200));
+    --state-layer-focus: rgba(var(--color-neutral-8-rgb), var(--opacity-50));
+    --state-layer-hover: rgba(var(--color-neutral-8-rgb), var(--opacity-50));
+    --state-layer-pressed: rgba(var(--color-neutral-8-rgb), var(--opacity-100));
+    --state-layer-drag: rgba(var(--color-neutral-8-rgb), var(--opacity-150));
     --color-ai-gradient-full-spectrum: linear-gradient(
         223deg,
         var(--color-ai-solid-yellow-strong) 9.79%,


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2315 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Added hover and pressed states. Per DS, the state tokens needed to be revised as well (includede).

## Notes
Since hovers exposed the `rgba` transparency color and made buttons look yellow, I also removed the yellow background color from the `toggle-button-group` docs to avoid relaying misinformation to devs about its potential usage inside any container with any other background color. 

## Screenshots

**Before**

Hover

<kbd><img width="88" alt="image" src="https://github.com/eBay/skin/assets/1675667/cf256271-6d12-4084-b363-b5aa9a3f99fa"></kbd>

Pressed

<kbd><img width="88" alt="image" src="https://github.com/eBay/skin/assets/1675667/a89fd25a-3f14-4bd7-8353-b5a919f91fcc"></kbd>


**After**

Hover
<kbd><img width="94" alt="image" src="https://github.com/eBay/skin/assets/1675667/816124a3-3fe8-4888-9dd5-8db1f4691230"></kbd>

Pressed(active)

<kbd><img width="93" alt="image" src="https://github.com/eBay/skin/assets/1675667/b9bb1a83-f593-48f5-b5c4-ed264af16caf"></kbd>


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
