### PR TITLE
fix(dialog): wrap instead of truncating

### DIFF
--- a/dist/drawer-dialog/drawer-dialog.css
+++ b/dist/drawer-dialog/drawer-dialog.css
@@ -37,9 +37,6 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .drawer-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
@@ -94,11 +91,13 @@
 .drawer-dialog__footer > :not(:first-child) {
   margin-left: 8px;
 }
-button.icon-button.drawer-dialog__close {
-  background-color: transparent;
+button.icon-btn.drawer-dialog__close {
+  align-self: start;
   border: 0;
-  height: auto;
-  outline-offset: -8px;
+  height: 32px;
+  min-width: 32px;
+  position: relative;
+  width: 32px;
   z-index: 1;
 }
 .drawer-dialog__window {

--- a/dist/drawer-dialog/drawer-dialog.css
+++ b/dist/drawer-dialog/drawer-dialog.css
@@ -37,12 +37,14 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow-wrap: anywhere;
 }
 .drawer-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
           margin-inline-start: var(--spacing-200);
 }
 .drawer-dialog__header .fake-link {
+  align-self: flex-start;
   text-decoration: none;
 }
 .drawer-dialog__handle {
@@ -92,7 +94,7 @@
   margin-left: 8px;
 }
 button.icon-btn.drawer-dialog__close {
-  align-self: start;
+  align-self: flex-start;
   border: 0;
   height: 32px;
   min-width: 32px;

--- a/dist/fullscreen-dialog/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/fullscreen-dialog.css
@@ -47,12 +47,14 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow-wrap: anywhere;
 }
 .fullscreen-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
           margin-inline-start: var(--spacing-200);
 }
 .fullscreen-dialog__header .fake-link {
+  align-self: flex-start;
   outline-offset: 4px;
   text-decoration: none;
 }
@@ -86,7 +88,7 @@ button.icon-btn.fullscreen-dialog__close {
 }
 button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
-  align-self: start;
+  align-self: flex-start;
   border: 0;
   padding: 0;
   position: relative;

--- a/dist/fullscreen-dialog/fullscreen-dialog.css
+++ b/dist/fullscreen-dialog/fullscreen-dialog.css
@@ -47,9 +47,6 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .fullscreen-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
@@ -89,7 +86,7 @@ button.icon-btn.fullscreen-dialog__close {
 }
 button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
-  align-self: center;
+  align-self: start;
   border: 0;
   padding: 0;
   position: relative;

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -52,9 +52,6 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .lightbox-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
@@ -108,7 +105,7 @@
 }
 button.icon-btn.lightbox-dialog__prev,
 button.icon-btn.lightbox-dialog__close {
-  align-self: center;
+  align-self: start;
   border: 0;
   height: 32px;
   min-width: 32px;

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -52,6 +52,7 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow-wrap: anywhere;
 }
 .lightbox-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
@@ -105,7 +106,7 @@
 }
 button.icon-btn.lightbox-dialog__prev,
 button.icon-btn.lightbox-dialog__close {
-  align-self: start;
+  align-self: flex-start;
   border: 0;
   height: 32px;
   min-width: 32px;

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -52,9 +52,6 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .panel-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
@@ -89,7 +86,7 @@
   margin-top: var(--spacing-200);
 }
 button.icon-btn.panel-dialog__close {
-  align-self: center;
+  align-self: start;
   border: 0;
   height: 32px;
   min-width: 32px;

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -52,12 +52,14 @@
   align-self: center;
   flex: 1 1 auto;
   margin: 0;
+  overflow-wrap: anywhere;
 }
 .panel-dialog__header > :last-child:not(:only-child) {
   -webkit-margin-start: var(--spacing-200);
           margin-inline-start: var(--spacing-200);
 }
 .panel-dialog__header .fake-link {
+  align-self: flex-start;
   outline-offset: 4px;
   text-decoration: none;
 }
@@ -86,7 +88,7 @@
   margin-top: var(--spacing-200);
 }
 button.icon-btn.panel-dialog__close {
-  align-self: start;
+  align-self: flex-start;
   border: 0;
   height: 32px;
   min-width: 32px;

--- a/dist/toast-dialog/toast-dialog.css
+++ b/dist/toast-dialog/toast-dialog.css
@@ -52,8 +52,9 @@
   margin: 0;
 }
 button.toast-dialog__close {
-  align-self: center;
+  align-self: start;
   border: 0;
+  flex-shrink: 0;
   color: var(--toast-dialog-foreground-color, var(--color-foreground-on-information));
   -webkit-margin-start: auto;
           margin-inline-start: auto;

--- a/dist/toast-dialog/toast-dialog.css
+++ b/dist/toast-dialog/toast-dialog.css
@@ -52,7 +52,7 @@
   margin: 0;
 }
 button.toast-dialog__close {
-  align-self: start;
+  align-self: flex-start;
   border: 0;
   flex-shrink: 0;
   color: var(--toast-dialog-foreground-color, var(--color-foreground-on-information));

--- a/src/less/alert-dialog/stories/alert-dialog.stories.js
+++ b/src/less/alert-dialog/stories/alert-dialog.stories.js
@@ -31,3 +31,19 @@ export const textSpacing = () => `
     </div>
 </div>
 `;
+
+export const baseWithHeaderOverflow = () => `
+<div aria-labelledby="alert-dialog-title" aria-modal="true" class="alert-dialog alert-dialog--mask-fade" role="alertdialog">
+    <div class="alert-dialog__window alert-dialog__window--fade">
+        <div class="alert-dialog__header">
+            <h2 id="alert-dialog-title" class="alert-dialog__title">Alert! This title is so long that it wraps to the next line. No dialog should ever have a title this long.</h2>
+        </div>
+        <div class="alert-dialog__main">
+            <p id="alert-description-0">You must acknowledge this alert to continue.</p>
+        </div>
+        <div class="alert-dialog__footer">
+            <button class="btn btn--primary alert-dialog__acknowledge" aria-describedby="alert-description-0">OK</button>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/confirm-dialog/stories/confirm-dialog.stories.js
+++ b/src/less/confirm-dialog/stories/confirm-dialog.stories.js
@@ -33,3 +33,20 @@ export const textSpacing = () => `
     </div>
 </div>
 `;
+
+export const baseWithHeaderOverflow = () => `
+<div aria-labelledby="confirm-dialog-title" aria-modal="true" class="confirm-dialog confirm-dialog--mask-fade" role="dialog">
+    <div class="confirm-dialog__window confirm-dialog__window--fade">
+        <div class="confirm-dialog__header">
+            <h2 id="confirm-dialog-title" class="confirm-dialog__title">This title is long enough that it needs to wrap into multiple lines. No dialog header should ever be this long.</h2>
+        </div>
+        <div class="confirm-dialog__main">
+            <p id="confirm-dialog__description">You will permanently lose this address.</p>
+        </div>
+        <div class="confirm-dialog__footer">
+            <button class="btn confirm-dialog__reject">Cancel</button>
+            <button class="btn btn--primary confirm-dialog__confirm" aria-describedby="confirm-dialog__description">Delete</button>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/drawer-dialog/drawer-dialog.less
+++ b/src/less/drawer-dialog/drawer-dialog.less
@@ -66,11 +66,13 @@
 
 // inherits from .icon-btn
 // Added icon button selector so it doesn't override fake-link
-button.icon-button.drawer-dialog__close {
-    background-color: transparent;
+button.icon-btn.drawer-dialog__close {
+    align-self: start;
     border: 0;
-    height: auto;
-    outline-offset: -8px;
+    height: 32px;
+    min-width: 32px;
+    position: relative;
+    width: 32px;
     z-index: 1;
 }
 

--- a/src/less/drawer-dialog/drawer-dialog.less
+++ b/src/less/drawer-dialog/drawer-dialog.less
@@ -17,6 +17,7 @@
 }
 
 .drawer-dialog__header .fake-link {
+    align-self: flex-start;
     text-decoration: none;
 }
 
@@ -67,7 +68,7 @@
 // inherits from .icon-btn
 // Added icon button selector so it doesn't override fake-link
 button.icon-btn.drawer-dialog__close {
-    align-self: start;
+    align-self: flex-start;
     border: 0;
     height: 32px;
     min-width: 32px;

--- a/src/less/drawer-dialog/stories/drawer-dialog.stories.js
+++ b/src/less/drawer-dialog/stories/drawer-dialog.stories.js
@@ -256,3 +256,30 @@ export const textClose = () => `
     </div>
 </div>
 `;
+
+export const withFooterAndHeaderOverflow = () => `
+<div aria-labelledby="drawer-dialog-title" aria-modal="true" class="drawer-dialog drawer-dialog--mask-fade-slow" role="dialog">
+    <div class="drawer-dialog__window drawer-dialog__window--slide">
+        <button class="drawer-dialog__handle"></button>
+        <div class="drawer-dialog__header">
+            <h2 id="dialog-title" class="large-text-1 bold-text">Heading that is so long it needs to wrap across multiple lines. In order for this to happen, text needs to span the entire width of the screen. No dialog header should ever be this long.</h2>
+            <button aria-label="Close dialog" class="icon-btn drawer-dialog__close" type="button">
+                <svg aria-hidden="true" class="icon icon--close-16" height="16" width="16">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="drawer-dialog__main">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            </p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+        <div class="drawer-dialog__footer">
+            <button class="btn">Cancel</button>
+            <button class="btn btn--primary">Submit</button>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/fullscreen-dialog/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/fullscreen-dialog.less
@@ -46,7 +46,7 @@ button.icon-btn.fullscreen-dialog__close {
 // inherits from .icon-btn
 button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
-    align-self: center;
+    align-self: start;
     border: 0;
     padding: 0;
     position: relative;

--- a/src/less/fullscreen-dialog/fullscreen-dialog.less
+++ b/src/less/fullscreen-dialog/fullscreen-dialog.less
@@ -23,6 +23,7 @@
 }
 
 .fullscreen-dialog__header .fake-link {
+    align-self: flex-start;
     outline-offset: 4px;
     text-decoration: none;
 }
@@ -46,7 +47,7 @@ button.icon-btn.fullscreen-dialog__close {
 // inherits from .icon-btn
 button.fullscreen-dialog__close,
 button.fullscreen-dialog__back {
-    align-self: start;
+    align-self: flex-start;
     border: 0;
     padding: 0;
     position: relative;

--- a/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
+++ b/src/less/fullscreen-dialog/stories/fullscreen-dialog.stories.js
@@ -143,3 +143,26 @@ export const textSpacing = () => `
     </div>
 </div>
 `;
+
+export const closeButtonWithHeaderOverflow = () => `
+<div aria-labelledby="fullscreen-dialog-title" aria-modal="true" class="fullscreen-dialog" role="dialog">
+    <div class="fullscreen-dialog__window">
+        <div class="fullscreen-dialog__header">
+            <h2 id="fullscreen-dialog-title">Dialog Full screen with title so long that it needs to wrap into multiple lines. This is a fullscreen dialog so it needs to be even longer than in others before it overflows. No dialog header should ever be this long.</h2>
+            <button class="icon-btn fullscreen-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="fullscreen-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -61,7 +61,7 @@
 // Might need to see if icon-btn can support a small version
 button.icon-btn.lightbox-dialog__prev,
 button.icon-btn.lightbox-dialog__close {
-    align-self: start;
+    align-self: flex-start;
     border: 0;
     height: 32px;
     min-width: 32px;

--- a/src/less/lightbox-dialog/lightbox-dialog.less
+++ b/src/less/lightbox-dialog/lightbox-dialog.less
@@ -61,7 +61,7 @@
 // Might need to see if icon-btn can support a small version
 button.icon-btn.lightbox-dialog__prev,
 button.icon-btn.lightbox-dialog__close {
-    align-self: center;
+    align-self: start;
     border: 0;
     height: 32px;
     min-width: 32px;

--- a/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
+++ b/src/less/lightbox-dialog/stories/lightbox-dialog.stories.js
@@ -516,3 +516,27 @@ export const textSpacing = () => `
     </div>
 </div>
 `;
+
+export const baseWithHeaderOverflow = () => `
+<div aria-labelledby="lightbox-dialog-title" aria-modal="true" class="lightbox-dialog" role="dialog">
+    <div class="lightbox-dialog__window">
+        <button class="lightbox-dialog__handle" aria-label="Expand Dialog" type="button"></button>
+        <div class="lightbox-dialog__header">
+            <h2 id="lightbox-dialog-title">Dialog Lightbox with a title that is so long it wraps across multiple lines. No dialog header should ever be this long.</h2>
+            <button class="icon-btn lightbox-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="lightbox-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/mixins/private/dialog-mixins.less
+++ b/src/less/mixins/private/dialog-mixins.less
@@ -71,9 +71,6 @@
         align-self: center;
         flex: 1 1 auto;
         margin: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
     }
 
     & > :last-child:not(:only-child) {

--- a/src/less/mixins/private/dialog-mixins.less
+++ b/src/less/mixins/private/dialog-mixins.less
@@ -71,6 +71,7 @@
         align-self: center;
         flex: 1 1 auto;
         margin: 0;
+        overflow-wrap: anywhere;
     }
 
     & > :last-child:not(:only-child) {

--- a/src/less/panel-dialog/panel-dialog.less
+++ b/src/less/panel-dialog/panel-dialog.less
@@ -48,7 +48,7 @@
 // inherits from .icon-btn
 // Might need to see to add a small icon btn
 button.icon-btn.panel-dialog__close {
-    align-self: center;
+    align-self: start;
     border: 0;
     height: 32px;
     min-width: 32px;

--- a/src/less/panel-dialog/panel-dialog.less
+++ b/src/less/panel-dialog/panel-dialog.less
@@ -30,6 +30,7 @@
 }
 
 .panel-dialog__header .fake-link {
+    align-self: flex-start;
     outline-offset: 4px;
     text-decoration: none;
 }
@@ -48,7 +49,7 @@
 // inherits from .icon-btn
 // Might need to see to add a small icon btn
 button.icon-btn.panel-dialog__close {
-    align-self: start;
+    align-self: flex-start;
     border: 0;
     height: 32px;
     min-width: 32px;

--- a/src/less/panel-dialog/stories/panel-dialog.stories.js
+++ b/src/less/panel-dialog/stories/panel-dialog.stories.js
@@ -247,3 +247,26 @@ export const textSpacing = () => `
     </div>
 </div>
 `;
+
+export const panelStartWithHeaderOverflow = () => `
+<div aria-labelledby="panel-title" aria-modal="true" class="panel-dialog" role="dialog">
+    <div class="panel-dialog__window">
+        <div class="panel-dialog__header">
+            <h2 id="panel-title">Left Panel with a title that's so long it wraps to the next line. No dialog should ever have a title this long.</h2>
+            <button class="icon-btn panel-dialog__close" type="button" aria-label="Close Dialog">
+                <svg class="icon icon--close-16" aria-hidden="true">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="panel-dialog__main">
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <h3>Heading</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus convallis molestie erat, ut adipiscing risus blandit vel. Vivamus luctus elementum lorem, eu sodales velit sagittis id.</p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+        </div>
+    </div>
+</div>
+`;

--- a/src/less/toast-dialog/stories/toast-dialog.stories.js
+++ b/src/less/toast-dialog/stories/toast-dialog.stories.js
@@ -92,3 +92,25 @@ export const textSpacing = () => `
     </div>
 </aside>
 `;
+
+export const primaryActionWithHeaderOverflow = () => `
+<aside class="toast-dialog" aria-label="Notification" aria-live="polite" aria-modal="false" role="dialog">
+    <div class="toast-dialog__window">
+        <div class="toast-dialog__header">
+            <h2>User Privacy Preferences but with a title that's super long so it wraps to the next line. No dialog header should ever be this long.</h2>
+            <button class="icon-btn icon-btn--transparent toast-dialog__close" type="button" aria-label="Close notification dialog">
+                <svg class="icon icon--close icon--close-16">
+                    <use href="#icon-close-16"></use>
+                </svg>
+            </button>
+        </div>
+        <div class="toast-dialog__main">
+            <p>We detected something unusual about a recent sign-in to your eBay account.
+            To help keep you safe, we recommend you change the password.</p>
+        </div>
+        <div class="toast-dialog__footer">
+            <button accesskey="a" class="btn btn--primary">Accept</button>
+        </div>
+    </div>
+</aside>
+`;

--- a/src/less/toast-dialog/toast-dialog.less
+++ b/src/less/toast-dialog/toast-dialog.less
@@ -65,7 +65,7 @@
 
 // inherits from .icon-btn
 button.toast-dialog__close {
-    align-self: start;
+    align-self: flex-start;
     border: 0;
     flex-shrink: 0;
     .color-token(toast-dialog-foreground-color, color-foreground-on-information);

--- a/src/less/toast-dialog/toast-dialog.less
+++ b/src/less/toast-dialog/toast-dialog.less
@@ -65,8 +65,9 @@
 
 // inherits from .icon-btn
 button.toast-dialog__close {
-    align-self: center;
+    align-self: start;
     border: 0;
+    flex-shrink: 0;
     .color-token(toast-dialog-foreground-color, color-foreground-on-information);
     // margin: 0 0 0 auto;
     margin-inline-start: auto;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
- Fixes #2333

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
- Wrap instead of truncating titles in dialogs.
- Ensure that any icons/buttons on the same flex row as the title align to top instead of center.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<img width="677" alt="image" src="https://github.com/eBay/skin/assets/26027232/44e7a42a-78a5-4de3-ba88-7b5280b36f79">
<img width="661" alt="image" src="https://github.com/eBay/skin/assets/26027232/a589145b-f0dd-4266-a4aa-dc18c7d41ea9">
<img width="660" alt="image" src="https://github.com/eBay/skin/assets/26027232/5b8e28ca-709c-4aaa-9729-2bc739885aa4">
<img width="404" alt="image" src="https://github.com/eBay/skin/assets/26027232/9e35607f-72df-4847-b3a9-6e9cea248cf5">
<img width="491" alt="image" src="https://github.com/eBay/skin/assets/26027232/6a55be7b-2019-4cb7-a92d-41801e67a14d">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
