### PR TITLE
fix(fake-menu): added badge support

### DIFF
--- a/.changeset/khaki-fans-pretend.md
+++ b/.changeset/khaki-fans-pretend.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fake-menu: added badge suport

--- a/dist/menu/menu.css
+++ b/dist/menu/menu.css
@@ -32,6 +32,7 @@ span.fake-menu__items {
 }
 .menu__item > svg.icon--tick-16:last-child,
 .fake-menu__item > svg.icon--tick-16:last-child,
+.fake-menu__item .badge,
 .menu__item .badge {
   margin-left: var(--spacing-100);
   margin-right: var(--spacing-100);

--- a/src/less/menu/menu.less
+++ b/src/less/menu/menu.less
@@ -33,6 +33,7 @@ span.fake-menu__items {
 
 .menu__item > svg.icon--tick-16:last-child,
 .fake-menu__item > svg.icon--tick-16:last-child,
+.fake-menu__item .badge,
 .menu__item .badge {
     margin-left: var(--spacing-100);
     margin-right: var(--spacing-100);

--- a/src/less/menu/stories/fake-menu.stories.js
+++ b/src/less/menu/stories/fake-menu.stories.js
@@ -97,3 +97,13 @@ export const buttonsDisabled = () => `
     </ul>
 </div>
 `;
+
+export const badged = () => `
+<span class="fake-menu">
+    <span class="fake-menu__items" role="menu">
+        <a class="fake-menu__item fake-menu__item--badged" role="menuitem" href="https://www.ebay.com"><span>Button 1<span class="badge">1</span></span></a>
+        <a class="fake-menu__item fake-menu__item--badged" role="menuitem" href="https://www.ebay.com"><span>Button 2<span class="badge">10</span></span></a>
+        <a class="fake-menu__item fake-menu__item--badged" role="menuitem" href="https://www.ebay.com"><span>Button 3<span class="badge">99+</span></span></a>
+    </span>
+</span>
+`;


### PR DESCRIPTION
Fixes #2208

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added `badge` selector for `fake-menu`

## Notes
* Added new story for it 

## Screenshots
<img width="293" alt="Screenshot 2024-05-14 at 11 50 38 AM" src="https://github.com/eBay/skin/assets/1755269/45e64694-9c61-47ec-bbfd-d618214d508d">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue


- [X] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
