### PR TITLE
docs: update Design System name mapping for modules

### DIFF
--- a/.changeset/lovely-apples-watch.md
+++ b/.changeset/lovely-apples-watch.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+docs: update Design System name mapping for modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,6 @@ Add applicable metadata about the component to the `module_metadata` map in [doc
 ```yaml
 your-module-name: # the Skin module name
     ds-component: # module's relationship with the eBay Design System
-        group: # eBay Design System component group
         name: # eBay Design System component name
         version: # version of the eBay Design System component implemented in Skin
     status: # status, e.g. "beta", "deprecated", "in-progress"

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@ ds: 6
 module_metadata:
   alert-dialog:
     ds-component:
-      name: alert-dialog
+      name: dialog
       version: 2.1
     submodules:
       - button
@@ -153,7 +153,7 @@ module_metadata:
       - icon
   lightbox-dialog:
     ds-component:
-      - name: modal
+      - name: dialog
         version: 2.1
       - name: bottom-sheet
         version: 2.1

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,6 @@ module_metadata:
       - icon
   button:
     ds-component:
-      group: button
       name: button
       version: 1.6
   carousel:
@@ -49,11 +48,11 @@ module_metadata:
       version: 1.0
   chip:
     ds-component:
-      name: input-chip
+      name: chip
       version: 1.0.0
   chips-combobox:
     ds-component:
-      name: chip-combobox
+      name: combobox
       version: 1.0.0
     submodules:
       - chip
@@ -74,7 +73,6 @@ module_metadata:
       - button
   cta-button:
     ds-component:
-      group: button
       name: button
       version: 1.2
   date-textbox:
@@ -103,7 +101,7 @@ module_metadata:
       version: 1.0
   eek:
     ds-component:
-      name: eek
+      name: eek-ratings
       version: 1.1
     submodules:
       - icon
@@ -143,7 +141,7 @@ module_metadata:
       - icon
   infotip:
     ds-component:
-      name: infotip
+      name: tourtip
       version: 2.0
     submodules:
       - icon-button
@@ -228,7 +226,7 @@ module_metadata:
       version: 3.1
   progress-bar-expressive:
     ds-component:
-      name: expressive-loader
+      name: loading-expressive
       version: 1.1
   progress-spinner:
     ds-component:
@@ -271,7 +269,7 @@ module_metadata:
       version: 1.0
   skeleton:
     ds-component:
-      name: skeleton
+      name: loading-skeleton
       status: beta
       version: 1.0
   snackbar-dialog:
@@ -282,7 +280,6 @@ module_metadata:
       - button
   split-button:
     ds-component:
-      group: button
       name: split-button
       version: 1.6
     submodules:
@@ -302,11 +299,13 @@ module_metadata:
       version: 2.1
   tabs:
     ds-component:
-      name: tabs
+      name: tab
       version: 2.1
   textbox:
     ds-component:
-      name: form-field
+      name:
+      - text-area
+      - text-field
       version: 2.2
     submodules:
       - icon-button

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@ module_metadata:
       - button
   cta-button:
     ds-component:
-      name: button
+      name: cta-button
       version: 1.2
   date-textbox:
     ds-component:

--- a/docs/index.html
+++ b/docs/index.html
@@ -303,10 +303,10 @@ module_metadata:
       version: 2.1
   textbox:
     ds-component:
-      name:
-      - text-area
-      - text-field
-      version: 2.2
+      - name: text-area
+        version: 2.2
+      - name: text-field
+        version: 2.2
     submodules:
       - icon-button
   toast-dialog:

--- a/docs/index.html
+++ b/docs/index.html
@@ -134,7 +134,6 @@ module_metadata:
       version: 1.3
   icon-button:
     ds-component:
-      group: button
       name: icon-button
       version: 1.6
     submodules:

--- a/scripts/develop-module_proper/code-generators/doc-generator.js
+++ b/scripts/develop-module_proper/code-generators/doc-generator.js
@@ -36,7 +36,6 @@ const getMainContent = (moduleId) => `
 
 const getMetadataContent = (moduleId) => `  ${moduleId}:
     ds-component: # module's relationship with the eBay Design System
-      group: # eBay Design System component group
       name: # eBay Design System component name
       version: # version of the eBay Design System component implemented in Skin
     status: # status, e.g. "beta", "deprecated", "in-progress"


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Addresses #2371

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
Update a few modules' Design System component name mappings to match our latest Design System canonical names, so we can accurately query for component status. Simplify this mapping by removing the optional `group` field, which our Component Status API can infer from name.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
N/A

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue
