### PR TITLE
fix(tokens): update foreground background attention color

### DIFF
--- a/.changeset/fluffy-balloons-love.md
+++ b/.changeset/fluffy-balloons-love.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+color-tokens: fix foreground and background attention colors

--- a/dist/tokens/evo-light.css
+++ b/dist/tokens/evo-light.css
@@ -4,7 +4,7 @@
     --color-background-tertiary: var(--color-neutral-300);
     --color-background-disabled: var(--color-neutral-400);
     --color-background-inverse: var(--color-neutral-700);
-    --color-background-attention: var(--color-red-500);
+    --color-background-attention: var(--color-red-600);
     --color-background-confirmation: var(--color-kiwi-600);
     --color-background-information: var(--color-blue-500);
     --color-background-education: #ecf7fe;
@@ -14,7 +14,7 @@
     --color-foreground-primary: var(--color-neutral-800);
     --color-foreground-secondary: var(--color-neutral-600);
     --color-foreground-disabled: var(--color-neutral-400);
-    --color-foreground-attention: var(--color-red-500);
+    --color-foreground-attention: var(--color-red-600);
     --color-foreground-confirmation: var(--color-kiwi-600);
     --color-foreground-information: var(--color-blue-500);
     --color-foreground-accent: var(--color-blue-500);

--- a/src/tokens/evo-light.css
+++ b/src/tokens/evo-light.css
@@ -4,7 +4,7 @@
     --color-background-tertiary: var(--color-neutral-300);
     --color-background-disabled: var(--color-neutral-400);
     --color-background-inverse: var(--color-neutral-700);
-    --color-background-attention: var(--color-red-500);
+    --color-background-attention: var(--color-red-600);
     --color-background-confirmation: var(--color-kiwi-600);
     --color-background-information: var(--color-blue-500);
     --color-background-education: #ecf7fe;
@@ -14,7 +14,7 @@
     --color-foreground-primary: var(--color-neutral-800);
     --color-foreground-secondary: var(--color-neutral-600);
     --color-foreground-disabled: var(--color-neutral-400);
-    --color-foreground-attention: var(--color-red-500);
+    --color-foreground-attention: var(--color-red-600);
     --color-foreground-confirmation: var(--color-kiwi-600);
     --color-foreground-information: var(--color-blue-500);
     --color-foreground-accent: var(--color-blue-500);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2388 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Update background-attention and foreground-attention as per [playbook](https://playbook.ebaydesign.tech/design-system/tokens/color-tokens)

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

Write color contrast:

<img width="321" alt="Screen Shot 2024-07-22 at 12 08 20 PM" src="https://github.com/user-attachments/assets/eb4f865c-3ed7-4238-9bab-478d790fb633">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
