### PR TITLE
fix(textbox): fixed large textbox height

### DIFF
--- a/.changeset/curvy-bobcats-tie.md
+++ b/.changeset/curvy-bobcats-tie.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(textbox): fixed large textbox height

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -148,6 +148,7 @@ textarea.textbox__control::placeholder {
     opacity: 1;
 }
 
+.textbox--large,
 .textbox--large > input.textbox__control {
     height: 48px;
 }

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -153,10 +153,6 @@ textarea.textbox__control::placeholder {
     opacity: 1;
 }
 
-.textbox--large {
-    height: var(--input-large-height);
-}
-
 input.textbox__control {
     height: calc(var(--input-default-height) - 2px);
 }

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -1,3 +1,8 @@
+:root {
+    --input-default-height: 40px;
+    --input-large-height: 48px;
+}
+
 .textbox {
     align-items: center;
     background-color: var(
@@ -148,9 +153,16 @@ textarea.textbox__control::placeholder {
     opacity: 1;
 }
 
-.textbox--large,
-.textbox--large > input.textbox__control {
+.textbox--large {
     height: 48px;
+}
+
+input.textbox__control {
+    height: calc(var(--input-default-height) - 2px);
+}
+
+.textbox--large input.textbox__control {
+    height: calc(var(--input-large-height) - 2px);
 }
 
 .textbox .icon-btn > svg,

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -154,7 +154,7 @@ textarea.textbox__control::placeholder {
 }
 
 .textbox--large {
-    height: 48px;
+    height: var(--input-large-height);
 }
 
 input.textbox__control {

--- a/src/sass/textbox/textbox.scss
+++ b/src/sass/textbox/textbox.scss
@@ -198,10 +198,6 @@ textarea.textbox__control {
     }
 }
 
-.textbox--large {
-    height: var(--input-large-height);
-}
-
 input.textbox__control {
     height: calc(var(--input-default-height) - 2px);
 }

--- a/src/sass/textbox/textbox.scss
+++ b/src/sass/textbox/textbox.scss
@@ -1,6 +1,11 @@
 @import "../variables/variables";
 @import "../mixins/private/token-mixins";
 
+:root {
+    --input-default-height: 40px;
+    --input-large-height: 48px;
+}
+
 .textbox {
     @include color-token(
         textbox-foreground-color,
@@ -197,8 +202,12 @@ textarea.textbox__control {
     height: 48px;
 }
 
-.textbox--large > input.textbox__control {
-    height: 48px;
+input.textbox__control {
+    height: calc(var(--input-default-height) - 2px);
+}
+
+.textbox--large input.textbox__control {
+    height: calc(var(--input-large-height) - 2px);
 }
 
 .textbox > svg,

--- a/src/sass/textbox/textbox.scss
+++ b/src/sass/textbox/textbox.scss
@@ -193,6 +193,10 @@ textarea.textbox__control {
     }
 }
 
+.textbox--large {
+    height: 48px;
+}
+
 .textbox--large > input.textbox__control {
     height: 48px;
 }

--- a/src/sass/textbox/textbox.scss
+++ b/src/sass/textbox/textbox.scss
@@ -199,7 +199,7 @@ textarea.textbox__control {
 }
 
 .textbox--large {
-    height: 48px;
+    height: var(--input-large-height);
 }
 
 input.textbox__control {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2389 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixes large textbox height.

## Screenshots

**Before**

<kbd><img width="369" alt="Screenshot 2024-07-24 at 8 44 13 AM" src="https://github.com/user-attachments/assets/93c2ee9f-502d-452d-a90a-de50e70aebcf"></kbd>


**After**

<kbd><img width="380" alt="Screenshot 2024-07-24 at 8 45 01 AM" src="https://github.com/user-attachments/assets/14d1ab70-ef08-4608-bb50-c67b8bb426a8"></kbd>


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
