### PR TITLE
fix(textbox): fixed textbox overlap

### DIFF
--- a/.changeset/curvy-bobcats-tie.md
+++ b/.changeset/curvy-bobcats-tie.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(textbox): fixed large textbox height

--- a/.changeset/honest-maps-jog.md
+++ b/.changeset/honest-maps-jog.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+fix(textbox): fixed textbox overlap

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -148,6 +148,7 @@ textarea.textbox__control::placeholder {
     opacity: 1;
 }
 
+.textbox--large,
 .textbox--large > input.textbox__control {
     height: 48px;
 }

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -16,6 +16,7 @@
     display: inline-flex;
     font-size: var(--font-size-default);
     gap: var(--spacing-100);
+    overflow: hidden;
     position: relative;
     width: -moz-fit-content;
     width: fit-content;

--- a/src/sass/textbox/textbox.scss
+++ b/src/sass/textbox/textbox.scss
@@ -193,6 +193,10 @@ textarea.textbox__control {
     }
 }
 
+.textbox--large {
+    height: 48px;
+}
+
 .textbox--large > input.textbox__control {
     height: 48px;
 }

--- a/src/sass/textbox/textbox.scss
+++ b/src/sass/textbox/textbox.scss
@@ -21,6 +21,7 @@
 
     /* to align with buttons and select, it needs same font-size */
     font-size: var(--font-size-default);
+    overflow: hidden;
     position: relative;
     width: fit-content;
     gap: var(--spacing-100);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2386 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Fixed the textbox input overlapping the rounded corners.

## Screenshots

**Before**

<kbd><img width="251" alt="Screenshot 2024-07-24 at 12 12 51 PM" src="https://github.com/user-attachments/assets/78545240-cbba-4b7e-9572-c2e0d648a316"></kbd>

**After**

<kbd><img width="239" alt="Screenshot 2024-07-24 at 12 13 25 PM" src="https://github.com/user-attachments/assets/9f010ee9-349d-42a4-8617-37d29404c807"></kbd>

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
