### PR TITLE
docs(button): fix busy state broken example

### DIFF
--- a/docs/_includes/button.html
+++ b/docs/_includes/button.html
@@ -226,7 +226,7 @@
                 <button class="btn btn--primary" aria-label="Busy...">
                     <span class="btn__cell">
                         <span class="progress-spinner">
-                            <svg aria-hidden="true" class="icon icon--30" height="30" width="30">
+                            <svg aria-hidden="true" class="icon icon--24" height="24" width="24">
                                 {% include symbol.html name="spinner-24" %}
                             </svg>
                         </span>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2394 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Use correct spinner-24 instead of spinner-30

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="674" alt="Screen Shot 2024-07-25 at 9 54 43 AM" src="https://github.com/user-attachments/assets/e1b67a43-c529-401d-a622-846f924e7bc7">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
