### PR TITLE
fix(progress-spinner): wobble

### DIFF
--- a/.changeset/funny-months-fix.md
+++ b/.changeset/funny-months-fix.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+progress-spinner: fixed wobble

--- a/dist/progress-spinner/progress-spinner.css
+++ b/dist/progress-spinner/progress-spinner.css
@@ -13,9 +13,9 @@
         transform: rotate(2turn);
     }
 }
-.progress-spinner > svg.icon.icon--spinner-20,
-.progress-spinner > svg.icon.icon--spinner-24,
-.progress-spinner > svg.icon.icon--spinner-30 {
+.progress-spinner > svg.icon.icon--20,
+.progress-spinner > svg.icon.icon--24,
+.progress-spinner > svg.icon.icon--30 {
     height: inherit;
     margin: 0;
     max-height: inherit;

--- a/docs/_includes/button.html
+++ b/docs/_includes/button.html
@@ -226,7 +226,7 @@
                 <button class="btn btn--primary" aria-label="Busy...">
                     <span class="btn__cell">
                         <span class="progress-spinner">
-                            <svg aria-hidden="true" class="icon icon--30" height="30" width="30">
+                            <svg aria-hidden="true" class="icon icon--24" height="30" width="30">
                                 {% include symbol.html name="spinner-24" %}
                             </svg>
                         </span>

--- a/src/sass/button/stories/button/base.stories.js
+++ b/src/sass/button/stories/button/base.stories.js
@@ -37,6 +37,18 @@ export const busy = () => `
 </button>
 `;
 
+export const busyLarge = () => `
+<button class="btn btn--large" aria-label="Busy">
+    <span class="btn__cell">
+        <span class="progress-spinner">
+            <svg class="icon icon--24" aria-hidden="true">
+                <use href="#icon-spinner-24"></use>
+            </svg>
+        </span>
+    </span>
+</button>
+`;
+
 export const formBusy = () => `
 <button class="btn btn--form" aria-label="Busy">
     <span class="btn__cell">

--- a/src/sass/progress-spinner/progress-spinner.scss
+++ b/src/sass/progress-spinner/progress-spinner.scss
@@ -20,9 +20,9 @@
 }
 
 /* fixes wobble */
-.progress-spinner > svg.icon.icon--spinner-20,
-.progress-spinner > svg.icon.icon--spinner-24,
-.progress-spinner > svg.icon.icon--spinner-30 {
+.progress-spinner > svg.icon.icon--20,
+.progress-spinner > svg.icon.icon--24,
+.progress-spinner > svg.icon.icon--30 {
     height: inherit;
     margin: 0;
     max-height: inherit;


### PR DESCRIPTION

Fixes #2397


- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* We had some styles which fixed the progress spinner wobble but they were targetting the old classes instead of the new. 

## Notes
* Added story for large button with progress spinner

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue


- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
