### PR TITLE
feat(details): updated styling

### DIFF
--- a/.changeset/dull-chicken-dance.md
+++ b/.changeset/dull-chicken-dance.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+details: updated design

--- a/dist/details/details.css
+++ b/dist/details/details.css
@@ -3,9 +3,11 @@ summary.details__summary {
     box-sizing: border-box;
     color: var(
         --details-summary-foreground-color,
-        var(--color-foreground-accent)
+        var(--color-foreground-primary)
     );
-    display: inline-block;
+    display: inline-flex;
+    font-size: var(--font-size-default);
+    font-weight: var(--font-weight-bold);
     list-style-position: inside;
     list-style-type: none;
     padding: 12px 8px;
@@ -19,11 +21,11 @@ summary.details__summary::-webkit-details-marker {
 }
 summary.details__summary:focus,
 summary.details__summary:hover {
-    color: var(--color-state-accent-hover);
+    outline: 1;
 }
 
 summary.details__summary--center {
-    text-align: center;
+    justify-content: center;
 }
 
 summary.details__summary--small {
@@ -36,7 +38,7 @@ span.details__icon {
     margin-inline-start: 8px;
 }
 span.details__icon[hidden] {
-    display: inline-block;
+    display: inline-flex;
 }
 
 details.details[open] span.details__icon {

--- a/dist/details/details.css
+++ b/dist/details/details.css
@@ -11,7 +11,6 @@ summary.details__summary {
     list-style-position: inside;
     list-style-type: none;
     padding: 12px 8px;
-    width: 100%;
 }
 summary.details__summary:before {
     content: none;
@@ -26,6 +25,7 @@ summary.details__summary:hover {
 
 summary.details__summary--center {
     justify-content: center;
+    width: 100%;
 }
 
 summary.details__summary--small {

--- a/dist/details/details.css
+++ b/dist/details/details.css
@@ -1,5 +1,6 @@
 summary.details__summary {
     align-items: center;
+    border-radius: var(--expand-btn-border-radius, var(--border-radius-50));
     box-sizing: border-box;
     color: var(
         --details-summary-foreground-color,
@@ -20,6 +21,11 @@ summary.details__summary::-webkit-details-marker {
 }
 summary.details__summary:focus,
 summary.details__summary:hover {
+    background-color: var(--color-state-secondary-hover);
+    outline: 1;
+}
+summary.details__summary:active {
+    background-color: var(--color-state-secondary-active);
     outline: 1;
 }
 

--- a/docs/_includes/details.html
+++ b/docs/_includes/details.html
@@ -12,8 +12,8 @@
                 <summary class="details__summary">
                     <span class="details__label">Details</span>
                     <span class="details__icon" hidden>
-                        <svg class="icon icon--12" aria-hidden="true">
-                            {% include symbol.html name="chevron-down-12" %}
+                        <svg class="icon icon--16" aria-hidden="true">
+                            {% include symbol.html name="chevron-down-16" %}
                         </svg>
                     </span>
                 </summary>
@@ -27,8 +27,8 @@
     <summary class="details__summary">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -45,8 +45,8 @@
                 <summary class="details__summary">
                     <span class="details__label">Details</span>
                     <span class="details__icon" hidden>
-                        <svg class="icon icon--12" aria-hidden="true">
-                            {% include symbol.html name="chevron-down-12" %}
+                        <svg class="icon icon--16" aria-hidden="true">
+                            {% include symbol.html name="chevron-down-16" %}
                         </svg>
                     </span>
                 </summary>
@@ -60,8 +60,8 @@
     <summary class="details__summary">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -78,8 +78,8 @@
                 <summary class="details__summary details__summary--center">
                     <span class="details__label">Details</span>
                     <span class="details__icon" hidden>
-                        <svg class="icon icon--12" aria-hidden="true">
-                            {% include symbol.html name="chevron-down-12" %}
+                        <svg class="icon icon--16" aria-hidden="true">
+                            {% include symbol.html name="chevron-down-16" %}
                         </svg>
                     </span>
                 </summary>
@@ -93,8 +93,8 @@
     <summary class="details__summary details__summary--center">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -110,8 +110,8 @@
                 <summary class="details__summary details__summary--small">
                     <span class="details__label">Details</span>
                     <span class="details__icon" hidden>
-                        <svg class="icon icon--12" aria-hidden="true">
-                            {% include symbol.html name="chevron-down-12" %}
+                        <svg class="icon icon--16" aria-hidden="true">
+                            {% include symbol.html name="chevron-down-16" %}
                         </svg>
                     </span>
                 </summary>
@@ -125,8 +125,8 @@
     <summary class="details__summary details__summary--small">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -142,8 +142,8 @@
                 <summary class="details__summary">
                     <span class="details__label">Details</span>
                     <span class="details__icon" hidden>
-                        <svg class="icon icon--12" aria-hidden="true">
-                            {% include symbol.html name="chevron-down-12" %}
+                        <svg class="icon icon--16" aria-hidden="true">
+                            {% include symbol.html name="chevron-down-16" %}
                         </svg>
                     </span>
                 </summary>
@@ -156,8 +156,8 @@
     <summary class="details__summary">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>

--- a/docs/_includes/details.html
+++ b/docs/_includes/details.html
@@ -69,39 +69,6 @@
 </details>
     {% endhighlight %}
 
-    <h3>Centered Details</h3>
-    <p>Apply the <span class="highlight">details__summary--center</span> class to center the summary.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <details class="details">
-                <summary class="details__summary details__summary--center">
-                    <span class="details__label">Details</span>
-                    <span class="details__icon" hidden>
-                        <svg class="icon icon--16" aria-hidden="true">
-                            {% include symbol.html name="chevron-down-16" %}
-                        </svg>
-                    </span>
-                </summary>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-            </details>
-        </div>
-    </div>
-
-    {% highlight html %}
-<details class="details">
-    <summary class="details__summary details__summary--center">
-        <span class="details__label">Details</span>
-        <span class="details__icon" hidden>
-            <svg class="icon icon--16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
-        </span>
-    </summary>
-    <p>Sample content</p>
-</details>
-    {% endhighlight %}
-
     <h3>Small Details</h3>
     <p>Apply the <span class="highlight">details__summary--small</span> class to use the smaller version of summary.</p>
     <div class="demo">

--- a/src/sass/details/details.scss
+++ b/src/sass/details/details.scss
@@ -15,7 +15,6 @@ summary.details__summary {
     list-style-position: inside;
     list-style-type: none; /* Remove details marker for non-webkit */
     padding: 12px 8px;
-    width: 100%;
 
     &::before {
         content: none;
@@ -34,6 +33,7 @@ summary.details__summary {
 
 summary.details__summary--center {
     justify-content: center;
+    width: 100%;
 }
 
 summary.details__summary--small {

--- a/src/sass/details/details.scss
+++ b/src/sass/details/details.scss
@@ -6,10 +6,12 @@ summary.details__summary {
     box-sizing: border-box;
     @include color-token(
         details-summary-foreground-color,
-        color-foreground-accent
+        color-foreground-primary
     );
 
-    display: inline-block;
+    display: inline-flex;
+    font-size: var(--font-size-default);
+    font-weight: var(--font-weight-bold);
     list-style-position: inside;
     list-style-type: none; /* Remove details marker for non-webkit */
     padding: 12px 8px;
@@ -26,12 +28,12 @@ summary.details__summary {
 
     &:hover,
     &:focus {
-        color: var(--color-state-accent-hover);
+        outline: 1;
     }
 }
 
 summary.details__summary--center {
-    text-align: center;
+    justify-content: center;
 }
 
 summary.details__summary--small {
@@ -45,7 +47,7 @@ span.details__icon {
 
 /* progressive enhancement - override hidden SVG */
 span.details__icon[hidden] {
-    display: inline-block;
+    display: inline-flex;
 }
 
 details.details[open] {

--- a/src/sass/details/details.scss
+++ b/src/sass/details/details.scss
@@ -2,13 +2,14 @@
 @import "../mixins/private/token-mixins";
 
 summary.details__summary {
-    align-items: center;
-    box-sizing: border-box;
+    @include border-radius-token(expand-btn-border-radius, border-radius-50);
     @include color-token(
         details-summary-foreground-color,
         color-foreground-primary
     );
 
+    align-items: center;
+    box-sizing: border-box;
     display: inline-flex;
     font-size: var(--font-size-default);
     font-weight: var(--font-weight-bold);
@@ -25,8 +26,14 @@ summary.details__summary {
         display: none;
     }
 
-    &:hover,
-    &:focus {
+    &:focus,
+    &:hover {
+        background-color: var(--color-state-secondary-hover);
+        outline: 1;
+    }
+
+    &:active {
+        background-color: var(--color-state-secondary-active);
         outline: 1;
     }
 }

--- a/src/sass/details/stories/cascade.stories.js
+++ b/src/sass/details/stories/cascade.stories.js
@@ -6,8 +6,8 @@ export const RTL = () => `
         <summary class="details__summary">
             <span class="details__label">Details</span>
             <span class="details__icon" hidden>
-                <svg class="icon icon--12" aria-hidden="true">
-                    <use href="#icon-chevron-down-12"></use>
+                <svg class="icon icon--16" aria-hidden="true">
+                    <use href="#icon-chevron-down-16"></use>
                 </svg>
             </span>
         </summary>
@@ -22,8 +22,8 @@ export const colour = () => `
         <summary class="details__summary">
             <span class="details__label">Details</span>
             <span class="details__icon" hidden>
-                <svg class="icon icon--12" aria-hidden="true">
-                    <use href="#icon-chevron-down-12"></use>
+                <svg class="icon icon--16" aria-hidden="true">
+                    <use href="#icon-chevron-down-16"></use>
                 </svg>
             </span>
         </summary>
@@ -38,8 +38,8 @@ export const fontSize = () => `
         <summary class="details__summary">
             <span class="details__label">Details</span>
             <span class="details__icon" hidden>
-                <svg class="icon icon--12" aria-hidden="true">
-                    <use href="#icon-chevron-down-12"></use>
+                <svg class="icon icon--16" aria-hidden="true">
+                    <use href="#icon-chevron-down-16"></use>
                 </svg>
             </span>
         </summary>

--- a/src/sass/details/stories/details.stories.js
+++ b/src/sass/details/stories/details.stories.js
@@ -5,8 +5,8 @@ export const closed = () => `
     <summary class="details__summary">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -19,8 +19,8 @@ export const open = () => `
     <summary class="details__summary">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -33,8 +33,8 @@ export const textSpacing = () => `
     <summary class="details__summary">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -47,8 +47,8 @@ export const centered = () => `
     <summary class="details__summary details__summary--center">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
-            <svg class="icon icon--12" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
     </summary>
@@ -59,6 +59,36 @@ export const centered = () => `
 export const small = () => `
 <details class="details" open>
     <summary class="details__summary details__summary--small">
+        <span class="details__label">Details</span>
+        <span class="details__icon" hidden>
+            <svg class="icon icon--16" aria-hidden="true">
+                <use href="#icon-chevron-down-16"></use>
+            </svg>
+        </span>
+    </summary>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</details>
+`;
+
+// Deprecated stories
+export const closed12pxIcon = () => `
+<details class="details">
+    <summary class="details__summary">
+        <span class="details__label">Details</span>
+        <span class="details__icon" hidden>
+            <svg class="icon icon--12" aria-hidden="true">
+                <use href="#icon-chevron-down-12"></use>
+            </svg>
+        </span>
+    </summary>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</details>
+`;
+
+// Deprecated stories
+export const open12pxIcon = () => `
+<details class="details" open>
+    <summary class="details__summary">
         <span class="details__label">Details</span>
         <span class="details__icon" hidden>
             <svg class="icon icon--12" aria-hidden="true">


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2036

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Updated details visual style
* Fixed icon layout (for old icon it should still align)

## Notes
* Design wants width to be fixed to item. For now, I left it as is and have the width span the whole content of the button. This is in order to prevent possible layout shift if we have things on the left/right of it
This is what it looks like if we remove width 100% (current not in this change)
<img width="1253" alt="Screenshot 2024-07-29 at 11 01 45 AM" src="https://github.com/user-attachments/assets/b22d4f0d-5a36-4a94-b8fd-c68f86b9c9f5">
With width 100%
<img width="1226" alt="Screenshot 2024-07-29 at 10 45 03 AM" src="https://github.com/user-attachments/assets/a2ec0867-2849-4e2b-8cbd-0e47c5771172">

## Screenshots
Old icon (12px)
<img width="288" alt="Screenshot 2024-07-29 at 10 56 11 AM" src="https://github.com/user-attachments/assets/17efd8ba-8d93-4281-94ae-fa82d6af3334">
New Icon (16px)
<img width="265" alt="Screenshot 2024-07-29 at 10 56 56 AM" src="https://github.com/user-attachments/assets/5ec04924-0f4f-47cd-9305-c26e49835cba">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode

- [X] I added/updated/removed Storybook coverage as appropriate
