### PR TITLE
fix(textbox): use 100% width on input for fluid variant

### DIFF
--- a/.changeset/beige-buttons-check.md
+++ b/.changeset/beige-buttons-check.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": patch
+---
+
+Use 100% width on input for fluid variant

--- a/dist/textbox/textbox.css
+++ b/dist/textbox/textbox.css
@@ -199,6 +199,7 @@ textarea.textbox__control[readonly]:focus {
     text-decoration: underline;
 }
 
-.textbox--fluid {
+.textbox--fluid,
+.textbox--fluid .textbox__control {
     width: 100%;
 }

--- a/src/sass/textbox/stories/textbox.stories.js
+++ b/src/sass/textbox/stories/textbox.stories.js
@@ -59,8 +59,8 @@ export const errorWithValue = () => `
 `;
 
 export const fluid = () => `
-<div class="textbox">
-    <input class="textbox__control textbox__control--fluid" type="text" placeholder="placeholder text" />
+<div class="textbox textbox--fluid">
+    <input class="textbox__control" type="text" placeholder="placeholder text" />
 </div>
 `;
 

--- a/src/sass/textbox/textbox.scss
+++ b/src/sass/textbox/textbox.scss
@@ -242,6 +242,7 @@ textarea.textbox__control[readonly]:focus {
     text-decoration: underline;
 }
 
-.textbox--fluid {
+.textbox--fluid,
+.textbox--fluid .textbox__control {
     width: 100%;
 }


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2404 

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Added `width: 100%` for `textbox--fluid` variant on `input` element
- Updated `textbox` fluid story with new structure

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

Before
<img width="891" alt="Screenshot 2024-07-29 at 2 10 18 PM" src="https://github.com/user-attachments/assets/84db6fe8-a926-4cb3-b5c0-1febf1cc26e5">

After
<img width="891" alt="Screenshot 2024-07-29 at 2 10 23 PM" src="https://github.com/user-attachments/assets/54e92c8e-25bc-4ca9-be63-b23d72ced563">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [x] I added/updated/removed Storybook coverage as appropriate
