### PR TITLE
fix(toggle-button-group): fixed buttons per row and added min layout exceptions

### DIFF
--- a/.changeset/three-melons-decide.md
+++ b/.changeset/three-melons-decide.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fix(toggle-button-group): fixed buttons per row and added min layout exceptions

--- a/dist/toggle-button-group/toggle-button-group.css
+++ b/dist/toggle-button-group/toggle-button-group.css
@@ -9,7 +9,7 @@
     --row-list-toggle-buttons-sm: 2;
     --row-list-toggle-buttons-md: 3;
     --row-list-toggle-buttons-xl: 5;
-    --row-gallery-toggle-buttons-min: 1;
+    --row-gallery-toggle-buttons-min: 2;
     --row-gallery-toggle-buttons-xs: 2;
     --row-gallery-toggle-buttons-sm: 3;
     --row-gallery-toggle-buttons-md: 4;
@@ -20,6 +20,30 @@
     container: toggle-buttons-container/inline-size;
 }
 
+@supports not (contain: inline-size) {
+    @media (max-width: 320px) {
+        .toggle-button-group[data-columns-min="1"] ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .toggle-button-group[data-columns-min="2"] ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .toggle-button-group[data-columns-min="3"] ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+    }
+}
+@container toggle-buttons-container (inline-size < 320px) {
+    .toggle-button-group[data-columns-min="1"] ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .toggle-button-group[data-columns-min="2"] ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .toggle-button-group[data-columns-min="3"] ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
 .toggle-button-group ul {
     display: grid;
     gap: var(--spacing-100);
@@ -43,10 +67,18 @@
     max-width: 100%;
     width: 100%;
 }
+.toggle-button-group--list-layout ul {
+    grid-template-columns: repeat(var(--row-list-toggle-buttons-min), 1fr);
+}
+
 .toggle-button-group--list-layout .toggle-button {
     justify-content: left;
     max-width: 100%;
     min-width: auto;
+}
+
+.toggle-button-group--gallery-layout ul {
+    grid-template-columns: repeat(var(--row-gallery-toggle-buttons-min), 1fr);
 }
 
 .toggle-button-group--gallery-layout li {

--- a/src/sass/toggle-button-group/stories/gallery-layout-exceptions.stories.js
+++ b/src/sass/toggle-button-group/stories/gallery-layout-exceptions.stories.js
@@ -2,6 +2,123 @@ export default {
     title: "Skin/Toggle Button Group/Gallery Layout/Layouts Exceptions",
 };
 
+export const minContainer1button = () => `
+<div style="width: 240px; border: 1px dashed orange;">
+    <div class="toggle-button-group toggle-button-group--gallery-layout" data-columns-min="1">
+        <ul aria-label="Buttons">
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 30%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+
 export const _320container1button = () => `
 <div style="width: 320px; border: 1px dashed orange;">
     <div class="toggle-button-group toggle-button-group--gallery-layout" data-columns-xs="1">

--- a/src/sass/toggle-button-group/stories/gallery-layout.stories.js
+++ b/src/sass/toggle-button-group/stories/gallery-layout.stories.js
@@ -95,6 +95,123 @@ export const usingCSSImage = () => `
 </div>
 `;
 
+export const minContainer = () => `
+<div style="width: 280px; border: 1px dashed orange;">
+    <div class="toggle-button-group toggle-button-group--gallery-layout">
+        <ul aria-label="Buttons">
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 30%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-landscape-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image" style="background-image: url(https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-square-pic.jpg); background-repeat: no-repeat; background-position: center; background-size: cover; background-position: center 15%;">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Gallery Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+
 export const _320container = () => `
 <div style="width: 320px; border: 1px dashed orange;">
     <div class="toggle-button-group toggle-button-group--gallery-layout">

--- a/src/sass/toggle-button-group/stories/list-layout-exceptions.stories.js
+++ b/src/sass/toggle-button-group/stories/list-layout-exceptions.stories.js
@@ -2,6 +2,55 @@ export default {
     title: "Skin/Toggle Button Group/List Layout/Layouts Exceptions",
 };
 
+export const minContainer2buttons = () => `
+<div style="width: 280px; border: 1px dashed orange;">
+    <div class="toggle-button-group toggle-button-group--list-layout" data-columns-min="2">
+        <ul aria-label="Buttons">
+            <li>
+                <button type="button" class="toggle-button toggle-button--list-layout" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button toggle-button--list-layout" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button toggle-button--list-layout" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button toggle-button--list-layout" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button toggle-button--list-layout" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+
 export const _320container2buttons = () => `
 <div style="width: 320px; border: 1px dashed orange;">
     <div class="toggle-button-group toggle-button-group--list-layout" data-columns-xs="2">

--- a/src/sass/toggle-button-group/stories/list-layout.stories.js
+++ b/src/sass/toggle-button-group/stories/list-layout.stories.js
@@ -133,6 +133,132 @@ export const mixedContent = () => `
 </div>
 `;
 
+export const _minContainer = () => `
+<div style="width: 240px; border: 1px dashed orange;">
+    <div class="toggle-button-group toggle-button-group--list-layout">
+        <ul aria-label="Buttons">
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__image-container">
+                        <span class="toggle-button__image">
+                            <img src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/tb-profile-pic.jpg" alt="">
+                        </span>
+                    </span>
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">List Layout Title</span>
+                        <span class="toggle-button__subtitle">Subtitle</span>
+                    </span>
+                </button>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+
 export const _320container = () => `
 <div style="width: 320px; border: 1px dashed orange;">
     <div class="toggle-button-group toggle-button-group--list-layout">

--- a/src/sass/toggle-button-group/stories/minimal-layout-exceptions.stories.js
+++ b/src/sass/toggle-button-group/stories/minimal-layout-exceptions.stories.js
@@ -2,6 +2,78 @@ export default {
     title: "Skin/Toggle Button Group/Minimal Layout/Layouts Exceptions",
 };
 
+export const _mincontainer1button = () => `
+<div style="width: 240px; border: 1px dashed orange;">
+    <div class="toggle-button-group" data-columns-min="1">
+        <ul aria-label="Buttons">
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">4.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">5.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">6</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">6.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">7</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">7.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">8</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">8.5</span>
+                    </span>
+                </button>
+            </li>
+        </ul>
+    </div>
+</div>
+`;
+
 export const _320container3buttons = () => `
 <div style="width: 320px; border: 1px dashed orange;">
     <div class="toggle-button-group" data-columns-xs="3">

--- a/src/sass/toggle-button-group/stories/minimal-layout.stories.js
+++ b/src/sass/toggle-button-group/stories/minimal-layout.stories.js
@@ -1,5 +1,78 @@
 export default { title: "Skin/Toggle Button Group/Minimal Layout" };
 
+export const minContainer = () => `
+<div style="width: 240px; border: 1px dashed orange;">
+    <div class="toggle-button-group">
+        <ul aria-label="Buttons">
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">4.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false">
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">5.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">6</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">6.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">7</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">7.5</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">8</span>
+                    </span>
+                </button>
+            </li>
+            <li>
+                <button type="button" class="toggle-button" aria-pressed="false"> 
+                    <span class="toggle-button__content">
+                        <span class="toggle-button__title">8.5</span>
+                    </span>
+                </button>
+            </li>
+        </ul>
+    </div>
+</div>
+
+`;
+
 export const _320container = () => `
 <div style="width: 320px; border: 1px dashed orange;">
     <div class="toggle-button-group">

--- a/src/sass/toggle-button-group/toggle-button-group.scss
+++ b/src/sass/toggle-button-group/toggle-button-group.scss
@@ -38,7 +38,7 @@
     --row-list-toggle-buttons-xl: 5;
 
     // Gallery Layout
-    --row-gallery-toggle-buttons-min: 1;
+    --row-gallery-toggle-buttons-min: 2;
     --row-gallery-toggle-buttons-xs: 2;
     --row-gallery-toggle-buttons-sm: 3;
     --row-gallery-toggle-buttons-md: 4;
@@ -47,6 +47,38 @@
 
 .toggle-button-group {
     container: toggle-buttons-container / inline-size;
+}
+
+// These provide a generic override for the number of buttons per line
+// for containers under 320px wide. No more than 3 should be needed.
+@supports not (contain: inline-size) {
+    @media (max-width: $_screen-size-XS) {
+        .toggle-button-group[data-columns-min="1"] ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+
+        .toggle-button-group[data-columns-min="2"] ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        .toggle-button-group[data-columns-min="3"] ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+    }
+}
+
+@container toggle-buttons-container (inline-size < #{$_screen-size-XS}) {
+    .toggle-button-group[data-columns-min="1"] ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+
+    .toggle-button-group[data-columns-min="2"] ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .toggle-button-group[data-columns-min="3"] ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
 }
 
 .toggle-button-group ul {
@@ -74,10 +106,18 @@
 }
 
 /* Layout Themes */
+.toggle-button-group--list-layout ul {
+    grid-template-columns: repeat(var(--row-list-toggle-buttons-min), 1fr);
+}
+
 .toggle-button-group--list-layout .toggle-button {
     justify-content: left;
     max-width: 100%;
     min-width: auto;
+}
+
+.toggle-button-group--gallery-layout ul {
+    grid-template-columns: repeat(var(--row-gallery-toggle-buttons-min), 1fr);
 }
 
 .toggle-button-group--gallery-layout li {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2401 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
1. I fixed the list and gallery variation minimal screen/container buttons so that any container/screen under `320px` will use the actual `css` props. The `css` props implemented initially weren't actually being used for the respective button layouts.
2. I changed the default gallery variation minimal screen/container (`< 320px`) buttons to 2 since it has since now been using that inheriting the min layout button `css` prop, to avoid breaking current implementations and since it looks better overall.
3. I added 3 minimal layout (`< 320px`) exceptions for more implementation flexibility with *any* of the layout type buttons.
4. I added a few stories, both for the missing use cases and for the new minimal container exceptions for all the button layouts.

## Screenshots

**Before**

<kbd><img width="349" alt="image" src="https://github.com/user-attachments/assets/cdaaaa91-3303-43ce-943d-1eb58946c38c"></kbd>

**After**

<kbd><img width="345" alt="image" src="https://github.com/user-attachments/assets/9d3eed36-18fd-4210-bea9-8fb68a595348"></kbd>


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
