### PR TITLE
fix(fake-button): updated disabled styles

### DIFF
--- a/.changeset/fair-shoes-teach.md
+++ b/.changeset/fair-shoes-teach.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fix(fake-button): updated disabled styles

--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -39,6 +39,14 @@ button.btn[disabled] {
     );
 }
 
+a.fake-btn:not([href]),
+a.fake-btn[aria-disabled="true"] {
+    color: var(
+        --link-foreground-color-disabled,
+        var(--color-foreground-disabled)
+    );
+}
+
 a.fake-btn--borderless,
 button.btn--borderless {
     border-color: transparent;
@@ -302,6 +310,10 @@ a.fake-btn--primary[aria-disabled="true"] {
         --btn-primary-disabled-border-color,
         var(--color-foreground-disabled)
     );
+    color: var(
+        --btn-primary-foreground-color,
+        var(--color-foreground-on-accent)
+    );
 }
 
 a.fake-btn--secondary,
@@ -433,10 +445,15 @@ button.btn--tertiary:not([disabled], [aria-disabled="true"]):active {
 }
 
 a.fake-btn--tertiary:not([href]),
+a.fake-btn--tertiary[aria-disabled="true"],
 button.btn--tertiary[aria-disabled="true"]:not(
         [aria-live="polite"][aria-disabled="true"]
     ),
 button.btn--tertiary[disabled] {
+    border-color: var(
+        --expand-btn-disabled-border-color,
+        var(--color-stroke-disabled)
+    );
     color: var(
         --btn-tertiary-disabled-foreground-color,
         var(--color-background-disabled)

--- a/src/sass/button/button.scss
+++ b/src/sass/button/button.scss
@@ -28,6 +28,14 @@ button.btn[aria-disabled="true"] {
     );
 }
 
+a.fake-btn:not([href]),
+a.fake-btn[aria-disabled="true"] {
+    @include color-token(
+        link-foreground-color-disabled,
+        color-foreground-disabled
+    );
+}
+
 button.btn--borderless,
 a.fake-btn--borderless {
     border-color: transparent;
@@ -256,6 +264,10 @@ a.fake-btn--primary[aria-disabled="true"] {
         btn-primary-disabled-border-color,
         color-foreground-disabled
     );
+    @include color-token(
+        btn-primary-foreground-color,
+        color-foreground-on-accent
+    );
 }
 
 button.btn--secondary,
@@ -394,10 +406,15 @@ button.btn--tertiary[disabled],
 button.btn--tertiary[aria-disabled="true"]:not(
         [aria-live="polite"][aria-disabled="true"]
     ),
-a.fake-btn--tertiary:not([href]) {
+a.fake-btn--tertiary:not([href]),
+a.fake-btn--tertiary[aria-disabled="true"] {
     @include color-token(
         btn-tertiary-disabled-foreground-color,
         color-background-disabled
+    );
+    @include border-color-token(
+        expand-btn-disabled-border-color,
+        color-stroke-disabled
     );
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2387

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->

Updated the disabled styles to make fake button look disabled

## Screenshots

<img width="685" alt="image" src="https://github.com/user-attachments/assets/4aa8c5fc-71cd-4559-b8f8-13030aacdbbd">
<img width="685" alt="image" src="https://github.com/user-attachments/assets/20ca4a8b-caa4-4d12-a79a-a227a00270e4">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
