### PR TITLE
feat(education-notice): updated education background color

### DIFF
--- a/.changeset/flat-carrots-kneel.md
+++ b/.changeset/flat-carrots-kneel.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(education-notice): updated education background color

--- a/dist/tokens/evo-dark.css
+++ b/dist/tokens/evo-dark.css
@@ -8,7 +8,7 @@
         --color-background-attention: var(--color-red-400);
         --color-background-confirmation: var(--color-kiwi-500);
         --color-background-information: var(--color-blue-500);
-        --color-background-education: #2f373c;
+        --color-background-education: var(--color-indigo-800);
         --color-background-accent: var(--color-blue-400);
         --color-background-invalid: var(--color-red-200);
         --color-background-elevated: var(--color-neutral-800);

--- a/dist/tokens/evo-light.css
+++ b/dist/tokens/evo-light.css
@@ -7,7 +7,7 @@
     --color-background-attention: var(--color-red-600);
     --color-background-confirmation: var(--color-kiwi-600);
     --color-background-information: var(--color-blue-500);
-    --color-background-education: #ecf7fe;
+    --color-background-education: var(--color-blue-100);
     --color-background-accent: var(--color-blue-500);
     --color-background-invalid: var(--color-red-200);
     --color-background-elevated: var(--color-neutral-100);

--- a/src/tokens/evo-dark.css
+++ b/src/tokens/evo-dark.css
@@ -8,7 +8,7 @@
         --color-background-attention: var(--color-red-400);
         --color-background-confirmation: var(--color-kiwi-500);
         --color-background-information: var(--color-blue-500);
-        --color-background-education: #2f373c;
+        --color-background-education: var(--color-indigo-800);
         --color-background-accent: var(--color-blue-400);
         --color-background-invalid: var(--color-red-200);
         --color-background-elevated: var(--color-neutral-800);

--- a/src/tokens/evo-light.css
+++ b/src/tokens/evo-light.css
@@ -7,7 +7,7 @@
     --color-background-attention: var(--color-red-600);
     --color-background-confirmation: var(--color-kiwi-600);
     --color-background-information: var(--color-blue-500);
-    --color-background-education: #ecf7fe;
+    --color-background-education: var(--color-blue-100);
     --color-background-accent: var(--color-blue-500);
     --color-background-invalid: var(--color-red-200);
     --color-background-elevated: var(--color-neutral-100);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2370

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Updated tokens to reflect new DS colors for education notice

## Notes
- Pending Percy testing

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="1318" alt="image" src="https://github.com/user-attachments/assets/3fb52bbc-59a7-454a-9b9f-60707cd70fe0">

<img width="1318" alt="image" src="https://github.com/user-attachments/assets/338f936f-35b0-42e6-b3d7-a6c30ea393fe">

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
