### PR TITLE
fix(menu-button): added direct selector for icons

### DIFF
--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -109,8 +109,8 @@ div.menu-button__item[role^="menuitem"]:last-child {
     );
 }
 
-.fake-menu-button__item svg.icon--16,
-.menu-button__item svg.icon--16 {
+.fake-menu-button__item > svg.icon--16,
+.menu-button__item > svg.icon--16 {
     align-self: center;
     fill: currentColor;
     margin: 0 auto;
@@ -119,8 +119,8 @@ div.menu-button__item[role^="menuitem"]:last-child {
     stroke-width: 0;
 }
 
-.fake-menu-button__item svg.icon--16:last-child,
-.menu-button__item svg.icon--16:last-child {
+.fake-menu-button__item > svg.icon--16:last-child,
+.menu-button__item > svg.icon--16:last-child {
     margin-left: var(--spacing-100);
 }
 a.fake-menu-button__item {

--- a/src/sass/menu-button/menu-button.scss
+++ b/src/sass/menu-button/menu-button.scss
@@ -42,13 +42,13 @@ div.menu-button__item[role^="menuitem"] {
     cursor: default; /* needed to override text cursor */
 }
 
-.menu-button__item svg.icon--16,
-.fake-menu-button__item svg.icon--16 {
+.menu-button__item > svg.icon--16,
+.fake-menu-button__item > svg.icon--16 {
     @include menu-menuitem-status();
 }
 
-.menu-button__item svg.icon--16:last-child,
-.fake-menu-button__item svg.icon--16:last-child {
+.menu-button__item > svg.icon--16:last-child,
+.fake-menu-button__item > svg.icon--16:last-child {
     margin-left: var(--spacing-100);
 }
 


### PR DESCRIPTION

Fixes #2424


- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Changed selector to be direct descendent. 

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
