### PR TITLE
feat(lightbox): add divider over footer

### DIFF
--- a/.changeset/healthy-eyes-trade.md
+++ b/.changeset/healthy-eyes-trade.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(lightbox): add divider over footer

--- a/dist/lightbox-dialog/lightbox-dialog.css
+++ b/dist/lightbox-dialog/lightbox-dialog.css
@@ -79,6 +79,8 @@
 }
 
 .lightbox-dialog__footer {
+    border-top: 1px solid
+        var(--dialog-lightbox-separator-color, var(--color-stroke-subtle));
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -283,7 +285,6 @@ button.icon-btn.lightbox-dialog__prev {
     .lightbox-dialog__window .lightbox-dialog__footer {
         flex-direction: row;
         justify-content: flex-end;
-        padding: 0 var(--spacing-200) var(--spacing-200);
     }
     .lightbox-dialog__window .lightbox-dialog__footer > :not(:first-child) {
         margin-left: var(--spacing-100);

--- a/src/sass/lightbox-dialog/lightbox-dialog.scss
+++ b/src/sass/lightbox-dialog/lightbox-dialog.scss
@@ -28,6 +28,9 @@
 
 .lightbox-dialog__footer {
     @include dialog-footer-content();
+
+    border-top: 1px solid
+        var(--dialog-lightbox-separator-color, var(--color-stroke-subtle));
 }
 
 .lightbox-dialog__image {

--- a/src/sass/mixins/private/_dialog-mixins.scss
+++ b/src/sass/mixins/private/_dialog-mixins.scss
@@ -122,7 +122,6 @@
 @mixin dialog-footer-content-large() {
     flex-direction: row;
     justify-content: flex-end;
-    padding: 0 var(--spacing-200) var(--spacing-200);
 
     & > :not(:first-child) {
         margin-left: var(--spacing-100);


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2408

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Added border top to show the divider over the lightbox footer.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
-  Not sure why `padding-top` was set to `0` in `dialog-footer-content-large` mixin. Removed assuming legacy code.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="627" alt="image" src="https://github.com/user-attachments/assets/11290834-adec-42c7-8fad-51f974e290ef">

<img width="627" alt="image" src="https://github.com/user-attachments/assets/e72dcda1-a4f5-4643-ba1b-a888305727b1">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [x] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
