### PR TITLE
fix(icon-button): refactored and fixed focus

### DIFF
--- a/.changeset/twenty-buttons-beam.md
+++ b/.changeset/twenty-buttons-beam.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fix(icon-button): refactored and fixed focus

--- a/dist/icon-button/icon-button.css
+++ b/dist/icon-button/icon-button.css
@@ -98,15 +98,11 @@ button.icon-btn.icon-btn--large {
     height: 48px;
     width: 48px;
 }
-
 a.icon-link--transparent,
-button.icon-btn--transparent {
-    background-color: initial;
-    outline-offset: -10px;
-}
 a.icon-link--transparent:active,
 a.icon-link--transparent:focus,
 a.icon-link--transparent:hover,
+button.icon-btn--transparent,
 button.icon-btn--transparent:active,
 button.icon-btn--transparent:focus,
 button.icon-btn--transparent:hover {

--- a/dist/toast-dialog/toast-dialog.css
+++ b/dist/toast-dialog/toast-dialog.css
@@ -82,11 +82,10 @@ button.toast-dialog__close {
         var(--color-foreground-on-information)
     );
     margin-inline-start: auto;
-    outline-offset: calc(var(--spacing-100) * -1);
     padding: 0;
 }
 button.toast-dialog__close:focus {
-    outline: 1px dashed white;
+    outline: 2px solid var(--color-foreground-on-information);
 }
 button.toast-dialog__close:focus,
 button.toast-dialog__close:hover {
@@ -133,7 +132,7 @@ button.toast-dialog__close > svg {
 }
 .toast-dialog__footer button.btn--primary:focus,
 .toast-dialog__footer button.btn--secondary:focus {
-    outline: 1px dashed var(--color-foreground-on-information);
+    outline: 2px solid var(--color-foreground-on-information);
 }
 .toast-dialog__footer button.btn--primary:not([disabled]):focus,
 .toast-dialog__footer button.btn--primary:not([disabled]):hover {

--- a/src/sass/icon-button/icon-button.scss
+++ b/src/sass/icon-button/icon-button.scss
@@ -107,7 +107,6 @@ a.icon-link.icon-link--large {
 button.icon-btn--transparent,
 a.icon-link--transparent {
     background-color: transparent;
-    outline-offset: -10px;
 
     &:active,
     &:focus,

--- a/src/sass/toast-dialog/stories/toast-dialog.stories.js
+++ b/src/sass/toast-dialog/stories/toast-dialog.stories.js
@@ -6,7 +6,7 @@ export const primaryAction = () => `
         <div class="toast-dialog__header">
             <h2>User Privacy Preferences</h2>
             <button class="icon-btn icon-btn--transparent toast-dialog__close" type="button" aria-label="Close notification dialog">
-                <svg class="icon icon--close icon--close-16">
+                <svg class="icon icon--16">
                     <use href="#icon-close-16"></use>
                 </svg>
             </button>
@@ -28,7 +28,7 @@ export const secondaryAction = () => `
         <div class="toast-dialog__header">
             <h2>User Privacy Preferences</h2>
             <button class="icon-btn icon-btn--transparent toast-dialog__close" type="button" aria-label="Close notification dialog">
-                <svg class="icon icon--close icon--close-16">
+                <svg class="icon icon--16">
                     <use href="#icon-close-16"></use>
                 </svg>
             </button>
@@ -52,7 +52,7 @@ export const RTL = () => `
             <div class="toast-dialog__header">
                 <h2>User Privacy Preferences</h2>
                 <button class="icon-btn icon-btn--transparent toast-dialog__close" type="button" aria-label="Close notification dialog">
-                    <svg class="icon icon--close icon--close-16">
+                    <svg class="icon icon--16">
                         <use href="#icon-close-16"></use>
                     </svg>
                 </button>
@@ -76,7 +76,7 @@ export const textSpacing = () => `
         <div class="toast-dialog__header">
             <h2>User Privacy Preferences</h2>
             <button class="icon-btn icon-btn--transparent toast-dialog__close" type="button" aria-label="Close notification dialog">
-                <svg class="icon icon--close icon--close-16">
+                <svg class="icon icon--16">
                     <use href="#icon-close-16"></use>
                 </svg>
             </button>
@@ -99,7 +99,7 @@ export const primaryActionWithHeaderOverflow = () => `
         <div class="toast-dialog__header">
             <h2>User Privacy Preferences but with a title that's super long so it wraps to the next line. No dialog header should ever be this long.</h2>
             <button class="icon-btn icon-btn--transparent toast-dialog__close" type="button" aria-label="Close notification dialog">
-                <svg class="icon icon--close icon--close-16">
+                <svg class="icon icon--16">
                     <use href="#icon-close-16"></use>
                 </svg>
             </button>

--- a/src/sass/toast-dialog/toast-dialog.scss
+++ b/src/sass/toast-dialog/toast-dialog.scss
@@ -84,9 +84,7 @@ button.toast-dialog__close {
     align-self: flex-start;
     border: 0;
     flex-shrink: 0;
-    /* margin: 0 0 0 auto; */
     margin-inline-start: auto;
-    outline-offset: calc(var(--spacing-100) * -1);
     padding: 0;
     @include color-token(
         toast-dialog-foreground-color,
@@ -94,7 +92,7 @@ button.toast-dialog__close {
     );
 
     &:focus {
-        outline: 1px dashed white;
+        outline: 2px solid var(--color-foreground-on-information);
     }
 
     &:hover,
@@ -150,7 +148,7 @@ button.toast-dialog__close > svg {
 
     button.btn--primary:focus,
     button.btn--secondary:focus {
-        outline: 1px dashed var(--color-foreground-on-information);
+        outline: 2px solid var(--color-foreground-on-information);
     }
 
     button.btn--primary:not([disabled]) {


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2295 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
I removed focus overrides in transparent icon button, itemized where icon buttons were being used, and verified fixes to styling issues when used in other modules. That fixed issues in:
* Calendar
* Date Textbox
* Pagination
* Textbox

I also manually removed focus overrides and added styling in Toast Dialog to bring it to parity, create consistency.

## Screenshots

**Before and After**

<kbd><img width="833" alt="transparent-button-fix-calendar-before" src="https://github.com/user-attachments/assets/f629d593-e2c9-4f4b-94e6-ab33333cb809">
<img width="775" alt="transparent-button-fix-calendar-after" src="https://github.com/user-attachments/assets/d33c23fa-c792-4b11-b2ef-5541f2f5ccea"></kbd>

<kbd><img width="260" alt="Screenshot 2024-09-16 at 1 42 35 PM" src="https://github.com/user-attachments/assets/3dedf251-fc60-4de0-89ce-4d53e74041dc">
<img width="254" alt="Screenshot 2024-09-16 at 1 42 41 PM" src="https://github.com/user-attachments/assets/4390f1d4-f4be-4fac-83bf-ce96c423741c"></kbd>

<kbd><img width="444" alt="Screenshot 2024-09-16 at 1 49 51 PM" src="https://github.com/user-attachments/assets/53258959-2286-4945-8157-f63819b1270f">
<img width="451" alt="Screenshot 2024-09-16 at 1 50 09 PM" src="https://github.com/user-attachments/assets/23154496-c381-4b99-9c02-164e31a3baaa"></kbd>

<kbd><img width="306" alt="Screenshot 2024-09-16 at 1 51 26 PM" src="https://github.com/user-attachments/assets/86a35498-3356-4051-9f77-ffc7200c5fa3">
<img width="305" alt="Screenshot 2024-09-16 at 1 51 36 PM" src="https://github.com/user-attachments/assets/0e985564-4c66-41df-95b9-74958f0bdff5"></kbd>

<kbd><img width="500" alt="Screenshot 2024-09-17 at 6 58 05 AM" src="https://github.com/user-attachments/assets/fa66c333-6f9c-4bf3-9911-ee8c4a0357b5">
<img width="498" alt="Screenshot 2024-09-17 at 6 58 12 AM" src="https://github.com/user-attachments/assets/27779667-99e6-42c6-ac02-e1fd1534bbed"></kbd>


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
