### PR TITLE
fix(button): update focus outline and offset

### DIFF
--- a/.changeset/tricky-hats-bake.md
+++ b/.changeset/tricky-hats-bake.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fix(button): update focus outline and offset

--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -22,9 +22,16 @@ button.btn--fixed-height,
 button.btn--truncated {
     height: 40px;
 }
+a.fake-btn:focus,
+button.btn:focus {
+    outline-offset: var(--spacing-25);
+    outline-style: solid;
+    outline-width: var(--spacing-25);
+}
 a.fake-btn:focus:not(:focus-visible),
 button.btn:focus:not(:focus-visible) {
     outline: none;
+    outline-offset: 0;
 }
 
 button.btn[aria-disabled="true"],

--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -22,8 +22,8 @@ button.btn--fixed-height,
 button.btn--truncated {
     height: 40px;
 }
-a.fake-btn:focus,
-button.btn:focus {
+a.fake-btn:focus-visible,
+button.btn:focus-visible {
     outline-offset: var(--spacing-25);
     outline-style: solid;
     outline-width: var(--spacing-25);
@@ -31,7 +31,6 @@ button.btn:focus {
 a.fake-btn:focus:not(:focus-visible),
 button.btn:focus:not(:focus-visible) {
     outline: none;
-    outline-offset: 0;
 }
 
 button.btn[aria-disabled="true"],

--- a/dist/cta-button/cta-button.css
+++ b/dist/cta-button/cta-button.css
@@ -21,8 +21,14 @@ a.cta-btn--fixed-height,
 a.cta-btn--truncated {
     height: 40px;
 }
+a.cta-btn:focus {
+    outline-offset: var(--spacing-25);
+    outline-style: solid;
+    outline-width: var(--spacing-25);
+}
 a.cta-btn:focus:not(:focus-visible) {
     outline: none;
+    outline-offset: 0;
 }
 
 a.cta-btn:visited {

--- a/dist/cta-button/cta-button.css
+++ b/dist/cta-button/cta-button.css
@@ -21,14 +21,13 @@ a.cta-btn--fixed-height,
 a.cta-btn--truncated {
     height: 40px;
 }
-a.cta-btn:focus {
+a.cta-btn:focus-visible {
     outline-offset: var(--spacing-25);
     outline-style: solid;
     outline-width: var(--spacing-25);
 }
 a.cta-btn:focus:not(:focus-visible) {
     outline: none;
-    outline-offset: 0;
 }
 
 a.cta-btn:visited {

--- a/src/sass/mixins/private/_button-mixins.scss
+++ b/src/sass/mixins/private/_button-mixins.scss
@@ -28,8 +28,7 @@ $button-border-radius-large: 24px;
         height: 40px;
     }
 
-    /* TODO: use :focus-visble once we support safari 15+ */
-    &:focus {
+    &:focus-visible {
         outline-offset: var(--spacing-25);
         outline-style: solid;
         outline-width: var(--spacing-25);
@@ -38,7 +37,6 @@ $button-border-radius-large: 24px;
     /* https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/ */
     &:focus:not(:focus-visible) {
         outline: none;
-        outline-offset: 0;
     }
 }
 

--- a/src/sass/mixins/private/_button-mixins.scss
+++ b/src/sass/mixins/private/_button-mixins.scss
@@ -28,9 +28,17 @@ $button-border-radius-large: 24px;
         height: 40px;
     }
 
+    /* TODO: use :focus-visble once we support safari 15+ */
+    &:focus {
+        outline-offset: var(--spacing-25);
+        outline-style: solid;
+        outline-width: var(--spacing-25);
+    }
+
     /* https://developer.paciellogroup.com/blog/2018/03/focus-visible-and-backwards-compatibility/ */
     &:focus:not(:focus-visible) {
         outline: none;
+        outline-offset: 0;
     }
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2075

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- For `button:btn` &  `a.fake-btn:focus` added `outline` for `:focus-visible` pseudo selector 

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->
- Outline color need to be changed consistently across all buttons and other interactive elements. #2421 
- Another issue noticed is the focus overlapping on skin docs site when multiple buttons are adjacent to each other.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
<img width="486" alt="image" src="https://github.com/user-attachments/assets/8e08dad7-ec39-42ec-920b-839c731bd188">
<img width="486" alt="image" src="https://github.com/user-attachments/assets/c947117f-3fa6-4a98-bb77-47f0b199f98e">

Primary Button
<img width="486" alt="image" src="https://github.com/user-attachments/assets/63dd4903-eb9d-4299-a58a-ddd01e40cc52">
<img width="486" alt="image" src="https://github.com/user-attachments/assets/9edca200-8ab2-4958-873b-801d3d30cd95">


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
