### PR TITLE
feat(list): new component

### DIFF
--- a/.changeset/strong-dingos-suffer.md
+++ b/.changeset/strong-dingos-suffer.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(list): new component

--- a/dist/list/list.css
+++ b/dist/list/list.css
@@ -1,0 +1,74 @@
+.list {
+    max-width: 480px;
+}
+
+.list__item {
+    align-items: center;
+    background-color: var(
+        --list-background-color,
+        var(--color-background-primary)
+    );
+    box-sizing: border-box;
+    color: var(--color-foreground-on-primary);
+    display: inline-flex;
+    font-size: var(--font-size-16);
+    min-height: var(--spacing-600);
+    padding: var(--spacing-150) var(--spacing-200);
+    width: 100%;
+}
+
+.list__leading {
+    margin-right: var(--spacing-200);
+}
+
+.list__trailing {
+    margin-left: var(--spacing-200);
+}
+
+.list__body {
+    flex: 1;
+}
+
+.list a.list__item,
+.list button.list__item {
+    border: none;
+    text-align: left;
+    text-decoration: none;
+}
+
+.list a.list__item:focus,
+.list a.list__item:hover,
+.list button.list__item:focus,
+.list button.list__item:hover {
+    background-color: var(
+        --list-background-hover-color,
+        var(--color-state-primary-hover)
+    );
+    color: var(--color-foreground-on-primary);
+}
+
+.list a.list__item:active,
+.list button.list__item:active {
+    background-color: var(
+        --list-background-hover-color,
+        var(--color-state-primary-hover)
+    );
+}
+
+.list__divider {
+    border-top: 1px solid var(--color-stroke-subtle);
+    margin: 0 var(--spacing-200);
+}
+
+[dir="rtl"] .list__leading {
+    margin-left: var(--spacing-200);
+    margin-right: inherit;
+}
+[dir="rtl"] .list__trailing {
+    margin-left: inherit;
+    margin-right: var(--spacing-200);
+}
+[dir="rtl"] .list a.list__item,
+[dir="rtl"] .list button.list__item {
+    text-align: right;
+}

--- a/dist/list/list.css
+++ b/dist/list/list.css
@@ -18,6 +18,7 @@
     color: var(--color-foreground-on-primary);
     display: inline-flex;
     font-size: var(--font-size-16);
+    margin: 1px;
     min-height: var(--spacing-600);
     padding: var(--spacing-150) var(--spacing-200);
     width: 100%;

--- a/dist/list/list.css
+++ b/dist/list/list.css
@@ -18,18 +18,18 @@
     color: var(--color-foreground-on-primary);
     display: inline-flex;
     font-size: var(--font-size-16);
-    margin: 1px;
+    margin-block: 1px;
     min-height: var(--spacing-600);
     padding: var(--spacing-150) var(--spacing-200);
     width: 100%;
 }
 
 .list__leading {
-    margin-right: var(--spacing-200);
+    margin-inline-end: var(--spacing-200);
 }
 
 .list__trailing {
-    margin-left: var(--spacing-200);
+    margin-inline-start: var(--spacing-200);
 }
 
 .list__body {
@@ -66,18 +66,10 @@
     border: 0;
     border-top: 1px solid var(--color-stroke-subtle);
     height: 1px;
-    margin: 0 var(--spacing-200);
+    margin-inline: var(--spacing-200);
     padding: 0;
 }
 
-[dir="rtl"] .list__leading {
-    margin-left: var(--spacing-200);
-    margin-right: inherit;
-}
-[dir="rtl"] .list__trailing {
-    margin-left: inherit;
-    margin-right: var(--spacing-200);
-}
 [dir="rtl"] .list li > a,
 [dir="rtl"] .list li > button {
     text-align: right;

--- a/dist/list/list.css
+++ b/dist/list/list.css
@@ -2,7 +2,13 @@
     max-width: 480px;
 }
 
-.list__item {
+.list ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.list ul li > * {
     align-items: center;
     background-color: var(
         --list-background-color,
@@ -29,35 +35,38 @@
     flex: 1;
 }
 
-.list a.list__item,
-.list button.list__item {
+.list li > a,
+.list li > button {
     border: none;
     text-align: left;
     text-decoration: none;
 }
 
-.list a.list__item:focus,
-.list a.list__item:hover,
-.list button.list__item:focus,
-.list button.list__item:hover {
-    background-color: var(
-        --list-background-hover-color,
-        var(--color-state-primary-hover)
-    );
+.list li > a:focus,
+.list li > a:hover,
+.list li > button:focus,
+.list li > button:hover {
     color: var(--color-foreground-on-primary);
 }
 
-.list a.list__item:active,
-.list button.list__item:active {
+.list li > a:active,
+.list li > a:focus,
+.list li > a:hover,
+.list li > button:active,
+.list li > button:focus,
+.list li > button:hover {
     background-color: var(
         --list-background-hover-color,
         var(--color-state-primary-hover)
     );
 }
 
-.list__divider {
+.list hr {
+    border: 0;
     border-top: 1px solid var(--color-stroke-subtle);
+    height: 1px;
     margin: 0 var(--spacing-200);
+    padding: 0;
 }
 
 [dir="rtl"] .list__leading {
@@ -68,7 +77,7 @@
     margin-left: inherit;
     margin-right: var(--spacing-200);
 }
-[dir="rtl"] .list a.list__item,
-[dir="rtl"] .list button.list__item {
+[dir="rtl"] .list li > a,
+[dir="rtl"] .list li > button {
     text-align: right;
 }

--- a/src/modules/list.marko
+++ b/src/modules/list.marko
@@ -1,0 +1,314 @@
+<div id="list">
+    <section-header metadata=input.metadata name=input.name/>
+    <p>A list component is used to display certain types of data in a structured format. It can be used to display a list of items, a list of links, or a list of buttons.</p>
+
+
+    <h3 id="list-default">Default List</h3>
+   <div class="demo">
+        <div class="demo__inner">
+            <div class="list">
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Text 1
+                    </span>
+                </div>
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Text 2
+                    </span>
+                </div>
+                 <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="key-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Text 3
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <highlight-code type="html" >
+        <div class="list">
+            <div class="list__item">
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-folder-16"/>
+                    </svg>
+                </span>
+                <span class="list__body">
+                    Text 1
+                </span>
+            </div>
+            <div class="list__item">
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-file-16"/>
+                    </svg>
+                </span>
+                <span class="list__body">
+                    Text 2
+                </span>
+            </div>
+            <div class="list__item">
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-key-16"/>
+                    </svg>
+                </span>
+                <span class="list__body">
+                    Text 3
+                </span>
+            </div>
+        </div>
+    </highlight-code>
+
+    <h3 id="list-actionable">Actionable list</h3>
+    <p>List also supports buttons or links as a list item. Actionable components, such as a switch, can be added in the trailing portion of the list, but they cannot be used in conjunction with buttons or link.</p>
+   <div class="demo">
+        <div class="demo__inner">
+            <div class="list">
+                <button class="list__item">
+                    Button
+                </button>
+                <a class="list__item" href="www.ebay.com">
+                    <span class="list__body">
+                        Link
+                    </span>
+                    <span class="list__trailing">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="chevron-right-16"/>
+                        </svg>
+                    </span>
+                </a>
+                <div class="list__item">
+                    <span class="list__body">
+                        Item 1 with an action
+                    </span>
+                    <span class="list__trailing">
+                        <span class="switch">
+                            <span
+                                aria-label="Switch Demo"
+                                class="switch__control"
+                                role="switch"
+                                tabindex="-1"
+                                aria-checked="false"
+                                aria-disabled="true"
+                            />
+                            <span class="switch__button"/>
+                        </span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <highlight-code type="html" >
+            <div class="list">
+                <button class="list__item">
+                    Button
+                </button>
+                <a class="list__item" href="www.ebay.com">
+                    <span class="list__body">
+                        Link
+                    </span>
+                    <span class="list__trailing">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-chevron-right-16"/>
+                        </svg>
+                    </span>
+                </a>
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 1 with an action
+                    </span>
+                    <span class="list__trailing">
+                        <span class="switch">
+                            <span
+                                aria-label="Switch Demo"
+                                class="switch__control"
+                                role="switch"
+                                tabindex="-1"
+                                aria-checked="false"
+                                aria-disabled="true"
+                            />
+                            <span class="switch__button"/>
+                        </span>
+                    </span>
+                </div>
+        </div>
+    </highlight-code>
+
+
+
+    <h3 id="list-with-divider">List with dividers</h3>
+    <p> To add a divider, add a <span class="highlight">list__divider</span> class after the list item. </p>
+   <div class="demo">
+        <div class="demo__inner">
+            <div class="list">
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 1
+                    </span>
+                </div>
+                <div class="list__divider"/>
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 2
+                    </span>
+                </div>
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item with a large amount of text that should wrap and go to the next line. If there is too much it would wrap
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <highlight-code type="html">
+            <div class="list">
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 1
+                    </span>
+                </div>
+                <div class="list__divider"/>
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 2
+                    </span>
+                </div>
+                <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item with a large amount of text that should wrap and go to the next line. If there is too much it would wrap
+                    </span>
+                </div>
+            </div>
+    </highlight-code>
+
+
+
+    <h3 id="list-with-divider">List with variable width</h3>
+    <p> The list will adjust to the width of the container it is in. </p>
+   <div class="demo">
+        <div class="demo__inner">
+            <div style="width: 200px">
+            <div class="list">
+               <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 1
+                    </span>
+                </div>
+
+
+               <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 2
+                    </span>
+                    <span class="list__trailing">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <icon-symbol name="money-back-guarantee-16"/>
+                        </svg>
+                    </span>
+
+                </div>
+            </div>
+        </div>
+        </div>
+    </div>
+
+    <highlight-code type="html">
+            <div class="list">
+               <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 1
+                    </span>
+                </div>
+
+
+               <div class="list__item">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 2
+                    </span>
+                    <span class="list__trailing">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-money-back-guarantee-16"/>
+                        </svg>
+                    </span>
+
+                </div>
+            </div>
+   </highlight-code>
+</div>
+export const metadata = {
+    "ds-component": {
+        name: "list",
+        version: 1.0,
+    },
+};

--- a/src/modules/list.marko
+++ b/src/modules/list.marko
@@ -7,71 +7,87 @@
    <div class="demo">
         <div class="demo__inner">
             <div class="list">
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="folder-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Text 1
-                    </span>
-                </div>
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="file-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Text 2
-                    </span>
-                </div>
-                 <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="key-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Text 3
-                    </span>
-                </div>
+                <ul>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="folder-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Text 1
+                            </span>
+                        </div>
+                    </li>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="file-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Text 2
+                            </span>
+                        </div>
+                    </li>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="key-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Text 3
+                            </span>
+                        </div>
+                    </li>
+                </ul>
             </div>
         </div>
     </div>
     <highlight-code type="html" >
         <div class="list">
-            <div class="list__item">
-                <span class="list__leading">
-                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                        <use href="#icon-folder-16"/>
-                    </svg>
-                </span>
-                <span class="list__body">
-                    Text 1
-                </span>
-            </div>
-            <div class="list__item">
-                <span class="list__leading">
-                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                        <use href="#icon-file-16"/>
-                    </svg>
-                </span>
-                <span class="list__body">
-                    Text 2
-                </span>
-            </div>
-            <div class="list__item">
-                <span class="list__leading">
-                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                        <use href="#icon-key-16"/>
-                    </svg>
-                </span>
-                <span class="list__body">
-                    Text 3
-                </span>
-            </div>
+            <ul>
+                <li>
+                    <div>
+                        <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-folder-16"/>
+                            </svg>
+                        </span>
+                        <span class="list__body">
+                            Text 1
+                        </span>
+                    </div>
+                </li>
+                <li>
+                    <div>
+                        <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-file-16"/>
+                            </svg>
+                        </span>
+                        <span class="list__body">
+                            Text 2
+                        </span>
+                    </div>
+                </li>
+                <li>
+                    <div>
+                        <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-key-16"/>
+                            </svg>
+                        </span>
+                        <span class="list__body">
+                            Text 3
+                        </span>
+                    </div>
+                </li>
+            </ul>
         </div>
     </highlight-code>
 
@@ -80,155 +96,178 @@
    <div class="demo">
         <div class="demo__inner">
             <div class="list">
-                <button class="list__item">
-                    Button
-                </button>
-                <a class="list__item" href="www.ebay.com">
-                    <span class="list__body">
-                        Link
-                    </span>
-                    <span class="list__trailing">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="chevron-right-16"/>
-                        </svg>
-                    </span>
-                </a>
-                <div class="list__item">
-                    <span class="list__body">
-                        Item 1 with an action
-                    </span>
-                    <span class="list__trailing">
-                        <span class="switch">
-                            <span
-                                aria-label="Switch Demo"
-                                class="switch__control"
-                                role="switch"
-                                tabindex="-1"
-                                aria-checked="false"
-                                aria-disabled="true"
-                            />
-                            <span class="switch__button"/>
-                        </span>
-                    </span>
-                </div>
+                <ul>
+                    <li>
+                        <button>
+                            Button
+                        </button>
+                    </li>
+                    <li>
+                        <a href="www.ebay.com">
+                            <span class="list__body">
+                                Link
+                            </span>
+                            <span class="list__trailing">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="chevron-right-16"/>
+                                </svg>
+                            </span>
+                        </a>
+                    </li>
+                    <li>
+                        <div>
+                            <span class="list__body">
+                                Item 1 with an action
+                            </span>
+                            <span class="list__trailing">
+                                <span class="switch">
+                                    <span
+                                        aria-label="Switch Demo"
+                                        class="switch__control"
+                                        role="switch"
+                                        tabindex="-1"
+                                        aria-checked="false"
+                                        aria-disabled="true"
+                                    />
+                                    <span class="switch__button"/>
+                                </span>
+                            </span>
+                        </div>
+                    </li>
+                </ul>
             </div>
         </div>
     </div>
     <highlight-code type="html" >
             <div class="list">
-                <button class="list__item">
-                    Button
-                </button>
-                <a class="list__item" href="www.ebay.com">
-                    <span class="list__body">
-                        Link
-                    </span>
-                    <span class="list__trailing">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-chevron-right-16"/>
-                        </svg>
-                    </span>
-                </a>
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-folder-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 1 with an action
-                    </span>
-                    <span class="list__trailing">
-                        <span class="switch">
-                            <span
-                                aria-label="Switch Demo"
-                                class="switch__control"
-                                role="switch"
-                                tabindex="-1"
-                                aria-checked="false"
-                                aria-disabled="true"
-                            />
-                            <span class="switch__button"/>
+            <ul>
+                <li>
+                    <button>
+                        Button
+                    </button>
+                </li>
+                <li>
+                    <a href="www.ebay.com">
+                        <span class="list__body">
+                            Link
                         </span>
-                    </span>
-                </div>
+                        <span class="list__trailing">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-chevron-right-16"/>
+                            </svg>
+                        </span>
+                    </a>
+                </li>
+                <li>
+                    <div>
+                        <span class="list__body">
+                            Item 1 with an action
+                        </span>
+                        <span class="list__trailing">
+                            <span class="switch">
+                                <span
+                                    aria-label="Switch Demo"
+                                    class="switch__control"
+                                    role="switch"
+                                    tabindex="-1"
+                                    aria-checked="false"
+                                    aria-disabled="true"
+                                />
+                                <span class="switch__button"/>
+                            </span>
+                        </span>
+                    </div>
+                </li>
+            </ul>
         </div>
     </highlight-code>
 
-
-
     <h3 id="list-with-divider">List with dividers</h3>
-    <p> To add a divider, add a <span class="highlight">list__divider</span> class after the list item. </p>
+    <p> To add a divider, add a <span class="highlight">hr</span> element after the list item. </p>
    <div class="demo">
         <div class="demo__inner">
             <div class="list">
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="folder-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 1
-                    </span>
-                </div>
-                <div class="list__divider"/>
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="file-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 2
-                    </span>
-                </div>
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="folder-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item with a large amount of text that should wrap and go to the next line. If there is too much it would wrap
-                    </span>
-                </div>
+                <ul>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="folder-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 1
+                            </span>
+                        </div>
+                    </li>
+                    <hr/>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="file-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 2
+                            </span>
+                        </div>
+                    </li>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="folder-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item with a large amount of text that should wrap and go to the next line. If there is too much it would wrap
+                            </span>
+                        </div>
+                    </li>
+                </ul>
             </div>
         </div>
     </div>
     <highlight-code type="html">
             <div class="list">
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-folder-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 1
-                    </span>
-                </div>
-                <div class="list__divider"/>
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-file-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 2
-                    </span>
-                </div>
-                <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-folder-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item with a large amount of text that should wrap and go to the next line. If there is too much it would wrap
-                    </span>
-                </div>
+                <ul>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <use href="#icon-folder-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 1
+                            </span>
+                        </div>
+                    </li>
+                    <hr/>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <use href="#icon-file-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 2
+                            </span>
+                        </div>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <use href="#icon-folder-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item with a large amount of text that should wrap and go to the next line. If there is too much it would wrap
+                            </span>
+                        </div>
+                    </li>
+                </ul>
             </div>
     </highlight-code>
 
@@ -240,34 +279,37 @@
         <div class="demo__inner">
             <div style="width: 200px">
             <div class="list">
-               <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="file-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 1
-                    </span>
-                </div>
-
-
-               <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="file-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 2
-                    </span>
-                    <span class="list__trailing">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <icon-symbol name="money-back-guarantee-16"/>
-                        </svg>
-                    </span>
-
-                </div>
+                <ul>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="file-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 1
+                            </span>
+                        </div>
+                    </li>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="file-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 2
+                            </span>
+                            <span class="list__trailing">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <icon-symbol name="money-back-guarantee-16"/>
+                                </svg>
+                            </span>
+                        </div>
+                    </li>
+                </ul>
             </div>
         </div>
         </div>
@@ -275,34 +317,37 @@
 
     <highlight-code type="html">
             <div class="list">
-               <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-file-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 1
-                    </span>
-                </div>
-
-
-               <div class="list__item">
-                    <span class="list__leading">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-file-16"/>
-                        </svg>
-                    </span>
-                    <span class="list__body">
-                        Item 2
-                    </span>
-                    <span class="list__trailing">
-                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                            <use href="#icon-money-back-guarantee-16"/>
-                        </svg>
-                    </span>
-
-                </div>
+                <ul>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <use href="#icon-file-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 1
+                            </span>
+                        </div>
+                    </li>
+                    <li>
+                        <div>
+                            <span class="list__leading">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <use href="#icon-file-16"/>
+                                </svg>
+                            </span>
+                            <span class="list__body">
+                                Item 2
+                            </span>
+                            <span class="list__trailing">
+                                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                    <use href="#icon-money-back-guarantee-16"/>
+                                </svg>
+                            </span>
+                        </div>
+                    </li>
+                </ul>
             </div>
    </highlight-code>
 </div>

--- a/src/modules/list.marko
+++ b/src/modules/list.marko
@@ -1,7 +1,7 @@
 <div id="list">
     <section-header metadata=input.metadata name=input.name/>
     <p>A list component is used to display certain types of data in a structured format. It can be used to display a list of items, a list of links, or a list of buttons.</p>
-
+    <p>This can be placed inside a container and will resize to fit the contents. The list expands to a maxumum of 480px.</p>
 
     <h3 id="list-default">Default List</h3>
    <div class="demo">

--- a/src/modules/list.marko
+++ b/src/modules/list.marko
@@ -116,21 +116,21 @@
                     </li>
                     <li>
                         <div>
-                            <span class="list__body">
+                            <span class="list__body" id="switch-in-list">
                                 Item 1 with an action
                             </span>
                             <span class="list__trailing">
                                 <span class="switch">
                                     <span
-                                        aria-label="Switch Demo"
+                                        aria-labelledby="switch-in-list"
                                         class="switch__control"
                                         role="switch"
-                                        tabindex="-1"
+                                        tabindex="0"
                                         aria-checked="false"
-                                        aria-disabled="true"
                                     />
                                     <span class="switch__button"/>
                                 </span>
+
                             </span>
                         </div>
                     </li>
@@ -160,21 +160,21 @@
                 </li>
                 <li>
                     <div>
-                        <span class="list__body">
+                        <span class="list__body" id="switch-in-list">
                             Item 1 with an action
                         </span>
                         <span class="list__trailing">
                             <span class="switch">
                                 <span
-                                    aria-label="Switch Demo"
+                                    aria-labelledby="switch-in-list"
                                     class="switch__control"
                                     role="switch"
-                                    tabindex="-1"
+                                    tabindex="0"
                                     aria-checked="false"
-                                    aria-disabled="true"
                                 />
                                 <span class="switch__button"/>
                             </span>
+
                         </span>
                     </div>
                 </li>

--- a/src/sass/bundles/skin-headless.scss
+++ b/src/sass/bundles/skin-headless.scss
@@ -40,6 +40,7 @@
 @import "../inline-notice/inline-notice";
 @import "../lightbox-dialog/lightbox-dialog";
 @import "../link/link";
+@import "../list/list";
 @import "../listbox/listbox";
 @import "../listbox-button/listbox-button";
 @import "../menu/menu";

--- a/src/sass/list/list.scss
+++ b/src/sass/list/list.scss
@@ -23,6 +23,7 @@
     color: var(--color-foreground-on-primary);
     display: inline-flex;
     font-size: var(--font-size-16);
+    margin: 1px;
     min-height: var(--spacing-600);
     padding: var(--spacing-150) var(--spacing-200);
     width: 100%;

--- a/src/sass/list/list.scss
+++ b/src/sass/list/list.scss
@@ -23,18 +23,18 @@
     color: var(--color-foreground-on-primary);
     display: inline-flex;
     font-size: var(--font-size-16);
-    margin: 1px;
+    margin-block: 1px;
     min-height: var(--spacing-600);
     padding: var(--spacing-150) var(--spacing-200);
     width: 100%;
 }
 
 .list__leading {
-    margin-right: var(--spacing-200);
+    margin-inline-end: var(--spacing-200);
 }
 
 .list__trailing {
-    margin-left: var(--spacing-200);
+    margin-inline-start: var(--spacing-200);
 }
 
 .list__body {
@@ -75,20 +75,11 @@
     border: 0;
     border-top: 1px solid var(--color-stroke-subtle);
     height: 1px;
-    margin: 0 var(--spacing-200);
+    margin-inline: var(--spacing-200);
     padding: 0;
 }
 
 [dir="rtl"] {
-    .list__leading {
-        margin-left: var(--spacing-200);
-        margin-right: inherit;
-    }
-
-    .list__trailing {
-        margin-left: inherit;
-        margin-right: var(--spacing-200);
-    }
     .list li > a,
     .list li > button {
         text-align: right;

--- a/src/sass/list/list.scss
+++ b/src/sass/list/list.scss
@@ -1,0 +1,85 @@
+@import "../variables/variables";
+@import "../mixins/private/button-mixins";
+@import "../mixins/private/token-mixins";
+
+.list {
+    max-width: 480px;
+}
+.list__item {
+    @include background-color-token(
+        list-background-color,
+        color-background-primary
+    );
+
+    align-items: center;
+    box-sizing: border-box;
+    color: var(--color-foreground-on-primary);
+    display: inline-flex;
+    font-size: var(--font-size-16);
+    min-height: var(--spacing-600);
+    padding: var(--spacing-150) var(--spacing-200);
+    width: 100%;
+}
+
+.list__leading {
+    margin-right: var(--spacing-200);
+}
+
+.list__trailing {
+    margin-left: var(--spacing-200);
+}
+
+.list__body {
+    flex: 1;
+}
+
+.list a.list__item,
+.list button.list__item {
+    border: none;
+    text-align: left;
+    text-decoration: none;
+}
+
+.list a.list__item,
+.list button.list__item {
+    &:hover,
+    &:focus {
+        @include background-color-token(
+            list-background-hover-color,
+            color-state-primary-hover
+        );
+
+        color: var(--color-foreground-on-primary);
+    }
+}
+
+.list button.list__item,
+.list a.list__item {
+    &:active {
+        @include background-color-token(
+            list-background-hover-color,
+            color-state-primary-hover
+        );
+    }
+}
+
+.list__divider {
+    border-top: 1px solid var(--color-stroke-subtle);
+    margin: 0 var(--spacing-200);
+}
+
+[dir="rtl"] {
+    .list__leading {
+        margin-left: var(--spacing-200);
+        margin-right: inherit;
+    }
+
+    .list__trailing {
+        margin-left: inherit;
+        margin-right: var(--spacing-200);
+    }
+    .list a.list__item,
+    .list button.list__item {
+        text-align: right;
+    }
+}

--- a/src/sass/list/list.scss
+++ b/src/sass/list/list.scss
@@ -5,7 +5,14 @@
 .list {
     max-width: 480px;
 }
-.list__item {
+
+.list ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.list ul li > * {
     @include background-color-token(
         list-background-color,
         color-background-primary
@@ -33,15 +40,15 @@
     flex: 1;
 }
 
-.list a.list__item,
-.list button.list__item {
+.list li > a,
+.list li > button {
     border: none;
     text-align: left;
     text-decoration: none;
 }
 
-.list a.list__item,
-.list button.list__item {
+.list li > a,
+.list li > button {
     &:hover,
     &:focus {
         @include background-color-token(
@@ -53,8 +60,8 @@
     }
 }
 
-.list button.list__item,
-.list a.list__item {
+.list li > button,
+.list li > a {
     &:active {
         @include background-color-token(
             list-background-hover-color,
@@ -63,9 +70,12 @@
     }
 }
 
-.list__divider {
+.list hr {
+    border: 0;
     border-top: 1px solid var(--color-stroke-subtle);
+    height: 1px;
     margin: 0 var(--spacing-200);
+    padding: 0;
 }
 
 [dir="rtl"] {
@@ -78,8 +88,8 @@
         margin-left: inherit;
         margin-right: var(--spacing-200);
     }
-    .list a.list__item,
-    .list button.list__item {
+    .list li > a,
+    .list li > button {
         text-align: right;
     }
 }

--- a/src/sass/list/stories/list.stories.js
+++ b/src/sass/list/stories/list.stories.js
@@ -2,277 +2,330 @@ export default { title: "Skin/List" };
 
 export const base = () => `
 <div class="list">
-    <div class="list__item">
-       <span class="list__body">
-            Text 0
-        </span>
-    </div>
-    <div class="list__item">
-       <span class="list__body">
-            Text 1
-        </span>
-    </div>
-    <div class="list__item">
-       <span class="list__body">
-            Text 2
-        </span>
-    </div>
+    <ul>
+        <li>
+            <div>
+            <span class="list__body">
+                    Text 0
+                </span>
+            </div>
+        </li>
+        <li>
+            <div>
+            <span class="list__body">
+                    Text 1
+                </span>
+            </div>
+            <div>
+            <span class="list__body">
+                    Text 2
+                </span>
+            </div>
+        </li>
+    </ul>
 </div>
 `;
 
 export const withLeading = () => `
 <div class="list">
-    <div class="list__item">
-        <span class="list__leading">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-folder-16"/>
-            </svg>
-        </span>
-        <span class="list__body">
-            Text 0
-        </span>
-    </div>
-    <div class="list__item">
-        <span class="list__leading">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-file-16"/>
-            </svg>
-        </span>
-       <span class="list__body">
-            Text 1
-        </span>
-    </div>
-    <div class="list__item">
-        <span class="list__leading">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-key-16"/>
-            </svg>
-        </span>
-       <span class="list__body">
-            Text 2
-        </span>
-    </div>
+    <ul>
+        <li>
+            <div>
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-folder-16"/>
+                    </svg>
+                </span>
+                <span class="list__body">
+                    Text 0
+                </span>
+            </div>
+        </li>
+        <li>
+            <div>
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-file-16"/>
+                    </svg>
+                </span>
+            <span class="list__body">
+                    Text 1
+                </span>
+            </div>
+        </li>
+        <li>
+            <div>
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-key-16"/>
+                    </svg>
+                </span>
+            <span class="list__body">
+                    Text 2
+                </span>
+            </div>
+        </li>
+    </ul>
 </div>
 
 `;
 
 export const multiLine = () => `
 <div class="list">
-    <div class="list__item">
-        <span class="list__leading">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-folder-16"/>
-            </svg>
-        </span>
-        <span class="list__body">
-            Text 0 with a long line that should wrap to the next line. This is testing to see how well the component wraps.
-        </span>
-    </div>
-    <div class="list__item">
-        <span class="list__leading">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-file-16"/>
-            </svg>
-        </span>
-       <span class="list__body">
-            Text 1 with a long line that should wrap to the next line. This is testing to see how well the component wraps, but also has an end item.
-        </span>
-        <span class="list__trailing">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-information-16"/>
-            </svg>
-        </span>
-    </div>
-    <div class="list__item">
-        <span class="list__leading">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-key-16"/>
-            </svg>
-        </span>
-       <span class="list__body">
-            Text 2, this one is normal.
-        </span>
-    </div>
+    <ul>
+        <li>
+            <div>
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-folder-16"/>
+                    </svg>
+                </span>
+                <span class="list__body">
+                    Text 0 with a long line that should wrap to the next line. This is testing to see how well the component wraps.
+                </span>
+            </div>
+        </li>
+        <li>
+            <div>
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-file-16"/>
+                    </svg>
+                </span>
+            <span class="list__body">
+                    Text 1 with a long line that should wrap to the next line. This is testing to see how well the component wraps, but also has an end item.
+                </span>
+                <span class="list__trailing">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-information-16"/>
+                    </svg>
+                </span>
+            </div>
+        </li>
+        <li>
+            <div>
+                <span class="list__leading">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-key-16"/>
+                    </svg>
+                </span>
+            <span class="list__body">
+                    Text 2, this one is normal.
+                </span>
+            </div>
+        </li>
+    </ul>
 </div>
 
 `;
 
 export const action = () => `
 <div class="list">
-    <button class="list__item">
-        Button
-    </button>
-    <a class="list__item" href="www.ebay.com">
-        <span class="list__body">
-            Link
-        </span>
-        <span class="list__trailing">
-            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                <use href="#icon-chevron-right-16"/>
-            </svg>
-        </span>
-    </a>
-    <div class="list__item">
-        <span class="list__body">
-            Item 1 with an action
-        </span>
-        <span class="list__trailing">
-            <span class="switch">
-                <input
-                    aria-label="Checkbox switch demo"
-                    class="switch__control"
-                    role="switch"
-                    type="checkbox"
-                    aria-checked="false"
-                >
-                <span class="switch__button"/>
-            </span>
-        </span>
-    </div>
+    <ul>
+        <li>
+            <button>
+                Button
+            </button>
+        </li>
+        <li>
+            <a href="www.ebay.com">
+                <span class="list__body">
+                    Link
+                </span>
+                <span class="list__trailing">
+                    <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                        <use href="#icon-chevron-right-16"/>
+                    </svg>
+                </span>
+            </a>
+        </li>
+        <li>
+            <div>
+                <span class="list__body">
+                    Item 1 with an action
+                </span>
+                <span class="list__trailing">
+                    <span class="switch">
+                        <input
+                            aria-label="Checkbox switch demo"
+                            class="switch__control"
+                            role="switch"
+                            type="checkbox"
+                            aria-checked="false"
+                        >
+                        <span class="switch__button"/>
+                    </span>
+                </span>
+            </div>
+        </li>
+    </ul>
 </div>
 `;
 
 export const RTL = () => `
 <div dir="rtl">
     <div class="list">
-        <button class="list__item">
-            <span class="list__leading">
-                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                    <use href="#icon-folder-16"/>
-                </svg>
-            </span>
+        <ul>
+            <li>
+                <button>
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-folder-16"/>
+                        </svg>
+                    </span>
 
-            Button
-        </button>
-        <a class="list__item" href="www.ebay.com">
-            <span class="list__leading">
-                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                    <use href="#icon-folder-16"/>
-                </svg>
-            </span>
-            <span class="list__body">
-                Link
-            </span>
-            <span class="list__trailing">
-                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                    <use href="#icon-chevron-left-16"/>
-                </svg>
-            </span>
-        </a>
-        <div class="list__item">
-            <span class="list__leading">
-                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                    <use href="#icon-folder-16"/>
-                </svg>
-            </span>
-            <span class="list__body">
-                Item 1 with an action
-            </span>
-            <span class="list__trailing">
-                <span class="switch">
-                    <input
-                        aria-label="Checkbox switch demo"
-                        class="switch__control"
-                        role="switch"
-                        type="checkbox"
-                        aria-checked="false"
-                    >
-                    <span class="switch__button"/>
-                </span>
-            </span>
-        </div>
+                    Button
+                </button>
+            </li>
+            <li>
+                <a href="www.ebay.com">
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Link
+                    </span>
+                    <span class="list__trailing">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-chevron-left-16"/>
+                        </svg>
+                    </span>
+                </a>
+            </li>
+            <li>
+                <div>
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-folder-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 1 with an action
+                    </span>
+                    <span class="list__trailing">
+                        <span class="switch">
+                            <input
+                                aria-label="Checkbox switch demo"
+                                class="switch__control"
+                                role="switch"
+                                type="checkbox"
+                                aria-checked="false"
+                            >
+                            <span class="switch__button"/>
+                        </span>
+                    </span>
+                </div>
+            </li>
+        </ul>
     </div>
 </div>
 `;
 export const variableWidth = () =>
     `<div style="width: 200px">
     <div class="list">
-       <div class="list__item">
-            <span class="list__leading">
-                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                    <use href="#icon-file-16"/>
-                </svg>
-            </span>
-            <span class="list__body">
-                Item 1
-            </span>
-        </div>
-
-
-       <div class="list__item">
-            <span class="list__leading">
-                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                    <use href="#icon-file-16"/>
-                </svg>
-            </span>
-            <span class="list__body">
-                Item 2
-            </span>
-            <span class="list__trailing">
-                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-                    <use href="#icon-money-back-guarantee-16"/>
-                </svg>
-            </span>
-
-        </div>
+        <ul>
+            <li>
+                <div>
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 1
+                    </span>
+                </div>
+            </li>
+            <li>
+                <div>
+                    <span class="list__leading">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-file-16"/>
+                        </svg>
+                    </span>
+                    <span class="list__body">
+                        Item 2
+                    </span>
+                    <span class="list__trailing">
+                        <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                            <use href="#icon-money-back-guarantee-16"/>
+                        </svg>
+                    </span>
+                </div>
+            </li>
+        </ul>
+    </div>
 </div>`;
 
 export const withDivider = () => `
 <div class="list">
-  <div class="list__item">
-    <span class="list__leading">
-      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-        <use href="#icon-folder-16" />
-      </svg>
-    </span>
-    <span class="list__body"> Item 1 </span>
-  </div>
-  <div class="list__divider"></div>
-  <div class="list__item">
-    <span class="list__leading">
-      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-        <use href="#icon-file-16" />
-      </svg>
-    </span>
-    <span class="list__body"> Item 2 </span>
-  </div>
-  <div class="list__item">
-    <span class="list__leading">
-      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-        <use href="#icon-file-16" />
-      </svg>
-    </span>
-    <span class="list__body"> Item 3 </span>
-  </div>
-  <div class="list__item">
-    <span class="list__leading">
-      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-        <use href="#icon-file-16" />
-      </svg>
-    </span>
-    <span class="list__body"> Item 4 </span>
-  </div>
-  <div class="list__divider"></div>
-
-  <div class="list__item">
-    <span class="list__leading">
-      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-        <use href="#icon-key-16" />
-      </svg>
-    </span>
-    <span class="list__body">
-        Item 5
-    </span>
-  </div>
-  <div class="list__item">
-    <span class="list__leading">
-      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
-        <use href="#icon-key-16" />
-      </svg>
-    </span>
-    <span class="list__body">
-        Item 6
-    </span>
-  </div>
-</div>
+    <ul>
+        <li>
+            <div>
+                <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-folder-16" />
+                </svg>
+                </span>
+                <span class="list__body"> Item 1 </span>
+            </div>
+        </li>
+        <hr />
+        <li>
+            <div>
+                <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-file-16" />
+                </svg>
+                </span>
+                <span class="list__body"> Item 2 </span>
+            </div>
+        </li>
+        <li>
+            <div>
+                <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-file-16" />
+                </svg>
+                </span>
+                <span class="list__body"> Item 3 </span>
+            </div>
+        </li>
+        <li>
+            <div>
+                <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-file-16" />
+                </svg>
+                </span>
+                <span class="list__body"> Item 4 </span>
+            </div>
+        </li>
+        <hr />
+        <li>
+            <div>
+                <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-key-16" />
+                </svg>
+                </span>
+                <span class="list__body">
+                    Item 5
+                </span>
+            </div>
+        </li>
+        <li>
+            <div>
+                <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-key-16" />
+                </svg>
+                </span>
+                <span class="list__body">
+                    Item 6
+                </span>
+            </div>
+        </div>
 `;

--- a/src/sass/list/stories/list.stories.js
+++ b/src/sass/list/stories/list.stories.js
@@ -1,0 +1,278 @@
+export default { title: "Skin/List" };
+
+export const base = () => `
+<div class="list">
+    <div class="list__item">
+       <span class="list__body">
+            Text 0
+        </span>
+    </div>
+    <div class="list__item">
+       <span class="list__body">
+            Text 1
+        </span>
+    </div>
+    <div class="list__item">
+       <span class="list__body">
+            Text 2
+        </span>
+    </div>
+</div>
+`;
+
+export const withLeading = () => `
+<div class="list">
+    <div class="list__item">
+        <span class="list__leading">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-folder-16"/>
+            </svg>
+        </span>
+        <span class="list__body">
+            Text 0
+        </span>
+    </div>
+    <div class="list__item">
+        <span class="list__leading">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-file-16"/>
+            </svg>
+        </span>
+       <span class="list__body">
+            Text 1
+        </span>
+    </div>
+    <div class="list__item">
+        <span class="list__leading">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-key-16"/>
+            </svg>
+        </span>
+       <span class="list__body">
+            Text 2
+        </span>
+    </div>
+</div>
+
+`;
+
+export const multiLine = () => `
+<div class="list">
+    <div class="list__item">
+        <span class="list__leading">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-folder-16"/>
+            </svg>
+        </span>
+        <span class="list__body">
+            Text 0 with a long line that should wrap to the next line. This is testing to see how well the component wraps.
+        </span>
+    </div>
+    <div class="list__item">
+        <span class="list__leading">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-file-16"/>
+            </svg>
+        </span>
+       <span class="list__body">
+            Text 1 with a long line that should wrap to the next line. This is testing to see how well the component wraps, but also has an end item.
+        </span>
+        <span class="list__trailing">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-information-16"/>
+            </svg>
+        </span>
+    </div>
+    <div class="list__item">
+        <span class="list__leading">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-key-16"/>
+            </svg>
+        </span>
+       <span class="list__body">
+            Text 2, this one is normal.
+        </span>
+    </div>
+</div>
+
+`;
+
+export const action = () => `
+<div class="list">
+    <button class="list__item">
+        Button
+    </button>
+    <a class="list__item" href="www.ebay.com">
+        <span class="list__body">
+            Link
+        </span>
+        <span class="list__trailing">
+            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                <use href="#icon-chevron-right-16"/>
+            </svg>
+        </span>
+    </a>
+    <div class="list__item">
+        <span class="list__body">
+            Item 1 with an action
+        </span>
+        <span class="list__trailing">
+            <span class="switch">
+                <input
+                    aria-label="Checkbox switch demo"
+                    class="switch__control"
+                    role="switch"
+                    type="checkbox"
+                    aria-checked="false"
+                >
+                <span class="switch__button"/>
+            </span>
+        </span>
+    </div>
+</div>
+`;
+
+export const RTL = () => `
+<div dir="rtl">
+    <div class="list">
+        <button class="list__item">
+            <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-folder-16"/>
+                </svg>
+            </span>
+
+            Button
+        </button>
+        <a class="list__item" href="www.ebay.com">
+            <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-folder-16"/>
+                </svg>
+            </span>
+            <span class="list__body">
+                Link
+            </span>
+            <span class="list__trailing">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-chevron-left-16"/>
+                </svg>
+            </span>
+        </a>
+        <div class="list__item">
+            <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-folder-16"/>
+                </svg>
+            </span>
+            <span class="list__body">
+                Item 1 with an action
+            </span>
+            <span class="list__trailing">
+                <span class="switch">
+                    <input
+                        aria-label="Checkbox switch demo"
+                        class="switch__control"
+                        role="switch"
+                        type="checkbox"
+                        aria-checked="false"
+                    >
+                    <span class="switch__button"/>
+                </span>
+            </span>
+        </div>
+    </div>
+</div>
+`;
+export const variableWidth = () =>
+    `<div style="width: 200px">
+    <div class="list">
+       <div class="list__item">
+            <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-file-16"/>
+                </svg>
+            </span>
+            <span class="list__body">
+                Item 1
+            </span>
+        </div>
+
+
+       <div class="list__item">
+            <span class="list__leading">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-file-16"/>
+                </svg>
+            </span>
+            <span class="list__body">
+                Item 2
+            </span>
+            <span class="list__trailing">
+                <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                    <use href="#icon-money-back-guarantee-16"/>
+                </svg>
+            </span>
+
+        </div>
+</div>`;
+
+export const withDivider = () => `
+<div class="list">
+  <div class="list__item">
+    <span class="list__leading">
+      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+        <use href="#icon-folder-16" />
+      </svg>
+    </span>
+    <span class="list__body"> Item 1 </span>
+  </div>
+  <div class="list__divider"></div>
+  <div class="list__item">
+    <span class="list__leading">
+      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+        <use href="#icon-file-16" />
+      </svg>
+    </span>
+    <span class="list__body"> Item 2 </span>
+  </div>
+  <div class="list__item">
+    <span class="list__leading">
+      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+        <use href="#icon-file-16" />
+      </svg>
+    </span>
+    <span class="list__body"> Item 3 </span>
+  </div>
+  <div class="list__item">
+    <span class="list__leading">
+      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+        <use href="#icon-file-16" />
+      </svg>
+    </span>
+    <span class="list__body"> Item 4 </span>
+  </div>
+  <div class="list__divider"></div>
+
+  <div class="list__item">
+    <span class="list__leading">
+      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+        <use href="#icon-key-16" />
+      </svg>
+    </span>
+    <span class="list__body">
+        Item 5
+    </span>
+  </div>
+  <div class="list__item">
+    <span class="list__leading">
+      <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+        <use href="#icon-key-16" />
+      </svg>
+    </span>
+    <span class="list__body">
+        Item 6
+    </span>
+  </div>
+</div>
+`;

--- a/src/sass/list/stories/list.stories.js
+++ b/src/sass/list/stories/list.stories.js
@@ -141,18 +141,18 @@ export const action = () => `
         </li>
         <li>
             <div>
-                <span class="list__body">
+                <span class="list__body" id="switch-in-list">
                     Item 1 with an action
                 </span>
                 <span class="list__trailing">
                     <span class="switch">
                         <input
-                            aria-label="Checkbox switch demo"
+                            aria-labelledby="switch-in-list"
                             class="switch__control"
                             role="switch"
                             type="checkbox"
                             aria-checked="false"
-                        >
+                        />
                         <span class="switch__button"/>
                     </span>
                 </span>


### PR DESCRIPTION
Fixes #2453

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added new list component.
* Im happy to change the name of the component. However, looking around to other libraries, they call this component list (material, bootstrap calls is list-group). Please provide feedback and the name you would like!
* I did not have this use grid because from what the designs look like, they do not all need to be the same size as each other. Some elements can be larger depending on the content. 
* Added both `a` and `button` type overrides for the root
* For the items before and after, used `trailing` and `leading`. Again, these were the terms used by both design and outside design libraries (material etc). Again, happy to use other terms as needed. 

## Screenshots
<img width="1218" alt="Screenshot 2024-10-14 at 10 45 09 AM" src="https://github.com/user-attachments/assets/acb2bdd4-b3dd-45b6-b9ee-c210a1ca259f">

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
