### PR TITLE
feat(eek): added large styles

### DIFF
--- a/.changeset/flat-snakes-sell.md
+++ b/.changeset/flat-snakes-sell.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(eek): added large size and fixed regular arrow

--- a/dist/eek/eek.css
+++ b/dist/eek/eek.css
@@ -7,6 +7,10 @@
     position: relative;
 }
 
+.eek--large {
+    height: 32px;
+}
+
 .eek__container {
     align-items: center;
     border: 1px solid #000;
@@ -17,6 +21,10 @@
 
 .eek .icon--eek-arrow {
     width: 9px;
+}
+
+.eek--large .icon--eek-arrow {
+    width: 12.5px;
 }
 
 .eek__arrow {
@@ -105,6 +113,10 @@
         -0.5px -0.5px 0 #000;
 }
 
+.eek--large .eek__rating {
+    font-size: 24px;
+}
+
 .eek__rating-range {
     align-items: center;
     background-color: #fff;
@@ -116,13 +128,28 @@
     padding: 0 1px;
 }
 
+.eek--large .eek__rating-range {
+    height: 28px;
+}
+
 .eek__rating-range > .icon--eek-range-arrow {
     height: 6px;
     width: 5px;
 }
 
+.eek--large .eek__rating-range > .icon--eek-range-arrow {
+    height: 7px;
+    width: 6px;
+}
+
 .eek__rating-range > span {
     font-size: 8px;
+    height: 8px;
+}
+
+.eek--large .eek__rating-range > span {
+    font-size: 10px;
+    height: 10px;
 }
 @media not all and (-webkit-min-device-pixel-ratio: 0),
     not all and (min-resolution: 0.001dpcm) {
@@ -133,4 +160,11 @@
             -webkit-text-stroke-color: #000;
         }
     }
+}
+[dir="rtl"] .eek .icon--eek-arrow {
+    transform: rotate(180deg);
+}
+[dir="rtl"] .eek__container {
+    border-left: none;
+    border-right: 1px solid #000;
 }

--- a/src/modules/eek.marko
+++ b/src/modules/eek.marko
@@ -138,6 +138,7 @@
         </tbody>
     </table>
 
+    <h3 id="button-default">EEK examples</h3>
     <div class="demo">
         <div class="demo__inner">
             <div class="eek eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
@@ -246,6 +247,119 @@
         </svg>
     </div>
     </highlight-code>
+
+
+    <h3 id="button-default">Large EEK</h3>
+    <p>In order to match other items on the screen, you can use <span class="highlight">eek--large</span> class to increase the size</p>
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="eek eek--large eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
+                <div class="eek__container">
+                    <span class="eek__rating-range">
+                        <span aria-hidden="true">A+++</span>
+                        <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                            <icon-symbol name="eek-range-arrow" />
+                        </svg>
+                        <span aria-hidden="true">D</span>
+                    </span>
+                    <span class="eek__rating" aria-hidden="true">
+                        A+++
+                    </span>
+                </div>
+                <svg class="icon icon--eek-arrow" aria-hidden="true">
+                    <icon-symbol name="eek-arrow" />
+                </svg>
+            </div>
+            <div class="eek eek--large eek--rating-4" role="figure" aria-label="Energy Rating: B. Range: A++ - E">
+                <div class="eek__container">
+                    <span class="eek__rating-range">
+                        <span aria-hidden="true">A++</span>
+                        <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                            <icon-symbol name="eek-range-arrow" />
+                        </svg>
+                        <span aria-hidden="true">E</span>
+                    </span>
+                    <span class="eek__rating" aria-hidden="true">
+                        B
+                    </span>
+                </div>
+                <svg class="icon icon--eek-arrow" aria-hidden="true">
+                    <icon-symbol name="eek-arrow" />
+                </svg>
+            </div>
+            <div class="eek eek--large eek--rating-7" role="figure" aria-label="Energy Rating: G. Range: A+ - G">
+                <div class="eek__container">
+                    <span class="eek__rating-range">
+                        <span aria-hidden="true">A+</span>
+                        <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                            <icon-symbol name="eek-range-arrow" />
+                        </svg>
+                        <span aria-hidden="true">E</span>
+                    </span>
+                    <span class="eek__rating" aria-hidden="true">
+                        G
+                    </span>
+                </div>
+                <svg class="icon icon--eek-arrow" aria-hidden="true">
+                    <icon-symbol name="eek-arrow" />
+                </svg>
+            </div>
+        </div>
+    </div>
+    <highlight-code type="html" >
+    <div class="eek eek--large eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
+        <div class="eek__container">
+            <span class="eek__rating-range">
+                <span aria-hidden="true">A+++</span>
+                <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                    <use href="#icon-eek-range-arrow"></use>
+                </svg>
+                <span aria-hidden="true">D</span>
+            </span>
+            <span class="eek__rating" aria-hidden="true">
+                A+++
+            </span>
+        </div>
+        <svg class="icon icon--eek-arrow" aria-hidden="true">
+            <use href="#icon-eek-arrow"></use>
+        </svg>
+    </div>
+    <div class="eek eek--large eek--rating-4" role="figure" aria-label="Energy Rating: B. Range: A++ - E">
+        <div class="eek__container">
+            <span class="eek__rating-range">
+                <span aria-hidden="true">A++</span>
+                <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                    <use href="#icon-eek-range-arrow"></use>
+                </svg>
+                <span aria-hidden="true">E</span>
+            </span>
+            <span class="eek__rating" aria-hidden="true">
+                B
+            </span>
+        </div>
+        <svg class="icon icon--eek-arrow" aria-hidden="true">
+            <use href="#icon-eek-arrow"></use>
+        </svg>
+    </div>
+    <div class="eek eek--large eek--rating-7" role="figure" aria-label="Energy Rating: G. Range: A+ - G">
+        <div class="eek__container">
+            <span class="eek__rating-range">
+                <span aria-hidden="true">A+</span>
+                <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                    <use href="#icon-eek-range-arrow"></use>
+                </svg>
+                <span aria-hidden="true">E</span>
+            </span>
+            <span class="eek__rating" aria-hidden="true">
+                G
+            </span>
+        </div>
+        <svg class="icon icon--eek-arrow" aria-hidden="true">
+            <use href="#icon-eek-arrow"></use>
+        </svg>
+    </div>
+    </highlight-code>
+
 
 
 </div>

--- a/src/modules/eek.marko
+++ b/src/modules/eek.marko
@@ -1,6 +1,7 @@
 <div id="eek">
     <section-header metadata=input.metadata name=input.name/>
     <p>
+        EEK is an icon that is used for energy ratings. It is a rating system that is used to show how energy efficient a product is.
         EEKs have two parts, a range, and a rating.
         The following ranges are available:
     </p>
@@ -138,7 +139,7 @@
         </tbody>
     </table>
 
-    <h3 id="button-default">EEK examples</h3>
+    <h3 id="eek-default">EEK examples</h3>
     <div class="demo">
         <div class="demo__inner">
             <div class="eek eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
@@ -249,7 +250,7 @@
     </highlight-code>
 
 
-    <h3 id="button-default">Large EEK</h3>
+    <h3 id="eek-large">Large EEK</h3>
     <p>In order to match other items on the screen, you can use <span class="highlight">eek--large</span> class to increase the size</p>
     <div class="demo">
         <div class="demo__inner">

--- a/src/sass/eek/eek.scss
+++ b/src/sass/eek/eek.scss
@@ -3,6 +3,7 @@
 
 /* Calculate hypotenuse of a 28px square (for rotation). */
 /* Formula is: sqrt(pow(28px, 2) / 2) */
+/* Heights defined in this should not use variables. This is because they are specific to legal requirements and should not change */
 
 $eek-arrow-size: #{math.sqrt(392)}px;
 /* These are custom colors not part of ebay palette */
@@ -26,6 +27,10 @@ $eek-border-color: $eek-color;
     position: relative;
 }
 
+.eek--large {
+    height: 32px;
+}
+
 .eek__container {
     align-items: center;
     border: 1px solid $eek-color;
@@ -38,6 +43,10 @@ $eek-border-color: $eek-color;
     width: 9px;
 }
 
+.eek--large .icon--eek-arrow {
+    width: 12.5px;
+}
+
 .eek__arrow {
     overflow: hidden;
     width: 17px;
@@ -48,13 +57,11 @@ $eek-border-color: $eek-color;
     border-radius: 2px;
     content: "";
     display: block;
-    /* stylelint-disable-next-line number-max-precision */
     height: $eek-arrow-size;
     margin-top: 2.3px;
     position: relative;
     right: 12px;
     transform: rotate(45deg);
-    /* stylelint-disable-next-line number-max-precision */
     width: $eek-arrow-size;
 }
 
@@ -119,6 +126,10 @@ $eek-border-color: $eek-color;
         -0.5px -0.5px 0 $eek-color;
 }
 
+.eek--large .eek__rating {
+    font-size: 24px;
+}
+
 .eek__rating-range {
     align-items: center;
     background-color: $eek-background-color;
@@ -130,13 +141,28 @@ $eek-border-color: $eek-color;
     padding: 0 1px;
 }
 
+.eek--large .eek__rating-range {
+    height: 28px;
+}
+
 .eek__rating-range > .icon--eek-range-arrow {
     height: 6px;
     width: 5px;
 }
 
+.eek--large .eek__rating-range > .icon--eek-range-arrow {
+    height: 7px;
+    width: 6px;
+}
+
 .eek__rating-range > span {
     font-size: 8px;
+    height: 8px;
+}
+
+.eek--large .eek__rating-range > span {
+    font-size: 10px;
+    height: 10px;
 }
 
 /*
@@ -151,5 +177,15 @@ Changed a bit of styles there only in order to make it work
             -webkit-text-stroke: 0.5px;
             -webkit-text-stroke-color: $eek-color;
         }
+    }
+}
+
+[dir="rtl"] {
+    .eek .icon--eek-arrow {
+        transform: rotate(180deg);
+    }
+    .eek__container {
+        border-left: none;
+        border-right: 1px solid $eek-color;
     }
 }

--- a/src/sass/eek/stories/eek.stories.js
+++ b/src/sass/eek/stories/eek.stories.js
@@ -1,0 +1,85 @@
+export default { title: "Skin/EEK" };
+
+export const typical = () => `
+    <div class="eek eek--rating-4" role="figure" aria-label="Energy Rating: B. Range: A++ - E">
+        <div class="eek__container">
+            <span class="eek__rating-range">
+                <span aria-hidden="true">A++</span>
+                <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                    <use href="#icon-eek-range-arrow"></use>
+                </svg>
+                <span aria-hidden="true">E</span>
+            </span>
+            <span class="eek__rating" aria-hidden="true">
+                B
+            </span>
+        </div>
+        <svg class="icon icon--eek-arrow" aria-hidden="true">
+            <use href="#icon-eek-arrow"></use>
+        </svg>
+    </div>
+`;
+
+export const large = () => `
+    <div class="eek eek--large eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
+        <div class="eek__container">
+            <span class="eek__rating-range">
+                <span aria-hidden="true">A+++</span>
+                <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                    <use href="#icon-eek-range-arrow"></use>
+                </svg>
+                <span aria-hidden="true">D</span>
+            </span>
+            <span class="eek__rating" aria-hidden="true">
+                A+++
+            </span>
+        </div>
+        <svg class="icon icon--eek-arrow" aria-hidden="true">
+            <use href="#icon-eek-arrow"></use>
+        </svg>
+    </div>
+`;
+
+export const RTL = () => `
+<div dir="rtl">
+    <div class="eek eek--rating-4" role="figure" aria-label="Energy Rating: B. Range: A++ - E">
+        <div class="eek__container">
+            <span class="eek__rating-range">
+                <span aria-hidden="true">A++</span>
+                <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                    <use href="#icon-eek-range-arrow"></use>
+                </svg>
+                <span aria-hidden="true">E</span>
+            </span>
+            <span class="eek__rating" aria-hidden="true">
+                B
+            </span>
+        </div>
+        <svg class="icon icon--eek-arrow" aria-hidden="true">
+            <use href="#icon-eek-arrow"></use>
+        </svg>
+    </div>
+</div>
+`;
+
+export const RTLLarge = () => `
+<div dir="rtl">
+    <div class="eek eek--large eek--rating-1" role="figure" aria-label="Energy Rating: A+++. Range: A+++ - D">
+        <div class="eek__container">
+            <span class="eek__rating-range">
+                <span aria-hidden="true">A+++</span>
+                <svg class="icon icon--eek-range-arrow" aria-hidden="true">
+                    <use href="#icon-eek-range-arrow"></use>
+                </svg>
+                <span aria-hidden="true">D</span>
+            </span>
+            <span class="eek__rating" aria-hidden="true">
+                A+++
+            </span>
+        </div>
+        <svg class="icon icon--eek-arrow" aria-hidden="true">
+            <use href="#icon-eek-arrow"></use>
+        </svg>
+    </div>
+</div>
+`;


### PR DESCRIPTION
Fixes #2469

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added large eek size
* As part of this, I noticed the eek arrow was too small, fixed it to be larger
* There were no stories, so I added those as well. 
* After adding storeis, I saw there were some RTL issues. Fixed RTL issues as well. 
* __note__ there is an open question to design about the regular EEK size but that can be done in a followup. The main issue is the height of the range portion is 20px, but the text range is supposed to be 8px and the icon is 6px. So 8+8+6 = 22px which is too large. But this isn't a problem in large EEK. 

## Screenshots
<img width="832" alt="Screenshot 2024-11-01 at 9 08 34 AM" src="https://github.com/user-attachments/assets/0a7cf922-6e1a-4287-9fc5-b2bc80c1a319">


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
