### PR TITLE
docs(link): added disabled fake-link

### DIFF
--- a/.changeset/tame-monkeys-sparkle.md
+++ b/.changeset/tame-monkeys-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+docs(link): added disabled fake-link

--- a/src/modules/link.marko
+++ b/src/modules/link.marko
@@ -146,6 +146,28 @@
         >
 <button class="fake-link" type="button">Button</button>
     </highlight-code>
+
+
+    <h3 id="link-fake">
+        Disabled Fake Link
+    </h3>
+    <p>
+        To disable a button styled to look like a link, use the disabled attribute.
+    </p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <button class="fake-link" disabled type="button">
+                Button
+            </button>
+        </div>
+    </div>
+
+    <highlight-code
+        type="html"
+        >
+<button class="fake-link" type="button" disabled>Button</button>
+    </highlight-code>
     <!--
     <p>To style a button to look like an <em>action</em> link, use the <span class="highlight">fake-link--action</span> modifier.</p>
 

--- a/src/sass/link/stories/link.stories.js
+++ b/src/sass/link/stories/link.stories.js
@@ -21,6 +21,9 @@ export const RTL = () => `
 export const fake = () =>
     `<button class="fake-link" type="button">Button</button>`;
 
+export const disabledFake = () =>
+    `<button class="fake-link" disbaled type="button">Button</button>`;
+
 export const nav = () =>
     `<a class="nav-link" href="https://www.ebay.com/?r=${Math.floor(
         Math.random() * Math.floor(1000),


### PR DESCRIPTION

Fixes #2488

- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
* Added documentation for fake-link disabled

## Screenshots
<img width="805" alt="Screenshot 2024-12-11 at 1 29 46 PM" src="https://github.com/user-attachments/assets/a95e0d19-0b67-4490-95d3-6f220673ce4d" />

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
