### PR TITLE
fix(alert/confirm-dialog): changed alignment to left and right for footer

### DIFF
--- a/.changeset/mean-goats-smile.md
+++ b/.changeset/mean-goats-smile.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fix(alert/confirm-dialog): changed alignment to left by default and right for footer

--- a/dist/alert-dialog/alert-dialog.css
+++ b/dist/alert-dialog/alert-dialog.css
@@ -38,7 +38,6 @@
     min-height: 55px;
     min-width: 208px;
     padding: var(--spacing-200);
-    text-align: center;
     will-change: opacity, transform;
 }
 
@@ -47,6 +46,10 @@
     font-weight: var(--font-weight-bold);
     line-height: 28px;
     margin: 0;
+}
+
+.alert-dialog__footer {
+    text-align: right;
 }
 
 .alert-dialog__main {

--- a/dist/confirm-dialog/confirm-dialog.css
+++ b/dist/confirm-dialog/confirm-dialog.css
@@ -38,7 +38,6 @@
     min-height: 55px;
     min-width: 208px;
     padding: var(--spacing-200);
-    text-align: center;
     will-change: opacity, transform;
 }
 
@@ -58,6 +57,10 @@
 }
 .confirm-dialog__main > :last-child {
     margin-bottom: 0;
+}
+
+.confirm-dialog__footer {
+    text-align: right;
 }
 
 a.confirm-dialog__confirm,

--- a/src/sass/alert-dialog/alert-dialog.scss
+++ b/src/sass/alert-dialog/alert-dialog.scss
@@ -13,13 +13,16 @@
     margin-left: var(--spacing-200);
     margin-right: var(--spacing-200);
     padding: var(--spacing-200);
-    text-align: center;
 }
 
 .alert-dialog__title {
     @include typography-large-1();
 
     margin: 0;
+}
+
+.alert-dialog__footer {
+    text-align: right;
 }
 
 .alert-dialog__main {

--- a/src/sass/confirm-dialog/confirm-dialog.scss
+++ b/src/sass/confirm-dialog/confirm-dialog.scss
@@ -13,7 +13,6 @@
     margin-left: var(--spacing-200);
     margin-right: var(--spacing-200);
     padding: var(--spacing-200);
-    text-align: center;
 }
 
 .confirm-dialog__title {
@@ -33,6 +32,10 @@
     & > :last-child {
         margin-bottom: 0;
     }
+}
+
+.confirm-dialog__footer {
+    text-align: right;
 }
 
 a.confirm-dialog__confirm,


### PR DESCRIPTION
Fixes #2489

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Changed dialogs to be left aligned except footer to be right aligned.

## Screenshots
<img width="852" alt="Screenshot 2024-12-11 at 2 09 47 PM" src="https://github.com/user-attachments/assets/e729acc4-f5ca-4267-9373-c2279b6a8dba" />


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue


- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
