### PR TITLE
fix(progress-stepper): updated upcoming color to meet contrast

### DIFF
--- a/.changeset/twenty-berries-eat.md
+++ b/.changeset/twenty-berries-eat.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fix(progress-stepper): update incomplete step color to meet contrast

--- a/dist/svg/icon/icon-stepper-upcoming-24.svg
+++ b/dist/svg/icon/icon-stepper-upcoming-24.svg
@@ -3,6 +3,6 @@
     fill-rule="evenodd"
     clip-rule="evenodd"
     d="M12 2.5C6.47759 2.5 2 6.97649 2 12.5C2 18.0223 6.47775 22.5 12 22.5C17.5223 22.5 22 18.0223 22 12.5C22 6.97649 17.5224 2.5 12 2.5ZM0 12.5C0 5.87176 5.37318 0.5 12 0.5C18.6268 0.5 24 5.87176 24 12.5C24 19.1268 18.6268 24.5 12 24.5C5.37318 24.5 0 19.1268 0 12.5Z"
-    fill="var(--progress-stepper-upcoming-icon, var(--color-background-disabled))"
+    fill="var(--progress-stepper-upcoming-icon, var(--color-stroke-default))"
   />
 </svg>

--- a/dist/svg/icons.svg
+++ b/dist/svg/icons.svg
@@ -8749,7 +8749,7 @@
       fill-rule="evenodd"
       clip-rule="evenodd"
       d="M12 2.5C6.47759 2.5 2 6.97649 2 12.5C2 18.0223 6.47775 22.5 12 22.5C17.5223 22.5 22 18.0223 22 12.5C22 6.97649 17.5224 2.5 12 2.5ZM0 12.5C0 5.87176 5.37318 0.5 12 0.5C18.6268 0.5 24 5.87176 24 12.5C24 19.1268 18.6268 24.5 12 24.5C5.37318 24.5 0 19.1268 0 12.5Z"
-      fill="var(--progress-stepper-upcoming-icon, var(--color-background-disabled))"
+      fill="var(--progress-stepper-upcoming-icon, var(--color-stroke-default))"
     />
   </symbol>
   <symbol viewBox="0 0 16 16" id="icon-store-16">

--- a/src/components/master-icons.marko
+++ b/src/components/master-icons.marko
@@ -8749,7 +8749,7 @@
       fill-rule="evenodd"
       clip-rule="evenodd"
       d="M12 2.5C6.47759 2.5 2 6.97649 2 12.5C2 18.0223 6.47775 22.5 12 22.5C17.5223 22.5 22 18.0223 22 12.5C22 6.97649 17.5224 2.5 12 2.5ZM0 12.5C0 5.87176 5.37318 0.5 12 0.5C18.6268 0.5 24 5.87176 24 12.5C24 19.1268 18.6268 24.5 12 24.5C5.37318 24.5 0 19.1268 0 12.5Z"
-      fill="var(--progress-stepper-upcoming-icon, var(--color-background-disabled))"
+      fill="var(--progress-stepper-upcoming-icon, var(--color-stroke-default))"
     />
   </symbol>
   <symbol viewBox="0 0 16 16" id="icon-store-16">

--- a/src/routes/static/icon/icon-stepper-upcoming-24.svg
+++ b/src/routes/static/icon/icon-stepper-upcoming-24.svg
@@ -3,6 +3,6 @@
     fill-rule="evenodd"
     clip-rule="evenodd"
     d="M12 2.5C6.47759 2.5 2 6.97649 2 12.5C2 18.0223 6.47775 22.5 12 22.5C17.5223 22.5 22 18.0223 22 12.5C22 6.97649 17.5224 2.5 12 2.5ZM0 12.5C0 5.87176 5.37318 0.5 12 0.5C18.6268 0.5 24 5.87176 24 12.5C24 19.1268 18.6268 24.5 12 24.5C5.37318 24.5 0 19.1268 0 12.5Z"
-    fill="var(--progress-stepper-upcoming-icon, var(--color-background-disabled))"
+    fill="var(--progress-stepper-upcoming-icon, var(--color-stroke-default))"
   />
 </svg>

--- a/src/routes/static/icons.svg
+++ b/src/routes/static/icons.svg
@@ -8749,7 +8749,7 @@
       fill-rule="evenodd"
       clip-rule="evenodd"
       d="M12 2.5C6.47759 2.5 2 6.97649 2 12.5C2 18.0223 6.47775 22.5 12 22.5C17.5223 22.5 22 18.0223 22 12.5C22 6.97649 17.5224 2.5 12 2.5ZM0 12.5C0 5.87176 5.37318 0.5 12 0.5C18.6268 0.5 24 5.87176 24 12.5C24 19.1268 18.6268 24.5 12 24.5C5.37318 24.5 0 19.1268 0 12.5Z"
-      fill="var(--progress-stepper-upcoming-icon, var(--color-background-disabled))"
+      fill="var(--progress-stepper-upcoming-icon, var(--color-stroke-default))"
     />
   </symbol>
   <symbol viewBox="0 0 16 16" id="icon-store-16">

--- a/src/svg/icon/icon-stepper-upcoming-24.svg
+++ b/src/svg/icon/icon-stepper-upcoming-24.svg
@@ -3,6 +3,6 @@
     fill-rule="evenodd"
     clip-rule="evenodd"
     d="M12 2.5C6.47759 2.5 2 6.97649 2 12.5C2 18.0223 6.47775 22.5 12 22.5C17.5223 22.5 22 18.0223 22 12.5C22 6.97649 17.5224 2.5 12 2.5ZM0 12.5C0 5.87176 5.37318 0.5 12 0.5C18.6268 0.5 24 5.87176 24 12.5C24 19.1268 18.6268 24.5 12 24.5C5.37318 24.5 0 19.1268 0 12.5Z"
-    fill="var(--progress-stepper-upcoming-icon, var(--color-background-disabled))"
+    fill="var(--progress-stepper-upcoming-icon, var(--color-stroke-default))"
   />
 </svg>

--- a/src/svg/icons.svg
+++ b/src/svg/icons.svg
@@ -8749,7 +8749,7 @@
       fill-rule="evenodd"
       clip-rule="evenodd"
       d="M12 2.5C6.47759 2.5 2 6.97649 2 12.5C2 18.0223 6.47775 22.5 12 22.5C17.5223 22.5 22 18.0223 22 12.5C22 6.97649 17.5224 2.5 12 2.5ZM0 12.5C0 5.87176 5.37318 0.5 12 0.5C18.6268 0.5 24 5.87176 24 12.5C24 19.1268 18.6268 24.5 12 24.5C5.37318 24.5 0 19.1268 0 12.5Z"
-      fill="var(--progress-stepper-upcoming-icon, var(--color-background-disabled))"
+      fill="var(--progress-stepper-upcoming-icon, var(--color-stroke-default))"
     />
   </symbol>
   <symbol viewBox="0 0 16 16" id="icon-store-16">


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2494

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Updated the icon color to `--color-stroke-default` from `--color-background-disabled` in icons.svg file for `icon-stepper-upcoming-24` to meet contrast.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->
**Before**
<img width="340" alt="image" src="https://github.com/user-attachments/assets/2853555d-13c2-4a05-9f27-374e93f52dcc" />

**After**
<img width="340" alt="image" src="https://github.com/user-attachments/assets/9d86f6f5-5050-4264-8d87-7ee9179ac54a" />


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [x] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [x] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
