### PR TITLE
feat(floating-ui): added support for floating-ui in dropdowns

### DIFF
--- a/dist/chips-combobox/chips-combobox.css
+++ b/dist/chips-combobox/chips-combobox.css
@@ -61,7 +61,7 @@
 }
 
 .chips-combobox .combobox__listbox {
-    top: calc(100% + var(--spacing-150));
+    top: 0;
 }
 
 .chips-combobox .combobox__option[role^="option"] {

--- a/dist/chips-combobox/chips-combobox.css
+++ b/dist/chips-combobox/chips-combobox.css
@@ -60,8 +60,8 @@
     transition: transform 0.2s linear;
 }
 
-.chips-combobox .combobox__listbox {
-    top: 0;
+.chips-combobox .combobox__listbox--set-position {
+    top: calc(100% + var(--spacing-150));
 }
 
 .chips-combobox .combobox__option[role^="option"] {

--- a/dist/combobox/combobox.css
+++ b/dist/combobox/combobox.css
@@ -38,12 +38,17 @@ span.combobox {
     display: none;
     left: 0;
     max-height: 400px;
-    min-width: 100%;
     overflow-y: auto;
     position: absolute;
+    top: 0;
+    width: -moz-fit-content;
+    width: fit-content;
+    z-index: 2;
+}
+.combobox__listbox--set-position {
+    min-width: 100%;
     top: calc(100% + 4px);
     width: auto;
-    z-index: 2;
 }
 
 .combobox__listbox--reverse,

--- a/dist/filter-menu-button/filter-menu-button.css
+++ b/dist/filter-menu-button/filter-menu-button.css
@@ -152,13 +152,16 @@ button.filter-menu-button__button[aria-pressed="true"][disabled]:hover {
     border-radius: 16px;
     box-shadow: var(--bubble-shadow);
     display: none;
-    max-width: 288px;
     min-width: 144px;
     overflow: hidden;
     position: absolute;
-    top: calc(100% + 8px);
+    top: 0;
     width: max-content;
     z-index: 1;
+}
+
+.filter-menu-button__menu--set-position {
+    top: calc(100% + 8px);
 }
 
 button.filter-menu-button__button[aria-expanded="true"]
@@ -168,7 +171,6 @@ button.filter-menu-button__button[aria-expanded="true"]
 
 .filter-menu-button__items {
     margin-top: 8px;
-    max-height: calc(50vh - 40px);
     min-width: 100%;
     overflow-y: auto;
     position: relative;

--- a/dist/filter-menu-button/filter-menu-button.css
+++ b/dist/filter-menu-button/filter-menu-button.css
@@ -171,6 +171,7 @@ button.filter-menu-button__button[aria-expanded="true"]
 
 .filter-menu-button__items {
     margin-top: 8px;
+    max-height: 400px;
     min-width: 100%;
     overflow-y: auto;
     position: relative;

--- a/dist/listbox-button/listbox-button.css
+++ b/dist/listbox-button/listbox-button.css
@@ -37,12 +37,17 @@ div.listbox-button__listbox {
     display: none;
     left: 0;
     max-height: 400px;
-    min-width: 100%;
     overflow-y: auto;
     position: absolute;
+    top: 0;
+    width: -moz-fit-content;
+    width: fit-content;
+    z-index: 2;
+}
+div.listbox-button__listbox--set-position {
+    min-width: 100%;
     top: calc(100% + 4px);
     width: auto;
-    z-index: 2;
 }
 [dir="rtl"] div.listbox-button__listbox {
     left: unset;

--- a/dist/menu-button/menu-button.css
+++ b/dist/menu-button/menu-button.css
@@ -23,13 +23,19 @@
     display: none;
     left: 0;
     max-height: 400px;
-    min-width: 100%;
     outline: 0;
     overflow-y: auto;
     position: absolute;
+    top: 0;
+    width: -moz-fit-content;
+    width: fit-content;
+    z-index: 2;
+}
+.fake-menu-button__menu--set-position,
+.menu-button__menu--set-position {
+    min-width: 100%;
     top: calc(100% + 4px);
     width: auto;
-    z-index: 2;
 }
 [dir="rtl"] .fake-menu-button__menu,
 [dir="rtl"] .menu-button__menu {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@commitlint/cli": "^19.6.1",
                 "@commitlint/config-conventional": "^19.6.0",
                 "@ebay/browserslist-config": "^2.10.0",
-                "@floating-ui/dom": "^1.6.12",
+                "@floating-ui/dom": "^1.6.13",
                 "@marko/run": "^0.5.13",
                 "@marko/run-adapter-static": "^0.2.1",
                 "@percy/cli": "^1.30.5",
@@ -2871,19 +2871,19 @@
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.6.12",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-            "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+            "version": "1.6.13",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+            "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
             "dev": true,
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
-                "@floating-ui/utils": "^0.2.8"
+                "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-            "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
             "dev": true
         },
         "node_modules/@gulpjs/messages": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
         "@ebay/browserslist-config": "^2.10.0",
-        "@floating-ui/dom": "^1.6.12",
+        "@floating-ui/dom": "^1.6.13",
         "@marko/run": "^0.5.13",
         "@marko/run-adapter-static": "^0.2.1",
         "@percy/cli": "^1.30.5",

--- a/src/routes/main.js
+++ b/src/routes/main.js
@@ -41,6 +41,7 @@ import {
     flip,
     computePosition,
     shift,
+    size,
     offset,
     arrow,
     inline,
@@ -81,6 +82,60 @@ const debounce = (func, wait) => {
         timeout = setTimeout(later, wait);
     };
 };
+
+class PopperDropdown {
+    constructor(widgetEl, hostSelector, overlaySelector) {
+        this.el = widgetEl;
+        if (!hostSelector) {
+            this.host = widgetEl;
+        } else {
+            this.host = widgetEl.querySelector(hostSelector);
+        }
+        this.overlay = widgetEl.querySelector(overlaySelector);
+
+        if (this.host && this.overlay) {
+            this.isInitialized = true;
+        }
+    }
+
+    attachEvents() {
+        this.el.addEventListener("expander-expand", () => {
+            this.show();
+        });
+        this.el.addEventListener("expander-collapse", () => {
+            this.hide();
+        });
+    }
+
+    init() {
+        this.cleanup = autoUpdate(
+            this.host,
+            this.overlay,
+            this.update.bind(this),
+        );
+    }
+
+    update() {
+        if (this.isInitialized) {
+            computePosition(this.host, this.overlay, {
+                placement: "bottom-start",
+                middleware: [offset(4), flip(), shift()],
+            }).then(({ x, y }) => {
+                Object.assign(this.overlay.style, {
+                    left: `${x}px`,
+                    top: `${y}px`,
+                });
+            });
+        }
+    }
+
+    show() {
+        this.init();
+    }
+    hide() {
+        if (this.cleanup) this.cleanup();
+    }
+}
 
 // BUSY BUTTON
 document.getElementById("busy-button")?.addEventListener("click", function () {
@@ -132,17 +187,31 @@ document.querySelectorAll(".expand-btn").forEach(function (el) {
     });
 });
 
-document
-    .querySelectorAll(".filter-menu-button--form button")
-    .forEach(function (el) {
-        el.addEventListener("click", function () {
-            const isExpanded = this.getAttribute("aria-expanded") === "true";
-            this.setAttribute("aria-expanded", !isExpanded);
-        });
+document.querySelectorAll(".filter-menu-button--form").forEach(function (el) {
+    const popperDropdown = new PopperDropdown(
+        el,
+        "button",
+        ".filter-menu-button__menu",
+    );
+    el.querySelector("button").addEventListener("click", function () {
+        const isExpanded = this.getAttribute("aria-expanded") === "true";
+        this.setAttribute("aria-expanded", !isExpanded);
+        if (isExpanded) {
+            popperDropdown.hide();
+        } else {
+            popperDropdown.show();
+        }
     });
+});
 
 // FAKE MENU BUTTON
 document.querySelectorAll(".fake-menu-button").forEach(function (widgetEl) {
+    let popperDropdown = new PopperDropdown(
+        widgetEl,
+        "button",
+        ".fake-menu-button__menu",
+    );
+
     let hostSelector = ".icon-btn";
     if (widgetEl.querySelector(".expand-btn")) {
         hostSelector = ".expand-btn";
@@ -160,12 +229,21 @@ document.querySelectorAll(".fake-menu-button").forEach(function (widgetEl) {
             hostSelector,
         }),
     );
+    popperDropdown.attachEvents();
 });
 
 // COMBOBOX
 document.querySelectorAll(".combobox").forEach(function (widgetEl) {
     pageWidgets.push(new Combobox(widgetEl));
 
+    if (!widgetEl.parentElement.classList.contains("chips-combobox")) {
+        let popperDropdown = new PopperDropdown(
+            widgetEl,
+            "input",
+            ".combobox__listbox",
+        );
+        popperDropdown.attachEvents();
+    }
     widgetEl.addEventListener("makeup-combobox-change", logEvent);
 });
 
@@ -557,6 +635,12 @@ document.querySelectorAll(".listbox-button").forEach(function (widgetEl) {
         return;
     }
 
+    let popperDropdown = new PopperDropdown(
+        widgetEl,
+        "button",
+        ".listbox-button__listbox",
+    );
+
     const options = {
         autoSelect: widgetEl.dataset.makeupAutoSelect === "true",
         buttonLabelSelector: ".btn__text",
@@ -567,6 +651,7 @@ document.querySelectorAll(".listbox-button").forEach(function (widgetEl) {
 
     pageWidgets.push(new ListboxButton(widgetEl, options));
 
+    popperDropdown.attachEvents();
     widgetEl.addEventListener("makeup-listbox-button-change", (e) => {
         console.log(e.type, e.detail);
     });
@@ -585,6 +670,12 @@ document
 
         pageWidgets.push(new ListboxButton(widgetEl, options));
 
+        let popperDropdown = new PopperDropdown(
+            widgetEl,
+            "button",
+            ".listbox-button__listbox",
+        );
+
         widgetEl.addEventListener("makeup-listbox-button-change", (e) => {
             console.log(e.type, e.detail);
             const selectedOption = widgetEl.querySelector(
@@ -595,13 +686,23 @@ document
             ).textContent =
                 `+${selectedOption.querySelector("span.fflag")?.dataset.countryCode}`;
         });
+
+        popperDropdown.attachEvents();
     });
 
 document.querySelectorAll(".menu-button").forEach(function (widgetEl) {
+    const popperDropdown = new PopperDropdown(
+        widgetEl,
+        "button",
+        ".menu-button__menu",
+    );
+
     const widget = new MenuButton(widgetEl, {
         menuSelector: ".menu-button__menu",
         buttonTextSelector: `.btn__text`,
     });
+
+    popperDropdown.attachEvents();
 
     widget.menu.el.addEventListener("makeup-menu-select", logEvent);
     widget.menu.el.addEventListener("makeup-menu-change", logEvent);
@@ -614,9 +715,16 @@ document
             expandedClass: "filter-menu-button--expanded",
             menuSelector: ".filter-menu-button__menu",
         });
+        const popperDropdown = new PopperDropdown(
+            widgetEl,
+            "button",
+            ".filter-menu-button__menu",
+        );
 
         widget.menu.el.addEventListener("makeup-menu-select", logEvent);
         widget.menu.el.addEventListener("makeup-menu-change", logEvent);
+
+        popperDropdown.attachEvents();
     });
 
 document.querySelectorAll(".menu").forEach(function (widgetEl) {
@@ -859,6 +967,13 @@ document.querySelectorAll(".field").forEach(function (elCharContainer) {
     document
         .querySelectorAll(".chips-combobox")
         .forEach(function (elChipsCombobox) {
+            let popperDropdown = new PopperDropdown(
+                elChipsCombobox,
+                null,
+                ".combobox__listbox",
+            );
+            popperDropdown.attachEvents();
+
             const elChipsItems = elChipsCombobox.querySelector(
                     ".chips-combobox__items",
                 ),

--- a/src/sass/chips-combobox/chips-combobox.scss
+++ b/src/sass/chips-combobox/chips-combobox.scss
@@ -63,7 +63,7 @@
 }
 
 .chips-combobox .combobox__listbox {
-    top: calc(100% + var(--spacing-150));
+    top: 0;
 }
 
 .chips-combobox .combobox__option[role^="option"] {

--- a/src/sass/chips-combobox/chips-combobox.scss
+++ b/src/sass/chips-combobox/chips-combobox.scss
@@ -62,8 +62,8 @@
     transition: transform 200ms linear;
 }
 
-.chips-combobox .combobox__listbox {
-    top: 0;
+.chips-combobox .combobox__listbox--set-position {
+    top: calc(100% + var(--spacing-150));
 }
 
 .chips-combobox .combobox__option[role^="option"] {

--- a/src/sass/chips-combobox/stories/chips-combobox.stories.js
+++ b/src/sass/chips-combobox/stories/chips-combobox.stories.js
@@ -10,7 +10,7 @@ export const empty = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>
@@ -37,7 +37,7 @@ export const fluid = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>
@@ -95,7 +95,7 @@ export const prefilled = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>
@@ -273,7 +273,7 @@ export const manyChips = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>
@@ -331,7 +331,7 @@ export const expanded = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>
@@ -389,7 +389,7 @@ export const textSpacing = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>
@@ -447,7 +447,7 @@ export const disabledState = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>
@@ -505,7 +505,7 @@ export const errorState = () => `
                 <use href="#icon-chevron-down-16"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Soccer</span>

--- a/src/sass/combobox/stories/combobox.stories.js
+++ b/src/sass/combobox/stories/combobox.stories.js
@@ -8,7 +8,7 @@ export const collapsed = () => `
             <use href="#icon-chevron-down-12"></use>
         </svg>
     </span>
-    <div class="combobox__listbox">
+    <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
@@ -29,7 +29,7 @@ export const expanded = () => `
             <use href="#icon-chevron-down-12"></use>
         </svg>
     </span>
-    <div class="combobox__listbox">
+    <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
@@ -50,7 +50,7 @@ export const textSpacing = () => `
             <use href="#icon-chevron-down-12"></use>
         </svg>
     </span>
-    <div class="combobox__listbox">
+    <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
@@ -71,7 +71,7 @@ export const disabled = () => `
             <use href="#icon-chevron-down-12"></use>
         </svg>
     </span>
-    <div class="combobox__listbox">
+    <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
@@ -92,7 +92,7 @@ export const large = () => `
             <use href="#icon-chevron-down-12"></use>
         </svg>
     </span>
-    <div class="combobox__listbox">
+    <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
@@ -113,7 +113,7 @@ export const longOptions = () => `
             <use href="#icon-chevron-down-12"></use>
         </svg>
     </span>
-    <div class="combobox__listbox">
+    <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
@@ -136,7 +136,7 @@ export const actionable = () => `
             </svg>
         </button>
     </span>
-    <div class="combobox__listbox">
+    <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
             <div class="combobox__option" role="option">
                 <span>Option 1</span>
@@ -161,7 +161,7 @@ export const RTL = () => `
                 <use href="#icon-chevron-down-12"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Option 1</span>
@@ -186,7 +186,7 @@ export const actionableRTL = () => `
                 </svg>
             </button>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox5" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Option 1</span>
@@ -212,7 +212,7 @@ export const inheritColour = () => `
                 <use href="#icon-chevron-down-12"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Option 1</span>
@@ -235,7 +235,7 @@ export const inheritFontSize = () => `
                 <use href="#icon-chevron-down-12"></use>
             </svg>
         </span>
-        <div class="combobox__listbox">
+        <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox1" class="combobox__options" role="listbox">
                 <div class="combobox__option" role="option">
                     <span>Option 1</span>

--- a/src/sass/filter-menu-button/filter-menu-button.scss
+++ b/src/sass/filter-menu-button/filter-menu-button.scss
@@ -145,6 +145,7 @@ button.filter-menu-button__button[aria-expanded="true"]
 
 .filter-menu-button__items {
     margin-top: 8px;
+    max-height: 400px;
     min-width: 100%;
     overflow-y: auto;
     position: relative;

--- a/src/sass/filter-menu-button/filter-menu-button.scss
+++ b/src/sass/filter-menu-button/filter-menu-button.scss
@@ -126,13 +126,16 @@ button.filter-menu-button__button[aria-pressed="true"][aria-disabled="true"]:hov
     border-radius: 16px;
     box-shadow: var(--bubble-shadow);
     display: none;
-    max-width: 288px; /* TODO remove max-width restriction to filter-menu styles */
     min-width: 144px;
     overflow: hidden;
     position: absolute;
-    top: calc(100% + 8px);
+    top: 0;
     width: max-content;
     z-index: 1;
+}
+
+.filter-menu-button__menu--set-position {
+    top: calc(100% + 8px);
 }
 
 button.filter-menu-button__button[aria-expanded="true"]
@@ -142,10 +145,6 @@ button.filter-menu-button__button[aria-expanded="true"]
 
 .filter-menu-button__items {
     margin-top: 8px;
-    max-height: calc(
-        50vh - 40px
-    ); /* half of the viewport height || TODO remove max-height restriction to filter-menu styles */
-
     min-width: 100%;
     overflow-y: auto;
     position: relative;

--- a/src/sass/filter-menu-button/stories/filter-menu-button.stories.js
+++ b/src/sass/filter-menu-button/stories/filter-menu-button.stories.js
@@ -10,7 +10,7 @@ export const collapsed = () => `
             </svg>
         </span>
     </button>
-    <div class="filter-menu-button__menu">
+    <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
         <div class="filter-menu-button__items" role="menu">
             <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
                 <span class="filter-menu-button__checkbox">
@@ -61,7 +61,7 @@ export const expanded = () => `
             </svg>
         </span>
     </button>
-    <div class="filter-menu-button__menu">
+    <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
         <div class="filter-menu-button__items" role="menu">
             <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
                 <span class="filter-menu-button__checkbox">
@@ -112,7 +112,7 @@ export const pressed = () => `
             </svg>
         </span>
     </button>
-    <div class="filter-menu-button__menu">
+    <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
         <div class="filter-menu-button__items" role="menu">
             <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
                 <span class="filter-menu-button__checkbox">
@@ -163,7 +163,7 @@ export const disabled = () => `
             </svg>
         </span>
     </button>
-    <div class="filter-menu-button__menu">
+    <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
         <div class="filter-menu-button__items" role="menu">
             <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
                 <span class="filter-menu-button__checkbox">
@@ -213,7 +213,7 @@ export const overflow = () => `
             </svg>
         </span>
     </button>
-    <div class="filter-menu-button__menu">
+    <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
         <div class="filter-menu-button__items" role="menu">
             <div class="filter-menu-button__item" role="menuitemcheckbox" tabindex="0" aria-checked="false">
                 <span class="filter-menu-button__checkbox">
@@ -451,7 +451,7 @@ export const textSpacing = () => `
             </svg>
         </span>
     </button>
-    <div class="filter-menu-button__menu">
+    <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
         <div class="filter-menu-button__items" role="menu">
             <div class="filter-menu-button__item" role="menuitemcheckbox" tabindex="0" aria-checked="false">
                 <span class="filter-menu-button__checkbox">
@@ -689,7 +689,7 @@ export const truncated = () => `
             </svg>
         </span>
     </button>
-    <div class="filter-menu-button__menu">
+    <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
         <div class="filter-menu-button__items" role="menu">
             <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
                 <span class="filter-menu-button__checkbox">
@@ -741,7 +741,7 @@ export const RTL = () => `
                 </svg>
             </span>
         </button>
-        <div class="filter-menu-button__menu">
+        <div class="filter-menu-button__menu filter-menu-button__menu--set-position">
             <div class="filter-menu-button__items" role="menu">
                 <div class="filter-menu-button__item" role="menuitemcheckbox" aria-checked="false">
                     <span class="filter-menu-button__checkbox">

--- a/src/sass/listbox-button/stories/base.stories.js
+++ b/src/sass/listbox-button/stories/base.stories.js
@@ -11,7 +11,7 @@ export const collapsedUnselected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -53,7 +53,7 @@ export const expandedUnselected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -95,7 +95,7 @@ export const collapsedSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -137,7 +137,7 @@ export const expandedSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -179,7 +179,7 @@ export const disabled = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -221,7 +221,7 @@ export const invalid = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -263,7 +263,7 @@ export const longOption = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red with very very very long text</span>
@@ -299,7 +299,7 @@ export const borderless = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox" tabindex="0">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">1</span>
@@ -335,7 +335,7 @@ export const floatingLabelSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox" tabindex="0">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -377,7 +377,7 @@ export const textSpacing = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/cascade.stories.js
+++ b/src/sass/listbox-button/stories/cascade.stories.js
@@ -12,7 +12,7 @@ export const RTL = () => `
                 </svg>
             </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
             <div class="listbox-button__options" role="listbox">
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>
@@ -56,7 +56,7 @@ export const color = () => `
                 </svg>
             </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
             <div class="listbox-button__options" role="listbox">
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>
@@ -100,7 +100,7 @@ export const fontSize = () => `
                 </svg>
             </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
             <div class="listbox-button__options" role="listbox">
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/dimensions.stories.js
+++ b/src/sass/listbox-button/stories/dimensions.stories.js
@@ -11,7 +11,7 @@ export const fluid = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/error/error.base.stories.js
+++ b/src/sass/listbox-button/stories/error/error.base.stories.js
@@ -11,7 +11,7 @@ export const collapsedUnselected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -53,7 +53,7 @@ export const expandedUnselected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -95,7 +95,7 @@ export const collapsedSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -137,7 +137,7 @@ export const expandedSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -179,7 +179,7 @@ export const invalid = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -221,7 +221,7 @@ export const longOption = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red with very very very long text</span>
@@ -257,7 +257,7 @@ export const borderless = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox" tabindex="0">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">1</span>
@@ -293,7 +293,7 @@ export const floatingLabelSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox" tabindex="0">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/error/error.cascade.stories.js
+++ b/src/sass/listbox-button/stories/error/error.cascade.stories.js
@@ -12,7 +12,7 @@ export const RTL = () => `
                 </svg>
             </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
             <div class="listbox-button__options" role="listbox">
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>
@@ -56,7 +56,7 @@ export const color = () => `
                 </svg>
             </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
             <div class="listbox-button__options" role="listbox">
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>
@@ -100,7 +100,7 @@ export const fontSize = () => `
                 </svg>
             </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
             <div class="listbox-button__options" role="listbox">
                 <div class="listbox-button__option" role="option" aria-selected="true">
                     <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/error/error.dimensions.stories.js
+++ b/src/sass/listbox-button/stories/error/error.dimensions.stories.js
@@ -11,7 +11,7 @@ export const fluid = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/error/error.form.stories.js
+++ b/src/sass/listbox-button/stories/error/error.form.stories.js
@@ -11,7 +11,7 @@ export const enabled = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -59,7 +59,7 @@ export const invalid = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/form.stories.js
+++ b/src/sass/listbox-button/stories/form.stories.js
@@ -11,7 +11,7 @@ export const enabled = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -59,7 +59,7 @@ export const disabled = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -107,7 +107,7 @@ export const invalid = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>

--- a/src/sass/listbox-button/stories/subtitle.stories.js
+++ b/src/sass/listbox-button/stories/subtitle.stories.js
@@ -11,7 +11,7 @@ export const collapsedUnselected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -65,7 +65,7 @@ export const expandedUnselected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -123,7 +123,7 @@ export const collapsedSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -181,7 +181,7 @@ export const expandedSelected = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -239,7 +239,7 @@ export const disabled = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -297,7 +297,7 @@ export const invalid = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
                 <span class="listbox-button__value">Red</span>
@@ -355,7 +355,7 @@ export const longOption = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red with very very very long text</span>
@@ -403,7 +403,7 @@ export const longSubtitle = () => `
             </svg>
         </span>
     </button>
-    <div class="listbox-button__listbox">
+    <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option" aria-selected="true">
                 <span class="listbox-button__value">Red</span>

--- a/src/sass/menu-button/stories/base.stories.js
+++ b/src/sass/menu-button/stories/base.stories.js
@@ -10,7 +10,7 @@ export const collapsed = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem">
                 <span>Item 10000</span>
@@ -36,7 +36,7 @@ export const disabled = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem">
                 <span>Item 10000</span>
@@ -62,7 +62,7 @@ export const expanded = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem" tabindex="0">
                 <span>Item 10000</span>
@@ -88,7 +88,7 @@ export const collapsedForm = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem">
                 <span>Item 10000</span>
@@ -114,7 +114,7 @@ export const expandedForm = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem" tabindex="0">
                 <span>Item 10000</span>
@@ -140,7 +140,7 @@ export const badged = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item menu-button__item--badged" role="menuitem" tabindex="0">
                 <span>Item 10000<span class="badge">2</span></span>
@@ -166,7 +166,7 @@ export const expandedDisabledItem = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div aria-disabled="true" class="menu-button__item" role="menuitem">
                 <span>Item 10000</span>
@@ -192,7 +192,7 @@ export const radioItems = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitemradio" tabindex="0" aria-checked="true">
                 <span>Item 10000</span>
@@ -227,7 +227,7 @@ export const radioItemsDisabledItem = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitemradio" aria-checked="true" aria-disabled="true">
                 <span>Item 10000</span>
@@ -262,7 +262,7 @@ export const checkboxItems = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitemcheckbox" tabindex="0" aria-checked="true">
                 <span>Item 10000</span>
@@ -297,7 +297,7 @@ export const checkboxItemsDisabledItem = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitemcheckbox" aria-checked="true" aria-disabled="true">
                 <span>Item 10000</span>
@@ -332,7 +332,7 @@ export const longOptionText = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem" tabindex="0">
                 <span>Item 1 with a very very very long string</span>
@@ -358,7 +358,7 @@ export const menuIcons = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem">
                 <svg class="icon icon--24" aria-label="Settings" role="icon">
@@ -399,7 +399,7 @@ export const separator = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem" tabindex="0">
                 <span>Item 10000</span>
@@ -426,7 +426,7 @@ export const textSpacing = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem" tabindex="0">
                 <span>Item 1 with a very very very long string</span>

--- a/src/sass/menu-button/stories/cascade.stories.js
+++ b/src/sass/menu-button/stories/cascade.stories.js
@@ -11,7 +11,7 @@ export const RTL = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu">
+    <div class="menu-button__menu menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem" tabindex="0">
                 <span>Item 10000</span>
@@ -39,7 +39,7 @@ export const colour = () => `
                 </svg>
             </span>
         </button>
-        <div class="menu-button__menu">
+        <div class="menu-button__menu menu-button__menu--set-position">
             <div class="menu-button__items" role="menu">
                 <div class="menu-button__item" role="menuitem" tabindex="0">
                     <span>Item 10000</span>
@@ -67,7 +67,7 @@ export const fontSize = () => `
                 </svg>
             </span>
         </button>
-        <div class="menu-button__menu">
+        <div class="menu-button__menu menu-button__menu--set-position">
             <div class="menu-button__items" role="menu">
                 <div class="menu-button__item" role="menuitemradio" tabindex="0" aria-checked="true">
                     <span>Item 10000</span>

--- a/src/sass/menu-button/stories/dimensions.stories.js
+++ b/src/sass/menu-button/stories/dimensions.stories.js
@@ -10,7 +10,7 @@ export const fixedWidth = () => `
             </svg>
         </span>
     </button>
-    <div class="menu-button__menu menu-button__menu--fix-width">
+    <div class="menu-button__menu menu-button__menu--fix-width menu-button__menu--set-position">
         <div class="menu-button__items" role="menu">
             <div class="menu-button__item" role="menuitem">
                 <span>Menu Item 1 with a long string</span>

--- a/src/sass/menu-button/stories/fake-menu-button.stories.js
+++ b/src/sass/menu-button/stories/fake-menu-button.stories.js
@@ -10,7 +10,7 @@ export const links = () => `
             </svg>
         </span>
     </button>
-    <ul class="fake-menu-button__menu">
+    <ul class="fake-menu-button__menu fake-menu-button__menu--set-position">
         <li>
             <a class="fake-menu-button__item" href="http://www.ebay.com" aria-current="page">
                 <span>Link 1</span>
@@ -40,7 +40,7 @@ export const linksSelected = () => `
             </svg>
         </span>
     </button>
-    <ul class="fake-menu-button__menu">
+    <ul class="fake-menu-button__menu fake-menu-button__menu--set-position">
         <li>
         <a aria-current="page" class="fake-menu-button__item" href="http://www.ebay.com">
             <span>Link 1</span>
@@ -73,7 +73,7 @@ export const linksDisabled = () => `
             </svg>
         </span>
     </button>
-    <ul class="fake-menu-button__menu">
+    <ul class="fake-menu-button__menu fake-menu-button__menu--fix-width">
         <li>
         <a aria-current="page" class="fake-menu-button__item">
             <span>Link 1</span>
@@ -106,7 +106,7 @@ export const linksFixedWidth = () => `
             </svg>
         </span>
     </button>
-    <ul class="fake-menu-button__menu fake-menu-button__menu--fix-width">
+    <ul class="fake-menu-button__menu fake-menu-button__menu--set-position">
         <li>
             <a class="fake-menu-button__item" href="http://www.ebay.com" aria-current="page">
                 <span>Link 10000</span>

--- a/src/sass/menu-button/stories/fake-menu-button.stories.js
+++ b/src/sass/menu-button/stories/fake-menu-button.stories.js
@@ -73,7 +73,7 @@ export const linksDisabled = () => `
             </svg>
         </span>
     </button>
-    <ul class="fake-menu-button__menu fake-menu-button__menu--fix-width">
+    <ul class="fake-menu-button__menu fake-menu-button__menu--set-position">
         <li>
         <a aria-current="page" class="fake-menu-button__item">
             <span>Link 1</span>

--- a/src/sass/mixins/private/_dropdown-mixins.scss
+++ b/src/sass/mixins/private/_dropdown-mixins.scss
@@ -12,12 +12,17 @@
     display: none;
     left: 0;
     max-height: 400px;
-    min-width: 100%;
     overflow-y: auto;
     position: absolute;
-    top: calc(100% + 4px);
-    width: auto;
+    top: 0;
+    width: fit-content;
     z-index: 2;
+
+    &--set-position {
+        min-width: 100%;
+        top: calc(100% + 4px);
+        width: auto;
+    }
 
     [dir="rtl"] & {
         left: unset;

--- a/src/sass/phone-input/stories/phone-input.stories.js
+++ b/src/sass/phone-input/stories/phone-input.stories.js
@@ -16,7 +16,7 @@ export const Default = () => `
           </svg>
         </span>
       </button>
-      <div class="listbox-button__listbox">
+      <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
           <div class="listbox-button__option" role="option">
             <span class="listbox-button__value">
@@ -99,7 +99,7 @@ export const Large = () => `
           </svg>
         </span>
       </button>
-      <div class="listbox-button__listbox">
+      <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
           <div class="listbox-button__option" role="option">
             <span class="listbox-button__value">
@@ -182,7 +182,7 @@ export const ReadOnly = () => `
           </svg>
         </span>
       </button>
-      <div class="listbox-button__listbox">
+      <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
           <div class="listbox-button__option" role="option">
             <span class="listbox-button__value">
@@ -265,7 +265,7 @@ export const Disabled = () => `
           </svg>
         </span>
       </button>
-      <div class="listbox-button__listbox">
+      <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
           <div class="listbox-button__option" role="option">
             <span class="listbox-button__value">
@@ -348,7 +348,7 @@ export const Error = () => `
           </svg>
         </span>
       </button>
-      <div class="listbox-button__listbox">
+      <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
           <div class="listbox-button__option" role="option">
             <span class="listbox-button__value">
@@ -431,7 +431,7 @@ export const Fluid = () => `
           </svg>
         </span>
       </button>
-      <div class="listbox-button__listbox">
+      <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
           <div class="listbox-button__option" role="option">
             <span class="listbox-button__value">
@@ -515,7 +515,7 @@ export const RTL = () => `
             </svg>
           </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
           <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
               <span class="listbox-button__value">
@@ -602,7 +602,7 @@ export const TextSpacing = () => `
           </svg>
         </span>
       </button>
-      <div class="listbox-button__listbox">
+      <div class="listbox-button__listbox listbox-button__listbox--set-position">
         <div class="listbox-button__options" role="listbox">
           <div class="listbox-button__option" role="option">
             <span class="listbox-button__value">
@@ -695,7 +695,7 @@ export const overrideFontSize = () => `
             </svg>
           </span>
         </button>
-        <div class="listbox-button__listbox">
+        <div class="listbox-button__listbox listbox-button__listbox--set-position">
           <div class="listbox-button__options" role="listbox">
             <div class="listbox-button__option" role="option">
               <span class="listbox-button__value">


### PR DESCRIPTION
Fixes #


- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* In order to support floating ui, we needed to add some default styles. We have these as the default. I kept around the old behavior of the dropdown as `menu-button__menu--set-position` in case we need it (I do not think its necessary, but others might; menu buttons should only be toggled with javascript, so having a no-js option isn't really feasible).
* For the width: I added it as fit-content. I also make sure it resizes appropriately. When I did max-content, there were some issues with overflowing menu items which would cause it to span across the whole page. 

## Screenshots
<img width="489" alt="Screenshot 2025-01-14 at 8 11 42 AM" src="https://github.com/user-attachments/assets/e9b0e448-0327-49f4-b020-3b3f03653600" />
<img width="328" alt="Screenshot 2025-01-14 at 8 11 37 AM" src="https://github.com/user-attachments/assets/b84095ae-dd7e-4f2d-949f-b29c3e50f843" />

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
