### PR TITLE
feat(combobox): remove chevron from combobox

### DIFF
--- a/.changeset/twelve-llamas-flash.md
+++ b/.changeset/twelve-llamas-flash.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": major
+---
+
+feat(combobox): remove chevron from combobox

--- a/src/routes/_index/component/chips-combobox/+page.marko
+++ b/src/routes/_index/component/chips-combobox/+page.marko
@@ -37,14 +37,6 @@
                             aria-haspopup="listbox"
                             aria-owns="listbox-chips-combobox-1"
                         >
-                        <svg
-                            class="icon icon--16"
-                            height="16"
-                            width="16"
-                            aria-hidden="true"
-                        >
-                            <icon-symbol name="chevron-down-16"/>
-                        </svg>
                     </span>
                     <div class="combobox__listbox">
                         <div
@@ -76,9 +68,6 @@
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -120,14 +109,6 @@
                             aria-haspopup="listbox"
                             aria-owns="listbox-chips-combobox-1"
                         >
-                        <svg
-                            class="icon icon--16"
-                            height="16"
-                            width="16"
-                            aria-hidden="true"
-                        >
-                            <icon-symbol name="chevron-down-16"/>
-                        </svg>
                     </span>
                     <div class="combobox__listbox">
                         <div
@@ -159,9 +140,6 @@
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -275,14 +253,6 @@
                             aria-haspopup="listbox"
                             aria-owns="listbox-chips-combobox-1"
                         >
-                        <svg
-                            class="icon icon--16"
-                            height="16"
-                            width="16"
-                            aria-hidden="true"
-                        >
-                            <icon-symbol name="chevron-down-16"/>
-                        </svg>
                     </span>
                     <div class="combobox__listbox">
                         <div
@@ -345,9 +315,6 @@
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -480,14 +447,6 @@
                             aria-owns="listbox-chips-combobox-1"
                             disabled
                         >
-                        <svg
-                            class="icon icon--16"
-                            height="16"
-                            width="16"
-                            aria-hidden="true"
-                        >
-                            <icon-symbol name="chevron-down-16"/>
-                        </svg>
                     </span>
                     <div class="combobox__listbox">
                         <div
@@ -550,9 +509,6 @@
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -684,14 +640,6 @@
                             aria-haspopup="listbox"
                             aria-owns="listbox-chips-combobox-1"
                         >
-                        <svg
-                            class="icon icon--16"
-                            height="16"
-                            width="16"
-                            aria-hidden="true"
-                        >
-                            <icon-symbol name="chevron-down-16"/>
-                        </svg>
                     </span>
                     <div class="combobox__listbox">
                         <div
@@ -754,9 +702,6 @@
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">

--- a/src/routes/_index/component/combobox/+page.marko
+++ b/src/routes/_index/component/combobox/+page.marko
@@ -36,14 +36,6 @@
                             aria-label="Combobox demo"
                             aria-owns="listbox-1"
                         >
-                        <svg
-                            class="icon icon--12"
-                            height="8"
-                            width="8"
-                            aria-hidden="true"
-                        >
-                            <icon-symbol name="chevron-down-12"/>
-                        </svg>
                     </span>
                     <div class="combobox__listbox">
                         <div
@@ -73,9 +65,6 @@
 <span class="combobox">
     <span class="combobox__control">
         <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox-1" />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox">
         <div id="listbox-1" class="combobox__options" role="listbox">
@@ -119,14 +108,6 @@
                             aria-owns="listbox-2"
                             disabled
                         >
-                        <svg
-                            class="icon icon--12"
-                            height="8"
-                            width="8"
-                            aria-hidden="true"
-                        >
-                            <icon-symbol name="chevron-down-12"/>
-                        </svg>
                     </span>
                     <div class="combobox__listbox">
                         <div
@@ -156,9 +137,6 @@
 <span class="combobox">
     <span class="combobox__control">
         <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox-2" disabled />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox">
         <div id="listbox-2" class="combobox__options" role="listbox">
@@ -175,143 +153,6 @@
     </div>
 </span>
     </highlight-code>
-    <!--
-    <h3 id="combobox-readonly">Readonly Combobox</h3>
-    <p>A readonly combobox is intended for use as a custom implementation of the native HTML select element. Unlike the default combobox, its options <em>do</em> have state. Notice that an additional span element is required within each option to host the status icon.</p>
-    <p>Unfortunately, a readonly combobox exhibits some UX issues on iOS, which is why for now we recommend using the <a href="#listbox">listbox</a> instead.</p>
-    <p>Apply the <span class="highlight">combobox--readonly</span> modifier and <span class="highlight">readonly</span> input property to create a readonly combobox.</p>
-    <p>By default, the textbox value should match the first option if the user does not specify a selection. This matches the behaviour of a native HTML select element.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <form action="index.html">
-                <span class="combobox combobox--readonly">
-                    <span class="combobox__control">
-                        <input name="combobox-readonly" role="combobox" type="text" value="Option 1" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox4" readonly />
-                        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-                            <icon-symbol name="chevron-down-12" />
-                        </svg>
-                    </span>
-                    <div class="combobox__listbox">
-                        <div id="listbox4" class="combobox__options" role="listbox">
-                            <div class="combobox__option" role="option">
-                                <span class="combobox__value">Option 1</span>
-                                <svg class="icon icon--16" height="8" width="8">
-                                    <icon-symbol name="tick-16" />
-                                </svg>
-                            </div>
-                            <div class="combobox__option" role="option">
-                                <span class="combobox__value">Option 2</span>
-                                <svg class="icon icon--16" height="8" width="8">
-                                    <icon-symbol name="tick-16" />
-                                </svg>
-                            </div>
-                            <div class="combobox__option" role="option">
-                                <span class="combobox__value">Option 3</span>
-                                <svg class="icon icon--16" height="8" width="8">
-                                    <icon-symbol name="tick-16" />
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-                </span>
-            </form>
-        </div>
-    </div>
-
-    <highlight-code type="html" >
-<span class="combobox combobox--readonly">
-    <span class="combobox__control">
-        <input role="combobox" type="text" value="Option 1" aria-haspopup="listbox" aria-owns="listbox4" readonly />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
-    </span>
-    <div class="combobox__listbox">
-        <div id="listbox4" class="combobox__options" role="listbox">
-            <div class="combobox__option" role="option">
-                <span class="combobox__value">Option 1</span>
-                <svg class="icon icon--16" height="8" width="8">
-                    <use href="#icon-tick-16"></use>
-                </svg>
-            </div>
-            <div class="combobox__option" role="option">
-                <span class="combobox__value">Option 2</span>
-                <svg class="icon icon--16" height="8" width="8">
-                    <use href="#icon-tick-16"></use>
-                </svg>
-            </div>
-            <div class="combobox__option" role="option">
-                <span class="combobox__value">Option 3</span>
-                <svg class="icon icon--16" height="8" width="8">
-                    <use href="#icon-tick-16"></use>
-                </svg>
-            </div>
-        </div>
-    </div>
-</span>
-    </highlight-code>
-
-    <h3 id="combobox-button">Icon Button Combobox</h3>
-    <p>In some cases, the suggestion overlay might be controlled by an <a href="#icon-button">icon button</a>. Use an <span class="highlight">icon-btn</span> and the <span class="highlight">combobox__control--actionable</span> modifier.</p>
-
-    <div class="demo">
-        <div class="demo__inner">
-            <form action="index.html">
-                <span class="combobox">
-                    <span class="combobox__control combobox__control--actionable">
-                        <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-label="Combobox demo" aria-owns="listbox5" />
-                        <button class="icon-btn" type="button" aria-label="Expand Suggestions">
-                            <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-                                <icon-symbol name="chevron-down-12" />
-                            </svg>
-                        </button>
-                    </span>
-                    <div class="combobox__listbox">
-                        <div id="listbox5" class="combobox__options" role="listbox">
-                            <div class="combobox__option" role="option">
-                                <span>Option 1</span>
-                            </div>
-                            <div class="combobox__option" role="option">
-                                <span>Option 2</span>
-                            </div>
-                            <div class="combobox__option" role="option">
-                                <span>Option 3</span>
-                            </div>
-                        </div>
-                    </div>
-                </span>
-            </form>
-        </div>
-    </div>
-
-    <highlight-code type="html" >
-<span class="combobox">
-    <span class="combobox__control combobox__control--actionable">
-        <input placeholder="Combobox" role="combobox" type="text" aria-haspopup="listbox" aria-owns="listbox5" />
-        <button class="icon-btn" type="button" aria-label="Expand Suggestions">
-            <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
-            </svg>
-        </button>
-    </span>
-    <div class="combobox__listbox">
-        <div id="listbox5" class="combobox__options" role="listbox">
-            <div class="combobox__option" role="option">
-                <span>Option 1</span>
-            </div>
-            <div class="combobox__option" role="option">
-                <span>Option 2</span>
-            </div>
-            <div class="combobox__option" role="option">
-                <span>Option 3</span>
-            </div>
-        </div>
-    </div>
-</span>
-    </highlight-code>
-
-    -->
 </div>
 export const metadata = {
     component: "combobox",

--- a/src/sass/chips-combobox/stories/chips-combobox.stories.js
+++ b/src/sass/chips-combobox/stories/chips-combobox.stories.js
@@ -6,9 +6,6 @@ export const empty = () => `
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -33,9 +30,6 @@ export const fluid = () => `
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -91,9 +85,6 @@ export const prefilled = () => `
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -269,9 +260,6 @@ export const manyChips = () => `
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -327,9 +315,6 @@ export const expanded = () => `
     <span class="combobox combobox--js combobox--expanded chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -385,9 +370,6 @@ export const textSpacing = () => `
     <span class="combobox combobox--js combobox--expanded chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -443,9 +425,6 @@ export const disabledState = () => `
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" disabled />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -501,9 +480,6 @@ export const errorState = () => `
     <span class="combobox combobox--js chips-combobox__combobox">
         <span class="combobox__control chips-combobox_combobox__control">
             <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-            <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                <use href="#icon-chevron-down-16"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">

--- a/src/sass/chips-combobox/stories/rtl-chips-combobox.stories.js
+++ b/src/sass/chips-combobox/stories/rtl-chips-combobox.stories.js
@@ -7,9 +7,6 @@ export const empty = () => `
         <span class="combobox combobox--js chips-combobox__combobox">
             <span class="combobox__control chips-combobox_combobox__control">
                 <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-                <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                    <use href="#icon-chevron-down-16"></use>
-                </svg>
             </span>
             <div class="combobox__listbox">
                 <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -36,9 +33,6 @@ export const fluid = () => `
         <span class="combobox combobox--js chips-combobox__combobox">
             <span class="combobox__control chips-combobox_combobox__control">
                 <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-                <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                    <use href="#icon-chevron-down-16"></use>
-                </svg>
             </span>
             <div class="combobox__listbox">
                 <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -96,9 +90,6 @@ export const prefilled = () => `
         <span class="combobox combobox--js chips-combobox__combobox">
             <span class="combobox__control chips-combobox_combobox__control">
                 <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-                <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                    <use href="#icon-chevron-down-16"></use>
-                </svg>
             </span>
             <div class="combobox__listbox">
                 <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -276,9 +267,6 @@ export const manyChips = () => `
         <span class="combobox combobox--js chips-combobox__combobox">
             <span class="combobox__control chips-combobox_combobox__control">
                 <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-                <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                    <use href="#icon-chevron-down-16"></use>
-                </svg>
             </span>
             <div class="combobox__listbox">
                 <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -336,9 +324,6 @@ export const expanded = () => `
         <span class="combobox combobox--js combobox--expanded chips-combobox__combobox">
             <span class="combobox__control chips-combobox_combobox__control">
                 <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-                <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                    <use href="#icon-chevron-down-16"></use>
-                </svg>
             </span>
             <div class="combobox__listbox">
                 <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -396,9 +381,6 @@ export const disabledState = () => `
         <span class="combobox combobox--js chips-combobox__combobox">
             <span class="combobox__control chips-combobox_combobox__control">
                 <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" disabled />
-                <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                    <use href="#icon-chevron-down-16"></use>
-                </svg>
             </span>
             <div class="combobox__listbox">
                 <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">
@@ -456,9 +438,6 @@ export const errorState = () => `
         <span class="combobox combobox--js chips-combobox__combobox">
             <span class="combobox__control chips-combobox_combobox__control">
                 <input id="chips-combobox-1-input" role="combobox" type="text" placeholder="Add Sport" aria-haspopup="listbox" aria-owns="listbox-chips-combobox-1" />
-                <svg class="icon icon--16" height="16" width="16" aria-hidden="true">
-                    <use href="#icon-chevron-down-16"></use>
-                </svg>
             </span>
             <div class="combobox__listbox">
                 <div id="listbox-chips-combobox-1" class="combobox__options" role="listbox">

--- a/src/sass/combobox/stories/combobox.stories.js
+++ b/src/sass/combobox/stories/combobox.stories.js
@@ -4,9 +4,6 @@ export const collapsed = () => `
 <span class="combobox">
     <span class="combobox__control">
         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="false" aria-haspopup="listbox" />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
@@ -25,9 +22,6 @@ export const expanded = () => `
 <span class="combobox combobox--expanded">
     <span class="combobox__control">
         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
@@ -46,9 +40,6 @@ export const textSpacing = () => `
 <span class="combobox combobox--expanded demo-a11y-text-spacing">
     <span class="combobox__control">
         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
@@ -67,9 +58,6 @@ export const disabled = () => `
 <span class="combobox">
     <span class="combobox__control">
         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="false" aria-haspopup="listbox" disabled />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
@@ -88,9 +76,6 @@ export const large = () => `
 <span class="combobox combobox--large combobox--expanded">
     <span class="combobox__control">
         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
@@ -109,9 +94,6 @@ export const longOptions = () => `
 <span class="combobox combobox--expanded">
     <span class="combobox__control">
         <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
-        <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-            <use href="#icon-chevron-down-12"></use>
-        </svg>
     </span>
     <div class="combobox__listbox combobox__listbox--set-position">
         <div id="listbox1" class="combobox__options" role="listbox">
@@ -157,9 +139,6 @@ export const RTL = () => `
     <span class="combobox combobox--expanded">
         <span class="combobox__control">
             <input class="pink-placeholder-text" name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
-            <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox1" class="combobox__options" role="listbox">
@@ -208,9 +187,6 @@ export const inheritColour = () => `
     <span class="combobox combobox--expanded">
         <span class="combobox__control">
             <input class="pink-placeholder-text" name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
-            <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox1" class="combobox__options" role="listbox">
@@ -231,9 +207,6 @@ export const inheritFontSize = () => `
     <span class="combobox combobox--expanded">
         <span class="combobox__control">
             <input name="combobox-default" placeholder="Combobox" role="combobox" type="text" aria-expanded="true" aria-haspopup="listbox" />
-            <svg class="icon icon--12" height="8" width="8" aria-hidden="true">
-                <use href="#icon-chevron-down-12"></use>
-            </svg>
         </span>
         <div class="combobox__listbox combobox__listbox--set-position">
             <div id="listbox1" class="combobox__options" role="listbox">


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Removes chevron from examples for `combobox` and `chips-combobox` to reduce confusion on it being an input and not a dropdown

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
