### PR TITLE
chore(docs): added sitemap to docs

### DIFF
--- a/src/components/site-footer.marko
+++ b/src/components/site-footer.marko
@@ -13,6 +13,7 @@ style {
             <li><anchor role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</anchor></li>
             <li><a role="menuitem" href="https://github.com/eBay/skin">Repo</a></li>
             <li><a role="menuitem" href="/storybook">Storybook</a></li>
+            <li><a role="menuitem" href="/sitemap">Sitemap</a></li>
         </ul>
     </nav>
     Copyright &copy; 2025 eBay, Inc. All rights reserved.

--- a/src/components/site-header.marko
+++ b/src/components/site-header.marko
@@ -68,6 +68,7 @@ import {components} from './components.marko';
                                                 <li><anchor role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</anchor></li>
                                                 <li><a role="menuitem" href="https://github.com/eBay/skin">Repo</a></li>
                                                 <li><a role="menuitem" href="/storybook">Storybook</a></li>
+                                                <li><a role="menuitem" href="/sitemap">Sitemap</a></li>
                                             </ul>
                                         </nav>
                                     </div>

--- a/src/routes/_index/+layout.style.scss
+++ b/src/routes/_index/+layout.style.scss
@@ -35,6 +35,10 @@ h1 {
     font-size: 1.25em;
 }
 
+main > div > h1 {
+    font-size: var(--font-size-large-2);
+}
+
 main > div > h2 {
     font-size: var(--font-size-large-1);
     margin-bottom: var(--spacing-100);

--- a/src/routes/_index/sitemap+page.marko
+++ b/src/routes/_index/sitemap+page.marko
@@ -1,0 +1,70 @@
+import siteMeta from "../../components/data/site.json" ;
+import {components} from '../../components/components.marko';
+
+style {
+    .page-sitemap {
+        nav {
+            margin-bottom: var(--spacing-400);
+        }
+
+        li {
+            margin-bottom: var(--spacing-200);
+        }
+
+        a.nav-link {
+            text-decoration: underline;
+        }
+
+        a.nav-link:visited,
+        a:visited {
+            color: revert;
+        }
+    }
+
+    .site-nav {
+        display: none;
+    }
+
+    main {
+        grid-area: 1 / 1 / span 1 / span 16;
+    }
+}
+
+<div class="page-sitemap">
+    <h1>Sitemap</h1>
+
+    <h2 id="sitemap-pages">Main Pages</h2>
+
+    <nav aria-labelledby="sitemap-pages">
+        <ul role="menubar">
+        <li><anchor role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</anchor></li>
+            <li><a role="menuitem" href="https://github.com/eBay/skin">Repo</a></li>
+            <li><a role="menuitem" href="/storybook">Storybook</a></li>
+        </ul>
+    </nav>
+
+    <h2 id="sitemap-components">CSS Components</h2>
+
+    <nav aria-labelledby="sitemap-components">
+        <ul role="menubar">
+            <components-list components=components/>
+        </ul>
+    </nav>
+
+    <h2 id="sitemap-guides">Guides</h2>
+
+    <nav aria-labelledby="sitemap-guides">
+        <ul role="menubar">
+            <li>
+                <anchor href="guide/page-grid" role="menuitem">
+                Page Grid Use Guide</anchor>
+            </li>
+            <li>
+                <anchor href="guide/skeleton" role="menuitem">Skeleton Use Guide</anchor>
+            </li>
+            <li>
+                <anchor href="guide/animation" role="menuitem">Animation Guide</anchor>
+            </li>
+        </ul>
+    </nav>
+</div>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2411

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [X] This PR does not contain CSS changes

## Description
This change adds a sitemap page to Skin docs for easier crawling and indexing by DocSearch and for SEO benefits. 

## Note
* The left rail is a bit redundant on larger screens. For now, instead of creating another layout with the left rail missing, I chose to simply hide it on the sitemap page. We can reassess this decision in the future, if needed.
* In the future, we should also move the site links into a JSON and use it from various parts of the site. ATM, they are static and duplication is necessary. 