### PR TITLE
fix(list): swapped to use marker

### DIFF
--- a/.changeset/lemon-falcons-live.md
+++ b/.changeset/lemon-falcons-live.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+fix(list): swapped to use marker

--- a/dist/list/list.css
+++ b/dist/list/list.css
@@ -8,8 +8,7 @@
     padding: 0;
 }
 
-.list ol li::marker,
-.list ul li::marker {
+.list li::marker {
     content: "";
     font-size: 0;
 }

--- a/dist/list/list.css
+++ b/dist/list/list.css
@@ -4,9 +4,14 @@
 
 .list ol,
 .list ul {
-    list-style: none;
     margin: 0;
     padding: 0;
+}
+
+.list ol li::marker,
+.list ul li::marker {
+    content: "";
+    font-size: 0;
 }
 
 .list fieldset > *,

--- a/src/sass/list/list.scss
+++ b/src/sass/list/list.scss
@@ -8,9 +8,14 @@
 
 .list ul,
 .list ol {
-    list-style: none;
     margin: 0;
     padding: 0;
+}
+
+.list ul li::marker,
+.list ol li::marker {
+    content: "";
+    font-size: 0;
 }
 
 .list li > *,

--- a/src/sass/list/list.scss
+++ b/src/sass/list/list.scss
@@ -12,8 +12,7 @@
     padding: 0;
 }
 
-.list ul li::marker,
-.list ol li::marker {
+.list li::marker {
     content: "";
     font-size: 0;
 }


### PR DESCRIPTION
Fixes #2515 

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Changed list-style to be marker for list.css

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
