### PR TITLE
feat(tooltip): updated colors

### DIFF
--- a/.changeset/giant-snails-jump.md
+++ b/.changeset/giant-snails-jump.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(tooltip): updated colors

--- a/dist/tooltip/tooltip.css
+++ b/dist/tooltip/tooltip.css
@@ -31,9 +31,9 @@ span.tooltip {
 .tooltip__mask {
     background-color: var(
         --tooltip-background-color,
-        var(--color-background-elevated)
+        var(--color-background-inverse)
     );
-    color: var(--tooltip-foreground-color, var(--color-foreground-primary));
+    color: var(--tooltip-foreground-color, var(--color-foreground-on-inverse));
     position: relative;
 }
 
@@ -48,7 +48,7 @@ span.tooltip__mask {
     word-break: normal;
 }
 .tooltip__cell a {
-    color: var(--tooltip-foreground-color, var(--color-foreground-primary));
+    color: var(--tooltip-foreground-color, var(--color-foreground-on-inverse));
 }
 .tooltip__cell a:focus {
     outline: 1px dashed currentColor;
@@ -80,7 +80,7 @@ button.tooltip__close {
 .tooltip__pointer {
     background-color: var(
         --tooltip-background-color,
-        var(--color-background-elevated)
+        var(--color-background-inverse)
     );
     height: 8px;
     position: absolute;

--- a/src/sass/tooltip/tooltip.scss
+++ b/src/sass/tooltip/tooltip.scss
@@ -18,9 +18,9 @@ span.tooltip {
     @include bubble-mask();
     @include background-color-token(
         tooltip-background-color,
-        color-background-elevated
+        color-background-inverse
     );
-    @include color-token(tooltip-foreground-color, color-foreground-primary);
+    @include color-token(tooltip-foreground-color, color-foreground-on-inverse);
 }
 
 span.tooltip__mask {
@@ -33,7 +33,7 @@ span.tooltip__mask {
     a {
         @include color-token(
             tooltip-foreground-color,
-            color-foreground-primary
+            color-foreground-on-inverse
         );
 
         &:focus {
@@ -54,7 +54,7 @@ button.tooltip__close {
     @include pointer-base();
     @include background-color-token(
         tooltip-background-color,
-        color-background-elevated
+        color-background-inverse
     );
 }
 


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2524 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Updated tooltip colors.

## Screenshots

**Before**

<kbd><img width="347" alt="image" src="https://github.com/user-attachments/assets/9628a07b-54f0-4824-bc0d-36269bffd2cd" /></kbd>


**After**

<kbd><img width="348" alt="image" src="https://github.com/user-attachments/assets/38aaa8c8-9ad4-437c-a08a-52a4e980c8fd" /></kbd>


## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [X] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
