### PR TITLE
feat(avatar): added fit modifier

### DIFF
--- a/.changeset/happy-turkeys-hang.md
+++ b/.changeset/happy-turkeys-hang.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(avatar): added custom fit avatar

--- a/dist/avatar/avatar.css
+++ b/dist/avatar/avatar.css
@@ -1,7 +1,6 @@
 .avatar {
     align-items: center;
     border-radius: 50%;
-    display: flex;
     display: inline-flex;
     font-size: var(--font-size-large-2);
     font-weight: var(--font-weight-bold);

--- a/dist/avatar/avatar.css
+++ b/dist/avatar/avatar.css
@@ -1,8 +1,7 @@
 .avatar {
     align-items: center;
-    background-color: #84b4fb;
     border-radius: 50%;
-    color: #002a69;
+    display: flex;
     display: inline-flex;
     font-size: var(--font-size-large-2);
     font-weight: var(--font-weight-bold);
@@ -10,7 +9,25 @@
     justify-content: center;
     line-height: 48px;
     overflow: hidden;
+    position: relative;
     width: 48px;
+}
+.avatar:after {
+    background: rgba(0, 0, 0, 0.05);
+    bottom: 0;
+    content: "";
+    display: block;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+}
+.avatar > img {
+    display: inline-block;
+    max-height: 100%;
+    max-width: 100%;
+    object-fit: contain;
 }
 
 .avatar > svg {
@@ -22,6 +39,10 @@
     height: 48px;
     object-fit: cover;
     width: 48px;
+}
+
+.avatar--fit > img {
+    object-fit: contain;
 }
 
 .avatar--teal {

--- a/dist/mixins/_utility-mixins.scss
+++ b/dist/mixins/_utility-mixins.scss
@@ -23,10 +23,10 @@
     white-space: nowrap;
 }
 
-@mixin image-treatment($border-radius: 8px) {
+@mixin image-treatment($border-radius: 8px, $display: flex) {
     align-items: center;
     border-radius: $border-radius;
-    display: flex;
+    display: $display;
     justify-content: center;
     overflow: hidden;
     position: relative;

--- a/src/routes/_index/component/avatar/+page.marko
+++ b/src/routes/_index/component/avatar/+page.marko
@@ -27,16 +27,17 @@
             </div>
         </div>
     </div>
-    <highlight-code
-        type="html"
-        >
-     <div class="avatar" role="img" aria-label="Profile picture - E">
-        <span>E</span>
-    </div>
+    <highlight-code type="html">
+        <div class="avatar" role="img" aria-label="Profile picture - E">
+            <span>E</span>
+        </div>
     </highlight-code>
 
     <p>
         The default avatar can have a background color of teal, light-teal, green, lime, yellow, orange, magenta, or pink.
+    </p>
+    <p>
+        <strong>NOTE:</strong> An avatar with an image should not use color modifier, otherwise the image-treatment scrim will not be applied.
     </p>
 
     <div class="demo">
@@ -99,67 +100,65 @@
             </div>
         </div>
     </div>
-    <highlight-code
-        type="html"
-        >
+    <highlight-code type="html">
 
-    <div
-        class="avatar avatar--teal"
-        role="img"
-        aria-label="Profile picture - A"
-    >
-        <span>A</span>
-    </div>
-    <div
-        class="avatar avatar--light-teal"
-        role="img"
-        aria-label="Profile picture - B"
-    >
-        <span>B</span>
-    </div>
-    <div
-        class="avatar avatar--green"
-        role="img"
-        aria-label="Profile picture - C"
-    >
-        <span>C</span>
-    </div>
-    <div
-        class="avatar avatar--lime"
-        role="img"
-        aria-label="Profile picture - D"
-    >
-        <span>D</span>
-    </div>
-    <div
-        class="avatar avatar--yellow"
-        role="img"
-        aria-label="Profile picture - E"
-    >
-        <span>E</span>
-    </div>
-    <div
-        class="avatar avatar--orange"
-        role="img"
-        aria-label="Profile picture - F"
-    >
-        <span>F</span>
-    </div>
-    <div
-        class="avatar avatar--magenta"
-        role="img"
-        aria-label="Profile picture - G"
-    >
-        <span>G</span>
-    </div>
-    <div
-        class="avatar avatar--pink"
-        role="img"
-        aria-label="Profile picture - G"
-    >
-        <span>H</span>
-    </div>
-     </highlight-code>
+        <div
+            class="avatar avatar--teal"
+            role="img"
+            aria-label="Profile picture - A"
+        >
+            <span>A</span>
+        </div>
+        <div
+            class="avatar avatar--light-teal"
+            role="img"
+            aria-label="Profile picture - B"
+        >
+            <span>B</span>
+        </div>
+        <div
+            class="avatar avatar--green"
+            role="img"
+            aria-label="Profile picture - C"
+        >
+            <span>C</span>
+        </div>
+        <div
+            class="avatar avatar--lime"
+            role="img"
+            aria-label="Profile picture - D"
+        >
+            <span>D</span>
+        </div>
+        <div
+            class="avatar avatar--yellow"
+            role="img"
+            aria-label="Profile picture - E"
+        >
+            <span>E</span>
+        </div>
+        <div
+            class="avatar avatar--orange"
+            role="img"
+            aria-label="Profile picture - F"
+        >
+            <span>F</span>
+        </div>
+        <div
+            class="avatar avatar--magenta"
+            role="img"
+            aria-label="Profile picture - G"
+        >
+            <span>G</span>
+        </div>
+        <div
+            class="avatar avatar--pink"
+            role="img"
+            aria-label="Profile picture - G"
+        >
+            <span>H</span>
+        </div>
+    </highlight-code>
 
     <h3 id="avatar-custom">
         Custom Avatar
@@ -184,13 +183,50 @@
             </div>
         </div>
     </div>
-     <highlight-code type="html" >
-    <div class="avatar" role="img" aria-label="Profile picture - Elizabeth">
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
-        >
+    <highlight-code type="html">
+        <div class="avatar" role="img" aria-label="Profile picture - Elizabeth">
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+    </highlight-code>
+
+    <h3 id="avatar-custom">
+        Custom Avatar with Fit
+    </h3>
+    <p>
+        When the image aspect ratio is below 3:4 and not a square, you can add
+        <span class="highlight">
+            .avatar--fit
+        </span>
+         to make the image fit inside the container
+    </p>
+    <div class="demo">
+        <div class="demo__inner">
+            <div
+                class="avatar avatar--fit image-treatment"
+                role="img"
+                aria-label="Profile picture - Elizabeth"
+            >
+                <img
+                    src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                    alt=""
+                >
+            </div>
+        </div>
     </div>
+    <highlight-code type="html">
+        <div
+            class="avatar avatar--fit"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
+        >
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
     </highlight-code>
 
     <h3 id="avatar-signed-out">
@@ -212,20 +248,24 @@
                 aria-label="Profile picture - Signed out"
             >
                 <svg class="icon" hidden="true">
-                    <icon-symbol name="avatar-signed-out" />
+                    <icon-symbol name="avatar-signed-out"/>
                 </svg>
             </div>
         </div>
     </div>
-    <highlight-code
-        type="html"
-        >
+    <highlight-code type="html">
 
-    <div class="avatar" role="img" aria-label="Profile picture - Signed out">
-        <svg class="icon" aria-hidden="true">
-            <use href="#icon-avatar-signed-out"/>
-        </svg>
-    </div>    </highlight-code>
+        <div
+            class="avatar"
+            role="img"
+            aria-label="Profile picture - Signed out"
+        >
+            <svg class="icon" aria-hidden="true">
+                <use href="#icon-avatar-signed-out"/>
+            </svg>
+        </div>
+
+    </highlight-code>
 
     <h3 id="avatar-sizes">
         Avatar Sizes
@@ -306,86 +346,84 @@
             </div>
         </div>
     </div>
-    <highlight-code
-        type="html"
-        >
+    <highlight-code type="html">
 
-    <div
-        class="avatar avatar--32"
-        role="img"
-        aria-label="Profile picture - Elizabeth"
-    >
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
+        <div
+            class="avatar avatar--32"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
         >
-    </div>
-    <div
-        class="avatar avatar--40"
-        role="img"
-        aria-label="Profile picture - Elizabeth"
-    >
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+        <div
+            class="avatar avatar--40"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
         >
-    </div>
-    <div
-        class="avatar avatar--48"
-        role="img"
-        aria-label="Profile picture - Elizabeth"
-    >
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+        <div
+            class="avatar avatar--48"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
         >
-    </div>
-    <div
-        class="avatar avatar--56"
-        role="img"
-        aria-label="Profile picture - Elizabeth"
-    >
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+        <div
+            class="avatar avatar--56"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
         >
-    </div>
-    <div
-        class="avatar avatar--64"
-        role="img"
-        aria-label="Profile picture - Elizabeth"
-    >
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+        <div
+            class="avatar avatar--64"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
         >
-    </div>
-    <div
-        class="avatar avatar--96"
-        role="img"
-        aria-label="Profile picture - Elizabeth"
-    >
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+        <div
+            class="avatar avatar--96"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
         >
-    </div>
-    <div
-        class="avatar avatar--128"
-        role="img"
-        aria-label="Profile picture - Elizabeth"
-    >
-        <img
-            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
-            alt=""
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+        <div
+            class="avatar avatar--128"
+            role="img"
+            aria-label="Profile picture - Elizabeth"
         >
-    </div>
-        </highlight-code>
+            <img
+                src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+                alt=""
+            >
+        </div>
+    </highlight-code>
 </div>
 export const metadata = {
     component: "avatar",
     "ds-component": {
         name: "avatar",
         version: 1,
-    }
+    },
 };

--- a/src/sass/avatar/avatar.scss
+++ b/src/sass/avatar/avatar.scss
@@ -20,11 +20,10 @@ $_avatar-magenta-foreground-color: #3e135f;
 $_avatar-magenta-background-color: #cc9ef0;
 
 .avatar {
-    @include image-treatment(50%);
+    @include image-treatment(50%, inline-flex);
 
     align-items: center;
     border-radius: 50%;
-    display: inline-flex;
     font-size: var(--font-size-large-2);
     font-weight: var(--font-weight-bold);
     height: 48px;

--- a/src/sass/avatar/avatar.scss
+++ b/src/sass/avatar/avatar.scss
@@ -1,4 +1,5 @@
 @import "../variables/variables";
+@import "../mixins/public/utility-mixins";
 
 /* These are temporary colors until we get the new palette */
 $_avatar-teal-foreground-color: #002a69;
@@ -19,10 +20,10 @@ $_avatar-magenta-foreground-color: #3e135f;
 $_avatar-magenta-background-color: #cc9ef0;
 
 .avatar {
+    @include image-treatment(50%);
+
     align-items: center;
-    background-color: $_avatar-teal-background-color;
     border-radius: 50%;
-    color: $_avatar-teal-foreground-color;
     display: inline-flex;
     font-size: var(--font-size-large-2);
     font-weight: var(--font-weight-bold);
@@ -41,6 +42,10 @@ $_avatar-magenta-background-color: #cc9ef0;
     height: 48px;
     object-fit: cover;
     width: 48px;
+}
+
+.avatar--fit > img {
+    object-fit: contain;
 }
 
 .avatar--teal {

--- a/src/sass/avatar/stories/avatar.stories.js
+++ b/src/sass/avatar/stories/avatar.stories.js
@@ -77,6 +77,29 @@ export const withImage = () => /* HTML */ `
     </div>
 `;
 
+export const withFitImage = () => /* HTML */ `
+    <div
+        class="avatar avatar--fit"
+        role="img"
+        aria-label="Profile picture - Elizabeth"
+    >
+        <img
+            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+            alt=""
+        />
+    </div>
+    <div
+        class="avatar avatar--fit avatar--128"
+        role="img"
+        aria-label="Profile picture - Elizabeth"
+    >
+        <img
+            src="https://ir.ebaystatic.com/cr/v/c01/skin/docs/dog_profile_optimized.jpg"
+            alt=""
+        />
+    </div>
+`;
+
 export const signedOut = () => /* HTML */ `
     <div class="avatar" role="img" aria-label="Profile picture - Signed out">
         <svg class="icon" aria-hidden="true">

--- a/src/sass/mixins/public/_utility-mixins.scss
+++ b/src/sass/mixins/public/_utility-mixins.scss
@@ -23,10 +23,10 @@
     white-space: nowrap;
 }
 
-@mixin image-treatment($border-radius: 8px) {
+@mixin image-treatment($border-radius: 8px, $display: flex) {
     align-items: center;
     border-radius: $border-radius;
-    display: flex;
+    display: $display;
     justify-content: center;
     overflow: hidden;
     position: relative;


### PR DESCRIPTION
Fixes #2539

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added a default `image-treatment` to avatar (this changes the default color, but is still usable)
* Added a `avatar--fit` modifier to allow the image to fit the contents. For making the behavior happen automatically, we can look into adding this into coreui to detect the image aspect ratio
* Added a note about using the image with colors so that the aspect ratio wont be applied. 

## Screenshots
<img width="901" alt="Screenshot 2025-02-10 at 8 43 45 AM" src="https://github.com/user-attachments/assets/d5428736-c76b-471b-aa59-5905855bdf2d" />
<img width="843" alt="Screenshot 2025-02-10 at 8 44 02 AM" src="https://github.com/user-attachments/assets/1b71203e-e2f1-4bc3-a2d1-017aaf09eb3e" />



## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
