### PR TITLE
feat(layout-grid): added new component

### DIFF
--- a/.changeset/three-trees-change.md
+++ b/.changeset/three-trees-change.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(layout-grid): added new component

--- a/dist/layout-grid/layout-grid.css
+++ b/dist/layout-grid/layout-grid.css
@@ -1,0 +1,915 @@
+.layout-grid {
+    --layout-grid-cell-height-min: 0;
+    --layout-grid-cell-gap: var(--spacing-100);
+    --layout-grid-columns-min: 1;
+    --layout-grid-columns-xs: 2;
+    --layout-grid-columns-sm: 3;
+    --layout-grid-columns-md: 4;
+    --layout-grid-columns-lg: 6;
+    --layout-grid-columns-xl: 8;
+    --layout-grid-columns-xl2: 10;
+    --layout-grid-columns-xl3: 12;
+    --layout-grid-columns-xl4: 14;
+    container: layout-grid-container/inline-size;
+}
+
+.layout-grid[data-columns-min="1"] > ul {
+    grid-template-columns: repeat(1, 1fr);
+}
+
+.layout-grid[data-columns-min="2"] > ul {
+    grid-template-columns: repeat(2, 1fr);
+}
+
+.layout-grid[data-columns-min="3"] > ul {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.layout-grid[data-columns-min="4"] > ul {
+    grid-template-columns: repeat(4, 1fr);
+}
+
+@container layout-grid-container (inline-size < 320px) {
+    .layout-grid[data-columns-min="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-min="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-min="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-min="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+.layout-grid > ul {
+    display: grid;
+    gap: var(--layout-grid-cell-gap);
+    grid-auto-rows: 1fr;
+    grid-template-columns: repeat(var(--layout-grid-columns-min), 1fr);
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.layout-grid > ul > li {
+    display: inline-block;
+    min-height: var(--layout-grid-cell-height-min);
+    width: 100%;
+}
+
+.layout-grid > ul > li::marker {
+    content: "";
+    font-size: 0;
+}
+@supports not (contain: inline-size) {
+    @media (min-width: 320px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xs), 1fr);
+        }
+        .layout-grid[data-columns-xs="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-xs="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-xs="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-xs="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-xs="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-xs="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-xs="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-xs="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-xs="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-xs="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-xs="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-xs="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-xs="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-xs="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-xs="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-xs="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+    @media (min-width: 512px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-sm), 1fr);
+        }
+        .layout-grid[data-columns-sm="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-sm="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-sm="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-sm="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-sm="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-sm="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-sm="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-sm="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-sm="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-sm="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-sm="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-sm="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-sm="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-sm="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-sm="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-sm="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+    @media (min-width: 768px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-md), 1fr);
+        }
+        .layout-grid[data-columns-md="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-md="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-md="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-md="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-md="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-md="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-md="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-md="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-md="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-md="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-md="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-md="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-md="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-md="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-md="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-md="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+    @media (min-width: 1024px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-lg), 1fr);
+        }
+        .layout-grid[data-columns-lg="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-lg="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-lg="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-lg="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-lg="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-lg="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-lg="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-lg="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-lg="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-lg="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-lg="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-lg="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-lg="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-lg="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-lg="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-lg="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+    @media (min-width: 1280px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl), 1fr);
+        }
+        .layout-grid[data-columns-xl="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-xl="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-xl="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-xl="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-xl="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-xl="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-xl="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-xl="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-xl="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-xl="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-xl="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-xl="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-xl="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-xl="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-xl="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-xl="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+    @media (min-width: 1440px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl2), 1fr);
+        }
+        .layout-grid[data-columns-xl2="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-xl2="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-xl2="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-xl2="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-xl2="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-xl2="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-xl2="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-xl2="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-xl2="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-xl2="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-xl2="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-xl2="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-xl2="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-xl2="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-xl2="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-xl2="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+    @media (min-width: 1680px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl3), 1fr);
+        }
+        .layout-grid[data-columns-xl3="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-xl3="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-xl3="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-xl3="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-xl3="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-xl3="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-xl3="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-xl3="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-xl3="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-xl3="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-xl3="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-xl3="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-xl3="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-xl3="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-xl3="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-xl3="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+    @media (min-width: 1920px) {
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl4), 1fr);
+        }
+        .layout-grid[data-columns-xl4="1"] > ul {
+            grid-template-columns: repeat(1, 1fr);
+        }
+        .layout-grid[data-columns-xl4="2"] > ul {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        .layout-grid[data-columns-xl4="3"] > ul {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        .layout-grid[data-columns-xl4="4"] > ul {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        .layout-grid[data-columns-xl4="5"] > ul {
+            grid-template-columns: repeat(5, 1fr);
+        }
+        .layout-grid[data-columns-xl4="6"] > ul {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        .layout-grid[data-columns-xl4="7"] > ul {
+            grid-template-columns: repeat(7, 1fr);
+        }
+        .layout-grid[data-columns-xl4="8"] > ul {
+            grid-template-columns: repeat(8, 1fr);
+        }
+        .layout-grid[data-columns-xl4="9"] > ul {
+            grid-template-columns: repeat(9, 1fr);
+        }
+        .layout-grid[data-columns-xl4="10"] > ul {
+            grid-template-columns: repeat(10, 1fr);
+        }
+        .layout-grid[data-columns-xl4="11"] > ul {
+            grid-template-columns: repeat(11, 1fr);
+        }
+        .layout-grid[data-columns-xl4="12"] > ul {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        .layout-grid[data-columns-xl4="13"] > ul {
+            grid-template-columns: repeat(13, 1fr);
+        }
+        .layout-grid[data-columns-xl4="14"] > ul {
+            grid-template-columns: repeat(14, 1fr);
+        }
+        .layout-grid[data-columns-xl4="15"] > ul {
+            grid-template-columns: repeat(15, 1fr);
+        }
+        .layout-grid[data-columns-xl4="16"] > ul {
+            grid-template-columns: repeat(16, 1fr);
+        }
+    }
+}
+@container layout-grid-container (inline-size >= 320px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xs), 1fr);
+    }
+    .layout-grid[data-columns-xs="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-xs="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-xs="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-xs="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-xs="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-xs="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-xs="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-xs="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-xs="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-xs="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-xs="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-xs="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-xs="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-xs="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-xs="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-xs="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}
+@container layout-grid-container (inline-size >= 512px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-sm), 1fr);
+    }
+    .layout-grid[data-columns-sm="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-sm="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-sm="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-sm="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-sm="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-sm="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-sm="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-sm="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-sm="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-sm="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-sm="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-sm="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-sm="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-sm="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-sm="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-sm="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}
+@container layout-grid-container (inline-size >= 768px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-md), 1fr);
+    }
+    .layout-grid[data-columns-md="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-md="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-md="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-md="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-md="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-md="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-md="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-md="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-md="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-md="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-md="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-md="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-md="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-md="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-md="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-md="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}
+@container layout-grid-container (inline-size >= 1024px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-lg), 1fr);
+    }
+    .layout-grid[data-columns-lg="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-lg="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-lg="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-lg="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-lg="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-lg="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-lg="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-lg="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-lg="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-lg="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-lg="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-lg="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-lg="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-lg="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-lg="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-lg="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}
+@container layout-grid-container (inline-size >= 1280px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl), 1fr);
+    }
+    .layout-grid[data-columns-xl="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-xl="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-xl="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-xl="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-xl="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-xl="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-xl="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-xl="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-xl="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-xl="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-xl="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-xl="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-xl="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-xl="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-xl="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-xl="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}
+@container layout-grid-container (inline-size >= 1440px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl), 1fr);
+    }
+    .layout-grid[data-columns-xl2="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-xl2="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-xl2="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-xl2="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-xl2="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-xl2="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-xl2="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-xl2="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-xl2="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-xl2="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-xl2="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-xl2="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-xl2="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-xl2="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-xl2="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-xl2="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}
+@container layout-grid-container (inline-size >= 1680px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl3), 1fr);
+    }
+    .layout-grid[data-columns-xl3="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-xl3="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-xl3="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-xl3="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-xl3="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-xl3="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-xl3="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-xl3="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-xl3="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-xl3="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-xl3="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-xl3="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-xl3="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-xl3="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-xl3="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-xl3="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}
+@container layout-grid-container (inline-size >= 1920px) {
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl4), 1fr);
+    }
+    .layout-grid[data-columns-xl4="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+    .layout-grid[data-columns-xl4="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .layout-grid[data-columns-xl4="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+    .layout-grid[data-columns-xl4="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    .layout-grid[data-columns-xl4="5"] > ul {
+        grid-template-columns: repeat(5, 1fr);
+    }
+    .layout-grid[data-columns-xl4="6"] > ul {
+        grid-template-columns: repeat(6, 1fr);
+    }
+    .layout-grid[data-columns-xl4="7"] > ul {
+        grid-template-columns: repeat(7, 1fr);
+    }
+    .layout-grid[data-columns-xl4="8"] > ul {
+        grid-template-columns: repeat(8, 1fr);
+    }
+    .layout-grid[data-columns-xl4="9"] > ul {
+        grid-template-columns: repeat(9, 1fr);
+    }
+    .layout-grid[data-columns-xl4="10"] > ul {
+        grid-template-columns: repeat(10, 1fr);
+    }
+    .layout-grid[data-columns-xl4="11"] > ul {
+        grid-template-columns: repeat(11, 1fr);
+    }
+    .layout-grid[data-columns-xl4="12"] > ul {
+        grid-template-columns: repeat(12, 1fr);
+    }
+    .layout-grid[data-columns-xl4="13"] > ul {
+        grid-template-columns: repeat(13, 1fr);
+    }
+    .layout-grid[data-columns-xl4="14"] > ul {
+        grid-template-columns: repeat(14, 1fr);
+    }
+    .layout-grid[data-columns-xl4="15"] > ul {
+        grid-template-columns: repeat(15, 1fr);
+    }
+    .layout-grid[data-columns-xl4="16"] > ul {
+        grid-template-columns: repeat(16, 1fr);
+    }
+}

--- a/src/components/data/site.json
+++ b/src/components/data/site.json
@@ -4216,6 +4216,9 @@
             "ds-component": { "name": "alert-notice", "version": "18.1.0" },
             "submodules": ["icon"]
         },
+        "layout-grid": {
+            "ds-component": [{ "name": "layout-grid", "version": "19.0.0" }]
+        },
         "lightbox-dialog": {
             "ds-component": [
                 { "name": "modal", "version": "18.1.0" },

--- a/src/routes/_index/component/layout-grid/+meta.json
+++ b/src/routes/_index/component/layout-grid/+meta.json
@@ -1,0 +1,4 @@
+{
+    "pageTitle": "Layout Grid Responsive CSS Component",
+    "pageDescription": "A generic responsive layout grid for repeating UI elements in a container."
+}

--- a/src/routes/_index/component/layout-grid/+page.marko
+++ b/src/routes/_index/component/layout-grid/+page.marko
@@ -1,0 +1,784 @@
+style {
+    .layout-grid label {
+        margin-inline-start: 8px;
+    }
+}
+
+<div id="layout-grid">
+    <section-header metadata=metadata/>
+    <h1>Layout Grid</h1>
+
+    <p>A generic responsive layout grid for repeating UI elements in a container. These could be purely visual elements or interactive. This component will lay out repeating elements based on internal rules per device viewport breakpoint.</p>
+
+    <p>The elements will responsively shrink and stretch inside their container at any and all screen sizes.</p>
+
+    <p>We use <span class="highlight"> display: grid </span>
+    ${" "}to create a predefined allotted number of elements slots per breakpoint. We also use container queries to modify how many slots should be available per breakpoint. This allows elements to shrink/stretch the predefined number of items at each breakpoint with a fallback to media queries for unsupported browsers.</p>
+
+    <p>The responsive rules around how many elements appear on a single line before wrapping into a new line have all been predefined and baked into the component, so developers don't need to provide anything else to have a responsive layout of elements at various screen sizes.</p>
+
+    <h2 id="layout-grid-default-display-rules">Default Display Breakpoint Rules</h2>
+
+    <div class="table table--density-compact" role="group" aria-labelledby="layout-grid-default-display-rules" tabindex="0">
+        <table>
+            <thead>
+                <tr>
+                    <th class="table-cell">Breakpoint</th>
+                    <th class="table-cell">Container/Screen Widths</th>
+                    <th class="table-cell table-cell--numeric">Number of Columns</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="table-cell">Min</td>
+                    <td class="table-cell">smallest/default</td>
+                    <td class="table-cell table-cell--numeric">1</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">XS</td>
+                    <td class="table-cell">320px</td>
+                    <td class="table-cell table-cell--numeric">2</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">SM</td>
+                    <td class="table-cell">512px</td>
+                    <td class="table-cell table-cell--numeric">3</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">MD</td>
+                    <td class="table-cell">768px</td>
+                    <td class="table-cell table-cell--numeric">4</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">LG</td>
+                    <td class="table-cell">1024px</td>
+                    <td class="table-cell table-cell--numeric">6</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">XL</td>
+                    <td class="table-cell">1280px</td>
+                    <td class="table-cell table-cell--numeric">8</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">XL2</td>
+                    <td class="table-cell">1440px</td>
+                    <td class="table-cell table-cell--numeric">10</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">XL3</td>
+                    <td class="table-cell">1680px</td>
+                    <td class="table-cell table-cell--numeric">12</td>
+                </tr>
+                <tr>
+                    <td class="table-cell">XL4</td>
+                    <td class="table-cell">1920px</td>
+                    <td class="table-cell table-cell--numeric">14</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>Default Layouts with Radio Buttons</h2>
+
+    <p>Accessibility is baked in using a link to an on-screen text with the use of the <span class="highlight">aria-labelledby</span> attribute on the list container. This is used to provide a label for the list of items. This mehod should be used when there is on-screen text.</p>
+
+    <p>Here's an example of the default layout grid component used with radio buttons to create a more balanced layout than would result from simply an inline treatment.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <h3 id="layout-grid-my-radio-title">My Radio Buttons</h3>
+            <div class="layout-grid">
+                <ul aria-labelledby="layout-grid-my-radio-title">
+                    <li>
+                        <span class="radio">
+                            <input
+                                id="radio-default-1"
+                                aria-label="Default radio example"
+                                class="radio__control"
+                                type="radio"
+                                name="radio-default"
+                            >
+                            <span class="radio__icon" hidden>
+                                <svg
+                                    class="radio__unchecked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-unchecked-18"/>
+                                </svg>
+                                <svg
+                                    class="radio__checked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-checked-18"/>
+                                </svg>
+                            </span>
+                        </span>
+                        <label for="radio-default-1">Option 1</label>
+                    </li>
+                    <li>
+                        <span class="radio">
+                            <input
+                                id="radio-default-2"
+                                aria-label="Default radio example"
+                                class="radio__control"
+                                type="radio"
+                                name="radio-default"
+                            >
+                            <span class="radio__icon" hidden>
+                                <svg
+                                    class="radio__unchecked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-unchecked-18"/>
+                                </svg>
+                                <svg
+                                    class="radio__checked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-checked-18"/>
+                                </svg>
+                            </span>
+                        </span>
+                        <label for="radio-default-2">Option 2</label>
+                    </li>
+                    <li>
+                        <span class="radio">
+                            <input
+                                id="radio-default-3"
+                                aria-label="Default radio example"
+                                class="radio__control"
+                                type="radio"
+                                name="radio-default"
+                            >
+                            <span class="radio__icon" hidden>
+                                <svg
+                                    class="radio__unchecked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-unchecked-18"/>
+                                </svg>
+                                <svg
+                                    class="radio__checked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-checked-18"/>
+                                </svg>
+                            </span>
+                        </span>
+                        <label for="radio-default-3">Option 3</label>
+                    </li>
+                    <li>
+                        <span class="radio">
+                            <input
+                                id="radio-default-4"
+                                aria-label="Default radio example"
+                                class="radio__control"
+                                type="radio"
+                                name="radio-default"
+                            >
+                            <span class="radio__icon" hidden>
+                                <svg
+                                    class="radio__unchecked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-unchecked-18"/>
+                                </svg>
+                                <svg
+                                    class="radio__checked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-checked-18"/>
+                                </svg>
+                            </span>
+                        </span>
+                        <label for="radio-default-4">Option 4</label>
+                    </li>
+                    <li>
+                        <span class="radio">
+                            <input
+                                id="radio-default-5"
+                                aria-label="Default radio example"
+                                class="radio__control"
+                                type="radio"
+                                name="radio-default"
+                            >
+                            <span class="radio__icon" hidden>
+                                <svg
+                                    class="radio__unchecked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-unchecked-18"/>
+                                </svg>
+                                <svg
+                                    class="radio__checked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-checked-18"/>
+                                </svg>
+                            </span>
+                        </span>
+                        <label for="radio-default-5">Option 5</label>
+                    </li>
+                    <li>
+                        <span class="radio">
+                            <input
+                                id="radio-default-6"
+                                aria-label="Default radio example"
+                                class="radio__control"
+                                type="radio"
+                                name="radio-default"
+                            >
+                            <span class="radio__icon" hidden>
+                                <svg
+                                    class="radio__unchecked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-unchecked-18"/>
+                                </svg>
+                                <svg
+                                    class="radio__checked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-checked-18"/>
+                                </svg>
+                            </span>
+                        </span>
+                        <label for="radio-default-6">Option 6</label>
+                    </li>
+                    <li>
+                        <span class="radio">
+                            <input
+                                id="radio-default-7"
+                                aria-label="Default radio example"
+                                class="radio__control"
+                                type="radio"
+                                name="radio-default"
+                            >
+                            <span class="radio__icon" hidden>
+                                <svg
+                                    class="radio__unchecked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-unchecked-18"/>
+                                </svg>
+                                <svg
+                                    class="radio__checked"
+                                    height="18"
+                                    width="18"
+                                    aria-hidden="true"
+                                >
+                                    <icon-symbol name="radio-checked-18"/>
+                                </svg>
+                            </span>
+                        </span>
+                        <label for="radio-default-7">Option 7</label>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <highlight-code type="html">
+<h3 id="layout-grid-my-radio-title">My Radio Buttons</h3>
+<div class="layout-grid">
+    <ul aria-labelledby="layout-grid-my-radio-title">
+        <li>
+            <span class="radio">
+                <input
+                    id="radio-default-1"
+                    aria-label="Default radio example"
+                    class="radio__control"
+                    type="radio"
+                    name="radio-default"
+                >
+                <span class="radio__icon" hidden>
+                    <svg
+                        class="radio__unchecked"
+                        height="18"
+                        width="18"
+                        aria-hidden="true"
+                    >
+                        <icon-symbol name="radio-unchecked-18"/>
+                    </svg>
+                    <svg
+                        class="radio__checked"
+                        height="18"
+                        width="18"
+                        aria-hidden="true"
+                    >
+                        <icon-symbol name="radio-checked-18"/>
+                    </svg>
+                </span>
+            </span>
+            <label for="radio-default-1">Option 1</label>
+        </li>
+        <li>
+            <span class="radio">
+                <input
+                    id="radio-default-2"
+                    aria-label="Default radio example"
+                    class="radio__control"
+                    type="radio"
+                    name="radio-default"
+                >
+                <span class="radio__icon" hidden>
+                    <svg
+                        class="radio__unchecked"
+                        height="18"
+                        width="18"
+                        aria-hidden="true"
+                    >
+                        <icon-symbol name="radio-unchecked-18"/>
+                    </svg>
+                    <svg
+                        class="radio__checked"
+                        height="18"
+                        width="18"
+                        aria-hidden="true"
+                    >
+                        <icon-symbol name="radio-checked-18"/>
+                    </svg>
+                </span>
+            </span>
+            <label for="radio-default-2">Option 2</label>
+        </li>
+        ...
+    </ul>
+</div>
+    </highlight-code>
+
+    <h2>Default Layouts with Buttons</h2>
+
+    <p>Here's an example of the default layout grid component used with buttons to create a more balanced layout than would result from simply an inline treatment.</p>
+
+    <p>Accessibility is baked in with the use of the <span class="highlight">aria-label</span> attribute on the list container. This is used to provide a label for the list of items. This mehod can be used when there is no on-screen text.</p>
+
+    <p>Here we're using fluid buttons to fill the available space in the layout grid.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="layout-grid">
+                <ul aria-label="List of options">
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <highlight-code type="html">
+<div class="layout-grid">
+    <ul aria-label="List of options">
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        ...
+    </ul>
+</div>
+    </highlight-code>
+
+    <h2>Custom Display Breakpoint Rules</h2>
+
+    <p>If you need to create custom display rules for how many items should appear per line at each breakpoint, you can override the default display rules by adding attributes to the layout grid container.</p>
+
+    <p>The attributes follow the format <span class="highlight">data-columns-[breakpoint]="[number]"</span> where <span class="highlight">[breakpoint]</span> is the breakpoint name and <span class="highlight">[number]</span> is the number of columns you want to display at that breakpoint.</p>
+
+    <h2>Custom Layouts with Buttons</h2>
+
+    <p>In this example, we're setting custom layout columns for various breakpoints. The default number of columns is 1, but we're setting it to 2. The default number of columns at the XS breakpoint is 2, but we're setting it to 3, so on and so forth. See the example code below for all the overrides. You may skip the breakpoints at which the default layout works for you.</p>
+
+    <div class="demo">
+        <div class="demo__inner">
+            <div class="layout-grid"
+                data-columns-min="2"
+                data-columns-xs="3"
+                data-columns-sm="4"
+                data-columns-md="6"
+                data-columns-lg="8"
+            >
+                <ul aria-label="List of options">
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                    <li>
+                        <button class="btn btn--fluid">Button</button>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <highlight-code type="html">
+<div class="layout-grid"
+    data-columns-min="2"
+    data-columns-xs="3"
+    data-columns-sm="4"
+    data-columns-md="6"
+    data-columns-lg="8"
+>
+    <ul aria-label="List of options">
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        ...
+    </ul>
+</div>
+    </highlight-code>
+
+    <h2>Custom Layouts with Lists</h2>
+
+    <p>In this example, we're creating a custom layout for the <span class="hightlight">list</span> component. Since <span class="hightlight">list</span> usually has a wider preferred layout, it may need more horizontal space. For that reason, we may want to use a custom layout for a group of <span class="hightlight">list</span> components.</p>
+
+    <p>See the list of <span class="hightlight">data-columns-[breakpoint]</span> attributes below for the custom layout. We've omitted custom breakpoint display rules that work well with the default rules.</p>
+
+    <div class="layout-grid"
+        data-columns-xs="2"
+        data-columns-md="3"
+        data-columns-lg="4"
+    >
+        <ul aria-label="List of options">
+            <li>
+                <h3>List 1</h3>
+                <div class="list">
+                    <ul>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-folder-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 1 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-file-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 2 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-key-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 3 </span>
+                        </div>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+
+            <li>
+                <h3>List 2</h3>
+                <div class="list">
+                    <ul>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-folder-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 1 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-file-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 2 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-key-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 3 </span>
+                        </div>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+
+            <li>
+                <h3>List 3</h3>
+                <div class="list">
+                    <ul>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-folder-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 1 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-file-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 2 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-key-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 3 </span>
+                        </div>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+
+            <li>
+                <h3>List 4</h3>
+                <div class="list">
+                    <ul>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-folder-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 1 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-file-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 2 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-key-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 3 </span>
+                        </div>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+
+            <li>
+                <h3>List 5</h3>
+                <div class="list">
+                    <ul>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-folder-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 1 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-file-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 2 </span>
+                        </div>
+                        </li>
+                        <li>
+                        <div>
+                            <span class="list__leading">
+                            <svg aria-hidden="true" class="icon icon--16" height="16" width="16">
+                                <use href="#icon-key-16" />
+                            </svg>
+                            </span>
+                            <span class="list__body"> Text 3 </span>
+                        </div>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+        </ul>
+    </div>
+
+    <highlight-code type="html">
+<div class="layout-grid"
+    data-columns-xs="2"
+    data-columns-md="3"
+    data-columns-lg="4"
+>
+    <ul aria-label="List of options">
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button</button>
+        </li>
+    </ul>
+</div>
+...
+</highlight-code>
+
+</div>
+
+export const metadata = {
+    component: "layout-grid",
+    "ds-component": {
+        name: "layout-grid",
+        version: "1.0.0",
+    },
+};

--- a/src/sass/bundles/skin-headless.scss
+++ b/src/sass/bundles/skin-headless.scss
@@ -40,6 +40,7 @@
 @import "../image-placeholder/image-placeholder";
 @import "../infotip/infotip";
 @import "../inline-notice/inline-notice";
+@import "../layout-grid/layout-grid";
 @import "../lightbox-dialog/lightbox-dialog";
 @import "../link/link";
 @import "../list/list";

--- a/src/sass/layout-grid/layout-grid.scss
+++ b/src/sass/layout-grid/layout-grid.scss
@@ -1,0 +1,253 @@
+@import "../variables/variables";
+
+// Recursive Mixin to build repetative class declarations for explicit dev overrides for various breakpoints
+@mixin layout-grid-templates($breakpoint, $repeatTo, $i: 1) {
+    @if $i <= $repeatTo {
+        .layout-grid[data-columns-#{$breakpoint}="#{$i}"] > ul {
+            grid-template-columns: repeat($i, 1fr);
+        }
+
+        @include layout-grid-templates($breakpoint, $repeatTo, ($i + 1));
+    }
+}
+
+.layout-grid {
+    --layout-grid-cell-height-min: 0;
+    --layout-grid-cell-gap: var(--spacing-100);
+    --layout-grid-columns-min: 1;
+    --layout-grid-columns-xs: 2;
+    --layout-grid-columns-sm: 3;
+    --layout-grid-columns-md: 4;
+    --layout-grid-columns-lg: 6;
+    --layout-grid-columns-xl: 8;
+    --layout-grid-columns-xl2: 10;
+    --layout-grid-columns-xl3: 12;
+    --layout-grid-columns-xl4: 14;
+
+    container: layout-grid-container / inline-size;
+}
+
+// smallest explicit dev display rule overrides
+// for default (any screen size) in the rules
+.layout-grid[data-columns-min="1"] > ul {
+    grid-template-columns: repeat(1, 1fr);
+}
+
+.layout-grid[data-columns-min="2"] > ul {
+    grid-template-columns: repeat(2, 1fr);
+}
+
+.layout-grid[data-columns-min="3"] > ul {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.layout-grid[data-columns-min="4"] > ul {
+    grid-template-columns: repeat(4, 1fr);
+}
+
+// smallest explicit dev display rule overrides
+// for when container queries are supported
+// to use the container sizes in the rules
+@container layout-grid-container (inline-size < #{$_screen-size-XS}) {
+    .layout-grid[data-columns-min="1"] > ul {
+        grid-template-columns: repeat(1, 1fr);
+    }
+
+    .layout-grid[data-columns-min="2"] > ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .layout-grid[data-columns-min="3"] > ul {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .layout-grid[data-columns-min="4"] > ul {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+.layout-grid > ul {
+    display: grid;
+    gap: var(--layout-grid-cell-gap);
+    grid-auto-rows: 1fr;
+    grid-template-columns: repeat(var(--layout-grid-columns-min), 1fr);
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.layout-grid > ul > li {
+    display: inline-block;
+    min-height: var(--layout-grid-cell-height-min);
+    width: 100%;
+}
+
+.layout-grid > ul > li::marker {
+    content: "";
+    font-size: 0;
+}
+
+/* Responsive Layouts */
+// first, we define media queries as a fallback for browsers not supporting container queries
+@supports not (contain: inline-size) {
+    @media (min-width: $_screen-size-XS) {
+        // Responsive columns based on XS breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xs), 1fr);
+        }
+
+        // Explicit developer overrides for XS breakpoint for exception cases
+        @include layout-grid-templates(xs, 16);
+    }
+
+    @media (min-width: $_screen-size-SM) {
+        // Responsive columns based on SM breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-sm), 1fr);
+        }
+
+        // Explicit developer overrides for SM breakpoint for exception cases
+        @include layout-grid-templates(sm, 16);
+    }
+
+    @media (min-width: $_screen-size-MD) {
+        // Responsive columns based on MD breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-md), 1fr);
+        }
+
+        // Explicit developer overrides for MD breakpoint for exception cases
+        @include layout-grid-templates(md, 16);
+    }
+
+    @media (min-width: $_screen-size-LG) {
+        // Responsive columns based on LG breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-lg), 1fr);
+        }
+
+        // Explicit developer overrides for LG breakpoint for exception cases
+        @include layout-grid-templates(lg, 16);
+    }
+
+    @media (min-width: $_screen-size-XL) {
+        // Responsive columns based on XL breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl), 1fr);
+        }
+
+        // Explicit developer overrides for XL breakpoint for exception cases
+        @include layout-grid-templates(xl, 16);
+    }
+
+    @media (min-width: $_screen-size-XL2) {
+        // Responsive columns based on XL2 breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl2), 1fr);
+        }
+
+        // Explicit developer overrides for XL2 breakpoint for exception cases
+        @include layout-grid-templates(xl2, 16);
+    }
+
+    @media (min-width: $_screen-size-XL3) {
+        // Responsive columns based on XL3 breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl3), 1fr);
+        }
+
+        // Explicit developer overrides for XL3 breakpoint for exception cases
+        @include layout-grid-templates(xl3, 16);
+    }
+
+    @media (min-width: $_screen-size-XL4) {
+        // Responsive columns based on XL4 breakpoint per button type
+        .layout-grid > ul {
+            grid-template-columns: repeat(var(--layout-grid-columns-xl4), 1fr);
+        }
+
+        // Explicit developer overrides for XL4 breakpoint for exception cases
+        @include layout-grid-templates(xl4, 16);
+    }
+}
+
+// For browsers that DO support container queries
+@container layout-grid-container (inline-size >= #{$_screen-size-XS}) {
+    // Responsive columns based on XS breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xs), 1fr);
+    }
+
+    // Explicit developer overrides for XS breakpoint for exception cases
+    @include layout-grid-templates(xs, 16);
+}
+
+@container layout-grid-container (inline-size >= #{$_screen-size-SM}) {
+    // Responsive columns based on SM breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-sm), 1fr);
+    }
+
+    // Explicit developer overrides for SM breakpoint for exception cases
+    @include layout-grid-templates(sm, 16);
+}
+
+@container layout-grid-container (inline-size >= #{$_screen-size-MD}) {
+    // Responsive columns based on MD breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-md), 1fr);
+    }
+
+    // Explicit developer overrides for MD breakpoint for exception cases
+    @include layout-grid-templates(md, 16);
+}
+
+@container layout-grid-container (inline-size >= #{$_screen-size-LG}) {
+    // Responsive columns based on LG breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-lg), 1fr);
+    }
+
+    // Explicit developer overrides for LG breakpoint for exception cases
+    @include layout-grid-templates(lg, 16);
+}
+
+@container layout-grid-container (inline-size >= #{$_screen-size-XL}) {
+    // Responsive columns based on XL breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl), 1fr);
+    }
+
+    // Explicit developer overrides for XL breakpoint for exception cases
+    @include layout-grid-templates(xl, 16);
+}
+
+@container layout-grid-container (inline-size >= #{$_screen-size-XL2}) {
+    // Responsive columns based on XL2 breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl), 1fr);
+    }
+
+    // Explicit developer overrides for XL2 breakpoint for exception cases
+    @include layout-grid-templates(xl2, 16);
+}
+
+@container layout-grid-container (inline-size >= #{$_screen-size-XL3}) {
+    // Responsive columns based on XL3 breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl3), 1fr);
+    }
+
+    // Explicit developer overrides for XL3 breakpoint for exception cases
+    @include layout-grid-templates(xl3, 16);
+}
+
+@container layout-grid-container (inline-size >= #{$_screen-size-XL4}) {
+    // Responsive columns based on XL4 breakpoint per button type
+    .layout-grid > ul {
+        grid-template-columns: repeat(var(--layout-grid-columns-xl4), 1fr);
+    }
+
+    // Explicit developer overrides for XL4 breakpoint for exception cases
+    @include layout-grid-templates(xl4, 16);
+}

--- a/src/sass/layout-grid/stories/layout-grid.stories.js
+++ b/src/sass/layout-grid/stories/layout-grid.stories.js
@@ -1,0 +1,120 @@
+export default { title: "Skin/Layout Grid" };
+
+export const base = () => `
+<div class="layout-grid">
+    <ul aria-label="List of options">
+        <li>
+            <button class="btn btn--fluid">Button 1</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 2</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 3</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 4</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 5</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 6</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 7</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 8</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 9</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 10</button>
+        </li>
+    </ul>
+</div>
+`;
+
+export const custom = () => `
+<div class="layout-grid"
+    data-columns-min="2"
+    data-columns-xs="3"
+    data-columns-sm="4"
+    data-columns-md="6"
+    data-columns-lg="8"
+>
+    <ul aria-label="List of options">
+        <li>
+            <button class="btn btn--fluid">Button 1</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 2</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 3</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 4</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 5</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 6</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 7</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 8</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 9</button>
+        </li>
+        <li>
+            <button class="btn btn--fluid">Button 10</button>
+        </li>
+    </ul>
+</div>
+`;
+
+export const RTL = () => `
+<div dir="rtl">
+    <div class="layout-grid">
+        <ul aria-label="List of options">
+            <li>
+                <button class="btn btn--fluid">Button 1</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 2</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 3</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 4</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 5</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 6</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 7</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 8</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 9</button>
+            </li>
+            <li>
+                <button class="btn btn--fluid">Button 10</button>
+            </li>
+        </ul>
+    </div>
+</div>
+`;


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2466 

<!-- Select which type of PR this is -->
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
Created a new generic and component-agnostic layout grid component that allows for the easy implementation of responsive layouts with multiple components or elements inside.

This component will remove redundancy and `CSS` duplication across all similar grouped components, such as `toggle-button-group`.

## Screenshots

**Unbalanced Layouts (previously)**

<kbd><img width="506" alt="image" src="https://github.com/user-attachments/assets/8691c1e3-8ffe-4934-9201-753c06282178" /></kbd>

**Balanced Layouts (new with this component)**

<kbd><img width="506" alt="image" src="https://github.com/user-attachments/assets/16fa321d-2c96-4ea3-8b54-a889d8d682c2" /></kbd>

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [X] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
