### PR TITLE
feat(avatar): aligned text within avatar

### DIFF
--- a/.changeset/cyan-snakes-add.md
+++ b/.changeset/cyan-snakes-add.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(avatar): aligned text within avatar

--- a/dist/avatar/avatar.css
+++ b/dist/avatar/avatar.css
@@ -2,6 +2,7 @@
     align-items: center;
     border-radius: 50%;
     display: inline-flex;
+    font-family: sans-serif;
     font-size: var(--font-size-large-2);
     font-weight: var(--font-weight-bold);
     height: 48px;

--- a/dist/variables/_variables.scss
+++ b/dist/variables/_variables.scss
@@ -27,6 +27,7 @@ $marketsans-fontname: "Market Sans";
 $marketsans-filename-regular: "MarketSans-Regular-WebS";
 $marketsans-filename-bold: "MarketSans-SemiBold-WebS";
 $font-family-default: $marketsans-fontname, Arial, sans-serif;
+$font-family-secondary: sans-serif;
 /* TODO: remove these in next major version */
 $font-weight-regular: 500;
 $font-weight-bold: 700;

--- a/src/sass/avatar/avatar.scss
+++ b/src/sass/avatar/avatar.scss
@@ -24,6 +24,7 @@ $_avatar-magenta-background-color: #cc9ef0;
 
     align-items: center;
     border-radius: 50%;
+    font-family: $font-family-secondary;
     font-size: var(--font-size-large-2);
     font-weight: var(--font-weight-bold);
     height: 48px;

--- a/src/sass/variables/_variables.scss
+++ b/src/sass/variables/_variables.scss
@@ -27,6 +27,7 @@ $marketsans-fontname: "Market Sans";
 $marketsans-filename-regular: "MarketSans-Regular-WebS";
 $marketsans-filename-bold: "MarketSans-SemiBold-WebS";
 $font-family-default: $marketsans-fontname, Arial, sans-serif;
+$font-family-secondary: sans-serif;
 /* TODO: remove these in next major version */
 $font-weight-regular: 500;
 $font-weight-bold: 700;


### PR DESCRIPTION

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Fixed avatar alignment

## Screenshots
<img width="599" alt="Screenshot 2025-02-14 at 10 09 03 AM" src="https://github.com/user-attachments/assets/c1a5a395-1975-41a2-977c-3f322b109418" />


- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
