### PR TITLE
Documentation: Internal hash links in documentation no longer work

### DIFF
--- a/src/components/themes.marko
+++ b/src/components/themes.marko
@@ -30,5 +30,5 @@
     </ul>
     -->
 
-    <p>Warning! Changing the value of any product-level token will cause a ripple effect through all skin modules. If this is not your intention, tokens are also available at the component-level. See <a href="#switch-variables">switch-variables</a> for an example.</p>
+    <p>Warning! Changing the value of any product-level token will cause a ripple effect through all skin modules. If this is not your intention, tokens are also available at the component-level. See <a href="https://opensource.ebay.com/skin/component/switch/#switch-variables">switch-variables</a> for an example.</p>
 </div>

--- a/src/components/token-system.marko
+++ b/src/components/token-system.marko
@@ -11,7 +11,7 @@
     <p>In order for Skin to render correctly, values for core tokens and light tokens are <strong>required</strong>.</p>
     <p>The easiest way to satisfy this requirement is to include one of the following bundles:</p>
     <ul>
-        <li><a href="#tokens">@ebay/skin/tokens</a></li>
+        <li><a href="https://opensource.ebay.com/skin/component/tokens">@ebay/skin/tokens</a></li>
     </ul>
 
     <p>It is also possible for a page to roll their own tokens sets, enabling a themed or even non-eBay branded look and feel. More information will be provided in a future release.</p>


### PR DESCRIPTION


<!-- Insert GitHub issue number below -->
Fixes #2570 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
Documentation: Internal hash links in documentation no longer work has been fixed with correct links

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [x] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
