### PR TITLE
fix(docs): fix broken internal hash links

### DIFF
--- a/src/components/about.marko
+++ b/src/components/about.marko
@@ -1,7 +1,7 @@
 <div id="about">
     <h2>About</h2>
     <p>Skin is a pure CSS framework, created by a team of passionate frontend engineers at eBay.</p>
-    <p>Skin's default stylesheet represents <a href="https://playbook.ebay.com">eBay Evo</a> - eBay's evolved brand and design system - but Skin also offers <a href="#token-system">token-based configuration</a> to enable non-eBay branded experiences.</p>
+    <p>Skin's default stylesheet represents <a href="https://playbook.ebay.com">eBay Evo</a> - eBay's evolved brand and design system - but Skin also offers <anchor href="#token-system">token-based configuration</anchor> to enable non-eBay branded experiences.</p>
     <p>Skin adheres to the following core principals:</p>
     <dl>
         <dt>Accessible</dt>
@@ -12,6 +12,6 @@
         <dd>Skin is decoupled from the JavaScript layer, meaning the HTML and CSS is agnostic of the frontend framework (BYOJ = Bring Your Own Javascript!)<sup>*</sup></dd>
         <dt>Scalable</dt>
         <dd>Skin is built on a system of <a href="https://tr.designtokens.org/format/">design tokens</a> (implemented as CSS Variables); enabling a scalable and consistent visual system for UI development.</dd>
-    </dl>   
+    </dl>
     <p><sup>*</sup>This website uses <a href="https://github.com/makeup/makeup-js">makeup-js</a> to add some basic interactivity to examples where needed.</p>
 </div>

--- a/src/components/components-list.marko
+++ b/src/components/components-list.marko
@@ -5,7 +5,7 @@ import path from 'path';
     $ const name = componentName.replace(/-([a-z])/g, function (g) { return ` ${g[1].toUpperCase()}`; });
     $ const properName = name.charAt(0).toUpperCase() + name.slice(1);
     <li>
-        <anchor href=`component/${componentName}` class="nav-link" role="menuitem">${properName}</anchor>
+        <anchor href=`component/${componentName}/` class="nav-link" role="menuitem">${properName}</anchor>
     </li>
 </for>
 

--- a/src/components/themes.marko
+++ b/src/components/themes.marko
@@ -30,5 +30,5 @@
     </ul>
     -->
 
-    <p>Warning! Changing the value of any product-level token will cause a ripple effect through all skin modules. If this is not your intention, tokens are also available at the component-level. See <a href="#switch-variables">switch-variables</a> for an example.</p>
+    <p>Warning! Changing the value of any product-level token will cause a ripple effect through all skin modules. If this is not your intention, tokens are also available at the component-level. See <anchor href="component/switch#switch-variables">switch-variables</anchor> for an example.</p>
 </div>

--- a/src/components/token-system.marko
+++ b/src/components/token-system.marko
@@ -11,7 +11,7 @@
     <p>In order for Skin to render correctly, values for core tokens and light tokens are <strong>required</strong>.</p>
     <p>The easiest way to satisfy this requirement is to include one of the following bundles:</p>
     <ul>
-        <li><anchor href="component/tokens">@ebay/skin/tokens</anchor></li>
+        <li><anchor href="component/tokens/">@ebay/skin/tokens</anchor></li>
     </ul>
 
     <p>It is also possible for a page to roll their own tokens sets, enabling a themed or even non-eBay branded look and feel. More information will be provided in a future release.</p>

--- a/src/components/token-system.marko
+++ b/src/components/token-system.marko
@@ -11,7 +11,7 @@
     <p>In order for Skin to render correctly, values for core tokens and light tokens are <strong>required</strong>.</p>
     <p>The easiest way to satisfy this requirement is to include one of the following bundles:</p>
     <ul>
-        <li><a href="#tokens">@ebay/skin/tokens</a></li>
+        <li><anchor href="component/tokens">@ebay/skin/tokens</anchor></li>
     </ul>
 
     <p>It is also possible for a page to roll their own tokens sets, enabling a themed or even non-eBay branded look and feel. More information will be provided in a future release.</p>

--- a/src/routes/_index/component/+page.marko
+++ b/src/routes/_index/component/+page.marko
@@ -6,7 +6,7 @@ import path from 'path';
 <ul>
 <for|key, folder| in=components>
     <li>
-        <anchor href=`component/${path.basename(folder)}` class="module-link">${path.basename(folder)}</anchor>
+        <anchor href=`component/${path.basename(folder)}/` class="module-link">${path.basename(folder)}</anchor>
     </li>
 </for>
 </ul>

--- a/src/routes/_index/component/badge/+page.marko
+++ b/src/routes/_index/component/badge/+page.marko
@@ -6,13 +6,13 @@
     </p>
     <p>
         The badge module contains the basic, base styles for a static badge element. Badges can also be placed inside of the${" "}
-        <a href="#icon-button-badged">
+        <anchor href="component/icon-button#icon-button-badged">
             icon button
-        </a>
+        </anchor>
          and
-        <a href="#menu-badged">
+        <anchor href="component/menu#menu-badged">
             menu
-        </a>
+        </anchor>
          modules.
     </p>
 

--- a/src/routes/_index/component/button/+page.marko
+++ b/src/routes/_index/component/button/+page.marko
@@ -219,7 +219,7 @@
     </highlight-code>
 
     <h3 id="button-busy">Busy State for Button</h3>
-        <p>Replace the button contents with a <anchor href="component/progress-spinner">progress spinner</anchor> to represent a busy state. Note also, that the button will need an aria-label to programmatically convey the busy state to assistive technology.</p>
+        <p>Replace the button contents with a <anchor href="component/progress-spinner/">progress spinner</anchor> to represent a busy state. Note also, that the button will need an aria-label to programmatically convey the busy state to assistive technology.</p>
 
         <div class="demo">
             <div class="demo__inner">
@@ -255,7 +255,7 @@
         </div>
     </div>
 
-    <p>NOTE: it is recommended to use a <anchor href="component/snackbar-dialog">snackbar dialog</anchor> or <anchor href="component/inline-notice">inline-notice</anchor> in order to convey any status of success or failure.</p>
+    <p>NOTE: it is recommended to use a <anchor href="component/snackbar-dialog/">snackbar dialog</anchor> or <anchor href="component/inline-notice/">inline-notice</anchor> in order to convey any status of success or failure.</p>
 
     <h3 id="button-layout">Flexible Button</h3>
 

--- a/src/routes/_index/component/button/+page.marko
+++ b/src/routes/_index/component/button/+page.marko
@@ -219,7 +219,7 @@
     </highlight-code>
 
     <h3 id="button-busy">Busy State for Button</h3>
-        <p>Replace the button contents with a <a href="#progress-spinner">progress spinner</a> to represent a busy state. Note also, that the button will need an aria-label to programmatically convey the busy state to assistive technology.</p>
+        <p>Replace the button contents with a <anchor href="component/progress-spinner">progress spinner</anchor> to represent a busy state. Note also, that the button will need an aria-label to programmatically convey the busy state to assistive technology.</p>
 
         <div class="demo">
             <div class="demo__inner">
@@ -255,7 +255,7 @@
         </div>
     </div>
 
-    <p>NOTE: it is recommended to use a <a href="#snackbar-dialog">snackbar dialog</a> or <a href="#inline-notice">inline-notice</a> in order to convey any status of success or failure.</p>
+    <p>NOTE: it is recommended to use a <anchor href="component/snackbar-dialog">snackbar dialog</anchor> or <anchor href="component/inline-notice">inline-notice</anchor> in order to convey any status of success or failure.</p>
 
     <h3 id="button-layout">Flexible Button</h3>
 

--- a/src/routes/_index/component/checkbox/+page.marko
+++ b/src/routes/_index/component/checkbox/+page.marko
@@ -295,7 +295,7 @@
     </p>
     <p>
         The following example uses the
-        <anchor href="component/field">
+        <anchor href="component/field/">
             field module
         </anchor>
          for simple layout of checkbox fields and labels.

--- a/src/routes/_index/component/checkbox/+page.marko
+++ b/src/routes/_index/component/checkbox/+page.marko
@@ -295,9 +295,9 @@
     </p>
     <p>
         The following example uses the
-        <a href="#field">
+        <anchor href="component/field">
             field module
-        </a>
+        </anchor>
          for simple layout of checkbox fields and labels.
     </p>
 

--- a/src/routes/_index/component/chips-combobox/+page.marko
+++ b/src/routes/_index/component/chips-combobox/+page.marko
@@ -544,9 +544,9 @@
             a11y
         </span>
         ${" "}rules, color alone should not be used to indicate an error. For more information, please see the${" "}
-        <a href="#field-error-state">
+        <anchor href="component/field/#field-error-state">
             field error state docs
-        </a>
+        </anchor>
         .
     </p>
 

--- a/src/routes/_index/component/date-textbox/+page.marko
+++ b/src/routes/_index/component/date-textbox/+page.marko
@@ -9,15 +9,15 @@
     </h3>
     <p>
         The single select date textbox consists of a
-        <anchor href="component/textbox">
+        <anchor href="component/textbox/">
             textbox
         </anchor>
          plus
-        <anchor href="component/icon-button">
+        <anchor href="component/icon-button/">
             icon button
         </anchor>
         . The icon button launches an interactive
-        <anchor href="component/calendar">
+        <anchor href="component/calendar/">
             calendar
         </anchor>
          inside of a flyout.

--- a/src/routes/_index/component/date-textbox/+page.marko
+++ b/src/routes/_index/component/date-textbox/+page.marko
@@ -9,17 +9,17 @@
     </h3>
     <p>
         The single select date textbox consists of a
-        <a href="#textbox">
+        <anchor href="component/textbox">
             textbox
-        </a>
+        </anchor>
          plus
-        <a href="#icon-button">
+        <anchor href="component/icon-button">
             icon button
-        </a>
+        </anchor>
         . The icon button launches an interactive
-        <a href="#calendar">
+        <anchor href="component/calendar">
             calendar
-        </a>
+        </anchor>
          inside of a flyout.
     </p>
     <p>

--- a/src/routes/_index/component/filter-menu/+page.marko
+++ b/src/routes/_index/component/filter-menu/+page.marko
@@ -3,7 +3,7 @@
 
     <p>
         A filter menu forms the basis of the
-        <anchor href="component/filter-menu-button">
+        <anchor href="component/filter-menu-button/">
             filter-menu-button
         </anchor>
         ${" "}module; we provide it here as a standalone version in the case it might be opened or rendered via other means (in a dialog for example).
@@ -527,11 +527,11 @@
     </h3>
     <p>
         A form version is also available. It uses the
-        <anchor href="component/checkbox">
+        <anchor href="component/checkbox/">
             checkbox
         </anchor>
          and
-        <anchor href="component/radio">
+        <anchor href="component/radio/">
             radio
         </anchor>
         ${" "}modules to render checkboxes or radios instead of ARIA menu items. The form version must contain a submit button.

--- a/src/routes/_index/component/filter-menu/+page.marko
+++ b/src/routes/_index/component/filter-menu/+page.marko
@@ -3,9 +3,9 @@
 
     <p>
         A filter menu forms the basis of the
-        <a href="#filter-menu-button">
+        <anchor href="component/filter-menu-button">
             filter-menu-button
-        </a>
+        </anchor>
         ${" "}module; we provide it here as a standalone version in the case it might be opened or rendered via other means (in a dialog for example).
     </p>
 
@@ -527,13 +527,13 @@
     </h3>
     <p>
         A form version is also available. It uses the
-        <a href="#checkbox">
+        <anchor href="component/checkbox">
             checkbox
-        </a>
+        </anchor>
          and
-        <a href="#radio">
+        <anchor href="component/radio">
             radio
-        </a>
+        </anchor>
         ${" "}modules to render checkboxes or radios instead of ARIA menu items. The form version must contain a submit button.
     </p>
 

--- a/src/routes/_index/component/icon-button/+page.marko
+++ b/src/routes/_index/component/icon-button/+page.marko
@@ -1,7 +1,7 @@
 <div id="icon-button">
     <section-header metadata=metadata/>
 
-    <p>Use the <span class="highlight">icon-btn</span> class (for buttons) or the <span class="highlight">icon-link</span> class (for links) and any of the available <anchor href="component/icon">icons</anchor> for a borderless, actionable icon style.</p>
+    <p>Use the <span class="highlight">icon-btn</span> class (for buttons) or the <span class="highlight">icon-link</span> class (for links) and any of the available <anchor href="component/icon/">icons</anchor> for a borderless, actionable icon style.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -100,7 +100,7 @@
     </highlight-code>
 
     <h3 id="icon-button-badged">Badged Icon Button</h3>
-    <p>An icon button can be badged using the <anchor href="component/badge">badge</anchor> module.</p>
+    <p>An icon button can be badged using the <anchor href="component/badge/">badge</anchor> module.</p>
     <p>The button or anchor element requires an additional <span class="highlight">icon-btn--badged</span> or <span class="highlight">icon-link--badged</span> modifier, respectively.</p>
 
     <div class="demo">

--- a/src/routes/_index/component/icon-button/+page.marko
+++ b/src/routes/_index/component/icon-button/+page.marko
@@ -1,7 +1,7 @@
 <div id="icon-button">
     <section-header metadata=metadata/>
 
-    <p>Use the <span class="highlight">icon-btn</span> class (for buttons) or the <span class="highlight">icon-link</span> class (for links) and any of the available <a href="#icon">icons</a> for a borderless, actionable icon style.</p>
+    <p>Use the <span class="highlight">icon-btn</span> class (for buttons) or the <span class="highlight">icon-link</span> class (for links) and any of the available <anchor href="component/icon">icons</anchor> for a borderless, actionable icon style.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -100,7 +100,7 @@
     </highlight-code>
 
     <h3 id="icon-button-badged">Badged Icon Button</h3>
-    <p>An icon button can be badged using the <a href="#badge">badge</a> module.</p>
+    <p>An icon button can be badged using the <anchor href="component/badge">badge</anchor> module.</p>
     <p>The button or anchor element requires an additional <span class="highlight">icon-btn--badged</span> or <span class="highlight">icon-link--badged</span> modifier, respectively.</p>
 
     <div class="demo">

--- a/src/routes/_index/component/icon/+page.marko
+++ b/src/routes/_index/component/icon/+page.marko
@@ -33,7 +33,7 @@ import iconJSON from '../../../../components/data/icons.json';
 
     <h3>Including an Icon</h3>
     <p>An icon <a href="https://raw.githubusercontent.com/eBay/skin/master/src/svg/icons.svg">symbol</a> declaration can
-        be referenced from the same file or an <anchor href="component/svg">external SVG</anchor> file. If in the same file, the symbol
+        be referenced from the same file or an <anchor href="component/svg/">external SVG</anchor> file. If in the same file, the symbol
         must be stamped on the page inside of an SVG block.</p>
     <p>We also provide individual icons as SVGs located in this <a href="https://github.com/eBay/skin/tree/master/src/svg/icon">directory</a>.
         You can include these on your page as raw SVGs as needed.</p>

--- a/src/routes/_index/component/icon/+page.marko
+++ b/src/routes/_index/component/icon/+page.marko
@@ -33,7 +33,7 @@ import iconJSON from '../../../../components/data/icons.json';
 
     <h3>Including an Icon</h3>
     <p>An icon <a href="https://raw.githubusercontent.com/eBay/skin/master/src/svg/icons.svg">symbol</a> declaration can
-        be referenced from the same file or an <a href="#svg">external SVG</a> file. If in the same file, the symbol
+        be referenced from the same file or an <anchor href="component/svg">external SVG</anchor> file. If in the same file, the symbol
         must be stamped on the page inside of an SVG block.</p>
     <p>We also provide individual icons as SVGs located in this <a href="https://github.com/eBay/skin/tree/master/src/svg/icon">directory</a>.
         You can include these on your page as raw SVGs as needed.</p>

--- a/src/routes/_index/component/link/+page.marko
+++ b/src/routes/_index/component/link/+page.marko
@@ -3,7 +3,7 @@
 
     <p>
         The link module itself does not provide any base styling of anchor tags, that styling instead comes from the${" "}
-        <anchor href="component/global">
+        <anchor href="component/global/">
             global
         </anchor>
          module.

--- a/src/routes/_index/component/link/+page.marko
+++ b/src/routes/_index/component/link/+page.marko
@@ -3,9 +3,9 @@
 
     <p>
         The link module itself does not provide any base styling of anchor tags, that styling instead comes from the${" "}
-        <a href="#global">
+        <anchor href="component/global">
             global
-        </a>
+        </anchor>
          module.
     </p>
 

--- a/src/routes/_index/component/listbox-button/+page.marko
+++ b/src/routes/_index/component/listbox-button/+page.marko
@@ -776,9 +776,9 @@
     </p>
     <p>
         This is a simple example with a simple error indication. For usage of the error state with an error message, please see the${" "}
-        <a href="#field">
+        <anchor href="component/field">
             field module
-        </a>
+        </anchor>
         .
     </p>
 

--- a/src/routes/_index/component/listbox-button/+page.marko
+++ b/src/routes/_index/component/listbox-button/+page.marko
@@ -776,7 +776,7 @@
     </p>
     <p>
         This is a simple example with a simple error indication. For usage of the error state with an error message, please see the${" "}
-        <anchor href="component/field">
+        <anchor href="component/field/">
             field module
         </anchor>
         .

--- a/src/routes/_index/component/menu-button/+page.marko
+++ b/src/routes/_index/component/menu-button/+page.marko
@@ -12,19 +12,19 @@
         A menu is
         <strong>not</strong>
         ${" "}a form control. If you wish to submit form data natively, without JavaScript, please consider${" "}
-        <anchor href="component/checkbox">
+        <anchor href="component/checkbox/">
             checkbox
         </anchor>
         ,
-        <anchor href="component/combobox">
+        <anchor href="component/combobox/">
             combobox
         </anchor>
         ,
-        <anchor href="component/select">
+        <anchor href="component/select/">
             select
         </anchor>
         , or
-        <anchor href="component/radio">
+        <anchor href="component/radio/">
             radio
         </anchor>
          instead.
@@ -450,7 +450,7 @@
                 single select menu button
             </anchor>
             . For example: "Sort: Price", "Color: Red". This technique is identical to the method used by${" "}
-            <anchor href="component/listbox-button">
+            <anchor href="component/listbox-button/">
                 Listbox Button
             </anchor>
             .
@@ -904,11 +904,11 @@
          be used as a dropdown for selecting and storing form
         <em>data</em>
         . Please use
-        <anchor href="component/button">
+        <anchor href="component/button/">
             select
         </anchor>
          or
-        <anchor href="component/button">
+        <anchor href="component/button/">
             listbox-button
         </anchor>
          for that purpose instead.

--- a/src/routes/_index/component/menu-button/+page.marko
+++ b/src/routes/_index/component/menu-button/+page.marko
@@ -12,21 +12,21 @@
         A menu is
         <strong>not</strong>
         ${" "}a form control. If you wish to submit form data natively, without JavaScript, please consider${" "}
-        <a href="#checkbox">
+        <anchor href="component/checkbox">
             checkbox
-        </a>
+        </anchor>
         ,
-        <a href="#combobox">
+        <anchor href="component/combobox">
             combobox
-        </a>
+        </anchor>
         ,
-        <a href="#select">
+        <anchor href="component/select">
             select
-        </a>
+        </anchor>
         , or
-        <a href="#radio">
+        <anchor href="component/radio">
             radio
-        </a>
+        </anchor>
          instead.
     </p>
     <p>
@@ -450,9 +450,9 @@
                 single select menu button
             </a>
             . For example: "Sort: Price", "Color: Red". This technique is identical to the method used by${" "}
-            <a href="#listbox-button">
+            <anchor href="component/listbox-button">
                 Listbox Button
-            </a>
+            </anchor>
             .
         </p>
 
@@ -904,13 +904,13 @@
          be used as a dropdown for selecting and storing form
         <em>data</em>
         . Please use
-        <a href="#button">
+        <anchor href="component/button">
             select
-        </a>
+        </anchor>
          or
-        <a href="#button">
+        <anchor href="component/button">
             listbox-button
-        </a>
+        </anchor>
          for that purpose instead.
     </p>
 

--- a/src/routes/_index/component/menu-button/+page.marko
+++ b/src/routes/_index/component/menu-button/+page.marko
@@ -33,9 +33,9 @@
         Selecting a menu item command should update the page
         <strong>without</strong>
         ${" "}a full page reload (i.e. acting similar to buttons, checkboxes or radios). If a full page load is required instead (i.e. acting like links), please refer to the${" "}
-        <a href="#menu-button-fake">
+        <anchor href="component/menu-button/#menu-button-fake">
             fake menu button
-        </a>
+        </anchor>
         .
     </p>
 
@@ -446,9 +446,9 @@
         </h4>
         <p>
             If a fixed label is not possible, the button's inner text can potentially be written as a key/value pair, where key denotes purpose and value repesents the current selection. This is most typical in a${" "}
-            <a href="#menu-button-radio">
+            <anchor href="component/menu-button/#menu-button-radio">
                 single select menu button
-            </a>
+            </anchor>
             . For example: "Sort: Price", "Color: Red". This technique is identical to the method used by${" "}
             <anchor href="component/listbox-button">
                 Listbox Button

--- a/src/routes/_index/component/menu/+page.marko
+++ b/src/routes/_index/component/menu/+page.marko
@@ -5,21 +5,21 @@
         A menu is
         <strong>not</strong>
         ${" "}a form control. If you wish to submit form data natively, without JavaScript, please consider${" "}
-        <a href="#checkbox">
+        <anchor href="component/checkbox">
             checkbox
-        </a>
+        </anchor>
         ,
-        <a href="#combobox">
+        <anchor href="component/combobox">
             combobox
-        </a>
+        </anchor>
         ,
-        <a href="#select">
+        <anchor href="component/select">
             select
-        </a>
+        </anchor>
         , or
-        <a href="#radio">
+        <anchor href="component/radio">
             radio
-        </a>
+        </anchor>
          instead.
     </p>
     <p>
@@ -104,9 +104,9 @@
     </h3>
     <p>
         A menu item can be badged using the
-        <a href="#badge">
+        <anchor href="component/badge">
             badge
-        </a>
+        </anchor>
          module.
     </p>
     <p>

--- a/src/routes/_index/component/menu/+page.marko
+++ b/src/routes/_index/component/menu/+page.marko
@@ -5,19 +5,19 @@
         A menu is
         <strong>not</strong>
         ${" "}a form control. If you wish to submit form data natively, without JavaScript, please consider${" "}
-        <anchor href="component/checkbox">
+        <anchor href="component/checkbox/">
             checkbox
         </anchor>
         ,
-        <anchor href="component/combobox">
+        <anchor href="component/combobox/">
             combobox
         </anchor>
         ,
-        <anchor href="component/select">
+        <anchor href="component/select/">
             select
         </anchor>
         , or
-        <anchor href="component/radio">
+        <anchor href="component/radio/">
             radio
         </anchor>
          instead.
@@ -104,7 +104,7 @@
     </h3>
     <p>
         A menu item can be badged using the
-        <anchor href="component/badge">
+        <anchor href="component/badge/">
             badge
         </anchor>
          module.

--- a/src/routes/_index/component/menu/+page.marko
+++ b/src/routes/_index/component/menu/+page.marko
@@ -26,9 +26,9 @@
         Selecting a menu item command should update the page
         <strong>without</strong>
         ${" "}a full page reload (i.e. acting similar to buttons, checkboxes or radios). If a full page load is required instead (i.e. acting like links), please refer to the${" "}
-        <a href="#menu-fake">
+        <anchor href="component/menu/#menu-fake">
             fake menu
-        </a>
+        </anchor>
         .
     </p>
     <p>

--- a/src/routes/_index/component/phone-input/+page.marko
+++ b/src/routes/_index/component/phone-input/+page.marko
@@ -267,9 +267,9 @@
             field
         </span>
          classes. For label inline usage, please see the
-        <a href="#field">
+        <anchor href="component/field">
             field module
-        </a>
+        </anchor>
          .
     </p>
     <div class="demo">

--- a/src/routes/_index/component/phone-input/+page.marko
+++ b/src/routes/_index/component/phone-input/+page.marko
@@ -267,7 +267,7 @@
             field
         </span>
          classes. For label inline usage, please see the
-        <anchor href="component/field">
+        <anchor href="component/field/">
             field module
         </anchor>
          .

--- a/src/routes/_index/component/radio/+page.marko
+++ b/src/routes/_index/component/radio/+page.marko
@@ -219,7 +219,7 @@
     </p>
     <p>
         The following example uses the
-        <anchor href="component/field">
+        <anchor href="component/field/">
             field module
         </anchor>
          for simple layout of radio button fields and labels.

--- a/src/routes/_index/component/radio/+page.marko
+++ b/src/routes/_index/component/radio/+page.marko
@@ -219,9 +219,9 @@
     </p>
     <p>
         The following example uses the
-        <a href="#field">
+        <anchor href="component/field">
             field module
-        </a>
+        </anchor>
          for simple layout of radio button fields and labels.
     </p>
     <div class="demo">

--- a/src/routes/_index/component/segmented-buttons/+page.marko
+++ b/src/routes/_index/component/segmented-buttons/+page.marko
@@ -124,7 +124,7 @@
     </h3>
     <p>
         Any 24x24
-        <anchor href="component/icon">
+        <anchor href="component/icon/">
             icon
         </anchor>
          can be added inside of a

--- a/src/routes/_index/component/segmented-buttons/+page.marko
+++ b/src/routes/_index/component/segmented-buttons/+page.marko
@@ -124,9 +124,9 @@
     </h3>
     <p>
         Any 24x24
-        <a href="#icon">
+        <anchor href="component/icon">
             icon
-        </a>
+        </anchor>
          can be added inside of a
         <span class="highlight">
             segmented-buttons__button-cell

--- a/src/routes/_index/component/select/+page.marko
+++ b/src/routes/_index/component/select/+page.marko
@@ -6,7 +6,7 @@
     </p>
     <p>
         The purpose of a select is to collect form data; therefore a select should always be used in conjunction with a form, label and submit button. If you are not submitting form data, then a${" "}
-        <anchor href="component/menu">
+        <anchor href="component/menu/">
             menu
         </anchor>
          maybe a better choice.
@@ -14,7 +14,7 @@
     <p>
         <strong>IMPORTANT:</strong>
         ${" "}The examples below show the select in isolation, without any label. Please see the${" "}
-        <anchor href="component/field">
+        <anchor href="component/field/">
             field
         </anchor>
         ${" "}module for details on labeling controls. Remember: every select requires a label!

--- a/src/routes/_index/component/select/+page.marko
+++ b/src/routes/_index/component/select/+page.marko
@@ -6,17 +6,17 @@
     </p>
     <p>
         The purpose of a select is to collect form data; therefore a select should always be used in conjunction with a form, label and submit button. If you are not submitting form data, then a${" "}
-        <a href="#menu">
+        <anchor href="component/menu">
             menu
-        </a>
+        </anchor>
          maybe a better choice.
     </p>
     <p>
         <strong>IMPORTANT:</strong>
         ${" "}The examples below show the select in isolation, without any label. Please see the${" "}
-        <a href="#field">
+        <anchor href="component/field">
             field
-        </a>
+        </anchor>
         ${" "}module for details on labeling controls. Remember: every select requires a label!
     </p>
 

--- a/src/routes/_index/component/skeleton/+page.marko
+++ b/src/routes/_index/component/skeleton/+page.marko
@@ -8,9 +8,9 @@
     </h2>
     <p>
         A skeleton is a graphical placeholder, reserving physical space in the page for content that is not yet available for the client to render. A skeleton can be considered as an alternative to the${" "}
-        <a href="#progress-spinner">
+        <anchor href="component/progress-spinner">
             progress spinner
-        </a>
+        </anchor>
          in many situations.
     </p>
     <p>

--- a/src/routes/_index/component/skeleton/+page.marko
+++ b/src/routes/_index/component/skeleton/+page.marko
@@ -8,7 +8,7 @@
     </h2>
     <p>
         A skeleton is a graphical placeholder, reserving physical space in the page for content that is not yet available for the client to render. A skeleton can be considered as an alternative to the${" "}
-        <anchor href="component/progress-spinner">
+        <anchor href="component/progress-spinner/">
             progress spinner
         </anchor>
          in many situations.

--- a/src/routes/_index/component/skeleton/+page.marko
+++ b/src/routes/_index/component/skeleton/+page.marko
@@ -79,9 +79,9 @@
         <tbody>
             <tr>
                 <td>
-                    <a href="#skeleton-avatar">
+                    <anchor href="component/skeleton/#skeleton-avatar">
                         Avatar
-                    </a>
+                    </anchor>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -129,9 +129,9 @@
             </tr>
             <tr>
                 <td>
-                    <a href="#skeleton-button">
+                    <anchor href="component/skeleton/#skeleton-button">
                         Button
-                    </a>
+                    </anchor>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -179,9 +179,9 @@
             </tr>
             <tr>
                 <td>
-                    <a href="#skeleton-textbox">
+                    <anchor href="component/skeleton/#skeleton-textbox">
                         Textbox
-                    </a>
+                    </anchor>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -227,9 +227,9 @@
             </tr>
             <tr>
                 <td>
-                    <a href="#skeleton-image">
+                    <anchor href="component/skeleton/#skeleton-image">
                         Image
-                    </a>
+                    </anchor>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -290,9 +290,9 @@
             </tr>
             <tr>
                 <td>
-                    <a href="#skeleton-text">
+                    <anchor href="component/skeleton/#skeleton-text">
                         Text
-                    </a>
+                    </anchor>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -348,9 +348,9 @@
             skeleton--green
         </span>
         . View the
-        <a href="#skeleton-composite">
+        <anchor href="component/skeleton/#skeleton-composite">
             composite skeletons
-        </a>
+        </anchor>
          examples for further details.
     </p>
 

--- a/src/routes/_index/component/snackbar-dialog/+page.marko
+++ b/src/routes/_index/component/snackbar-dialog/+page.marko
@@ -10,9 +10,9 @@
             hidden
         </span>
          property. Please refer to the
-        <a href="#dialog-transitions">
+        <anchor href="guide/animation/#dialog-transitions">
             Dialog Transitions
-        </a>
+        </anchor>
         ${" "}section for information on how to correctly trigger a CSS transition from a hidden state. With the correct JavaScript in place, applying the${" "}
         <span class="highlight">
             snackbar-dialog--transition

--- a/src/routes/_index/component/split-button/+page.marko
+++ b/src/routes/_index/component/split-button/+page.marko
@@ -1,7 +1,7 @@
 <div id="split-button">
     <section-header metadata=metadata/>
 
-    <p>A split button is a button broken into two seperately actionable portions: a common action (a <anchor href="component/button">button</anchor>) at the start, and supplemental actions (a <anchor href="component/menu-button">menu button</anchor>) at the end.</p>
+    <p>A split button is a button broken into two seperately actionable portions: a common action (a <anchor href="component/button/">button</anchor>) at the start, and supplemental actions (a <anchor href="component/menu-button/">menu button</anchor>) at the end.</p>
     <p>Split buttons are for actions only, and should not be used for site navigation.</p>
 
     <div class="demo">

--- a/src/routes/_index/component/split-button/+page.marko
+++ b/src/routes/_index/component/split-button/+page.marko
@@ -1,7 +1,7 @@
 <div id="split-button">
     <section-header metadata=metadata/>
 
-    <p>A split button is a button broken into two seperately actionable portions: a common action (a <a href="#button">button</a>) at the start, and supplemental actions (a <a href="#menu-button">menu button</a>) at the end.</p>
+    <p>A split button is a button broken into two seperately actionable portions: a common action (a <anchor href="component/button">button</anchor>) at the start, and supplemental actions (a <anchor href="component/menu-button">menu button</anchor>) at the end.</p>
     <p>Split buttons are for actions only, and should not be used for site navigation.</p>
 
     <div class="demo">

--- a/src/routes/_index/component/star-rating/+page.marko
+++ b/src/routes/_index/component/star-rating/+page.marko
@@ -17,7 +17,7 @@ $ const ratings = [
 
     <p>
         This is a non-interactive, display-only star rating pattern. For an interactive user-selectable star rating selection pattern, please refer to${" "}
-        <anchor href="component/star-rating-select">
+        <anchor href="component/star-rating-select/">
             Star Rating Select
         </anchor>
          .
@@ -46,7 +46,7 @@ $ const ratings = [
 
     <p>
         Below is the code example for how to use the "star-rating-2-5" symbol. Please refer to the${" "}
-        <anchor href="component/icon">
+        <anchor href="component/icon/">
             icon section
         </anchor>
          for full guidance on how to include and use SVG symbols.

--- a/src/routes/_index/component/star-rating/+page.marko
+++ b/src/routes/_index/component/star-rating/+page.marko
@@ -17,9 +17,9 @@ $ const ratings = [
 
     <p>
         This is a non-interactive, display-only star rating pattern. For an interactive user-selectable star rating selection pattern, please refer to${" "}
-        <a href="#star-rating-select">
+        <anchor href="component/star-rating-select">
             Star Rating Select
-        </a>
+        </anchor>
          .
     </p>
 
@@ -46,9 +46,9 @@ $ const ratings = [
 
     <p>
         Below is the code example for how to use the "star-rating-2-5" symbol. Please refer to the${" "}
-        <a href="#icon">
+        <anchor href="component/icon">
             icon section
-        </a>
+        </anchor>
          for full guidance on how to include and use SVG symbols.
     </p>
 

--- a/src/routes/_index/component/tabs/+page.marko
+++ b/src/routes/_index/component/tabs/+page.marko
@@ -14,13 +14,13 @@
         Selecting a tab should update the visible panel
         <strong>without</strong>
         ${" "}a full page reload. If a full page load is required instead (i.e. acting like a link), please see the${" "}
-        <a href="#tab-fake">
+        <anchor href="component/tabs/#tabs-fake">
             fake tab
-        </a>
+        </anchor>
          section below for more details.
     </p>
 
-    <h3 id="tab-default">
+    <h3 id="tabs-default">
         Default Tabs
     </h3>
     <p>
@@ -173,7 +173,7 @@
 </div>
     </highlight-code>
 
-    <h3 id="tab-fake">
+    <h3 id="tabs-fake">
         Fake Tabs
     </h3>
     <p>

--- a/src/routes/_index/component/textbox/+page.marko
+++ b/src/routes/_index/component/textbox/+page.marko
@@ -13,7 +13,7 @@
     <p>
         <strong>IMPORTANT:</strong>The examples below show the textbox in isolation, without any label. Remember: every textbox requires a label!
     </p>
-    <!-- <p><strong>IMPORTANT:</strong> The examples below show the textbox in isolation, without any label. Please see the <anchor href="component/field">field</anchor> module for details on labelling controls. Remember: every textbox requires a label!</p> -->
+    <!-- <p><strong>IMPORTANT:</strong> The examples below show the textbox in isolation, without any label. Please see the <anchor href="component/field/">field</anchor> module for details on labelling controls. Remember: every textbox requires a label!</p> -->
 
     <h3>Single-Line Textbox</h3>
     <p>Use an input tag for a single-line textbox.</p>
@@ -195,7 +195,7 @@
     </h3>
     <p>
         Single-line textboxes can be augmented with any SVG
-        <anchor href="component/icon">
+        <anchor href="component/icon/">
             icon
         </anchor>
         .
@@ -286,7 +286,7 @@
     </h3>
     <p>
         Single-line textboxes also support an
-        <anchor href="component/icon-button">
+        <anchor href="component/icon-button/">
             icon button
         </anchor>
          in the end position.

--- a/src/routes/_index/component/textbox/+page.marko
+++ b/src/routes/_index/component/textbox/+page.marko
@@ -13,7 +13,7 @@
     <p>
         <strong>IMPORTANT:</strong>The examples below show the textbox in isolation, without any label. Remember: every textbox requires a label!
     </p>
-    <!-- <p><strong>IMPORTANT:</strong> The examples below show the textbox in isolation, without any label. Please see the <a href="#field">field</a> module for details on labelling controls. Remember: every textbox requires a label!</p> -->
+    <!-- <p><strong>IMPORTANT:</strong> The examples below show the textbox in isolation, without any label. Please see the <anchor href="component/field">field</anchor> module for details on labelling controls. Remember: every textbox requires a label!</p> -->
 
     <h3>Single-Line Textbox</h3>
     <p>Use an input tag for a single-line textbox.</p>
@@ -195,9 +195,9 @@
     </h3>
     <p>
         Single-line textboxes can be augmented with any SVG
-        <a href="#icon">
+        <anchor href="component/icon">
             icon
-        </a>
+        </anchor>
         .
     </p>
 
@@ -286,9 +286,9 @@
     </h3>
     <p>
         Single-line textboxes also support an
-        <a href="#icon-button">
+        <anchor href="component/icon-button">
             icon button
-        </a>
+        </anchor>
          in the end position.
     </p>
 

--- a/src/routes/_index/component/toast-dialog/+page.marko
+++ b/src/routes/_index/component/toast-dialog/+page.marko
@@ -10,9 +10,9 @@
             hidden
         </span>
          property. Please refer to the
-        <a href="#dialog-transitions">
+        <anchor href="guide/animation/#dialog-transitions">
             Dialog Transitions
-        </a>
+        </anchor>
         ${" "}section for information on how to correctly trigger a CSS transition from a hidden state. With the correct JavaScript in place, applying the${" "}
         <span class="highlight">
             toast-dialog--transition

--- a/src/routes/_index/component/toggle-button-group/+page.marko
+++ b/src/routes/_index/component/toggle-button-group/+page.marko
@@ -52,12 +52,12 @@ import imgSquarePic from "/src/routes/static/img/tb-square-pic.jpg";
 
     <p>
         Effort was taken in these docs to provide a good amount of helpful information. Since this component has an atomic piece (
-        
-        <anchor href="component/toggle-button">
+
+        <anchor href="component/toggle-button/">
             Toggle Button
         </anchor>
         ), there may be some information crossover. Though efforts were taken to isolate the documentation for this parent component, at various touchpoints between the two components, there may be some redundancy. In other portions, where immediate information appears to be missing here, that information may reside in its child component. Please refer to${" "}
-        <anchor href="component/toggle-button">
+        <anchor href="component/toggle-button/">
             Toggle Button
         </anchor>
          docs in these situations.
@@ -1044,7 +1044,7 @@ import imgSquarePic from "/src/routes/static/img/tb-square-pic.jpg";
 
     <p>
         There are various layouts that can be used based on the specific needs at implementation. The implied theme (needs no modifier), is the minimal layout. For more information about types of layouts, refer to the${" "}
-        <anchor href="component/toggle-button">
+        <anchor href="component/toggle-button/">
             Toggle Button
         </anchor>
          component. The examples below will highlight various layouts.

--- a/src/routes/_index/component/tokens/+page.marko
+++ b/src/routes/_index/component/tokens/+page.marko
@@ -1,7 +1,7 @@
 $ const colors = ["avocado", "marigold", "blue", "coral", "orange", "dijon", "pink", "green", "red", "indigo", "teal", "jade", "yellow", "kiwi", "violet", "lilac", "neutral"];
 <div id="tokens">
     <section-header metadata=metadata/>
-    <p>Contains all custom properties necessary to correctly render the Evo Design System, in accordance with the <a href="#token-system">token system</a>.</p>
+    <p>Contains all custom properties necessary to correctly render the Evo Design System, in accordance with the <anchor href="#token-system">token system</anchor>.</p>
     <p>Core, light and dark token sets are individually exposed via the following submodules:</p>
     <dl>
         <dt><span class="secondary-text">@ebay/skin/tokens/</span>evo-core</dt>
@@ -12,7 +12,7 @@ $ const colors = ["avocado", "marigold", "blue", "coral", "orange", "dijon", "pi
         <dd>eBay semantic aliases for dark mode</dd>
     </dl>
     <p><sup>*</sup>This sub-module will not be included automatically by it's parent module; it must be explicitly included by any page that is itself dark-mode compatible.</p>
-    
+
     <h3 id="tokens-color-semantic">Semantic Color Tokens</h3>
     <div class="demo">
         <div class="demo__inner">
@@ -48,7 +48,7 @@ $ const colors = ["avocado", "marigold", "blue", "coral", "orange", "dijon", "pi
             </ul>
         </div>
     </div>
-    
+
     <details class="details">
         <summary class="details__summary">
             <h3 class="details__label">Primitive Color Tokens </h3>

--- a/src/routes/_index/component/typography/+page.marko
+++ b/src/routes/_index/component/typography/+page.marko
@@ -53,9 +53,9 @@
 
     <p>
         Product titles are regular font weight, use the
-        <a href="#marketsans">
+        <anchor href="component/marketsans">
             Market Sans
-        </a>
+        </anchor>
          font and are responsive based on a small or large screen size.
     </p>
 
@@ -84,9 +84,9 @@
 
     <p>
         Section titles are bold font weight, use the
-        <a href="#marketsans">
+        <anchor href="component/marketsans">
             Market Sans
-        </a>
+        </anchor>
          font and are responsive based on a small or large screen size.
     </p>
 

--- a/src/routes/_index/component/typography/+page.marko
+++ b/src/routes/_index/component/typography/+page.marko
@@ -53,7 +53,7 @@
 
     <p>
         Product titles are regular font weight, use the
-        <anchor href="component/marketsans">
+        <anchor href="component/marketsans/">
             Market Sans
         </anchor>
          font and are responsive based on a small or large screen size.
@@ -84,7 +84,7 @@
 
     <p>
         Section titles are bold font weight, use the
-        <anchor href="component/marketsans">
+        <anchor href="component/marketsans/">
             Market Sans
         </anchor>
          font and are responsive based on a small or large screen size.

--- a/src/routes/_index/guide/skeleton+page.marko
+++ b/src/routes/_index/guide/skeleton+page.marko
@@ -1,6 +1,6 @@
 <h1>Skeleton Usage Guide</h1>
 
-<p>This page details <anchor href="guide/skeleton/#techniques">implementation techniques</anchor> and <anchor href="guide/skeleton/#scenarios">common loading scenarios</anchor> for eBay Skin's <anchor href="component/skeleton">skeleton</anchor> module.</p>
+<p>This page details <anchor href="guide/skeleton/#techniques">implementation techniques</anchor> and <anchor href="guide/skeleton/#scenarios">common loading scenarios</anchor> for eBay Skin's <anchor href="component/skeleton/">skeleton</anchor> module.</p>
 <p><strong>NOTE:</strong> This page demonstrates both good and bad uses of skeletons; please be sure to read and understand carefully to avoid replicating an anti-pattern!</p>
 
 <hr />
@@ -27,7 +27,7 @@
 `></highlight-code>
 
 <p><strong>NOTE:</strong> The <span class="highlight">:empty</span> pseudo-class considers elements with whitespace as not empty!</p>
-<p>The downside is that our <anchor href="component/skeleton">skeleton classes</anchor> cannot be leveraged (in theory, LESS mixins could be provided) and <em>composite</em> skeletons (e.g. items tiles) may require some non-trivial use of CSS linear gradients for certain skeletons.</p>
+<p>The downside is that our <anchor href="component/skeleton/">skeleton classes</anchor> cannot be leveraged (in theory, LESS mixins could be provided) and <em>composite</em> skeletons (e.g. items tiles) may require some non-trivial use of CSS linear gradients for certain skeletons.</p>
 
 <hr />
 

--- a/src/routes/_index/guide/skeleton+page.marko
+++ b/src/routes/_index/guide/skeleton+page.marko
@@ -1,6 +1,6 @@
 <h1>Skeleton Usage Guide</h1>
 
-<p>This page details <a href="#techniques">implementation techniques</a> and <a href="#scenarios">common loading scenarios</a> for eBay Skin's <anchor href="component/skeleton">skeleton</anchor> module.</p>
+<p>This page details <anchor href="guide/skeleton/#techniques">implementation techniques</anchor> and <anchor href="guide/skeleton/#scenarios">common loading scenarios</anchor> for eBay Skin's <anchor href="component/skeleton">skeleton</anchor> module.</p>
 <p><strong>NOTE:</strong> This page demonstrates both good and bad uses of skeletons; please be sure to read and understand carefully to avoid replicating an anti-pattern!</p>
 
 <hr />


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes #2570

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
Ensure we're linking to the correct component page instead of the old single-page hash links. Accounts for deeply nested links and also unnecessary redirects (add trailing slashes).

## Notes

- Refactored all direct component links from `<a href="#component-name">` to `<anchor href="component/component-name/">`
- Refactored deeply nested hash links, e.g. `<a href="#field-error-state">` to `<anchor href="component/field/#field-error-state">`. For example, fixed `#field-error-state` on [chips-combobox](https://opensource.ebay.com/skin/component/chips-combobox/) to to link properly to https://opensource.ebay.com/skin/component/field/#field-error-state
    - Including a few deep links that didn't entirely follow the `[component]-[section]` pattern: [tabs](https://opensource.ebay.com/skin/component/tabs/) component page contained `#tab-fake` and `#tab-default` refactored to `#tabs-fake` and `#tabs-default`
- For consistency and environment neutral linking, chose to use `<anchor>` **even when** the link is going to the current page. As a result...
- Fixed existing `<anchor href="component/component-name">` links to include trailing slash `<anchor href="component/component-name/">` in order remove an unnecessary redirect site wide (also required for consistency and same page linking using `<anchor>` moving forward, per last bullet).



## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [x] I verify the build is in a non-broken state
- [x] I verify all changes are within scope of the linked issue
