### PR TITLE
refactor(docs): use `<base>` instead of custom `<anchor>`

### DIFF
--- a/src/components/about.marko
+++ b/src/components/about.marko
@@ -1,7 +1,7 @@
 <div id="about">
     <h2>About</h2>
     <p>Skin is a pure CSS framework, created by a team of passionate frontend engineers at eBay.</p>
-    <p>Skin's default stylesheet represents <a href="https://playbook.ebay.com">eBay Evo</a> - eBay's evolved brand and design system - but Skin also offers <anchor href="#token-system">token-based configuration</anchor> to enable non-eBay branded experiences.</p>
+    <p>Skin's default stylesheet represents <a href="https://playbook.ebay.com">eBay Evo</a> - eBay's evolved brand and design system - but Skin also offers <a href="#token-system">token-based configuration</a> to enable non-eBay branded experiences.</p>
     <p>Skin adheres to the following core principals:</p>
     <dl>
         <dt>Accessible</dt>

--- a/src/components/anchor.marko
+++ b/src/components/anchor.marko
@@ -1,5 +1,0 @@
-static const basePath = import.meta.env.BASE_URL;
-
-<a href=`${basePath}${input.href || ''}` class=input.class role=input.role target=input.target>
-    <${input.renderBody}/>
-</a>

--- a/src/components/components-list.marko
+++ b/src/components/components-list.marko
@@ -5,7 +5,7 @@ import path from 'path';
     $ const name = componentName.replace(/-([a-z])/g, function (g) { return ` ${g[1].toUpperCase()}`; });
     $ const properName = name.charAt(0).toUpperCase() + name.slice(1);
     <li>
-        <anchor href=`component/${componentName}/` class="nav-link" role="menuitem">${properName}</anchor>
+        <a href=`component/${componentName}/` class="nav-link" role="menuitem">${properName}</a>
     </li>
 </for>
 

--- a/src/components/site-footer.marko
+++ b/src/components/site-footer.marko
@@ -10,10 +10,10 @@ style {
 <footer class="page-grid-container">
     <nav class="primary-nav footer-nav" aria-label="Site navigation">
         <ul role="menubar">
-            <li><anchor role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</anchor></li>
+            <li><a role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</a></li>
             <li><a role="menuitem" href="https://github.com/eBay/skin">Repo</a></li>
             <li><a role="menuitem" href="/skin/storybook">Storybook</a></li>
-            <li><anchor role="menuitem" href="/sitemap">Sitemap</anchor></li>
+            <li><a role="menuitem" href="/sitemap">Sitemap</a></li>
         </ul>
     </nav>
     Copyright &copy; 2025 eBay, Inc. All rights reserved.

--- a/src/components/site-header.marko
+++ b/src/components/site-header.marko
@@ -18,7 +18,7 @@ import {components} from './components.marko';
                         </div>
                     </button>
                     <h1 class="app-bar__title">
-                        <anchor>${siteMeta.pageTitle}</anchor>
+                        <a>${siteMeta.pageTitle}</a>
                     </h1>
                     <div class="site-nav-mobile">
 
@@ -65,7 +65,7 @@ import {components} from './components.marko';
                                     <div class="tabs__cell">
                                         <nav id="primary-nav-mobile" class="primary-nav-mobile" aria-label="Site navigation">
                                             <ul class="app-bar__links" role="menubar">
-                                                <li><anchor role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</anchor></li>
+                                                <li><a role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</a></li>
                                                 <li><a role="menuitem" href="https://github.com/eBay/skin">Repo</a></li>
                                                 <li><a role="menuitem" href="/skin/storybook">Storybook</a></li>
                                                 <li><a role="menuitem" href="/sitemap">Sitemap</a></li>
@@ -99,14 +99,14 @@ import {components} from './components.marko';
                                         <nav class="examples-nav" aria-label="Guides">
                                             <ul class="modules-expander__list" role="menubar">
                                                 <li>
-                                                    <anchor href="guide/page-grid" role="menuitem">
-                                                    Page Grid Use Guide</anchor>
+                                                    <a href="guide/page-grid" role="menuitem">
+                                                    Page Grid Use Guide</a>
                                                 </li>
                                                 <li>
-                                                    <anchor href="guide/skeleton" role="menuitem">Skeleton Use Guide</anchor>
+                                                    <a href="guide/skeleton" role="menuitem">Skeleton Use Guide</a>
                                                 </li>
                                                 <li>
-                                                    <anchor href="guide/animation" role="menuitem">Animation Guide</anchor>
+                                                    <a href="guide/animation" role="menuitem">Animation Guide</a>
                                                 </li>
                                             </ul>
                                         </nav>
@@ -117,7 +117,7 @@ import {components} from './components.marko';
                     </div>
                     <nav id="primary-nav" class="primary-nav" aria-label="Site navigation">
                         <ul class="app-bar__links" role="menubar">
-                            <li><anchor role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</anchor></li>
+                            <li><a role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</a></li>
                             <li><a role="menuitem" href="https://github.com/eBay/skin">Repo</a></li>
                             <li><a role="menuitem" href="/skin/storybook">Storybook</a></li>
                         </ul>

--- a/src/components/site-navrail.marko
+++ b/src/components/site-navrail.marko
@@ -12,13 +12,13 @@ import {components} from './components.marko';
         <h2 id="navrail-guides-nav_title">Guides</h2>
         <ul role="menubar">
             <li>
-                <anchor href="guide/page-grid" role="menuitem">Page Grid Use Guide</anchor>
+                <a href="guide/page-grid" role="menuitem">Page Grid Use Guide</a>
             </li>
             <li>
-                <anchor href="guide/skeleton" role="menuitem">Skeleton Use Guide</anchor>
+                <a href="guide/skeleton" role="menuitem">Skeleton Use Guide</a>
             </li>
             <li>
-                <anchor href="guide/animation" role="menuitem">Animation Guide</anchor>
+                <a href="guide/animation" role="menuitem">Animation Guide</a>
             </li>
         </ul>
     </nav>

--- a/src/components/themes.marko
+++ b/src/components/themes.marko
@@ -30,5 +30,5 @@
     </ul>
     -->
 
-    <p>Warning! Changing the value of any product-level token will cause a ripple effect through all skin modules. If this is not your intention, tokens are also available at the component-level. See <anchor href="component/switch#switch-variables">switch-variables</anchor> for an example.</p>
+    <p>Warning! Changing the value of any product-level token will cause a ripple effect through all skin modules. If this is not your intention, tokens are also available at the component-level. See <a href="component/switch#switch-variables">switch-variables</a> for an example.</p>
 </div>

--- a/src/components/token-system.marko
+++ b/src/components/token-system.marko
@@ -11,7 +11,7 @@
     <p>In order for Skin to render correctly, values for core tokens and light tokens are <strong>required</strong>.</p>
     <p>The easiest way to satisfy this requirement is to include one of the following bundles:</p>
     <ul>
-        <li><anchor href="component/tokens/">@ebay/skin/tokens</anchor></li>
+        <li><a href="component/tokens/">@ebay/skin/tokens</a></li>
     </ul>
 
     <p>It is also possible for a page to roll their own tokens sets, enabling a themed or even non-eBay branded look and feel. More information will be provided in a future release.</p>

--- a/src/routes/_index/+layout.marko
+++ b/src/routes/_index/+layout.marko
@@ -1,3 +1,4 @@
+static const basePath = import.meta.env.BASE_URL;
 <!doctype html>
 <html lang="en">
     <head>
@@ -5,6 +6,7 @@
         <meta name="description" content=`${$global.meta.pageDescription || 'The official static CSS framework of eBay - Skin is a semantic, accessible, responsive, and highly usable framework and CSS component library.'}`>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <base href=basePath>
         <master-icons/>
         <master-flags/>
     </head>

--- a/src/routes/_index/component/+page.marko
+++ b/src/routes/_index/component/+page.marko
@@ -6,7 +6,7 @@ import path from 'path';
 <ul>
 <for|key, folder| in=components>
     <li>
-        <anchor href=`component/${path.basename(folder)}/` class="module-link">${path.basename(folder)}</anchor>
+        <a href=`component/${path.basename(folder)}/` class="module-link">${path.basename(folder)}</a>
     </li>
 </for>
 </ul>

--- a/src/routes/_index/component/badge/+page.marko
+++ b/src/routes/_index/component/badge/+page.marko
@@ -6,13 +6,13 @@
     </p>
     <p>
         The badge module contains the basic, base styles for a static badge element. Badges can also be placed inside of the${" "}
-        <anchor href="component/icon-button#icon-button-badged">
+        <a href="component/icon-button#icon-button-badged">
             icon button
-        </anchor>
+        </a>
          and
-        <anchor href="component/menu#menu-badged">
+        <a href="component/menu#menu-badged">
             menu
-        </anchor>
+        </a>
          modules.
     </p>
 

--- a/src/routes/_index/component/button/+page.marko
+++ b/src/routes/_index/component/button/+page.marko
@@ -219,7 +219,7 @@
     </highlight-code>
 
     <h3 id="button-busy">Busy State for Button</h3>
-        <p>Replace the button contents with a <anchor href="component/progress-spinner/">progress spinner</anchor> to represent a busy state. Note also, that the button will need an aria-label to programmatically convey the busy state to assistive technology.</p>
+        <p>Replace the button contents with a <a href="component/progress-spinner/">progress spinner</a> to represent a busy state. Note also, that the button will need an aria-label to programmatically convey the busy state to assistive technology.</p>
 
         <div class="demo">
             <div class="demo__inner">
@@ -255,7 +255,7 @@
         </div>
     </div>
 
-    <p>NOTE: it is recommended to use a <anchor href="component/snackbar-dialog/">snackbar dialog</anchor> or <anchor href="component/inline-notice/">inline-notice</anchor> in order to convey any status of success or failure.</p>
+    <p>NOTE: it is recommended to use a <a href="component/snackbar-dialog/">snackbar dialog</a> or <a href="component/inline-notice/">inline-notice</a> in order to convey any status of success or failure.</p>
 
     <h3 id="button-layout">Flexible Button</h3>
 

--- a/src/routes/_index/component/checkbox/+page.marko
+++ b/src/routes/_index/component/checkbox/+page.marko
@@ -295,9 +295,9 @@
     </p>
     <p>
         The following example uses the
-        <anchor href="component/field/">
+        <a href="component/field/">
             field module
-        </anchor>
+        </a>
          for simple layout of checkbox fields and labels.
     </p>
 

--- a/src/routes/_index/component/chips-combobox/+page.marko
+++ b/src/routes/_index/component/chips-combobox/+page.marko
@@ -544,9 +544,9 @@
             a11y
         </span>
         ${" "}rules, color alone should not be used to indicate an error. For more information, please see the${" "}
-        <anchor href="component/field/#field-error-state">
+        <a href="component/field/#field-error-state">
             field error state docs
-        </anchor>
+        </a>
         .
     </p>
 

--- a/src/routes/_index/component/date-textbox/+page.marko
+++ b/src/routes/_index/component/date-textbox/+page.marko
@@ -9,17 +9,17 @@
     </h3>
     <p>
         The single select date textbox consists of a
-        <anchor href="component/textbox/">
+        <a href="component/textbox/">
             textbox
-        </anchor>
+        </a>
          plus
-        <anchor href="component/icon-button/">
+        <a href="component/icon-button/">
             icon button
-        </anchor>
+        </a>
         . The icon button launches an interactive
-        <anchor href="component/calendar/">
+        <a href="component/calendar/">
             calendar
-        </anchor>
+        </a>
          inside of a flyout.
     </p>
     <p>

--- a/src/routes/_index/component/filter-menu/+page.marko
+++ b/src/routes/_index/component/filter-menu/+page.marko
@@ -3,9 +3,9 @@
 
     <p>
         A filter menu forms the basis of the
-        <anchor href="component/filter-menu-button/">
+        <a href="component/filter-menu-button/">
             filter-menu-button
-        </anchor>
+        </a>
         ${" "}module; we provide it here as a standalone version in the case it might be opened or rendered via other means (in a dialog for example).
     </p>
 
@@ -527,13 +527,13 @@
     </h3>
     <p>
         A form version is also available. It uses the
-        <anchor href="component/checkbox/">
+        <a href="component/checkbox/">
             checkbox
-        </anchor>
+        </a>
          and
-        <anchor href="component/radio/">
+        <a href="component/radio/">
             radio
-        </anchor>
+        </a>
         ${" "}modules to render checkboxes or radios instead of ARIA menu items. The form version must contain a submit button.
     </p>
 

--- a/src/routes/_index/component/icon-button/+page.marko
+++ b/src/routes/_index/component/icon-button/+page.marko
@@ -1,7 +1,7 @@
 <div id="icon-button">
     <section-header metadata=metadata/>
 
-    <p>Use the <span class="highlight">icon-btn</span> class (for buttons) or the <span class="highlight">icon-link</span> class (for links) and any of the available <anchor href="component/icon/">icons</anchor> for a borderless, actionable icon style.</p>
+    <p>Use the <span class="highlight">icon-btn</span> class (for buttons) or the <span class="highlight">icon-link</span> class (for links) and any of the available <a href="component/icon/">icons</a> for a borderless, actionable icon style.</p>
 
     <div class="demo">
         <div class="demo__inner">
@@ -100,7 +100,7 @@
     </highlight-code>
 
     <h3 id="icon-button-badged">Badged Icon Button</h3>
-    <p>An icon button can be badged using the <anchor href="component/badge/">badge</anchor> module.</p>
+    <p>An icon button can be badged using the <a href="component/badge/">badge</a> module.</p>
     <p>The button or anchor element requires an additional <span class="highlight">icon-btn--badged</span> or <span class="highlight">icon-link--badged</span> modifier, respectively.</p>
 
     <div class="demo">

--- a/src/routes/_index/component/icon/+page.marko
+++ b/src/routes/_index/component/icon/+page.marko
@@ -33,7 +33,7 @@ import iconJSON from '../../../../components/data/icons.json';
 
     <h3>Including an Icon</h3>
     <p>An icon <a href="https://raw.githubusercontent.com/eBay/skin/master/src/svg/icons.svg">symbol</a> declaration can
-        be referenced from the same file or an <anchor href="component/svg/">external SVG</anchor> file. If in the same file, the symbol
+        be referenced from the same file or an <a href="component/svg/">external SVG</a> file. If in the same file, the symbol
         must be stamped on the page inside of an SVG block.</p>
     <p>We also provide individual icons as SVGs located in this <a href="https://github.com/eBay/skin/tree/master/src/svg/icon">directory</a>.
         You can include these on your page as raw SVGs as needed.</p>

--- a/src/routes/_index/component/link/+page.marko
+++ b/src/routes/_index/component/link/+page.marko
@@ -3,9 +3,9 @@
 
     <p>
         The link module itself does not provide any base styling of anchor tags, that styling instead comes from the${" "}
-        <anchor href="component/global/">
+        <a href="component/global/">
             global
-        </anchor>
+        </a>
          module.
     </p>
 

--- a/src/routes/_index/component/listbox-button/+page.marko
+++ b/src/routes/_index/component/listbox-button/+page.marko
@@ -776,9 +776,9 @@
     </p>
     <p>
         This is a simple example with a simple error indication. For usage of the error state with an error message, please see the${" "}
-        <anchor href="component/field/">
+        <a href="component/field/">
             field module
-        </anchor>
+        </a>
         .
     </p>
 

--- a/src/routes/_index/component/menu-button/+page.marko
+++ b/src/routes/_index/component/menu-button/+page.marko
@@ -12,30 +12,30 @@
         A menu is
         <strong>not</strong>
         ${" "}a form control. If you wish to submit form data natively, without JavaScript, please consider${" "}
-        <anchor href="component/checkbox/">
+        <a href="component/checkbox/">
             checkbox
-        </anchor>
+        </a>
         ,
-        <anchor href="component/combobox/">
+        <a href="component/combobox/">
             combobox
-        </anchor>
+        </a>
         ,
-        <anchor href="component/select/">
+        <a href="component/select/">
             select
-        </anchor>
+        </a>
         , or
-        <anchor href="component/radio/">
+        <a href="component/radio/">
             radio
-        </anchor>
+        </a>
          instead.
     </p>
     <p>
         Selecting a menu item command should update the page
         <strong>without</strong>
         ${" "}a full page reload (i.e. acting similar to buttons, checkboxes or radios). If a full page load is required instead (i.e. acting like links), please refer to the${" "}
-        <anchor href="component/menu-button/#menu-button-fake">
+        <a href="component/menu-button/#menu-button-fake">
             fake menu button
-        </anchor>
+        </a>
         .
     </p>
 
@@ -446,13 +446,13 @@
         </h4>
         <p>
             If a fixed label is not possible, the button's inner text can potentially be written as a key/value pair, where key denotes purpose and value repesents the current selection. This is most typical in a${" "}
-            <anchor href="component/menu-button/#menu-button-radio">
+            <a href="component/menu-button/#menu-button-radio">
                 single select menu button
-            </anchor>
+            </a>
             . For example: "Sort: Price", "Color: Red". This technique is identical to the method used by${" "}
-            <anchor href="component/listbox-button/">
+            <a href="component/listbox-button/">
                 Listbox Button
-            </anchor>
+            </a>
             .
         </p>
 
@@ -904,13 +904,13 @@
          be used as a dropdown for selecting and storing form
         <em>data</em>
         . Please use
-        <anchor href="component/button/">
+        <a href="component/button/">
             select
-        </anchor>
+        </a>
          or
-        <anchor href="component/button/">
+        <a href="component/button/">
             listbox-button
-        </anchor>
+        </a>
          for that purpose instead.
     </p>
 

--- a/src/routes/_index/component/menu/+page.marko
+++ b/src/routes/_index/component/menu/+page.marko
@@ -5,30 +5,30 @@
         A menu is
         <strong>not</strong>
         ${" "}a form control. If you wish to submit form data natively, without JavaScript, please consider${" "}
-        <anchor href="component/checkbox/">
+        <a href="component/checkbox/">
             checkbox
-        </anchor>
+        </a>
         ,
-        <anchor href="component/combobox/">
+        <a href="component/combobox/">
             combobox
-        </anchor>
+        </a>
         ,
-        <anchor href="component/select/">
+        <a href="component/select/">
             select
-        </anchor>
+        </a>
         , or
-        <anchor href="component/radio/">
+        <a href="component/radio/">
             radio
-        </anchor>
+        </a>
          instead.
     </p>
     <p>
         Selecting a menu item command should update the page
         <strong>without</strong>
         ${" "}a full page reload (i.e. acting similar to buttons, checkboxes or radios). If a full page load is required instead (i.e. acting like links), please refer to the${" "}
-        <anchor href="component/menu/#menu-fake">
+        <a href="component/menu/#menu-fake">
             fake menu
-        </anchor>
+        </a>
         .
     </p>
     <p>
@@ -104,9 +104,9 @@
     </h3>
     <p>
         A menu item can be badged using the
-        <anchor href="component/badge/">
+        <a href="component/badge/">
             badge
-        </anchor>
+        </a>
          module.
     </p>
     <p>

--- a/src/routes/_index/component/page-grid/+page.marko
+++ b/src/routes/_index/component/page-grid/+page.marko
@@ -263,7 +263,7 @@
     <p>
         To see how the page grid system (engine) works in conjunction with various types of implementations (templates), check out the page grid guide that includes various examples.
     </p>
-    <anchor href="guide/page-grid" role="menuitem">Page Grid Use Guide</anchor>
+    <a href="guide/page-grid" role="menuitem">Page Grid Use Guide</a>
 
 </div>
 export const metadata = {

--- a/src/routes/_index/component/phone-input/+page.marko
+++ b/src/routes/_index/component/phone-input/+page.marko
@@ -267,9 +267,9 @@
             field
         </span>
          classes. For label inline usage, please see the
-        <anchor href="component/field/">
+        <a href="component/field/">
             field module
-        </anchor>
+        </a>
          .
     </p>
     <div class="demo">

--- a/src/routes/_index/component/radio/+page.marko
+++ b/src/routes/_index/component/radio/+page.marko
@@ -219,9 +219,9 @@
     </p>
     <p>
         The following example uses the
-        <anchor href="component/field/">
+        <a href="component/field/">
             field module
-        </anchor>
+        </a>
          for simple layout of radio button fields and labels.
     </p>
     <div class="demo">

--- a/src/routes/_index/component/segmented-buttons/+page.marko
+++ b/src/routes/_index/component/segmented-buttons/+page.marko
@@ -124,9 +124,9 @@
     </h3>
     <p>
         Any 24x24
-        <anchor href="component/icon/">
+        <a href="component/icon/">
             icon
-        </anchor>
+        </a>
          can be added inside of a
         <span class="highlight">
             segmented-buttons__button-cell

--- a/src/routes/_index/component/select/+page.marko
+++ b/src/routes/_index/component/select/+page.marko
@@ -6,17 +6,17 @@
     </p>
     <p>
         The purpose of a select is to collect form data; therefore a select should always be used in conjunction with a form, label and submit button. If you are not submitting form data, then a${" "}
-        <anchor href="component/menu/">
+        <a href="component/menu/">
             menu
-        </anchor>
+        </a>
          maybe a better choice.
     </p>
     <p>
         <strong>IMPORTANT:</strong>
         ${" "}The examples below show the select in isolation, without any label. Please see the${" "}
-        <anchor href="component/field/">
+        <a href="component/field/">
             field
-        </anchor>
+        </a>
         ${" "}module for details on labeling controls. Remember: every select requires a label!
     </p>
 

--- a/src/routes/_index/component/skeleton/+page.marko
+++ b/src/routes/_index/component/skeleton/+page.marko
@@ -8,9 +8,9 @@
     </h2>
     <p>
         A skeleton is a graphical placeholder, reserving physical space in the page for content that is not yet available for the client to render. A skeleton can be considered as an alternative to the${" "}
-        <anchor href="component/progress-spinner/">
+        <a href="component/progress-spinner/">
             progress spinner
-        </anchor>
+        </a>
          in many situations.
     </p>
     <p>
@@ -58,7 +58,7 @@
 
     <p>
         The
-        <anchor href="guide/skeleton">Skeleton Use Guide</anchor>
+        <a href="guide/skeleton">Skeleton Use Guide</a>
         ${" "}illustrates various techniques for implementing skeletons across some common loading scenarios.
     </p>
 
@@ -79,9 +79,9 @@
         <tbody>
             <tr>
                 <td>
-                    <anchor href="component/skeleton/#skeleton-avatar">
+                    <a href="component/skeleton/#skeleton-avatar">
                         Avatar
-                    </anchor>
+                    </a>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -129,9 +129,9 @@
             </tr>
             <tr>
                 <td>
-                    <anchor href="component/skeleton/#skeleton-button">
+                    <a href="component/skeleton/#skeleton-button">
                         Button
-                    </anchor>
+                    </a>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -179,9 +179,9 @@
             </tr>
             <tr>
                 <td>
-                    <anchor href="component/skeleton/#skeleton-textbox">
+                    <a href="component/skeleton/#skeleton-textbox">
                         Textbox
-                    </anchor>
+                    </a>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -227,9 +227,9 @@
             </tr>
             <tr>
                 <td>
-                    <anchor href="component/skeleton/#skeleton-image">
+                    <a href="component/skeleton/#skeleton-image">
                         Image
-                    </anchor>
+                    </a>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -290,9 +290,9 @@
             </tr>
             <tr>
                 <td>
-                    <anchor href="component/skeleton/#skeleton-text">
+                    <a href="component/skeleton/#skeleton-text">
                         Text
-                    </anchor>
+                    </a>
                 </td>
                 <td>
                     <div class="skeleton" role="img" aria-label="loading">
@@ -348,9 +348,9 @@
             skeleton--green
         </span>
         . View the
-        <anchor href="component/skeleton/#skeleton-composite">
+        <a href="component/skeleton/#skeleton-composite">
             composite skeletons
-        </anchor>
+        </a>
          examples for further details.
     </p>
 

--- a/src/routes/_index/component/snackbar-dialog/+page.marko
+++ b/src/routes/_index/component/snackbar-dialog/+page.marko
@@ -10,9 +10,9 @@
             hidden
         </span>
          property. Please refer to the
-        <anchor href="guide/animation/#dialog-transitions">
+        <a href="guide/animation/#dialog-transitions">
             Dialog Transitions
-        </anchor>
+        </a>
         ${" "}section for information on how to correctly trigger a CSS transition from a hidden state. With the correct JavaScript in place, applying the${" "}
         <span class="highlight">
             snackbar-dialog--transition

--- a/src/routes/_index/component/split-button/+page.marko
+++ b/src/routes/_index/component/split-button/+page.marko
@@ -1,7 +1,7 @@
 <div id="split-button">
     <section-header metadata=metadata/>
 
-    <p>A split button is a button broken into two seperately actionable portions: a common action (a <anchor href="component/button/">button</anchor>) at the start, and supplemental actions (a <anchor href="component/menu-button/">menu button</anchor>) at the end.</p>
+    <p>A split button is a button broken into two seperately actionable portions: a common action (a <a href="component/button/">button</a>) at the start, and supplemental actions (a <a href="component/menu-button/">menu button</a>) at the end.</p>
     <p>Split buttons are for actions only, and should not be used for site navigation.</p>
 
     <div class="demo">

--- a/src/routes/_index/component/star-rating/+page.marko
+++ b/src/routes/_index/component/star-rating/+page.marko
@@ -17,9 +17,9 @@ $ const ratings = [
 
     <p>
         This is a non-interactive, display-only star rating pattern. For an interactive user-selectable star rating selection pattern, please refer to${" "}
-        <anchor href="component/star-rating-select/">
+        <a href="component/star-rating-select/">
             Star Rating Select
-        </anchor>
+        </a>
          .
     </p>
 
@@ -46,9 +46,9 @@ $ const ratings = [
 
     <p>
         Below is the code example for how to use the "star-rating-2-5" symbol. Please refer to the${" "}
-        <anchor href="component/icon/">
+        <a href="component/icon/">
             icon section
-        </anchor>
+        </a>
          for full guidance on how to include and use SVG symbols.
     </p>
 

--- a/src/routes/_index/component/tabs/+page.marko
+++ b/src/routes/_index/component/tabs/+page.marko
@@ -14,9 +14,9 @@
         Selecting a tab should update the visible panel
         <strong>without</strong>
         ${" "}a full page reload. If a full page load is required instead (i.e. acting like a link), please see the${" "}
-        <anchor href="component/tabs/#tabs-fake">
+        <a href="component/tabs/#tabs-fake">
             fake tab
-        </anchor>
+        </a>
          section below for more details.
     </p>
 

--- a/src/routes/_index/component/textbox/+page.marko
+++ b/src/routes/_index/component/textbox/+page.marko
@@ -13,7 +13,7 @@
     <p>
         <strong>IMPORTANT:</strong>The examples below show the textbox in isolation, without any label. Remember: every textbox requires a label!
     </p>
-    <!-- <p><strong>IMPORTANT:</strong> The examples below show the textbox in isolation, without any label. Please see the <anchor href="component/field/">field</anchor> module for details on labelling controls. Remember: every textbox requires a label!</p> -->
+    <!-- <p><strong>IMPORTANT:</strong> The examples below show the textbox in isolation, without any label. Please see the <a href="component/field/">field</a> module for details on labelling controls. Remember: every textbox requires a label!</p> -->
 
     <h3>Single-Line Textbox</h3>
     <p>Use an input tag for a single-line textbox.</p>
@@ -195,9 +195,9 @@
     </h3>
     <p>
         Single-line textboxes can be augmented with any SVG
-        <anchor href="component/icon/">
+        <a href="component/icon/">
             icon
-        </anchor>
+        </a>
         .
     </p>
 
@@ -286,9 +286,9 @@
     </h3>
     <p>
         Single-line textboxes also support an
-        <anchor href="component/icon-button/">
+        <a href="component/icon-button/">
             icon button
-        </anchor>
+        </a>
          in the end position.
     </p>
 

--- a/src/routes/_index/component/toast-dialog/+page.marko
+++ b/src/routes/_index/component/toast-dialog/+page.marko
@@ -10,9 +10,9 @@
             hidden
         </span>
          property. Please refer to the
-        <anchor href="guide/animation/#dialog-transitions">
+        <a href="guide/animation/#dialog-transitions">
             Dialog Transitions
-        </anchor>
+        </a>
         ${" "}section for information on how to correctly trigger a CSS transition from a hidden state. With the correct JavaScript in place, applying the${" "}
         <span class="highlight">
             toast-dialog--transition

--- a/src/routes/_index/component/toggle-button-group/+page.marko
+++ b/src/routes/_index/component/toggle-button-group/+page.marko
@@ -53,13 +53,13 @@ import imgSquarePic from "/src/routes/static/img/tb-square-pic.jpg";
     <p>
         Effort was taken in these docs to provide a good amount of helpful information. Since this component has an atomic piece (
 
-        <anchor href="component/toggle-button/">
+        <a href="component/toggle-button/">
             Toggle Button
-        </anchor>
+        </a>
         ), there may be some information crossover. Though efforts were taken to isolate the documentation for this parent component, at various touchpoints between the two components, there may be some redundancy. In other portions, where immediate information appears to be missing here, that information may reside in its child component. Please refer to${" "}
-        <anchor href="component/toggle-button/">
+        <a href="component/toggle-button/">
             Toggle Button
-        </anchor>
+        </a>
          docs in these situations.
     </p>
 
@@ -1044,9 +1044,9 @@ import imgSquarePic from "/src/routes/static/img/tb-square-pic.jpg";
 
     <p>
         There are various layouts that can be used based on the specific needs at implementation. The implied theme (needs no modifier), is the minimal layout. For more information about types of layouts, refer to the${" "}
-        <anchor href="component/toggle-button/">
+        <a href="component/toggle-button/">
             Toggle Button
-        </anchor>
+        </a>
          component. The examples below will highlight various layouts.
     </p>
 

--- a/src/routes/_index/component/tokens/+page.marko
+++ b/src/routes/_index/component/tokens/+page.marko
@@ -1,7 +1,7 @@
 $ const colors = ["avocado", "marigold", "blue", "coral", "orange", "dijon", "pink", "green", "red", "indigo", "teal", "jade", "yellow", "kiwi", "violet", "lilac", "neutral"];
 <div id="tokens">
     <section-header metadata=metadata/>
-    <p>Contains all custom properties necessary to correctly render the Evo Design System, in accordance with the <anchor href="#token-system">token system</anchor>.</p>
+    <p>Contains all custom properties necessary to correctly render the Evo Design System, in accordance with the <a href="#token-system">token system</a>.</p>
     <p>Core, light and dark token sets are individually exposed via the following submodules:</p>
     <dl>
         <dt><span class="secondary-text">@ebay/skin/tokens/</span>evo-core</dt>

--- a/src/routes/_index/component/typography/+page.marko
+++ b/src/routes/_index/component/typography/+page.marko
@@ -53,9 +53,9 @@
 
     <p>
         Product titles are regular font weight, use the
-        <anchor href="component/marketsans/">
+        <a href="component/marketsans/">
             Market Sans
-        </anchor>
+        </a>
          font and are responsive based on a small or large screen size.
     </p>
 
@@ -84,9 +84,9 @@
 
     <p>
         Section titles are bold font weight, use the
-        <anchor href="component/marketsans/">
+        <a href="component/marketsans/">
             Market Sans
-        </anchor>
+        </a>
          font and are responsive based on a small or large screen size.
     </p>
 

--- a/src/routes/_index/guide/page-grid+page.marko
+++ b/src/routes/_index/guide/page-grid+page.marko
@@ -9,7 +9,7 @@ static const basePath = import.meta.env.BASE_URL;
         <div class="template--item_head">
             <h2>Blog with Sub-Grid</h2>
             <div class="template--item_head_actions">
-                <anchor href="guide-examples/page-grid-blog-stretchy-subgrid/" target="_blank">Open</anchor>
+                <a href="guide-examples/page-grid-blog-stretchy-subgrid/" target="_blank">Open</a>
             </div>
         </div>
         <iframe src=`${basePath}guide-examples/page-grid-blog-stretchy-subgrid/` frameborder="0"></iframe>
@@ -19,7 +19,7 @@ static const basePath = import.meta.env.BASE_URL;
         <div class="template--item_head">
             <h2>Pricing</h2>
             <div class="template--item_head_actions">
-                <anchor href="guide-examples/page-grid-pricing/" target="_blank">Open</anchor>
+                <a href="guide-examples/page-grid-pricing/" target="_blank">Open</a>
             </div>
         </div>
         <iframe src=`${basePath}guide-examples/page-grid-pricing/` frameborder="0"></iframe>

--- a/src/routes/_index/guide/skeleton+page.marko
+++ b/src/routes/_index/guide/skeleton+page.marko
@@ -1,6 +1,6 @@
 <h1>Skeleton Usage Guide</h1>
 
-<p>This page details <anchor href="guide/skeleton/#techniques">implementation techniques</anchor> and <anchor href="guide/skeleton/#scenarios">common loading scenarios</anchor> for eBay Skin's <anchor href="component/skeleton/">skeleton</anchor> module.</p>
+<p>This page details <a href="guide/skeleton/#techniques">implementation techniques</a> and <a href="guide/skeleton/#scenarios">common loading scenarios</a> for eBay Skin's <a href="component/skeleton/">skeleton</a> module.</p>
 <p><strong>NOTE:</strong> This page demonstrates both good and bad uses of skeletons; please be sure to read and understand carefully to avoid replicating an anti-pattern!</p>
 
 <hr />
@@ -27,7 +27,7 @@
 `></highlight-code>
 
 <p><strong>NOTE:</strong> The <span class="highlight">:empty</span> pseudo-class considers elements with whitespace as not empty!</p>
-<p>The downside is that our <anchor href="component/skeleton/">skeleton classes</anchor> cannot be leveraged (in theory, LESS mixins could be provided) and <em>composite</em> skeletons (e.g. items tiles) may require some non-trivial use of CSS linear gradients for certain skeletons.</p>
+<p>The downside is that our <a href="component/skeleton/">skeleton classes</a> cannot be leveraged (in theory, LESS mixins could be provided) and <em>composite</em> skeletons (e.g. items tiles) may require some non-trivial use of CSS linear gradients for certain skeletons.</p>
 
 <hr />
 
@@ -85,7 +85,7 @@
 
 <h4>The Empty Screen</h4>
 <p>This example simulates the delay (set to 3 seconds) and empty screen while the client waits for the entire HTML payload from the server.</p>
-<p><anchor href="guide-examples/skeleton-examples/buffered/example-1">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/buffered/example-1">View Example</a></p>
 <p>For many types of web site, so long as the delay is not too long, this empty screen can be a perfectly acceptable user experience and no further optimizations or skeletons are necessary.</p>
 
 <hr />
@@ -103,23 +103,23 @@
 
 <h4>One Column with Empty Space</h4>
 <p>Our first progressive rendering example shows how the main article content might be streamed in after the main navigation and featured articles.</p>
-<p><anchor href="guide-examples/skeleton-examples/in-order/example-1a/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/in-order/example-1a/">View Example</a></p>
 <p>We have added a 3 second delay in order to simulate a service that is slow to fetch the main content. Remember, this is a highly contrived use case! No web site should be taking that long to retrieve static content and therefore would never require a skeleton!</p>
 
 <h4>One Column with Skeleton</h4>
 <p>Now let's add a skeleton placeholder for the main content. Using progressive rendering we stream an opening div tag to the client, and while the server works on getting the next chunk ready, the element will match the CSS :empty rule.</p>
-<p><anchor href="guide-examples/skeleton-examples/in-order/example-1b/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/in-order/example-1b/">View Example</a></p>
 <p>Okay, that was easy, our white space has been replaced with a skeleton while we wait for the next chunk to arrive. But what about when we have two columns?</p>
 
 <h4>Two Columns with Empty Space</h4>
 <p>To keep things simple lets assume the second column is also static content that will be quickly flushed from the server.</p>
-<p><anchor href="guide-examples/skeleton-examples/in-order/example-2a/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/in-order/example-2a/">View Example</a></p>
 <p>The goal of a skeleton is to replace empty space with a placeholder graphic giving a rough approximation of the content and layout to come. Lets see if we can update our skeleton to show two columns instead of just one.</p>
 
 <h4>Two Columns with Skeleton</h4>
 <p>Our main column and side column are siblings elements, so we cannot start the side column element without flushing and closing the main column element that precedes it. This means we cannot have an :empty main column and an :empty side column simultaneously.</p>
 <p>With some clever CSS we can create a single background image graphic representing a two column layout on the :empty main column.</p>
-<p><anchor href="guide-examples/skeleton-examples/in-order/example-2b/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/in-order/example-2b/">View Example</a></p>
 <p>This might be satisfactory in some cases, but what if we want to show the main content without waiting for the side column to be flushed (the side content may be a slow service also)? What about responsive design? How will our two column skeleton respond at various breakpoints?</p>
 <p>At this point we start to see that choreographing more than one skeleton placeholder with in-order streaming can become quite tricky. When we have more than one slow service, and a need for multiple skeleton placeholders, it is time to think about out-of-order streaming, which can eliminate these choreography concerns, but on the flipside has the potential to introduce the dreaded layout shift. Read on to find out more.</p>
 
@@ -132,27 +132,27 @@
 
 <h4>Layout Shift</h4>
 <p>With our in-order streaming examples, the appereance of new content was always <em>appended</em>, therefore never caused existing content or layout to move. Let's see what happens when we stream in our main content, side column and footer out of order.</p>
-<p><anchor href="guide-examples/skeleton-examples/out-of-order/example-1/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/out-of-order/example-1/">View Example</a></p>
 <p>As the content is loading, try clicking on the link in the footer. Now imagine if it were an "Add to Cart" or "Buy Now" button and how infuriating that would be. Imagine being a keyboard user, and the element with keyboard focus being pushed down the page out of view</p>
 <p>So, while getting content to the user faster always sounds like a good idea in theory, this example showcases how it can cause some unintended consequences and a poor UX.</p>
 <p>The good news is that skeletons, under certain conditions, have the ability to mitigate or mask entirely the problems associated with content arriving out-of-order.</p>
 
 <h4>Reserving Space</h4>
 <p>Skeletons can prevent the layout shift associated with out-of-order streaming by reserving the physical space for that content.</p>
-<p><anchor href="guide-examples/skeleton-examples/out-of-order/example-2/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/out-of-order/example-2/">View Example</a></p>
 <p>The physical dimensions of the reserved space must be known ahead of time. When skeletons reserve the right amount of space, they will prevent layout from shifting. When they reserve too much or too little, layout will shift.</p>
 <p>For some kinds of content, we can be sure of the physical dimensions ahead of time, images, videos, carousels, for example. For text however, we can only approximate in most cases, and therefore blocks of text make poor candidates for skeletons.</p>
 
 <h4>Skeleton-itis</h4>
 <p>With in order streaming and the :empty technique, it is not possible to display more than one skeleton concurrently. With out-of-order streaming, this restriction is lifted. This is both a good and a bad thing.</p>
 <p>Let's see what happens when we create skeletons for all main page sections.</p>
-<p><anchor href="guide-examples/skeleton-examples/out-of-order/example-3/">View Example</anchor></p>
-<p>Compare this with our <anchor href="guide-examples/skeleton-examples/out-of-order/example-2/">previous example</anchor> or <anchor href="guide-examples/skeleton-examples/in-order/example-2b/">In-Order streaming</anchor>. The wait time for the main content is the same, but without any shift or flashing in-and-out of skeletons. Most web pages should not have a 1:1 mapping of page sections to skeletons!</p>
+<p><a href="guide-examples/skeleton-examples/out-of-order/example-3/">View Example</a></p>
+<p>Compare this with our <a href="guide-examples/skeleton-examples/out-of-order/example-2/">previous example</a> or <a href="guide-examples/skeleton-examples/in-order/example-2b/">In-Order streaming</a>. The wait time for the main content is the same, but without any shift or flashing in-and-out of skeletons. Most web pages should not have a 1:1 mapping of page sections to skeletons!</p>
 
 <h4>Out-of-order Placeholders Only</h4>
 <p>Perhaps there is a compromise? We have established that to avoid unexpected layout shift, skeletons must reserve exactly the same amount of space as the content. The exception to this rule is if the skeleton and its content is appended to the page.</p>
 <p>Out-of-order streaming allows us to lay down our placeholders all at the same time and reserve space <em>without</em> waiting for the rest of the page. We can then sequence the streaming in a way that only ever appends the content.</p>
-<p><anchor href="guide-examples/skeleton-examples/out-of-order/example-4/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/out-of-order/example-4/">View Example</a></p>
 <p>While this might seem to defeat the purpose of out-of-order streaming (i.e. getting content onscreen quicker, regardless of its position) this does provide us with one method of tackling undesired layout shift and gaining some of the perceived performance increase of skeletons.</p>
 
 <hr />
@@ -164,14 +164,14 @@
 
 <h4>Load More - Unpredictable Size</h4>
 <p>This example shows an initial expected layout shift upon clicking the load more button. After a 3 second wait we experience an unexpected layout shift (i.e. the button is shunted down the page) due to the skeletons not reserving the same amount of physical space as the content that is fetched.</p>
-<p><anchor href="guide-examples/skeleton-examples/csr/example-1/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/csr/example-1/">View Example</a></p>
 <p>Each item that is loaded has an arbitrary amount of text. How could we make it less arbitrary and more predictable?</p>
 
 <h4>Load More - Predictable Size</h4>
 <p>One way to make content length less arbitrary is via text truncation. In this example the content has been truncated to two lines, meaning we can be more sure about the physical space that needs to be reserved by the skeleton.</p>
-<p><anchor href="guide-examples/skeleton-examples/csr/example-2/">View Example</anchor></p>
+<p><a href="guide-examples/skeleton-examples/csr/example-2/">View Example</a></p>
 <p>Again though it is worth remembering, working with text is far less predictable than with images, video and the like. The more predictable the type of content and its size and shape, the better skeletons will work to mitigate layout shift.</p>
 
 <h4>Refreshing Content</h4>
 <p>In addition to adding more content to any section of the page, another common scenario is to refresh the content of an existing area of the page. For example, paginating to the next set of results, or refreshing a set of thumbnail images.</p>
-<p>Just as with loading more content, refreshing a section of content can fall afoul of layout shift if the content size is <anchor href="guide-examples/skeleton-examples/csr/example-3/">unpredictable</anchor>. Again the situation can be avoided with <anchor href="guide-examples/skeleton-examples/csr/example-4/">predictable</anchor> content size.</p>
+<p>Just as with loading more content, refreshing a section of content can fall afoul of layout shift if the content size is <a href="guide-examples/skeleton-examples/csr/example-3/">unpredictable</a>. Again the situation can be avoided with <a href="guide-examples/skeleton-examples/csr/example-4/">predictable</a> content size.</p>

--- a/src/routes/_index/sitemap+page.marko
+++ b/src/routes/_index/sitemap+page.marko
@@ -37,7 +37,7 @@ style {
 
     <nav aria-labelledby="sitemap-pages">
         <ul role="menubar">
-        <li><anchor role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</anchor></li>
+        <li><a role="menuitem" href="archive/index.html">Archive (v${siteMeta.version})</a></li>
             <li><a role="menuitem" href="https://github.com/eBay/skin">Repo</a></li>
             <li><a role="menuitem" href="/storybook">Storybook</a></li>
         </ul>
@@ -56,14 +56,14 @@ style {
     <nav aria-labelledby="sitemap-guides">
         <ul role="menubar">
             <li>
-                <anchor href="guide/page-grid" role="menuitem">
-                Page Grid Use Guide</anchor>
+                <a href="guide/page-grid" role="menuitem">
+                Page Grid Use Guide</a>
             </li>
             <li>
-                <anchor href="guide/skeleton" role="menuitem">Skeleton Use Guide</anchor>
+                <a href="guide/skeleton" role="menuitem">Skeleton Use Guide</a>
             </li>
             <li>
-                <anchor href="guide/animation" role="menuitem">Animation Guide</anchor>
+                <a href="guide/animation" role="menuitem">Animation Guide</a>
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
- Follow-up from #2570 

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
<!-- Briefly describe the proposed changes -->
- Simplify the links by switching from the custom `<anchor>` component to a `<base>` tag at the head of all documents.

## Notes
<!-- Be sure to mention anything unusual, out-of-scope or new technical debt, etc -->

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [ ] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
