### PR TITLE
fix: adding legacy hash link support

### DIFF
--- a/src/components/site-header.marko
+++ b/src/components/site-header.marko
@@ -170,4 +170,52 @@ window.addEventListener("keyup", (e) => {
         closeNavigation();
     }
 });
+
+// Legacy links: Support incoming links from external sources which pointed to our pre-2025 single-page site
+// For example, redirects from /#menu-button-radio to /component/menu-button#menu-button-radio
+document.addEventListener("DOMContentLoaded", function() {
+    if (!location.hash) return;
+
+    // Don't redirect if we're already on a guide or component page (since all legacy links will be pointing to the site root)
+    if (location.pathname.includes("guide") || location.pathname.includes("component")) return;
+
+    // See if this matches an ID on the current page (if it does, obviously don't redirect)
+    let hash = location.hash.substring(1);
+    const id = document.getElementById(hash);
+    if (id) return;
+
+    // One-off non-component edge case: The #animation hash moved to a dedicated guide page
+    if (hash === "animation") {
+        location.href = "/guide/animation";
+        return;
+    }
+
+    // For safety, bail if this isn't strictly formatted correctly:
+    // - must be lowercase alphanumeric with dashes
+    // - no  leading/trailing dashes
+    // - the longest possible candidate ID (pagination-overflow-horizontal-24-control) is 41 chars
+    if (!/^[a-z0-9-]+$/.test(hash) || hash.startsWith("-") || hash.endsWith("-") || hash.length > 41) return;
+
+    // Normalize component edge cases where the legacy hash link was refactored later to match the component name (e.g. "tab" to "tabs")
+    hash = hash.replace(/^tab-/, "tabs-"); // Deep links under the "tabs" component (base "tabs" is unaffected)
+
+    // Starting from the right, chip away at the hash at each dash segment until we get a match from our components nav
+    // Note: We're going from longest to shortest since we don't want to mismatch a shorter component when we have a
+    // component with the same prefix (e.g. menu-button vs menu). Also, we have to do this since some hashes will be
+    // linking to a section within the page as well (e.g. menu-button-radio will exist on the menu-button component page).
+    let lastIndex = Infinity, partialHash = hash;
+    do {
+        partialHash = partialHash.substring(0, lastIndex);
+        const navEl = document.querySelector(`[role=menuitem][href*="/component/${partialHash}/"]`);
+        if (navEl) {
+            // Use suffix only if it differs from the original hash (otherwise its redundant and scrolls unnecessarily)
+            // Note: Using the normalized hash (not the original location.hash)
+            const suffix = hash !== partialHash ? `#${hash}` : "";
+
+            // Found match, so build final URL, redirect and bail
+            location.href = navEl.getAttribute("href") + suffix;
+            return;
+        }
+    } while ((lastIndex = partialHash.lastIndexOf("-")) !== -1);
+});
 </script>


### PR DESCRIPTION
<!-- Insert GitHub issue number below -->
Fixes legacy hash links and redirects to the correct component or guide page

<!-- Select which type of PR this is -->
- [ ] This PR contains CSS changes
- [x] This PR does not contain CSS changes

## Description
Ensures that links going to the legacy URLs such as the following are properly redirected. Example test cases:

* `#menu-button-radio` redirects to `component/menu-button/#menu-button-radio` (retains deep link)
* `#menu-button` redirects to `component/menu-button/` (no trailing hash)
* `#menu` redirects to `components/menu/` (longer names above are greedily matched first to prevent partial mismatches)
* Non-component edge cases:
    * `#animation` redirects to `guide/animation/`.
    * The old "Setup" navigation links to `#about`, `#install`, `#bundling`, `#token-system` and `#themes` are still valid for the original landing page.
    * The new "page grid" guide didn't exist (so the old `#page-grid` still redirects as one would expect to its corresponding component page).

For components, it redirects safely by ensuring that it matches longer component names first and it automatically matches based on actual URLs mentioned in the page navigation (to prevent blindly redirecting to arbitrary URLs).

Operates on the following conventions:

* Component names are hyphenated lowercase strings
* Hash URLs are hyphenated lowercase alphanumeric strings (e.g. allows numbers for deep links such as `#pagination-overflow-horizontal-24-control` or `#toggle-button-group-x1`)
* "Deep" links share the prefix with the component name. This is also accounting for an edge case from the refactor in my last PR #2573, which renamed `tab-default` and `tab-fake` to be consistently `tabs-` prefixed


## Testing locally

```bash
git clone https://github.com/patricknelson/skin.git
cd skin
git checkout fix-legacy-links
npm i
npm run start
```

Links from above (for validation):

* [http://localhost:3000/#menu-button-radio](http://localhost:3000/#menu-button-radio)
* [http://localhost:3000/#menu-button](http://localhost:3000/#menu-button)
* [http://localhost:3000/#menu](http://localhost:3000/#menu)
* [http://localhost:3000/#page-grid](http://localhost:3000/#page-grid)
* [http://localhost:3000/#pagination-overflow-horizontal-24-control](http://localhost:3000/#pagination-overflow-horizontal-24-control)
* [http://localhost:3000/#toggle-button-group-x1](http://localhost:3000/#toggle-button-group-x1)
* Edge cases:
    * [http://localhost:3000/#animation](http://localhost:3000/#animation)
    * [http://localhost:3000/#tab-default](http://localhost:3000/#tab-default)
    * [http://localhost:3000/#tab-fake](http://localhost:3000/#tab-fake)


## Checklist

This is an ac hoc cowboy PR (no issue was created for this) 🤠

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue
