### PR TITLE
feat(eek): flipped EEK direction

### DIFF
--- a/.changeset/heavy-webs-try.md
+++ b/.changeset/heavy-webs-try.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(eek): flipped EEK direction

--- a/dist/eek/eek.css
+++ b/dist/eek/eek.css
@@ -1,6 +1,7 @@
 .eek {
     align-items: stretch;
     display: inline-flex;
+    flex-direction: row-reverse;
     font-family: Arial, sans-serif;
     font-weight: 700;
     height: 24px;
@@ -14,12 +15,14 @@
 .eek__container {
     align-items: center;
     border: 1px solid #000;
-    border-radius: 2px 0 0 2px;
-    border-right: none;
+    border-left: none;
+    border-radius: 0 2px 2px 0;
     display: inline-flex;
+    flex-direction: row-reverse;
 }
 
 .eek .icon--eek-arrow {
+    rotate: 180deg;
     width: 9px;
 }
 
@@ -38,7 +41,7 @@
     content: "";
     display: block;
     height: 19.7989898732px;
-    margin-top: 2.3px;
+    margin-block-start: 2.3px;
     position: relative;
     right: 12px;
     transform: rotate(45deg);
@@ -105,7 +108,7 @@
     color: #fff;
     display: inline-block;
     font-size: 18px;
-    margin-left: 8px;
+    margin-inline-end: 8px;
     text-shadow:
         -0.5px 0.5px 0 #000,
         0.5px 0.5px 0 #000,
@@ -161,10 +164,6 @@
         }
     }
 }
-[dir="rtl"] .eek .icon--eek-arrow {
-    transform: rotate(180deg);
-}
-[dir="rtl"] .eek__container {
-    border-left: none;
-    border-right: 1px solid #000;
+[dir="rtl"] .eek {
+    direction: ltr;
 }

--- a/src/routes/_index/component/eek/+page.marko
+++ b/src/routes/_index/component/eek/+page.marko
@@ -360,9 +360,6 @@
         </svg>
     </div>
     </highlight-code>
-
-
-
 </div>
 export const metadata = {
     component: "eek",

--- a/src/sass/eek/eek.scss
+++ b/src/sass/eek/eek.scss
@@ -21,6 +21,9 @@ $eek-border-color: $eek-color;
 .eek {
     align-items: stretch;
     display: inline-flex;
+
+    // TODO remove flex-direction next major version and swap markup to be icon first
+    flex-direction: row-reverse;
     font-family: Arial, sans-serif;
     font-weight: 700;
     height: 24px;
@@ -34,12 +37,16 @@ $eek-border-color: $eek-color;
 .eek__container {
     align-items: center;
     border: 1px solid $eek-color;
-    border-radius: 2px 0 0 2px;
-    border-right: none;
+    border-left: none;
+    border-radius: 0 2px 2px 0;
     display: inline-flex;
+
+    // TODO remove flex-direction next major version and swap markup to be icon first
+    flex-direction: row-reverse;
 }
 
 .eek .icon--eek-arrow {
+    rotate: 180deg;
     width: 9px;
 }
 
@@ -58,7 +65,7 @@ $eek-border-color: $eek-color;
     content: "";
     display: block;
     height: $eek-arrow-size;
-    margin-top: 2.3px;
+    margin-block-start: 2.3px;
     position: relative;
     right: 12px;
     transform: rotate(45deg);
@@ -118,7 +125,7 @@ $eek-border-color: $eek-color;
     color: $eek-background-color;
     display: inline-block;
     font-size: 18px;
-    margin-left: 8px;
+    margin-inline-end: 8px;
     text-shadow:
         -0.5px 0.5px 0 $eek-color,
         0.5px 0.5px 0 $eek-color,
@@ -181,11 +188,8 @@ Changed a bit of styles there only in order to make it work
 }
 
 [dir="rtl"] {
-    .eek .icon--eek-arrow {
-        transform: rotate(180deg);
-    }
-    .eek__container {
-        border-left: none;
-        border-right: 1px solid $eek-color;
+    .eek {
+        // Since this is a legal requirement component, we need to ensure that the text is always left-to-right
+        direction: ltr;
     }
 }


### PR DESCRIPTION
Fixes #2580

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* ~~Added option to flip EEK. I called it `eek--direction-start` (so that we use `start` instead of `left`). Happy to swap the option to another name if there are any suggestions.~~
* Changed default EEK to be flipped to the left. 

## Screenshots
<img width="134" alt="Screenshot 2025-03-03 at 4 12 01 PM" src="https://github.com/user-attachments/assets/7226cd83-3a7b-475b-ba34-01f5db65501e" />
<img width="220" alt="Screenshot 2025-03-03 at 4 12 04 PM" src="https://github.com/user-attachments/assets/9c1e07f9-5744-40f2-93c7-0dce4381a31c" />


## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [X] I tested the UI in dark mode and RTL mode
- [X] I added/updated/removed Storybook coverage as appropriate
