### PR TITLE
feat(button): added animation to buttons

### DIFF
--- a/.changeset/fuzzy-badgers-fix.md
+++ b/.changeset/fuzzy-badgers-fix.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(button): added animation to buttons

--- a/dist/button/button.css
+++ b/dist/button/button.css
@@ -171,6 +171,12 @@ button.btn--primary {
         var(--color-foreground-on-accent)
     );
     font-weight: 700;
+    transition: all var(--motion-duration-short-3)
+        var(--motion-easing-quick-enter);
+}
+a.fake-btn--primary:active,
+button.btn--primary:active {
+    transform: scale(0.97);
 }
 
 a.fake-btn--primary {
@@ -324,11 +330,19 @@ a.fake-btn--secondary,
 button.btn--secondary {
     background-color: var(--btn-secondary-background-color, transparent);
     border-color: var(--btn-secondary-border-color, var(--color-stroke-accent));
+    color: var(
+        --btn-secondary-foreground-color,
+        var(--color-foreground-accent)
+    );
+    transition: all var(--motion-duration-short-3)
+        var(--motion-easing-quick-enter);
+}
+a.fake-btn--secondary:active,
+button.btn--secondary:active {
+    transform: scale(0.97);
 }
 
-a.fake-btn--secondary,
-a.fake-btn--secondary:visited,
-button.btn--secondary {
+a.fake-btn--secondary:visited {
     color: var(
         --btn-secondary-foreground-color,
         var(--color-foreground-accent)
@@ -435,6 +449,12 @@ a.fake-btn--secondary[aria-disabled="true"] {
 a.fake-btn--tertiary,
 button.btn--tertiary {
     border-color: var(--btn-tertiary-border-color, var(--color-stroke-default));
+    transition: all var(--motion-duration-short-3)
+        var(--motion-easing-quick-enter);
+}
+a.fake-btn--tertiary:active,
+button.btn--tertiary:active {
+    transform: scale(0.97);
 }
 
 a.fake-btn--tertiary[href]:focus,

--- a/src/sass/button/button.scss
+++ b/src/sass/button/button.scss
@@ -124,6 +124,8 @@ a.fake-btn--primary {
         color-foreground-on-accent
     );
 
+    @include btn-animations();
+
     font-weight: bold;
 }
 
@@ -281,6 +283,8 @@ a.fake-btn--secondary {
         btn-secondary-foreground-color,
         color-foreground-accent
     );
+
+    @include btn-animations();
 }
 
 a.fake-btn--secondary:visited {
@@ -388,6 +392,8 @@ a.fake-btn--tertiary {
         btn-tertiary-border-color,
         color-stroke-default
     );
+
+    @include btn-animations();
 }
 
 button.btn--tertiary:not([disabled], [aria-disabled="true"]),

--- a/src/sass/mixins/private/_button-mixins.scss
+++ b/src/sass/mixins/private/_button-mixins.scss
@@ -101,3 +101,12 @@ $button-border-radius-large: 24px;
         @include btn-fixed-height();
     }
 }
+
+@mixin btn-animations() {
+    transition: all var(--motion-duration-short-3)
+        var(--motion-easing-quick-enter);
+
+    &:active {
+        transform: scale(0.97);
+    }
+}


### PR DESCRIPTION
Fixes #2554

- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added animation to buttons. 
* As per design, we are using motion-duration-short-3 since we can't differentiate between when it becomes pressed and when the button is released (plus the difference is 80ms so even so, its such a subtle difference)
* Added transition all, since all the transitions have the same values (and that way it affects both `filter` changes as well as `color` and `background`. 

## Screenshots
![button-animation](https://github.com/user-attachments/assets/39c55d64-38c8-4856-bb49-c20bddb3182d)

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised
- [X] I regenerated all CSS files under dist folder
- [X] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
