### PR TITLE
fix(dialogs): remove dialogs scroll on entry

### DIFF
--- a/dist/drawer-dialog/drawer-dialog.css
+++ b/dist/drawer-dialog/drawer-dialog.css
@@ -11,6 +11,7 @@
     -webkit-overflow-scrolling: touch;
     align-items: flex-end;
     overflow-y: auto;
+    overflow: hidden;
     position: fixed;
     right: 0;
     top: 0;

--- a/dist/panel-dialog/panel-dialog.css
+++ b/dist/panel-dialog/panel-dialog.css
@@ -10,7 +10,7 @@
     -webkit-overflow-scrolling: touch;
     flex-direction: column;
     overflow-y: auto;
-    overflow-y: hidden;
+    overflow: hidden;
     position: fixed;
     right: 0;
     top: 0;

--- a/src/sass/drawer-dialog/drawer-dialog.scss
+++ b/src/sass/drawer-dialog/drawer-dialog.scss
@@ -8,6 +8,7 @@
     @include dialog-base();
 
     align-items: flex-end;
+    overflow: hidden;
 }
 
 .drawer-dialog--no-mask[role="dialog"] {

--- a/src/sass/panel-dialog/panel-dialog.scss
+++ b/src/sass/panel-dialog/panel-dialog.scss
@@ -9,7 +9,7 @@
 
     /* need to override base as panel dialog is the only one to scroll the content only */
     /* stylelint-disable-next-line declaration-block-no-duplicate-properties */
-    overflow-y: hidden;
+    overflow: hidden;
 }
 
 .panel-dialog__window {


### PR DESCRIPTION
Fixes #2601

<!-- Select which type of PR this is -->
- [x] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
This PR fixes an issue with panel and drawer dialogs. When Those dialogs open they create un needed scrollbar.

https://github.com/user-attachments/assets/cdb4aa2b-6d48-469e-a4f4-49e87a121efc


## Notes
The original overflow is not needed in both of this cases as both of those dialogs have scrollable content with overflow auto.

## Screenshots
<!-- Upload screenshots of UI before & after these changes -->

## Checklist
<!-- Acknowledge completion of steps in checklists below. Delete lists that are not applicable -->

<!-- For all PR types -->
- [ ] I verify the build is in a non-broken state
- [ ] I verify all changes are within scope of the linked issue

<!-- For Markup Changes -->
- [ ] I verify the markup will not be a breaking change (if not a major release)
- [ ] I verify the MIND pattern for the component has been created/revised

<!-- For CSS changes -->
- [x] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
