### PR TITLE
feat(item-tile-group): add default layouts inside item-tile-group

### DIFF
--- a/.changeset/moody-pumas-wear.md
+++ b/.changeset/moody-pumas-wear.md
@@ -1,0 +1,5 @@
+---
+"@ebay/skin": minor
+---
+
+feat(item-tile-group): add default layouts inside item-tile-group

--- a/dist/item-tile-group/item-tile-group.css
+++ b/dist/item-tile-group/item-tile-group.css
@@ -1,3 +1,27 @@
+.layout-grid.item-tile-group {
+    --layout-grid-columns-min: 2;
+    --layout-grid-columns-xs: 2;
+    --layout-grid-columns-sm: 2;
+    --layout-grid-columns-md: 3;
+    --layout-grid-columns-lg: 4;
+    --layout-grid-columns-xl: 5;
+    --layout-grid-columns-xl2: 5;
+    --layout-grid-columns-xl3: 5;
+    --layout-grid-columns-xl4: 5;
+}
+
+.layout-grid.item-tile-group--list-view {
+    --layout-grid-columns-min: 1;
+    --layout-grid-columns-xs: 1;
+    --layout-grid-columns-sm: 1;
+    --layout-grid-columns-md: 1;
+    --layout-grid-columns-lg: 1;
+    --layout-grid-columns-xl: 2;
+    --layout-grid-columns-xl2: 2;
+    --layout-grid-columns-xl3: 2;
+    --layout-grid-columns-xl4: 2;
+}
+
 .item-tile-group .item-tile__title {
     -webkit-line-clamp: 3;
 }

--- a/src/routes/_index/component/item-tile-group/+page.marko
+++ b/src/routes/_index/component/item-tile-group/+page.marko
@@ -5,12 +5,7 @@
 <p>A standalone item tile on its own wouldn't be very useful. You'd typically use multiple item tiles inside a layout. Here's an example of a list of item tiles using the <highlight>layout-grid</highlight> component. The responsive display rules are set on the <highlight>layout-grid</highlight> using the specific breakpoint hooks using the various breakpoint attributes.</p>
 
 <demo>
-    <div class="item-tile-group layout-grid"
-        data-columns-min="2"
-        data-columns-md="3"
-        data-columns-lg="4"
-        data-columns-xl="5"
-    >
+    <div class="item-tile-group layout-grid">
         <ul aria-label="Items for sale">
             <li>
                 <div class="item-tile">
@@ -50,7 +45,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -99,7 +94,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -148,7 +143,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -197,7 +192,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -213,12 +208,7 @@
 </demo>
 
 <highlight-code type="html">
-<div class="item-tile-group layout-grid"
-    data-columns-min="2"
-    data-columns-md="3"
-    data-columns-lg="4"
-    data-columns-xl="5"
->
+<div class="item-tile-group layout-grid">
     <ul aria-label="Items for sale">
         <li>
             <div class="item-tile">
@@ -258,7 +248,7 @@
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -279,10 +269,7 @@
 <p>To use a set of List Layout Item Tiles in a layout, you can use the <highlight>layout-grid</highlight> component with the specific responsive display rules per specifications. This will ensure proper spacing of Item Tiles in relation to each other and maintain the horizontally-oriented Item Tiles stacked across all breakpoints until it hits the <highlight>xl</highlight> breakpoint, where it displays two Item Tiles per row.</p>
 
 <demo>
-    <div class="item-tile-group item-tile-group--list-view layout-grid"
-        data-columns-min="1"
-        data-columns-xl="2"
-    >
+    <div class="item-tile-group item-tile-group--list-view layout-grid">
         <ul aria-label="Items for sale">
             <li>
                 <div class="item-tile item-tile--list-view">
@@ -322,7 +309,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -371,7 +358,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -420,7 +407,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -469,7 +456,7 @@
                         </div>
                         <div class="item-tile__section-tertiary">
                             <p>
-                                $29.99 
+                                $29.99
                                 <span class="clipped">Was: </span>
                                 <s class="item-tile__list-price">$68.99</s>
                             </p>
@@ -485,10 +472,7 @@
 </demo>
 
 <highlight-code type="html">
-<div class="item-tile-group item-tile-group--list-view layout-grid"
-    data-columns-min="1"
-    data-columns-xl="2"
->
+<div class="item-tile-group item-tile-group--list-view layout-grid">
     <ul aria-label="Items for sale">
         <li>
             <div class="item-tile item-tile--list-view">
@@ -528,7 +512,7 @@
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>

--- a/src/sass/item-tile-group/item-tile-group.scss
+++ b/src/sass/item-tile-group/item-tile-group.scss
@@ -1,3 +1,26 @@
+.layout-grid.item-tile-group {
+    --layout-grid-columns-min: 2;
+    --layout-grid-columns-xs: 2;
+    --layout-grid-columns-sm: 2;
+    --layout-grid-columns-md: 3;
+    --layout-grid-columns-lg: 4;
+    --layout-grid-columns-xl: 5;
+    --layout-grid-columns-xl2: 5;
+    --layout-grid-columns-xl3: 5;
+    --layout-grid-columns-xl4: 5;
+}
+
+.layout-grid.item-tile-group--list-view {
+    --layout-grid-columns-min: 1;
+    --layout-grid-columns-xs: 1;
+    --layout-grid-columns-sm: 1;
+    --layout-grid-columns-md: 1;
+    --layout-grid-columns-lg: 1;
+    --layout-grid-columns-xl: 2;
+    --layout-grid-columns-xl2: 2;
+    --layout-grid-columns-xl3: 2;
+    --layout-grid-columns-xl4: 2;
+}
 .item-tile-group .item-tile__title {
     -webkit-line-clamp: 3;
 }

--- a/src/sass/item-tile-group/stories/item-tile-group.stories.js
+++ b/src/sass/item-tile-group/stories/item-tile-group.stories.js
@@ -1,12 +1,7 @@
 export default { title: "Skin/Item Tile Group" };
 
 export const galleryView = () => `
-<div class="item-tile-group layout-grid"
-    data-columns-min="2"
-    data-columns-md="3"
-    data-columns-lg="4"
-    data-columns-xl="5"
->
+<div class="item-tile-group layout-grid">
     <ul aria-label="Items for sale">
         <li>
             <div class="item-tile">
@@ -46,7 +41,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -95,7 +90,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -144,7 +139,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -193,7 +188,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -242,7 +237,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -291,7 +286,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -340,7 +335,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -389,7 +384,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -438,7 +433,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -487,7 +482,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -536,7 +531,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -585,7 +580,7 @@ export const galleryView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -601,10 +596,7 @@ export const galleryView = () => `
 `;
 
 export const listView = () => `
-<div class="item-tile-group item-tile-group--list-view layout-grid"
-    data-columns-min="1"
-    data-columns-xl="2"
->
+<div class="item-tile-group item-tile-group--list-view layout-grid">
     <ul aria-label="Items for sale">
         <li>
             <div class="item-tile item-tile--list-view">
@@ -644,7 +636,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -693,7 +685,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -742,7 +734,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -791,7 +783,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -840,7 +832,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -889,7 +881,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -938,7 +930,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -987,7 +979,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -1036,7 +1028,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -1085,7 +1077,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -1134,7 +1126,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>
@@ -1183,7 +1175,7 @@ export const listView = () => `
                     </div>
                     <div class="item-tile__section-tertiary">
                         <p>
-                            $29.99 
+                            $29.99
                             <span class="clipped">Was: </span>
                             <s class="item-tile__list-price">$68.99</s>
                         </p>


### PR DESCRIPTION
- [X] This PR contains CSS changes
- [ ] This PR does not contain CSS changes

## Description
* Added defaults for column sizes for item-tile-group. This allows us to build the item tile without specifying any data-columns
* I added `.layout-grid.item-tile-group` as the main selector. I think we could have reordered the class to get it to work, but I prefer to make sure styles are applied no matter what order the classes are specified. If there's a better way, please let me know!

## Screenshots
<img width="1149" alt="Screenshot 2025-04-04 at 11 10 49 AM" src="https://github.com/user-attachments/assets/ba7688bc-79cb-480a-8cec-b63260a4e0cd" />
<img width="1147" alt="Screenshot 2025-04-04 at 11 10 55 AM" src="https://github.com/user-attachments/assets/cfd01dc3-eaa0-4b3c-b270-e4e1bee3ca99" />

## Checklist
- [X] I verify the build is in a non-broken state
- [X] I verify all changes are within scope of the linked issue
- [X] I regenerated all CSS files under dist folder
- [ ] I tested the UI in all supported browsers
- [ ] I did a visual regression check of the components impacted by doing a Percy build and approved the build
- [ ] I tested the UI in dark mode and RTL mode
- [ ] I added/updated/removed Storybook coverage as appropriate
